### PR TITLE
fix: key validation

### DIFF
--- a/packages/spacecat-shared-dynamo/src/utils/guards.js
+++ b/packages/spacecat-shared-dynamo/src/utils/guards.js
@@ -25,14 +25,14 @@ const guardTableName = (tableName) => {
 };
 
 /**
- * Validates that the provided key is an object and contains a partitionKey.
+ * Validates that the provided key is an object and contains at least one property.
  *
  * @param {object} key - The key object to validate.
- * @throws {Error} If the key is not an object or does not contain a partitionKey.
+ * @throws {Error} If the key is not an object or does not contain at least one property.
  */
 const guardKey = (key) => {
-  if (!isObject(key) || !key.partitionKey) {
-    throw new Error('Key must be an object with a partitionKey.');
+  if (!isObject(key) || Object.keys(key).length === 0) {
+    throw new Error('Key must be a non-empty object.');
   }
 };
 

--- a/packages/spacecat-shared-dynamo/test/modules/getItem.test.js
+++ b/packages/spacecat-shared-dynamo/test/modules/getItem.test.js
@@ -54,7 +54,7 @@ describe('getItem', () => {
       await dynamoDbClient.getItem('TestTable', null);
       expect.fail('getItem did not throw with invalid key');
     } catch (error) {
-      expect(error.message).to.equal('Key must be an object with a partitionKey.');
+      expect(error.message).to.equal('Key must be a non-empty object.');
     }
   });
 

--- a/packages/spacecat-shared-dynamo/test/modules/removeItem.test.js
+++ b/packages/spacecat-shared-dynamo/test/modules/removeItem.test.js
@@ -54,7 +54,7 @@ describe('removeItem', () => {
       await dynamoDbClient.removeItem('TestTable', null);
       expect.fail('removeItem did not throw with invalid key');
     } catch (error) {
-      expect(error.message).to.equal('Key must be an object with a partitionKey.');
+      expect(error.message).to.equal('Key must be a non-empty object.');
     }
   });
 

--- a/packages/spacecat-shared-dynamo/test/utils/guards.test.js
+++ b/packages/spacecat-shared-dynamo/test/utils/guards.test.js
@@ -16,42 +16,44 @@ import { expect } from 'chai';
 import { guardKey, guardQueryParameters, guardTableName } from '../../src/utils/guards.js';
 
 describe('Query Parameter Guards', () => {
-  // Test guardTableName
   describe('guardTableName', () => {
-    it('should throw an error if tableName is empty', () => {
+    it('throws an error if tableName is empty', () => {
       expect(() => guardTableName('')).to.throw('Table name is required.');
     });
 
-    it('should not throw an error for valid tableName', () => {
+    it('does not throw an error for valid tableName', () => {
       expect(() => guardTableName('validTableName')).to.not.throw();
     });
   });
 
-  // Test guardKey
   describe('guardKey', () => {
-    it('should throw an error if key is not an object', () => {
-      expect(() => guardKey('notAnObject')).to.throw('Key must be an object with a partitionKey.');
+    it('throws an error if key is not an object', () => {
+      expect(() => guardKey('notAnObject')).to.throw('Key must be a non-empty object.');
     });
 
-    it('should throw an error if key does not have partitionKey', () => {
-      expect(() => guardKey({})).to.throw('Key must be an object with a partitionKey.');
+    it('throws an error if key is an empty object', () => {
+      expect(() => guardKey({})).to.throw('Key must be a non-empty object.');
     });
 
-    it('should not throw an error for a valid key', () => {
-      expect(() => guardKey({ partitionKey: 'value' })).to.not.throw();
+    it('does not throw an error for a valid key with one property', () => {
+      expect(() => guardKey({ somePartitionKeyField: 'value' })).to.not.throw();
+    });
+
+    it('does not throw an error for a valid key with two properties', () => {
+      expect(() => guardKey({ somePartitionKeyField: 'value', someOptionalRangeKey: 'anotherValue' })).to.not.throw();
     });
   });
 
   describe('guardQueryParameters', () => {
-    it('should throw an error if params is not an object', () => {
+    it('throws an error if params is not an object', () => {
       expect(() => guardQueryParameters('notAnObject')).to.throw('Query parameters must be an object.');
     });
 
-    it('should throw an error if any required parameter is missing', () => {
+    it('throws an error if any required parameter is missing', () => {
       expect(() => guardQueryParameters({ TableName: 'table' })).to.throw('Query parameters is missing required parameter: KeyConditionExpression');
     });
 
-    it('should not throw an error for valid params', () => {
+    it('does not throw an error for valid params', () => {
       const validParams = {
         TableName: 'table',
         KeyConditionExpression: 'expression',


### PR DESCRIPTION
Dynamo key expects a non-empty object instead of fixed property names as I previously assumed.