### PR TITLE
fix: auto-remove undefined values

### DIFF
--- a/packages/spacecat-shared-dynamo/src/index.js
+++ b/packages/spacecat-shared-dynamo/src/index.js
@@ -29,7 +29,12 @@ import removeItem from './modules/removeItem.js';
 const createClient = (
   log = console,
   dbClient = new DynamoDB(),
-  docClient = DynamoDBDocument.from(dbClient),
+  docClient = DynamoDBDocument.from(dbClient, {
+    marshallOptions: {
+      convertEmptyValues: true,
+      removeUndefinedValues: true,
+    },
+  }),
 ) => ({
   query: (params) => query(docClient, params, log),
   getItem: (tableName, key) => getItem(docClient, tableName, key, log),


### PR DESCRIPTION
Prevents errors like these:
```
inv.invocationId:30255aeb-f605-5b3e-8f81-07124f51d0e5inv.functionName:/spacecat-services/audit-worker/v1level:errorlogStream:2023/12/18/[512]8c74a45c07bd4741bd7a42a062158a0amessage:DB Put Item Error: Error: Pass options.removeUndefinedValues=true to remove undefined values from map/array/set.
at convertToAttr (/var/runtime/node_modules/@aws-sdk/util-dynamodb/dist-cjs/convertToAttr.js:7:15)
at /var/runtime/node_modules/@aws-sdk/util-dynamodb/dist-cjs/convertToAttr.js:118:54
at convertToMapAttrFromEnumerableProps (/var/runtime/node_modules/@aws-sdk/util-dynamodb/dist-cjs/convertToAttr.js:122:7)
at convertToAttr (/var/runtime/node_modules/@aws-sdk/util-dynamodb/dist-cjs/convertToAttr.js:23:16)
at /var/runtime/node_modules/@aws-sdk/util-dynamodb/dist-cjs/convertToAttr.js:118:54
at convertToMapAttrFromEnumerableProps (/var/runtime/node_modules/@aws-sdk/util-dynamodb/dist-cjs/convertToAttr.js:122:7)
at convertToAttr (/var/runtime/node_modules/@aws-sdk/util-dynamodb/dist-cjs/convertToAttr.js:23:16)
at marshall (/var/runtime/node_modules/@aws-sdk/util-dynamodb/dist-cjs/marshall.js:6:62)
at marshallFunc (/var/runtime/node_modules/@aws-sdk/lib-dynamodb/dist-cjs/commands/utils.js:39:71)
at processObj (/var/runtime/node_modules/@aws-sdk/lib-dynamodb/dist-cjs/commands/utils.js:8:20)timestamp:2023-12-18T03:06:11.468Z
```