### PR TITLE
fix: initialize scores as an empty object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12401,7 +12401,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-dynamo": "1.2.5",

--- a/packages/spacecat-shared-data-access/src/models/audit.js
+++ b/packages/spacecat-shared-data-access/src/models/audit.js
@@ -107,6 +107,9 @@ export const createAudit = (data) => {
     throw new Error('Audit result must be an object');
   }
 
+  if (!newState.scores) {
+    newState.scores = {};
+  }
   validateScores(data.auditResult, data.auditType);
 
   if (data.previousAuditResult && !isObject(data.previousAuditResult)) {


### PR DESCRIPTION
FIx for: not all audits have as result scores and adding an audit without scores is failing, hence initializing the scores to an empty object, if no scores in the result.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
