### PR TITLE
fix: semantic-release-monorepo ESM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/git": "10.0.1",
         "@semantic-release/npm": "11.0.2",
+        "@solaris007/semantic-release-monorepo": "0.0.0-development",
         "@typescript-eslint/eslint-plugin": "6.19.0",
         "@typescript-eslint/parser": "6.19.0",
         "ajv": "8.12.0",
@@ -28,7 +29,6 @@
         "mocha-multi-reporters": "1.5.1",
         "nock": "13.5.0",
         "semantic-release": "23.0.0",
-        "semantic-release-monorepo": "8.0.0",
         "typescript": "5.3.3"
       }
     },
@@ -2591,6 +2591,44 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@solaris007/semantic-release-monorepo": {
+      "version": "0.0.0-development",
+      "resolved": "https://registry.npmjs.org/@solaris007/semantic-release-monorepo/-/semantic-release-monorepo-0.0.0-development.tgz",
+      "integrity": "sha512-mnts9OvsrBX5Yh8yCWgVqf7rCZdaxVtOIkyl4Lih5/0rqo16g2Qp2j18XCof9og+G8RlS2ZJuX6FCqIOgmH9ZA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "execa": "^5.1.1",
+        "file-url": "^3.0.0",
+        "fs-extra": "^10.0.1",
+        "get-stream": "^6.0.1",
+        "git-log-parser": "^1.2.0",
+        "p-each-series": "^2.1.0",
+        "p-limit": "^3.1.0",
+        "pkg-up": "^3.1.0",
+        "ramda": "^0.27.2",
+        "read-pkg": "^5.2.0",
+        "semantic-release-plugin-decorators": "^4.0.0",
+        "tempy": "1.0.1"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=20"
+      }
+    },
+    "node_modules/@solaris007/semantic-release-monorepo/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "dev": true,
@@ -3844,8 +3882,9 @@
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3920,8 +3959,9 @@
     },
     "node_modules/del": {
       "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
+      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "globby": "^11.0.1",
         "graceful-fs": "^4.2.4",
@@ -3941,8 +3981,9 @@
     },
     "node_modules/del/node_modules/p-map": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -5331,8 +5372,9 @@
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -5678,8 +5720,9 @@
     },
     "node_modules/is-path-cwd": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -7020,8 +7063,9 @@
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -7031,8 +7075,9 @@
     },
     "node_modules/normalize-package-data/node_modules/semver": {
       "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -10023,8 +10068,9 @@
     },
     "node_modules/p-each-series": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -10466,8 +10512,9 @@
     },
     "node_modules/read-pkg": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/normalize-package-data": "^2.4.0",
         "normalize-package-data": "^2.5.0",
@@ -10582,8 +10629,9 @@
     },
     "node_modules/read-pkg/node_modules/type-fest": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
       }
@@ -10935,44 +10983,6 @@
       },
       "engines": {
         "node": ">=20.8.1"
-      }
-    },
-    "node_modules/semantic-release-monorepo": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/semantic-release-monorepo/-/semantic-release-monorepo-8.0.0.tgz",
-      "integrity": "sha512-mCJ0W8oUxcaYBKdBwqzcDVjPgVs4+CYVZzRMSg8F9Eo5kelZFF5v/SBpHhpWI/LXXHxmwtwZ5y6Qe+uoJ8A7QQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4",
-        "execa": "^5.1.1",
-        "file-url": "^3.0.0",
-        "fs-extra": "^10.0.1",
-        "get-stream": "^6.0.1",
-        "git-log-parser": "^1.2.0",
-        "p-each-series": "^2.1.0",
-        "p-limit": "^3.1.0",
-        "pkg-up": "^3.1.0",
-        "ramda": "^0.27.2",
-        "read-pkg": "^5.2.0",
-        "semantic-release-plugin-decorators": "^4.0.0",
-        "tempy": "1.0.1"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=20"
-      }
-    },
-    "node_modules/semantic-release-monorepo/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/semantic-release-plugin-decorators": {
@@ -11849,8 +11859,9 @@
     },
     "node_modules/temp-dir": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -11862,8 +11873,9 @@
     },
     "node_modules/tempy": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
+      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "del": "^6.0.0",
         "is-stream": "^2.0.0",
@@ -11880,8 +11892,9 @@
     },
     "node_modules/tempy/node_modules/type-fest": {
       "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+      "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -12160,8 +12173,9 @@
     },
     "node_modules/unique-string": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "crypto-random-string": "^2.0.0"
       },
@@ -12522,7 +12536,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "1.9.5",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-dynamo": "1.2.5",
@@ -15440,6 +15454,40 @@
         "tslib": "^2.5.0"
       }
     },
+    "@solaris007/semantic-release-monorepo": {
+      "version": "0.0.0-development",
+      "resolved": "https://registry.npmjs.org/@solaris007/semantic-release-monorepo/-/semantic-release-monorepo-0.0.0-development.tgz",
+      "integrity": "sha512-mnts9OvsrBX5Yh8yCWgVqf7rCZdaxVtOIkyl4Lih5/0rqo16g2Qp2j18XCof9og+G8RlS2ZJuX6FCqIOgmH9ZA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.4",
+        "execa": "^5.1.1",
+        "file-url": "^3.0.0",
+        "fs-extra": "^10.0.1",
+        "get-stream": "^6.0.1",
+        "git-log-parser": "^1.2.0",
+        "p-each-series": "^2.1.0",
+        "p-limit": "^3.1.0",
+        "pkg-up": "^3.1.0",
+        "ramda": "^0.27.2",
+        "read-pkg": "^5.2.0",
+        "semantic-release-plugin-decorators": "^4.0.0",
+        "tempy": "1.0.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "dev": true
@@ -16268,6 +16316,8 @@
     },
     "crypto-random-string": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "dev": true
     },
     "debug": {
@@ -16311,6 +16361,8 @@
     },
     "del": {
       "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
+      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
       "dev": true,
       "requires": {
         "globby": "^11.0.1",
@@ -16325,6 +16377,8 @@
       "dependencies": {
         "p-map": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
           "dev": true,
           "requires": {
             "aggregate-error": "^3.0.0"
@@ -17228,6 +17282,8 @@
     },
     "hosted-git-info": {
       "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-escaper": {
@@ -17433,6 +17489,8 @@
     },
     "is-path-cwd": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
       "dev": true
     },
     "is-path-inside": {
@@ -18314,6 +18372,8 @@
     },
     "normalize-package-data": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -18324,6 +18384,8 @@
       "dependencies": {
         "semver": {
           "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         }
       }
@@ -20331,6 +20393,8 @@
     },
     "p-each-series": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
       "dev": true
     },
     "p-filter": {
@@ -20600,6 +20664,8 @@
     },
     "read-pkg": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
       "dev": true,
       "requires": {
         "@types/normalize-package-data": "^2.4.0",
@@ -20610,6 +20676,8 @@
       "dependencies": {
         "type-fest": {
           "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
           "dev": true
         }
       }
@@ -21068,40 +21136,6 @@
         }
       }
     },
-    "semantic-release-monorepo": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/semantic-release-monorepo/-/semantic-release-monorepo-8.0.0.tgz",
-      "integrity": "sha512-mCJ0W8oUxcaYBKdBwqzcDVjPgVs4+CYVZzRMSg8F9Eo5kelZFF5v/SBpHhpWI/LXXHxmwtwZ5y6Qe+uoJ8A7QQ==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.3.4",
-        "execa": "^5.1.1",
-        "file-url": "^3.0.0",
-        "fs-extra": "^10.0.1",
-        "get-stream": "^6.0.1",
-        "git-log-parser": "^1.2.0",
-        "p-each-series": "^2.1.0",
-        "p-limit": "^3.1.0",
-        "pkg-up": "^3.1.0",
-        "ramda": "^0.27.2",
-        "read-pkg": "^5.2.0",
-        "semantic-release-plugin-decorators": "^4.0.0",
-        "tempy": "1.0.1"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
-      }
-    },
     "semantic-release-plugin-decorators": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/semantic-release-plugin-decorators/-/semantic-release-plugin-decorators-4.0.0.tgz",
@@ -21500,6 +21534,8 @@
     },
     "temp-dir": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
       "dev": true
     },
     "temp-path": {
@@ -21508,6 +21544,8 @@
     },
     "tempy": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-1.0.1.tgz",
+      "integrity": "sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==",
       "dev": true,
       "requires": {
         "del": "^6.0.0",
@@ -21519,6 +21557,8 @@
       "dependencies": {
         "type-fest": {
           "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+          "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
           "dev": true
         }
       }
@@ -21693,6 +21733,8 @@
     },
     "unique-string": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
       "dev": true,
       "requires": {
         "crypto-random-string": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "docs": "npm run docs:api",
     "test": "npm test -ws",
     "lint": "npm run lint -ws",
-    "semantic-release": "npx --no -ws semantic-release",
-    "semantic-release-dry": "npx --no -ws semantic-release --dry-run --branches $CI_BRANCH",
+    "semantic-release": "npx --no -ws semantic-release -e @solaris007/semantic-release-monorepo",
+    "semantic-release-dry": "npx --no -ws semantic-release -e @solaris007/semantic-release-monorepo --dry-run --branches $CI_BRANCH",
     "prepare": "husky install",
     "clean": "rm -rf package-lock.json node_modules"
   },
@@ -44,7 +44,7 @@
     "mocha-multi-reporters": "1.5.1",
     "nock": "13.5.0",
     "semantic-release": "23.0.0",
-    "semantic-release-monorepo": "8.0.0",
+    "@solaris007/semantic-release-monorepo": "0.0.0-development",
     "typescript": "5.3.3"
   },
   "lint-staged": {


### PR DESCRIPTION
Add custom-built semantic-release-monorepo (PR opened here https://github.com/pmowrer/semantic-release-monorepo/pull/148) to support ESM.

Using custom build published from here for the time being: https://github.com/solaris007/semantic-release-monorepo/tree/fix-esm-module