### PR TITLE
fix: createdAt test

### DIFF
--- a/packages/spacecat-shared-data-access/test/unit/models/base.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/base.test.js
@@ -35,7 +35,7 @@ describe('Base Model Tests', () => {
   describe('Getter Method Tests', () => {
     it('correctly returns the createdAt date if provided', () => {
       const createdAt = new Date().toISOString();
-      const baseEntity = Base({ createdAt });
+      const baseEntity = Base({ id: 'test-id', createdAt });
       expect(baseEntity.getCreatedAt()).to.equal(createdAt);
     });
 


### PR DESCRIPTION
In some cases, the test failed with assertion error, because it compared expected with passed `createdAt` on a new record (no id), whereas for new records a createdAt is generated in the constructor.
```
AssertionError: expected '2024-01-18T16:23:59.276Z' to equal '2024-01-18T16:23:59.275Z'
```

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
