### PR TITLE
feat: default value for disabled property of audit config

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/audit-config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/audit-config.js
@@ -19,10 +19,12 @@ const AUDIT_TYPE_DISABLED_DEFAULTS = {
 
 function getAuditTypeConfigs(auditTypeConfigs, auditsDisabled) {
   return Object.entries(auditTypeConfigs || {}).reduce((acc, [key, value]) => {
+    const disabled = value.disabled !== undefined
+      ? value.disabled : (AUDIT_TYPE_DISABLED_DEFAULTS[key] || auditsDisabled || false);
     acc[key] = AuditConfigType(
       {
         ...value,
-        disabled: AUDIT_TYPE_DISABLED_DEFAULTS[key] || auditsDisabled,
+        disabled,
       },
     );
     return acc;

--- a/packages/spacecat-shared-data-access/src/models/site/audit-config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/audit-config.js
@@ -18,6 +18,11 @@ const AUDIT_TYPE_DISABLED_DEFAULTS = {
 };
 
 function getAuditTypeConfigs(auditTypeConfigs, auditsDisabled) {
+  if (!auditTypeConfigs || Object.keys(auditTypeConfigs).length === 0) {
+    return {
+      [AUDIT_TYPE_BROKEN_BACKLINKS]: AuditConfigType({ disabled: true }),
+    };
+  }
   return Object.entries(auditTypeConfigs || {}).reduce((acc, [key, value]) => {
     const disabled = value.disabled !== undefined
       ? value.disabled : (AUDIT_TYPE_DISABLED_DEFAULTS[key] || auditsDisabled || false);

--- a/packages/spacecat-shared-data-access/src/models/site/audit-config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/audit-config.js
@@ -11,10 +11,20 @@
  */
 
 import AuditConfigType from './audit-config-type.js';
+import { AUDIT_TYPE_BROKEN_BACKLINKS } from '../audit.js';
+
+const AUDIT_TYPE_DISABLED_DEFAULTS = {
+  [AUDIT_TYPE_BROKEN_BACKLINKS]: true,
+};
 
 function getAuditTypeConfigs(auditTypeConfigs, auditsDisabled) {
   return Object.entries(auditTypeConfigs || {}).reduce((acc, [key, value]) => {
-    acc[key] = AuditConfigType(value, auditsDisabled);
+    acc[key] = AuditConfigType(
+      {
+        ...value,
+        disabled: AUDIT_TYPE_DISABLED_DEFAULTS[key] || auditsDisabled,
+      },
+    );
     return acc;
   }, {});
 }

--- a/packages/spacecat-shared-data-access/test/unit/models/site.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site.test.js
@@ -74,9 +74,9 @@ describe('Site Model Tests', () => {
       expect(auditConfig).to.be.an('object');
       expect(auditConfig.auditsDisabled()).to.be.true;
       expect(auditConfig.getAuditTypeConfig('type1')).to.be.an('object');
-      expect(auditConfig.getAuditTypeConfig('type1').disabled()).to.be.false;
+      expect(auditConfig.getAuditTypeConfig('type1').disabled()).to.be.true;
       expect(auditConfig.getAuditTypeConfig('type2')).to.be.an('object');
-      expect(auditConfig.getAuditTypeConfig('type2').disabled()).to.be.false;
+      expect(auditConfig.getAuditTypeConfig('type2').disabled()).to.be.true;
     });
   });
 

--- a/packages/spacecat-shared-data-access/test/unit/models/site/audit-config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/audit-config.test.js
@@ -32,13 +32,13 @@ describe('AuditConfig Tests', () => {
         auditsDisabled: true,
         auditTypeConfigs: {
           type1: { disabled: true },
-          type2: { disabled: false },
+          [AUDIT_TYPE_BROKEN_BACKLINKS]: { disabled: false },
         },
       };
       const auditConfig = AuditConfig(data);
       expect(auditConfig.auditsDisabled()).to.be.true;
       expect(auditConfig.getAuditTypeConfig('type1').disabled()).to.be.true;
-      expect(auditConfig.getAuditTypeConfig('type2').disabled()).to.be.false;
+      expect(auditConfig.getAuditTypeConfig(AUDIT_TYPE_BROKEN_BACKLINKS).disabled()).to.be.false;
     });
   });
 

--- a/packages/spacecat-shared-data-access/test/unit/models/site/audit-config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/audit-config.test.js
@@ -15,13 +15,16 @@
 import { expect } from 'chai';
 
 import AuditConfig from '../../../../src/models/site/audit-config.js';
+import { AUDIT_TYPE_BROKEN_BACKLINKS } from '../../../../src/models/audit.js';
 
 describe('AuditConfig Tests', () => {
   describe('AuditConfig Creation', () => {
     it('creates an AuditConfig with defaults when no data is provided', () => {
       const auditConfig = AuditConfig();
       expect(auditConfig.auditsDisabled()).to.be.false;
-      expect(auditConfig.getAuditTypeConfigs()).to.be.empty;
+      const auditTypeConfigs = auditConfig.getAuditTypeConfigs();
+      expect(auditTypeConfigs[AUDIT_TYPE_BROKEN_BACKLINKS]).to.be.an('object');
+      expect(auditTypeConfigs[AUDIT_TYPE_BROKEN_BACKLINKS].disabled()).to.be.true;
     });
 
     it('creates an AuditConfig with provided data', () => {
@@ -74,15 +77,6 @@ describe('AuditConfig Tests', () => {
       const auditConfig = AuditConfig(data);
       const typeConfigs = auditConfig.getAuditTypeConfigs();
       expect(typeConfigs).to.have.keys(['type1', 'type2']);
-    });
-
-    it('returns no audit type configurations', () => {
-      const data = {
-        auditTypeConfigs: {},
-      };
-      const auditConfig = AuditConfig(data);
-      const typeConfigs = auditConfig.getAuditTypeConfigs();
-      expect(typeConfigs).to.be.an('object').that.is.empty;
     });
   });
 


### PR DESCRIPTION
SEO-related audit types should have default value for disabled true (we enable one by one the sites, so we don't waste Ahrefs API units on sites not of interest at this post.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
