### PR TITLE
fix: set default organization

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/organization.js
+++ b/packages/spacecat-shared-data-access/src/models/organization.js
@@ -15,6 +15,8 @@ import { hasText, isObject } from '@adobe/spacecat-shared-utils';
 import { Base } from './base.js';
 import { Config, DEFAULT_CONFIG } from './site/config.js';
 
+export const DEFAULT_ORGANIZATION_ID = 'default';
+
 /**
  * Creates a new Organization.
  *

--- a/packages/spacecat-shared-data-access/src/models/site.js
+++ b/packages/spacecat-shared-data-access/src/models/site.js
@@ -10,11 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
-import { isObject, isValidUrl } from '@adobe/spacecat-shared-utils';
+import { hasText, isObject, isValidUrl } from '@adobe/spacecat-shared-utils';
 
 import { Base } from './base.js';
 import AuditConfig from './site/audit-config.js';
 import { Config, DEFAULT_CONFIG } from './site/config.js';
+import { DEFAULT_ORGANIZATION_ID } from './organization.js';
 
 export const DELIVERY_TYPES = {
   AEM_CS: 'aem_cs',
@@ -160,6 +161,10 @@ export const createSite = (data) => {
 
   if (!isValidUrl(newState.baseURL)) {
     throw new Error('Base URL must be a valid URL');
+  }
+
+  if (!hasText(newState.organizationId)) {
+    newState.organizationId = DEFAULT_ORGANIZATION_ID;
   }
 
   newState.deliveryType = newState.deliveryType || DEFAULT_DELIVERY_TYPE;

--- a/packages/spacecat-shared-data-access/test/unit/models/site.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site.test.js
@@ -46,6 +46,11 @@ describe('Site Model Tests', () => {
       expect(site.getBaseURL()).to.equal(validData.baseURL);
     });
 
+    it('creates a site with default organization id', () => {
+      const site = createSite({ ...validData, organizationId: undefined });
+      expect(site.getOrganizationId()).to.equal('default');
+    });
+
     it('creates a site with default auditConfig when none provided', () => {
       const site = createSite({ ...validData });
       const auditConfig = site.getAuditConfig();


### PR DESCRIPTION
We have to fix a default organization as the all-sites-with-org index expects its partition key (the site's org id) to be set. this prevents errors like these:
```
One or more parameter values were invalid: Type mismatch for Index Key organizationId Expected: S Actual: NULL IndexName: all-sites-organizations-dev
```

currently add / update sites operations are failing