### PR TITLE
test: fix updatedAt test

### DIFF
--- a/packages/spacecat-shared-data-access/test/unit/models/base.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/base.test.js
@@ -41,7 +41,7 @@ describe('Base Model Tests', () => {
 
     it('correctly returns the updatedAt date if provided', () => {
       const updatedAt = new Date().toISOString();
-      const baseEntity = Base({ updatedAt });
+      const baseEntity = Base({ id: 'test-id', updatedAt });
       expect(baseEntity.getUpdatedAt()).to.equal(updatedAt);
     });
   });


### PR DESCRIPTION
In some cases, the test failed with assertion error, because it compared expected with passed `updatedAt` on a new record (no id), whereas for new records an `updatedAt` is generated in the constructor.

```
AssertionError: expected '2024-01-18T16:23:59.276Z' to equal '2024-01-18T16:23:59.275Z'
```