### PR TITLE
feat: add broken-backlinks audit type (SITES-18417)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12401,7 +12401,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "1.6.3",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-dynamo": "1.2.5",
@@ -12930,7 +12930,7 @@
     },
     "packages/spacecat-shared-dynamo": {
       "name": "@adobe/spacecat-shared-dynamo",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.1.0",
@@ -12959,7 +12959,7 @@
     },
     "packages/spacecat-shared-http-utils": {
       "name": "@adobe/spacecat-shared-http-utils",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.1"
@@ -12970,7 +12970,7 @@
     },
     "packages/spacecat-shared-rum-api-client": {
       "name": "@adobe/spacecat-shared-rum-api-client",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.1",
@@ -12995,7 +12995,7 @@
     },
     "packages/spacecat-shared-utils": {
       "name": "@adobe/spacecat-shared-utils",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.1"

--- a/packages/spacecat-shared-data-access/src/models/audit.js
+++ b/packages/spacecat-shared-data-access/src/models/audit.js
@@ -13,6 +13,7 @@
 import { hasText, isIsoDate, isObject } from '@adobe/spacecat-shared-utils';
 import { Base } from './base.js';
 
+export const AUDIT_TYPE_BROKEN_BACKLINKS = 'broken-backlinks';
 export const AUDIT_TYPE_CWV = 'cwv';
 export const AUDIT_TYPE_LHS_DESKTOP = 'lhs-desktop';
 export const AUDIT_TYPE_LHS_MOBILE = 'lhs-mobile';
@@ -20,6 +21,7 @@ export const AUDIT_TYPE_LHS_MOBILE = 'lhs-mobile';
 const EXPIRES_IN_DAYS = 30;
 
 const AUDIT_TYPE_PROPERTIES = {
+  [AUDIT_TYPE_BROKEN_BACKLINKS]: [],
   [AUDIT_TYPE_CWV]: [],
   [AUDIT_TYPE_LHS_DESKTOP]: ['performance', 'seo', 'accessibility', 'best-practices'],
   [AUDIT_TYPE_LHS_MOBILE]: ['performance', 'seo', 'accessibility', 'best-practices'],
@@ -36,7 +38,7 @@ const validateScores = (auditResult, auditType) => {
     return true;
   }
 
-  if (!isObject(auditResult.scores)) {
+  if (auditType !== AUDIT_TYPE_BROKEN_BACKLINKS && !isObject(auditResult.scores)) {
     throw new Error(`Missing scores property for audit type '${auditType}'`);
   }
 


### PR DESCRIPTION
This PR adds the broken-backlinks as supported audit type for [SITES-18417](https://jira.corp.adobe.com/browse/SITES-18417).
Relates to https://github.com/adobe/spacecat-audit-worker/pull/77, https://github.com/adobe/spacecat-audit-post-processor/pull/37, https://github.com/adobe/spacecat-audit-scheduler/pull/27, https://github.com/adobe/spacecat-api-service/pull/97

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
