### PR TITLE
feat: introduce getSiteByID

### DIFF
--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -81,6 +81,9 @@ export interface DataAccess {
     baseUrl: string,
     auditType: string,
   ) => Promise<Site | null>;
+  getSiteByID: (
+    siteId: string,
+  ) => Promise<Site | null>;
   addSite: (
     siteData: object,
   ) => Promise<Site>;

--- a/packages/spacecat-shared-data-access/src/service/sites/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/sites/accessPatterns.js
@@ -42,16 +42,16 @@ export const getSites = async (dynamoClient, config) => {
 };
 
 /**
- * Retrieves a list of base URLs for all sites.
+ * Retrieves a list of site IDs of all sites.
  *
  * @param {DynamoDbClient} dynamoClient - The DynamoDB client.
  * @param {DataAccessConfig} config - The data access config.
- * @returns {Promise<Array<string>>} A promise that resolves to an array of base URLs for all sites.
+ * @returns {Promise<Array<string>>} A promise that resolves to an array of site IDs of all sites.
  */
 export const getSitesToAudit = async (dynamoClient, config) => {
   const sites = await getSites(dynamoClient, config);
 
-  return sites.map((site) => site.getBaseURL());
+  return sites.map((site) => site.getId());
 };
 
 /**
@@ -117,11 +117,7 @@ export const getSiteByBaseURL = async (
     Limit: 1,
   });
 
-  if (dynamoItems.length === 0) {
-    return null;
-  }
-
-  return SiteDto.fromDynamoItem(dynamoItems[0]);
+  return dynamoItems.length > 0 ? SiteDto.fromDynamoItem(dynamoItems[0]) : null;
 };
 
 /**
@@ -208,6 +204,27 @@ export const getSiteByBaseURLWithLatestAudit = async (
   baseUrl,
   auditType,
 ) => getSiteByBaseURLWithAuditInfo(dynamoClient, config, log, baseUrl, auditType, true);
+
+/**
+ * Retrieves a site by its ID.
+ *
+ * @param {DynamoDbClient} dynamoClient - The DynamoDB client.
+ * @param {DataAccessConfig} config - The data access config.
+ * @param {Logger} log - The logger.
+ * @param {string} siteId - The ID of the site to retrieve.
+ * @returns {Promise<Readonly<Site>|null>} A promise that resolves to the site object if found,
+ * otherwise null.
+ */
+export const getSiteByID = async (
+  dynamoClient,
+  config,
+  log,
+  siteId,
+) => {
+  const dynamoItem = await dynamoClient.getItem(config.tableNameSites, { id: siteId });
+
+  return isObject(dynamoItem) ? SiteDto.fromDynamoItem(dynamoItem) : null;
+};
 
 /**
  * Adds a site.

--- a/packages/spacecat-shared-data-access/src/service/sites/index.js
+++ b/packages/spacecat-shared-data-access/src/service/sites/index.js
@@ -16,6 +16,7 @@ import {
   getSiteByBaseURLWithAuditInfo,
   getSiteByBaseURLWithAudits,
   getSiteByBaseURLWithLatestAudit,
+  getSiteByID,
   getSites,
   getSitesToAudit,
   getSitesWithLatestAudit, removeSite,
@@ -43,6 +44,12 @@ export const siteFunctions = (dynamoClient, config, log) => ({
     config,
     log,
     baseUrl,
+  ),
+  getSiteByID: (siteId) => getSiteByID(
+    dynamoClient,
+    config,
+    log,
+    siteId,
   ),
   getSiteByBaseURLWithAuditInfo: (baseUrl, auditType, latestOnly) => getSiteByBaseURLWithAuditInfo(
     dynamoClient,

--- a/packages/spacecat-shared-data-access/test/it/db.test.js
+++ b/packages/spacecat-shared-data-access/test/it/db.test.js
@@ -16,7 +16,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import dynamoDbLocal from 'dynamo-db-local';
 
-import { isIsoDate, isValidUrl } from '@adobe/spacecat-shared-utils';
+import { isIsoDate } from '@adobe/spacecat-shared-utils';
 import { sleep } from '../unit/util.js';
 import { createDataAccess } from '../../src/service/index.js';
 import { AUDIT_TYPE_LHS_MOBILE } from '../../src/models/audit.js';
@@ -105,9 +105,8 @@ describe('DynamoDB Integration Test', async () => {
 
     expect(sites.length).to.equal(NUMBER_OF_SITES);
 
-    sites.forEach((baseURL) => {
-      expect(baseURL).to.be.a('string');
-      expect(isValidUrl(baseURL)).to.equal(true);
+    sites.forEach((siteId) => {
+      expect(siteId).to.be.a('string');
     });
   });
 
@@ -135,6 +134,16 @@ describe('DynamoDB Integration Test', async () => {
     expect(site).to.be.an('object');
 
     checkSite(site);
+  });
+
+  it('gets site by ID', async () => {
+    const siteId = (await dataAccess.getSites())[0].getId();
+    const site = await dataAccess.getSiteByID(siteId);
+
+    expect(site).to.be.an('object');
+
+    checkSite(site);
+    expect(site.getId()).to.equal(siteId);
   });
 
   it('adds a new site', async () => {

--- a/packages/spacecat-shared-data-access/test/unit/service/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/index.test.js
@@ -35,6 +35,7 @@ describe('Data Access Object Tests', () => {
     'getSiteByBaseURLWithAuditInfo',
     'getSiteByBaseURLWithAudits',
     'getSiteByBaseURLWithLatestAudit',
+    'getSiteByID',
   ];
 
   let dao;

--- a/packages/spacecat-shared-data-access/test/unit/service/sites/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/sites/index.test.js
@@ -152,10 +152,32 @@ describe('Site Access Pattern Tests', () => {
       expect(result).to.be.an('array').that.is.empty;
     });
 
-    it('calls getSiteByBaseURL and returns an array/object', async () => {
+    it('calls getSiteByBaseURL and returns null', async () => {
       const result = await exportedFunctions.getSiteByBaseURL();
       expect(result).to.be.null;
       expect(mockDynamoClient.query.called).to.be.true;
+    });
+
+    it('calls getSiteByID and returns null', async () => {
+      const result = await exportedFunctions.getSiteByID();
+      expect(result).to.be.null;
+      expect(mockDynamoClient.getItem.called).to.be.true;
+    });
+
+    it('calls getSiteByID and returns site', async () => {
+      const mockSiteData = {
+        id: 'site1',
+        baseURL: 'https://example.com',
+      };
+
+      mockDynamoClient.getItem.onFirstCall().resolves(mockSiteData);
+
+      const result = await exportedFunctions.getSiteByID();
+
+      expect(result).to.be.an('object');
+      expect(result.getId()).to.equal(mockSiteData.id);
+      expect(result.getBaseURL()).to.equal(mockSiteData.baseURL);
+      expect(mockDynamoClient.getItem.called).to.be.true;
     });
 
     it('calls getSiteByBaseURLWithAuditInfo and returns an array/object', async () => {


### PR DESCRIPTION
Introduces `getSiteByID` which can be leveraged by `getSitesToAudit` to return a list of IDs instead of BaseURLs. This in turn allows the audit worker to get a site to audit by ID, which will use a `getItem` operation in dynamo db instead of `query`.