### PR TITLE
feat: site candidate data model

### DIFF
--- a/packages/spacecat-shared-data-access/README.md
+++ b/packages/spacecat-shared-data-access/README.md
@@ -20,7 +20,7 @@ npm install @adobe/spacecat-shared-data-access
 
 ### SiteCandidates
 - **baseURL** (String): Base URL of the site candidate.
-- **status** (String): Status of the site candidate (DISCOVERED, PENDING, IGNORED, APPROVED)
+- **status** (String): Status of the site candidate (PENDING, IGNORED, APPROVED, ERROR)
 - **createdAt** (String): Timestamp of creation.
 - **updatedAt** (String): Timestamp of the last update.
 - **updatedBy** (String): Slack id of the last person updated the site candidate.
@@ -73,7 +73,7 @@ The module provides two main DAOs:
 - `removeSite`
 
 ### Site Candidate Functions
-- `addSiteCandidate`
+- `upsertSiteCandidate`
 - `siteCandidateExists`
 - `updateSiteCandidate`
 

--- a/packages/spacecat-shared-data-access/README.md
+++ b/packages/spacecat-shared-data-access/README.md
@@ -18,6 +18,13 @@ npm install @adobe/spacecat-shared-data-access
 - **updatedAt** (String): Timestamp of the last update.
 - **GSI1PK** (String): Partition key for the Global Secondary Index.
 
+### SiteCandidates
+- **baseURL** (String): Base URL of the site candidate.
+- **status** (String): Status of the site candidate (DISCOVERED, PENDING, IGNORED, APPROVED)
+- **createdAt** (String): Timestamp of creation.
+- **updatedAt** (String): Timestamp of the last update.
+- **updatedBy** (String): Slack id of the last person updated the site candidate.
+
 ### Audits
 - **siteId** (String): Identifier of the site being audited.
 - **SK** (String): Sort key, typically a composite of audit type and timestamp.
@@ -64,6 +71,11 @@ The module provides two main DAOs:
 - `addSite`
 - `updateSite`
 - `removeSite`
+
+### Site Candidate Functions
+- `addSiteCandidate`
+- `siteCandidateExists`
+- `updateSiteCandidate`
 
 ### Audit Functions
 - `getAuditsForSite`

--- a/packages/spacecat-shared-data-access/docs/schema.json
+++ b/packages/spacecat-shared-data-access/docs/schema.json
@@ -435,7 +435,7 @@
       "TableName": "spacecat-services-site-candidates",
       "KeyAttributes": {
         "PartitionKey": {
-          "AttributeName": "baseUrl",
+          "AttributeName": "baseURL",
           "AttributeType": "S"
         }
       },

--- a/packages/spacecat-shared-data-access/docs/schema.json
+++ b/packages/spacecat-shared-data-access/docs/schema.json
@@ -3,7 +3,7 @@
   "ModelMetadata": {
     "Author": "Dominique Jäggi",
     "DateCreated": "Nov 23, 2023, 07:00 AM",
-    "DateLastModified": "Feb 01, 2024, 03:27 PM",
+    "DateLastModified": "Feb 02, 2024, 10:39 AM",
     "Description": "",
     "AWSService": "Amazon DynamoDB",
     "Version": "3.0"
@@ -455,6 +455,10 @@
         {
           "AttributeName": "updatedBy",
           "AttributeType": "S"
+        },
+        {
+          "AttributeName": "siteId",
+          "AttributeType": "S"
         }
       ],
       "DataAccess": {
@@ -484,6 +488,10 @@
         "baseUrl": [
           "identifiers",
           "URL"
+        ],
+        "siteId": [
+          "identifiers",
+          "UUID"
         ]
       },
       "BillingMode": "PROVISIONED",

--- a/packages/spacecat-shared-data-access/docs/schema.json
+++ b/packages/spacecat-shared-data-access/docs/schema.json
@@ -3,7 +3,7 @@
   "ModelMetadata": {
     "Author": "Dominique Jäggi",
     "DateCreated": "Nov 23, 2023, 07:00 AM",
-    "DateLastModified": "Feb 02, 2024, 10:39 AM",
+    "DateLastModified": "Feb 02, 2024, 11:13 AM",
     "Description": "",
     "AWSService": "Amazon DynamoDB",
     "Version": "3.0"
@@ -458,6 +458,10 @@
         },
         {
           "AttributeName": "siteId",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "source",
           "AttributeType": "S"
         }
       ],

--- a/packages/spacecat-shared-data-access/docs/schema.json
+++ b/packages/spacecat-shared-data-access/docs/schema.json
@@ -3,7 +3,7 @@
   "ModelMetadata": {
     "Author": "Dominique Jäggi",
     "DateCreated": "Nov 23, 2023, 07:00 AM",
-    "DateLastModified": "Nov 23, 2023, 07:00 AM",
+    "DateLastModified": "Feb 01, 2024, 03:27 PM",
     "Description": "",
     "AWSService": "Amazon DynamoDB",
     "Version": "3.0"
@@ -399,6 +399,89 @@
           "ISO 8601 date and time"
         ],
         "fullAuditRef": [
+          "identifiers",
+          "URL"
+        ]
+      },
+      "BillingMode": "PROVISIONED",
+      "ProvisionedCapacitySettings": {
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": 5,
+          "WriteCapacityUnits": 5
+        },
+        "AutoScalingRead": {
+          "ScalableTargetRequest": {
+            "MinCapacity": 1,
+            "MaxCapacity": 10,
+            "ServiceRole": "AWSServiceRoleForApplicationAutoScaling_DynamoDBTable"
+          },
+          "ScalingPolicyConfiguration": {
+            "TargetValue": 70
+          }
+        },
+        "AutoScalingWrite": {
+          "ScalableTargetRequest": {
+            "MinCapacity": 1,
+            "MaxCapacity": 10,
+            "ServiceRole": "AWSServiceRoleForApplicationAutoScaling_DynamoDBTable"
+          },
+          "ScalingPolicyConfiguration": {
+            "TargetValue": 70
+          }
+        }
+      }
+    },
+    {
+      "TableName": "spacecat-services-site-candidates",
+      "KeyAttributes": {
+        "PartitionKey": {
+          "AttributeName": "baseUrl",
+          "AttributeType": "S"
+        }
+      },
+      "NonKeyAttributes": [
+        {
+          "AttributeName": "status",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "createdAt",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "updatedAt",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "updatedBy",
+          "AttributeType": "S"
+        }
+      ],
+      "DataAccess": {
+        "MySql": {}
+      },
+      "SampleDataFormats": {
+        "lastModifiedAt": [
+          "date",
+          "ISO 8601 date and time"
+        ],
+        "discoveredAt": [
+          "date",
+          "ISO 8601 date and time"
+        ],
+        "createdAt": [
+          "date",
+          "ISO 8601 date and time"
+        ],
+        "updatedBy": [
+          "identifiers",
+          "Full name"
+        ],
+        "updatedAt": [
+          "date",
+          "ISO 8601 date and time"
+        ],
+        "baseUrl": [
           "identifiers",
           "URL"
         ]

--- a/packages/spacecat-shared-data-access/package.json
+++ b/packages/spacecat-shared-data-access/package.json
@@ -41,6 +41,7 @@
     "chai": "4.4.1",
     "chai-as-promised": "7.1.1",
     "dynamo-db-local": "7.3.0",
-    "sinon": "17.0.1"
+    "sinon": "17.0.1",
+    "sinon-chai": "3.7.0"
   }
 }

--- a/packages/spacecat-shared-data-access/src/dto/site-candidate.js
+++ b/packages/spacecat-shared-data-access/src/dto/site-candidate.js
@@ -17,11 +17,12 @@ export const SiteCandidateDto = {
   /**
    * Converts a Site Candidate object into a DynamoDB item.
    * @param {Readonly<SiteCandidate>} siteCandidate - Site Candidate object.
-   * @returns {{baseURL, status, createdAt, updatedAt, updatedBy}}
+   * @returns {{baseURL, status, siteId, createdAt, updatedAt, updatedBy}}
    */
   toDynamoItem: (siteCandidate) => ({
     baseURL: siteCandidate.getBaseURL(),
     status: siteCandidate.getStatus(),
+    siteId: siteCandidate.getSiteId(),
     createdAt: siteCandidate.getCreatedAt(),
     updatedAt: siteCandidate.getUpdatedAt(),
     updatedBy: siteCandidate.getUpdatedBy(),

--- a/packages/spacecat-shared-data-access/src/dto/site-candidate.js
+++ b/packages/spacecat-shared-data-access/src/dto/site-candidate.js
@@ -17,12 +17,13 @@ export const SiteCandidateDto = {
   /**
    * Converts a Site Candidate object into a DynamoDB item.
    * @param {Readonly<SiteCandidate>} siteCandidate - Site Candidate object.
-   * @returns {{baseURL, status, siteId, createdAt, updatedAt, updatedBy}}
+   * @returns {{baseURL, siteId, source, status, createdAt, updatedAt, updatedBy}}
    */
   toDynamoItem: (siteCandidate) => ({
     baseURL: siteCandidate.getBaseURL(),
-    status: siteCandidate.getStatus(),
     siteId: siteCandidate.getSiteId(),
+    source: siteCandidate.getSource(),
+    status: siteCandidate.getStatus(),
     createdAt: siteCandidate.getCreatedAt(),
     updatedAt: siteCandidate.getUpdatedAt(),
     updatedBy: siteCandidate.getUpdatedBy(),

--- a/packages/spacecat-shared-data-access/src/dto/site-candidate.js
+++ b/packages/spacecat-shared-data-access/src/dto/site-candidate.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Data transfer object for Site Candidate.
+ */
+export const SiteCandidateDto = {
+  /**
+   * Converts a Site Candidate object into a DynamoDB item.
+   * @param {Readonly<SiteCandidate>} siteCandidate - Site Candidate object.
+   * @returns {{baseURL, status, createdAt, updatedAt, updatedBy}}
+   */
+  toDynamoItem: (siteCandidate) => ({
+    baseURL: siteCandidate.getBaseURL(),
+    status: siteCandidate.getStatus(),
+    createdAt: siteCandidate.getCreatedAt(),
+    updatedAt: siteCandidate.getUpdatedAt(),
+    updatedBy: siteCandidate.getUpdatedBy(),
+  }),
+};

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -388,6 +388,11 @@ export interface DataAccess {
   removeOrganization: (
       organizationId: string,
   ) => Promise<void>;
+
+  // site candidate functions
+  addSiteCandidate: (siteCandidateDate: object) => Promise<SiteCandidate>;
+  siteCandidateExists: (baseURL: string) => Promise<boolean>;
+  updateSiteCandidate: (siteCandidate: SiteCandidate) => Promise<SiteCandidate>;
 }
 
 interface DataAccessConfig {

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -242,13 +242,19 @@ export interface SiteCandidate {
   /**
    * Retrieves the site id of the site candidate.
    * Only set after APPROVED state
-   * @returns {string} The delivery type.
+   * @returns {string} site id
    */
   getSiteId: () => string;
 
   /**
+   * Retrieves the source of the site candidate.
+   * @returns {string} The source
+   */
+  getSource: () => string;
+
+  /**
    * Retrieves the status of the site candidate.
-   * @returns {string} The delivery type.
+   * @returns {string} The status
    */
   getStatus: () => string;
 

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -240,6 +240,13 @@ export interface SiteCandidate {
   getBaseURL: () => string;
 
   /**
+   * Retrieves the site id of the site candidate.
+   * Only set after APPROVED state
+   * @returns {string} The delivery type.
+   */
+  getSiteId: () => string;
+
+  /**
    * Retrieves the status of the site candidate.
    * @returns {string} The delivery type.
    */
@@ -390,7 +397,7 @@ export interface DataAccess {
   ) => Promise<void>;
 
   // site candidate functions
-  addSiteCandidate: (siteCandidateDate: object) => Promise<SiteCandidate>;
+  upsertSiteCandidate: (siteCandidateDate: object) => Promise<SiteCandidate>;
   siteCandidateExists: (baseURL: string) => Promise<boolean>;
   updateSiteCandidate: (siteCandidate: SiteCandidate) => Promise<SiteCandidate>;
 }

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -229,6 +229,41 @@ export interface Site {
   updateOrganizationId: (organizationId: string) => Site;
 }
 
+/**
+ * Represents a site candidate.
+ */
+export interface SiteCandidate {
+  /**
+   * Retrieves the base URL of the site candidate.
+   * @returns {string} The base URL.
+   */
+  getBaseURL: () => string;
+
+  /**
+   * Retrieves the status of the site candidate.
+   * @returns {string} The delivery type.
+   */
+  getStatus: () => string;
+
+  /**
+   * Retrieves the creation timestamp of the site candidate.
+   * @returns {string} The creation timestamp.
+   */
+  getCreatedAt: () => string;
+
+  /**
+   * Retrieves the last update timestamp of the site candidate.
+   * @returns {string} The last update timestamp.
+   */
+  getUpdatedAt: () => string;
+
+  /**
+   * Retrieves the slack id of the person who last updated the site candidate.
+   * @returns {string} The last update timestamp.
+   */
+  getUpdatedBy: () => string;
+}
+
 export interface Organization {
   /**
    * Retrieves the ID of the site.
@@ -360,6 +395,7 @@ interface DataAccessConfig {
   tableNameLatestAudits: string;
   tableNameOrganizations: string,
   tableNameSites: string;
+  tableNameSiteCandidates: string;
   indexNameAllSites: string;
   indexNameAllSitesOrganizations: string,
   indexNameAllSitesByDeliveryType: string;

--- a/packages/spacecat-shared-data-access/src/index.js
+++ b/packages/spacecat-shared-data-access/src/index.js
@@ -15,6 +15,7 @@ import { createDataAccess } from './service/index.js';
 const TABLE_NAME_AUDITS = 'spacecat-services-audits-dev';
 const TABLE_NAME_LATEST_AUDITS = 'spacecat-services-latest-audits-dev';
 const TABLE_NAME_SITES = 'spacecat-services-sites-dev';
+const TABLE_NAME_SITE_CANDIDATES = 'spacecat-services-site-candidates-dev';
 const TABLE_NAME_ORGANIZATIONS = 'spacecat-services-organizations-dev';
 
 const INDEX_NAME_ALL_SITES = 'spacecat-services-all-sites-dev';
@@ -36,6 +37,7 @@ export default function dataAccessWrapper(fn) {
         DYNAMO_TABLE_NAME_AUDITS = TABLE_NAME_AUDITS,
         DYNAMO_TABLE_NAME_LATEST_AUDITS = TABLE_NAME_LATEST_AUDITS,
         DYNAMO_TABLE_NAME_SITES = TABLE_NAME_SITES,
+        DYNAMO_TABLE_NAME_SITE_CANDIDATES = TABLE_NAME_SITE_CANDIDATES,
         DYNAMO_TABLE_NAME_ORGANIZATIONS = TABLE_NAME_ORGANIZATIONS,
         DYNAMO_INDEX_NAME_ALL_SITES = INDEX_NAME_ALL_SITES,
         DYNAMO_INDEX_NAME_ALL_SITES_BY_DELIVERY_TYPE = INDEX_NAME_ALL_SITES_BY_DELIVERY_TYPE,
@@ -49,6 +51,7 @@ export default function dataAccessWrapper(fn) {
         tableNameLatestAudits: DYNAMO_TABLE_NAME_LATEST_AUDITS,
         tableNameOrganizations: DYNAMO_TABLE_NAME_ORGANIZATIONS,
         tableNameSites: DYNAMO_TABLE_NAME_SITES,
+        tableNameSiteCandidates: DYNAMO_TABLE_NAME_SITE_CANDIDATES,
         indexNameAllSites: DYNAMO_INDEX_NAME_ALL_SITES,
         indexNameAllOrganizations: DYNAMO_INDEX_NAME_ALL_ORGANIZATIONS,
         indexNameAllSitesByDeliveryType: DYNAMO_INDEX_NAME_ALL_SITES_BY_DELIVERY_TYPE,

--- a/packages/spacecat-shared-data-access/src/models/site-candidate.js
+++ b/packages/spacecat-shared-data-access/src/models/site-candidate.js
@@ -17,10 +17,10 @@ import { Base } from './base.js';
 export const DEFAULT_UPDATED_BY = 'spacecat';
 
 export const SITE_CANDIDATE_STATUS = {
-  DISCOVERED: 'DISCOVERED', // site candidate is discovered
   PENDING: 'PENDING', // site candidate notification sent and waiting for human input
   IGNORED: 'IGNORED', // site candidate discarded: not to be added to star catalogue
   APPROVED: 'APPROVED', // site candidate is added to star catalogue
+  ERROR: 'ERROR', // site candidate is discovered
 };
 
 /**
@@ -37,8 +37,15 @@ const SiteCandidate = (data = {}) => {
   delete self.id; // no id property used in SiteCandidate modal
 
   self.getBaseURL = () => self.state.baseURL;
+  self.getSiteId = () => self.state.siteId;
   self.getStatus = () => self.state.status;
   self.getUpdatedBy = () => self.state.updatedBy;
+
+  self.setSiteId = (siteId) => {
+    self.state.siteId = siteId;
+    self.touch();
+    return self;
+  };
 
   self.setStatus = (status) => {
     self.state.status = status;

--- a/packages/spacecat-shared-data-access/src/models/site-candidate.js
+++ b/packages/spacecat-shared-data-access/src/models/site-candidate.js
@@ -30,15 +30,23 @@ export const SITE_CANDIDATE_STATUS = {
  * @returns {Readonly<SiteCandidate>} new site candidate
  */
 const SiteCandidate = (data = {}) => {
-  const self = Base(data);
+  const self = Base({
+    updatedBy: DEFAULT_UPDATED_BY,
+    ...data,
+  });
   delete self.id; // no id property used in SiteCandidate modal
 
   self.getBaseURL = () => self.state.baseURL;
   self.getStatus = () => self.state.status;
   self.getUpdatedBy = () => self.state.updatedBy;
 
-  self.setStatus = (status, updatedBy = DEFAULT_UPDATED_BY) => {
+  self.setStatus = (status) => {
     self.state.status = status;
+    self.touch();
+    return self;
+  };
+
+  self.setUpdatedBy = (updatedBy) => {
     self.state.updatedBy = updatedBy;
     self.touch();
     return self;

--- a/packages/spacecat-shared-data-access/src/models/site-candidate.js
+++ b/packages/spacecat-shared-data-access/src/models/site-candidate.js
@@ -16,6 +16,12 @@ import { Base } from './base.js';
 
 export const DEFAULT_UPDATED_BY = 'spacecat';
 
+export const SITE_CANDIDATE_SOURCES = {
+  SPACECAT_SLACK_BOT: 'SPACECAT_SLACK_BOT',
+  RUM: 'RUM',
+  CDN: 'CDN',
+};
+
 export const SITE_CANDIDATE_STATUS = {
   PENDING: 'PENDING', // site candidate notification sent and waiting for human input
   IGNORED: 'IGNORED', // site candidate discarded: not to be added to star catalogue
@@ -38,11 +44,18 @@ const SiteCandidate = (data = {}) => {
 
   self.getBaseURL = () => self.state.baseURL;
   self.getSiteId = () => self.state.siteId;
+  self.getSource = () => self.state.source;
   self.getStatus = () => self.state.status;
   self.getUpdatedBy = () => self.state.updatedBy;
 
   self.setSiteId = (siteId) => {
     self.state.siteId = siteId;
+    self.touch();
+    return self;
+  };
+
+  self.setSource = (source) => {
+    self.state.source = source;
     self.touch();
     return self;
   };

--- a/packages/spacecat-shared-data-access/src/models/site-candidate.js
+++ b/packages/spacecat-shared-data-access/src/models/site-candidate.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { hasText, isValidUrl } from '@adobe/spacecat-shared-utils';
+
+import { Base } from './base.js';
+
+export const DEFAULT_UPDATED_BY = 'spacecat';
+
+export const SITE_CANDIDATE_STATUS = {
+  DISCOVERED: 'DISCOVERED', // site candidate is discovered
+  PENDING: 'PENDING', // site candidate notification sent and waiting for human input
+  IGNORED: 'IGNORED', // site candidate discarded: not to be added to star catalogue
+  APPROVED: 'APPROVED', // site candidate is added to star catalogue
+};
+
+/**
+ * Creates a new Site Candidate.
+ *
+ * @param {object} data - site candidate data
+ * @returns {Readonly<SiteCandidate>} new site candidate
+ */
+const SiteCandidate = (data = {}) => {
+  const self = Base(data);
+  delete self.id; // no id property used in SiteCandidate modal
+
+  self.getBaseURL = () => self.state.baseURL;
+  self.getStatus = () => self.state.status;
+  self.getUpdatedBy = () => self.state.updatedBy;
+
+  self.setStatus = (status, updatedBy = DEFAULT_UPDATED_BY) => {
+    self.state.status = status;
+    self.state.updatedBy = updatedBy;
+    self.touch();
+    return self;
+  };
+
+  return Object.freeze(self);
+};
+
+/**
+ * Creates a new Site Candidate.
+ *
+ * @param {object} data - site candidate data
+ * @returns {Readonly<SiteCandidate>} new site candidate
+ */
+export const createSiteCandidate = (data) => {
+  const newState = { ...data };
+
+  if (!isValidUrl(newState.baseURL)) {
+    throw new Error('Base URL must be a valid URL');
+  }
+
+  if (!hasText(newState.updatedBy)) {
+    newState.updatedBy = DEFAULT_UPDATED_BY;
+  }
+
+  return SiteCandidate(newState);
+};

--- a/packages/spacecat-shared-data-access/src/service/index.js
+++ b/packages/spacecat-shared-data-access/src/service/index.js
@@ -31,7 +31,7 @@ export const createDataAccess = (config, log = console) => {
 
   const auditFuncs = auditFunctions(dynamoClient, config, log);
   const siteFuncs = siteFunctions(dynamoClient, config, log);
-  const siteCandidateFuncs = siteCandidateFunctions(dynamoClient, config);
+  const siteCandidateFuncs = siteCandidateFunctions(dynamoClient, config, log);
   const organizationFuncs = organizationFunctions(dynamoClient, config, log);
 
   return {

--- a/packages/spacecat-shared-data-access/src/service/index.js
+++ b/packages/spacecat-shared-data-access/src/service/index.js
@@ -13,6 +13,7 @@
 import { createClient } from '@adobe/spacecat-shared-dynamo';
 import { auditFunctions } from './audits/index.js';
 import { siteFunctions } from './sites/index.js';
+import { siteCandidateFunctions } from './site-candidates/index.js';
 import { organizationFunctions } from './organizations/index.js';
 
 /**
@@ -30,11 +31,13 @@ export const createDataAccess = (config, log = console) => {
 
   const auditFuncs = auditFunctions(dynamoClient, config, log);
   const siteFuncs = siteFunctions(dynamoClient, config, log);
+  const siteCandidateFuncs = siteCandidateFunctions(dynamoClient, config);
   const organizationFuncs = organizationFunctions(dynamoClient, config, log);
 
   return {
     ...auditFuncs,
     ...siteFuncs,
+    ...siteCandidateFuncs,
     ...organizationFuncs,
   };
 };

--- a/packages/spacecat-shared-data-access/src/service/site-candidates/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/site-candidates/accessPatterns.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import { isObject } from '@adobe/spacecat-shared-utils';
 import { createSiteCandidate } from '../../models/site-candidate.js';
 import { SiteCandidateDto } from '../../dto/site-candidate.js';
 
@@ -23,9 +24,7 @@ import { SiteCandidateDto } from '../../dto/site-candidate.js';
 export const exists = async (dynamoClient, config, baseURL) => {
   const dynamoItem = await dynamoClient.getItem(config.tableNameSiteCandidates, { baseURL });
 
-  // eslint-disable-next-line
-  console.log(`result of exists: ${JSON.stringify(dynamoItem)}`);
-  return dynamoItem !== null;
+  return isObject(dynamoItem);
 };
 
 /**

--- a/packages/spacecat-shared-data-access/src/service/site-candidates/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/site-candidates/accessPatterns.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { createSiteCandidate } from '../../models/site-candidate.js';
+import { SiteCandidateDto } from '../../dto/site-candidate.js';
+
+/**
+ * Checks if a site candidate exists in site candidates table using base url
+ * @param {DynamoDbClient} dynamoClient - The DynamoDB client.
+ * @param {DataAccessConfig} config - The data access config.
+ * @param {string} baseURL - base url of the site candidate.
+ * @return {Promise<Readonly<Boolean>>} A promise that resolves to true if site candidate exist
+ */
+export const exists = async (dynamoClient, config, baseURL) => {
+  const dynamoItem = await dynamoClient.getItem(config.tableNameSiteCandidates, { baseURL });
+  return dynamoItem !== null;
+};
+
+/**
+ * Adds a site candidate.
+ *
+ * @param {DynamoDbClient} dynamoClient - The DynamoDB client.
+ * @param {DataAccessConfig} config - The data access config.
+ * @param {object} siteCandidateData - The site candidate data.
+ * @returns {Promise<Readonly<SiteCandidate>>} newly created site candidate
+ */
+export const addSiteCandidate = async (
+  dynamoClient,
+  config,
+  siteCandidateData,
+) => {
+  const siteCandidate = createSiteCandidate(siteCandidateData);
+  const siteCandidateExists = await exists(dynamoClient, config, siteCandidate.getBaseURL());
+
+  if (siteCandidateExists) {
+    throw new Error(`Site candidate with base url ${siteCandidate.getBaseURL()} already exists`);
+  }
+
+  await dynamoClient.putItem(
+    config.tableNameSiteCandidates,
+    SiteCandidateDto.toDynamoItem(siteCandidate),
+  );
+
+  return siteCandidate;
+};
+
+/**
+ * Updates a site candidate.
+ *
+ * @param {DynamoDbClient} dynamoClient - The DynamoDB client.
+ * @param {DataAccessConfig} config - The data access config.
+ * @param {SiteCandidate} siteCandidate - The site candidate object to be updated.
+ * @returns {Promise<Readonly<Site>>} - The updated site candidate.
+ */
+export const updateSiteCandidate = async (
+  dynamoClient,
+  config,
+  siteCandidate,
+) => {
+  const siteCandidateExists = await exists(dynamoClient, config, siteCandidate.getBaseURL());
+
+  if (!siteCandidateExists) {
+    throw new Error(`Site candidate with base url ${siteCandidate.getBaseURL()} does not exist`);
+  }
+
+  await dynamoClient.putItem(
+    config.tableNameSiteCandidates,
+    SiteCandidateDto.toDynamoItem(siteCandidate),
+  );
+
+  return siteCandidate;
+};

--- a/packages/spacecat-shared-data-access/src/service/site-candidates/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/site-candidates/accessPatterns.js
@@ -22,6 +22,9 @@ import { SiteCandidateDto } from '../../dto/site-candidate.js';
  */
 export const exists = async (dynamoClient, config, baseURL) => {
   const dynamoItem = await dynamoClient.getItem(config.tableNameSiteCandidates, { baseURL });
+
+  // eslint-disable-next-line
+  console.log(`result of exists: ${JSON.stringify(dynamoItem)}`);
   return dynamoItem !== null;
 };
 

--- a/packages/spacecat-shared-data-access/src/service/site-candidates/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/site-candidates/accessPatterns.js
@@ -28,23 +28,26 @@ export const exists = async (dynamoClient, config, baseURL) => {
 };
 
 /**
- * Adds a site candidate.
+ * Upserts a site candidate.
  *
  * @param {DynamoDbClient} dynamoClient - The DynamoDB client.
  * @param {DataAccessConfig} config - The data access config.
+ * @param {object} log - the logger object
  * @param {object} siteCandidateData - The site candidate data.
- * @returns {Promise<Readonly<SiteCandidate>>} newly created site candidate
+ * @returns {Promise<Readonly<SiteCandidate>>} newly created site candidate if hadn't created before
  */
-export const addSiteCandidate = async (
+export const upsertSiteCandidate = async (
   dynamoClient,
   config,
+  log,
   siteCandidateData,
 ) => {
   const siteCandidate = createSiteCandidate(siteCandidateData);
   const siteCandidateExists = await exists(dynamoClient, config, siteCandidate.getBaseURL());
 
   if (siteCandidateExists) {
-    throw new Error(`Site candidate with base url ${siteCandidate.getBaseURL()} already exists`);
+    log.info(`Ignoring the site candidate with base url ${siteCandidate.getBaseURL()} because it already exists`);
+    return siteCandidate;
   }
 
   await dynamoClient.putItem(

--- a/packages/spacecat-shared-data-access/src/service/site-candidates/index.js
+++ b/packages/spacecat-shared-data-access/src/service/site-candidates/index.js
@@ -11,15 +11,16 @@
  */
 
 import {
-  addSiteCandidate,
+  upsertSiteCandidate,
   exists,
   updateSiteCandidate,
 } from './accessPatterns.js';
 
-export const siteCandidateFunctions = (dynamoClient, config) => ({
-  addSiteCandidate: (siteCandidateData) => addSiteCandidate(
+export const siteCandidateFunctions = (dynamoClient, config, log) => ({
+  upsertSiteCandidate: (siteCandidateData) => upsertSiteCandidate(
     dynamoClient,
     config,
+    log,
     siteCandidateData,
   ),
   siteCandidateExists: (baseUrl) => exists(

--- a/packages/spacecat-shared-data-access/src/service/site-candidates/index.js
+++ b/packages/spacecat-shared-data-access/src/service/site-candidates/index.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  addSiteCandidate,
+  exists,
+  updateSiteCandidate,
+} from './accessPatterns.js';
+
+export const siteCandidateFunctions = (dynamoClient, config) => ({
+  addSiteCandidate: (siteCandidateData) => addSiteCandidate(
+    dynamoClient,
+    config,
+    siteCandidateData,
+  ),
+  siteCandidateExists: (baseUrl) => exists(
+    dynamoClient,
+    config,
+    baseUrl,
+  ),
+  updateSiteCandidate: (siteCandidateData) => updateSiteCandidate(
+    dynamoClient,
+    config,
+    siteCandidateData,
+  ),
+});

--- a/packages/spacecat-shared-data-access/test/it/db.test.js
+++ b/packages/spacecat-shared-data-access/test/it/db.test.js
@@ -25,7 +25,7 @@ import { configSchema } from '../../src/models/site/config.js';
 import { AUDIT_TYPE_LHS_MOBILE } from '../../src/models/audit.js';
 
 import generateSampleData from './generateSampleData.js';
-import { createSiteCandidate, SITE_CANDIDATE_STATUS } from '../../src/models/site-candidate.js';
+import { createSiteCandidate, SITE_CANDIDATE_SOURCES, SITE_CANDIDATE_STATUS } from '../../src/models/site-candidate.js';
 
 const { expect } = chai;
 chai.use(chaiAsPromised);
@@ -644,6 +644,7 @@ describe('DynamoDB Integration Test', async () => {
       baseURL: 'https://example0.com',
       status: SITE_CANDIDATE_STATUS.APPROVED,
       siteId: 'some-site-id',
+      source: SITE_CANDIDATE_SOURCES.CDN,
     };
 
     const updatedSiteCandidate = await dataAccess.updateSiteCandidate(
@@ -652,6 +653,7 @@ describe('DynamoDB Integration Test', async () => {
 
     expect(updatedSiteCandidate.getBaseURL()).to.equal(siteCandidateData.baseURL);
     expect(updatedSiteCandidate.getSiteId()).to.equal(siteCandidateData.siteId);
+    expect(updatedSiteCandidate.getSource()).to.equal(siteCandidateData.source);
     expect(updatedSiteCandidate.getStatus()).to.equal(siteCandidateData.status);
   });
 });

--- a/packages/spacecat-shared-data-access/test/it/db.test.js
+++ b/packages/spacecat-shared-data-access/test/it/db.test.js
@@ -96,6 +96,7 @@ describe('DynamoDB Integration Test', async () => {
   let dataAccess;
 
   const NUMBER_OF_SITES = 10;
+  const NUMBER_OF_SITES_CANDIDATES = 100;
   const NUMBER_OF_ORGANIZATIONS = 3;
   const NUMBER_OF_AUDITS_PER_TYPE_AND_SITE = 3;
 
@@ -119,6 +120,7 @@ describe('DynamoDB Integration Test', async () => {
       TEST_DA_CONFIG,
       NUMBER_OF_ORGANIZATIONS,
       NUMBER_OF_SITES,
+      NUMBER_OF_SITES_CANDIDATES,
       NUMBER_OF_AUDITS_PER_TYPE_AND_SITE,
     );
 

--- a/packages/spacecat-shared-data-access/test/it/db.test.js
+++ b/packages/spacecat-shared-data-access/test/it/db.test.js
@@ -624,13 +624,13 @@ describe('DynamoDB Integration Test', async () => {
     expect(exists).to.be.false;
   });
 
-  it('verify the add site candidate flow', async () => {
+  it('verify the upsert site candidate flow', async () => {
     const siteCandidateData = {
       baseURL: 'https://some-base-url.com',
       status: SITE_CANDIDATE_STATUS.IGNORED,
     };
 
-    const siteCandidate = await dataAccess.addSiteCandidate(siteCandidateData);
+    const siteCandidate = await dataAccess.upsertSiteCandidate(siteCandidateData);
 
     const exists = await dataAccess.siteCandidateExists('https://some-base-url.com');
     expect(exists).to.be.true;
@@ -643,6 +643,7 @@ describe('DynamoDB Integration Test', async () => {
     const siteCandidateData = {
       baseURL: 'https://example0.com',
       status: SITE_CANDIDATE_STATUS.APPROVED,
+      siteId: 'some-site-id',
     };
 
     const updatedSiteCandidate = await dataAccess.updateSiteCandidate(
@@ -650,6 +651,7 @@ describe('DynamoDB Integration Test', async () => {
     );
 
     expect(updatedSiteCandidate.getBaseURL()).to.equal(siteCandidateData.baseURL);
+    expect(updatedSiteCandidate.getSiteId()).to.equal(siteCandidateData.siteId);
     expect(updatedSiteCandidate.getStatus()).to.equal(siteCandidateData.status);
   });
 });

--- a/packages/spacecat-shared-data-access/test/it/db.test.js
+++ b/packages/spacecat-shared-data-access/test/it/db.test.js
@@ -80,6 +80,7 @@ const TEST_DA_CONFIG = {
   tableNameLatestAudits: 'spacecat-services-latest-audits',
   tableNameOrganizations: 'spacecat-services-organizations',
   tableNameSites: 'spacecat-services-sites',
+  tableNameSiteCandidates: 'spacecat-services-site-candidates',
   indexNameAllSites: 'spacecat-services-all-sites',
   indexNameAllSitesOrganizations: 'spacecat-services-all-sites-organizations',
   indexNameAllOrganizations: 'spacecat-services-all-organizations',
@@ -608,5 +609,11 @@ describe('DynamoDB Integration Test', async () => {
     await expect(dataAccess.removeOrganization(organization.getId())).to.eventually.be.fulfilled;
     const organizationAfterRemoval = await dataAccess.getOrganizationByID(organization.getId());
     expect(organizationAfterRemoval).to.be.null;
+  });
+
+  it('checks if a site candidate exists', async () => {
+    const exists = await dataAccess.siteCandidateExists('https://example0.com');
+
+    expect(exists).to.be.true;
   });
 });

--- a/packages/spacecat-shared-data-access/test/it/db.test.js
+++ b/packages/spacecat-shared-data-access/test/it/db.test.js
@@ -619,7 +619,7 @@ describe('DynamoDB Integration Test', async () => {
     expect(exists).to.be.true;
   });
 
-  it('verify a previously added site candidate does not exist', async () => {
+  it('verify a previously non-added site candidate does not exist', async () => {
     const exists = await dataAccess.siteCandidateExists('https://non-existing-site.com');
     expect(exists).to.be.false;
   });

--- a/packages/spacecat-shared-data-access/test/it/generateSampleData.js
+++ b/packages/spacecat-shared-data-access/test/it/generateSampleData.js
@@ -12,6 +12,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 
+import { SITE_CANDIDATE_STATUS } from '../../src/models/site-candidate.js';
 import { dbClient, docClient as client } from './db.js';
 import { generateRandomAudit } from './auditUtils.js';
 import { createTable, deleteTable } from './tableOperations.js';
@@ -143,6 +144,7 @@ export default async function generateSampleData(
   config,
   numberOfOrganizations = 3,
   numberOfSites = 10,
+  numberOfSiteCandidates = 100,
   numberOfAuditsPerType = 5,
 ) {
   console.time('Sample data generated in');
@@ -156,6 +158,7 @@ export default async function generateSampleData(
 
   const auditTypes = ['lhs-mobile', 'cwv'];
   const sites = [];
+  const siteCandidates = [];
   const organizations = [];
   const auditItems = [];
   const latestAuditItems = [];
@@ -234,7 +237,16 @@ export default async function generateSampleData(
     }
   }
 
+  // Generate site candidate data
+  for (let i = 0; i < numberOfSiteCandidates; i += 1) {
+    siteCandidates.push({
+      baseURL: `https://example${i}.com`,
+      status: Object.values(SITE_CANDIDATE_STATUS).at(i % 4),
+    });
+  }
+
   await batchWrite(config.tableNameSites, sites);
+  await batchWrite(config.tableNameSiteCandidates, siteCandidates);
   await batchWrite(config.tableNameOrganizations, organizations);
   await batchWrite(config.tableNameAudits, auditItems);
   await batchWrite(config.tableNameLatestAudits, latestAuditItems);

--- a/packages/spacecat-shared-data-access/test/it/generateSampleData.js
+++ b/packages/spacecat-shared-data-access/test/it/generateSampleData.js
@@ -133,6 +133,7 @@ function generateAuditData(
  * @param {DataAccessConfig} config - The data access config.
  * @param {number} [numberOfOrganizations=3] - The number of organizations to generate.
  * @param {number} [numberOfSites=10] - The number of sites to generate.
+ * @param {number} [numberOfSiteCandidates=10] - The number of sites candidates to generate.
  * @param {number} [numberOfAuditsPerType=5] - The number of audits per type to generate
  * for each site.
  *
@@ -144,7 +145,7 @@ export default async function generateSampleData(
   config,
   numberOfOrganizations = 3,
   numberOfSites = 10,
-  numberOfSiteCandidates = 100,
+  numberOfSiteCandidates = 10,
   numberOfAuditsPerType = 5,
 ) {
   console.time('Sample data generated in');
@@ -241,7 +242,7 @@ export default async function generateSampleData(
   for (let i = 0; i < numberOfSiteCandidates; i += 1) {
     siteCandidates.push({
       baseURL: `https://example${i}.com`,
-      status: Object.values(SITE_CANDIDATE_STATUS).at(i % 4),
+      status: SITE_CANDIDATE_STATUS.PENDING,
     });
   }
 

--- a/packages/spacecat-shared-data-access/test/unit/models/site-candidate.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site-candidate.test.js
@@ -14,7 +14,6 @@
 
 import { expect } from 'chai';
 import { createSiteCandidate, SITE_CANDIDATE_STATUS, DEFAULT_UPDATED_BY } from '../../../src/models/site-candidate.js';
-import { sleep } from '../util.js';
 
 const validData = {
   baseURL: 'https://www.example.com',
@@ -52,16 +51,10 @@ describe('Site Candidate Model Tests', () => {
       expect(siteCandidate.getStatus()).to.equal(newStatus);
     });
 
-    it('updates updatedAt and updateBy when status is updated', async () => {
-      const initialUpdatedAt = siteCandidate.getUpdatedAt();
-      const initialUpdatedBy = siteCandidate.getUpdatedBy();
-
-      await sleep(20);
-
-      siteCandidate.setStatus(SITE_CANDIDATE_STATUS.APPROVED, 'new challenger');
-
-      expect(siteCandidate.getUpdatedAt()).to.not.equal(initialUpdatedAt);
-      expect(siteCandidate.getUpdatedBy()).to.not.equal(initialUpdatedBy);
+    it('updates updatedBy correctly', () => {
+      const newUpdatedBy = 'pablo';
+      siteCandidate.setUpdatedBy(newUpdatedBy);
+      expect(siteCandidate.getUpdatedBy()).to.equal(newUpdatedBy);
     });
   });
 });

--- a/packages/spacecat-shared-data-access/test/unit/models/site-candidate.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site-candidate.test.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { expect } from 'chai';
+import { createSiteCandidate, SITE_CANDIDATE_STATUS, DEFAULT_UPDATED_BY } from '../../../src/models/site-candidate.js';
+import { sleep } from '../util.js';
+
+const validData = {
+  baseURL: 'https://www.example.com',
+  status: 'PENDING',
+};
+
+describe('Site Candidate Model Tests', () => {
+  describe('Validation Tests', () => {
+    it('throws an error if baseURL is not a valid URL', () => {
+      expect(() => createSiteCandidate({ ...validData, baseURL: 'invalid-url' })).to.throw('Base URL must be a valid URL');
+    });
+
+    it('creates a site candidate object with valid baseURL', () => {
+      const siteCandidate = createSiteCandidate({ ...validData });
+      expect(siteCandidate).to.be.an('object');
+      expect(siteCandidate.getBaseURL()).to.equal(validData.baseURL);
+    });
+
+    it('creates a site candidate with default updated by', () => {
+      const siteCandidate = createSiteCandidate({ ...validData, updatedBy: undefined });
+      expect(siteCandidate.getUpdatedBy()).to.equal(DEFAULT_UPDATED_BY);
+    });
+  });
+
+  describe('Site Candidate Object Functionality', () => {
+    let siteCandidate;
+
+    beforeEach(() => {
+      siteCandidate = createSiteCandidate(validData);
+    });
+
+    it('updates status correctly', () => {
+      const newStatus = SITE_CANDIDATE_STATUS.APPROVED;
+      siteCandidate.setStatus(newStatus);
+      expect(siteCandidate.getStatus()).to.equal(newStatus);
+    });
+
+    it('updates updatedAt and updateBy when status is updated', async () => {
+      const initialUpdatedAt = siteCandidate.getUpdatedAt();
+      const initialUpdatedBy = siteCandidate.getUpdatedBy();
+
+      await sleep(20);
+
+      siteCandidate.setStatus(SITE_CANDIDATE_STATUS.APPROVED, 'new challenger');
+
+      expect(siteCandidate.getUpdatedAt()).to.not.equal(initialUpdatedAt);
+      expect(siteCandidate.getUpdatedBy()).to.not.equal(initialUpdatedBy);
+    });
+  });
+});

--- a/packages/spacecat-shared-data-access/test/unit/models/site-candidate.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site-candidate.test.js
@@ -13,7 +13,12 @@
 /* eslint-env mocha */
 
 import { expect } from 'chai';
-import { createSiteCandidate, SITE_CANDIDATE_STATUS, DEFAULT_UPDATED_BY } from '../../../src/models/site-candidate.js';
+import {
+  createSiteCandidate,
+  SITE_CANDIDATE_STATUS,
+  DEFAULT_UPDATED_BY,
+  SITE_CANDIDATE_SOURCES,
+} from '../../../src/models/site-candidate.js';
 
 const validData = {
   baseURL: 'https://www.example.com',
@@ -43,6 +48,18 @@ describe('Site Candidate Model Tests', () => {
 
     beforeEach(() => {
       siteCandidate = createSiteCandidate(validData);
+    });
+
+    it('updates site id correctly', () => {
+      const newSiteId = 'some-site-id';
+      siteCandidate.setSiteId(newSiteId);
+      expect(siteCandidate.getSiteId()).to.equal(newSiteId);
+    });
+
+    it('updates source correctly', () => {
+      const newSource = SITE_CANDIDATE_SOURCES.RUM;
+      siteCandidate.setSource(newSource);
+      expect(siteCandidate.getSource()).to.equal(newSource);
     });
 
     it('updates status correctly', () => {

--- a/packages/spacecat-shared-data-access/test/unit/service/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/index.test.js
@@ -43,6 +43,12 @@ describe('Data Access Object Tests', () => {
     'getSiteByID',
   ];
 
+  const siteCandidateFunctions = [
+    'addSiteCandidate',
+    'siteCandidateExists',
+    'updateSiteCandidate',
+  ];
+
   const organizationFunctions = [
     'getOrganizations',
     'getOrganizationByID',
@@ -69,9 +75,18 @@ describe('Data Access Object Tests', () => {
     });
   });
 
+  it('contains all known site candidate functions', () => {
+    siteCandidateFunctions.forEach((funcName) => {
+      expect(dao).to.have.property(funcName);
+    });
+  });
+
   it('does not contain any unexpected functions', () => {
-    const expectedFunctions = new Set([...auditFunctions,
-      ...siteFunctions, ...organizationFunctions]);
+    const expectedFunctions = new Set([
+      ...auditFunctions,
+      ...siteFunctions,
+      ...siteCandidateFunctions,
+      ...organizationFunctions]);
     Object.keys(dao).forEach((funcName) => {
       expect(expectedFunctions).to.include(funcName);
     });

--- a/packages/spacecat-shared-data-access/test/unit/service/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/index.test.js
@@ -44,7 +44,7 @@ describe('Data Access Object Tests', () => {
   ];
 
   const siteCandidateFunctions = [
-    'addSiteCandidate',
+    'upsertSiteCandidate',
     'siteCandidateExists',
     'updateSiteCandidate',
   ];

--- a/packages/spacecat-shared-data-access/test/unit/service/site-candidates/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/site-candidates/index.test.js
@@ -118,7 +118,7 @@ describe('Site Candidate Access Pattern Tests', () => {
 
     it('updates an existing site candidate successfully', async () => {
       const siteCandidateData = { baseURL: 'https://existingsite.com', status: SITE_CANDIDATE_STATUS.DISCOVERED };
-      mockDynamoClient.getItem.returns(Promise.resolve([siteCandidateData]));
+      mockDynamoClient.getItem.returns(Promise.resolve(siteCandidateData));
 
       const siteCandidate = createSiteCandidate({ baseURL: 'https://existingsite.com' });
       siteCandidate.setStatus(SITE_CANDIDATE_STATUS.PENDING);

--- a/packages/spacecat-shared-data-access/test/unit/service/site-candidates/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/site-candidates/index.test.js
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+
+import { siteCandidateFunctions } from '../../../../src/service/site-candidates/index.js';
+import { createSiteCandidate, SITE_CANDIDATE_STATUS } from '../../../../src/models/site-candidate.js';
+
+chai.use(chaiAsPromised);
+
+const { expect } = chai;
+
+const TEST_DA_CONFIG = {
+  tableNameAudits: 'test-audits',
+  tableNameLatestAudits: 'test-latest-audits',
+  tableNameSites: 'test-sites',
+  tableNameSiteCandidates: 'test-site-candidates',
+  indexNameAllSites: 'test-index-all-sites',
+  indexNameAllSitesByDeliveryType: 'test-index-all-sites-by-delivery-type',
+  indexNameAllSitesOrganizations: 'test-index-all-sites-organizations',
+  indexNameAllLatestAuditScores: 'test-index-all-latest-audit-scores',
+  pkAllSites: 'test-pk-all-sites',
+  pkAllLatestAudits: 'test-pk-all-latest-audits',
+};
+
+describe('Site Candidate Access Pattern Tests', () => {
+  describe('Site Candidate Functions Export Tests', () => {
+    const mockDynamoClient = {};
+
+    const exportedFunctions = siteCandidateFunctions(mockDynamoClient, TEST_DA_CONFIG);
+
+    it('exports addSiteCandidate function', () => {
+      expect(exportedFunctions).to.have.property('addSiteCandidate');
+      expect(exportedFunctions.addSiteCandidate).to.be.a('function');
+    });
+
+    it('exports siteCandidateExists function', () => {
+      expect(exportedFunctions).to.have.property('siteCandidateExists');
+      expect(exportedFunctions.siteCandidateExists).to.be.a('function');
+    });
+
+    it('exports updateSiteCandidate function', () => {
+      expect(exportedFunctions).to.have.property('updateSiteCandidate');
+      expect(exportedFunctions.updateSiteCandidate).to.be.a('function');
+    });
+  });
+
+  describe('Site Candidate Functions Tests', () => {
+    let mockDynamoClient;
+    let exportedFunctions;
+
+    beforeEach(() => {
+      mockDynamoClient = {
+        getItem: sinon.stub().returns(Promise.resolve(null)),
+        putItem: sinon.stub().returns(Promise.resolve()),
+      };
+
+      exportedFunctions = siteCandidateFunctions(mockDynamoClient, TEST_DA_CONFIG);
+    });
+
+    it('siteCandidateExists returns false when no site candidate exists', async () => {
+      const result = await exportedFunctions.siteCandidateExists('test-url');
+
+      expect(result).to.be.false;
+      expect(mockDynamoClient.getItem.called).to.be.true;
+    });
+
+    it('siteCandidateExists returns true when site candidate exists', async () => {
+      mockDynamoClient.getItem.returns(Promise.resolve({ baseURL: 'blah' }));
+
+      const result = await exportedFunctions.siteCandidateExists('test-url');
+
+      expect(result).to.be.true;
+      expect(mockDynamoClient.getItem.called).to.be.true;
+    });
+
+    it('adds a new site candidate successfully', async () => {
+      const siteCandidateData = { baseURL: 'https://newsite.com' };
+
+      const result = await exportedFunctions.addSiteCandidate(siteCandidateData);
+
+      expect(mockDynamoClient.getItem.calledOnce).to.be.true;
+      expect(mockDynamoClient.putItem.calledOnce).to.be.true;
+      expect(result.getBaseURL()).to.equal(siteCandidateData.baseURL);
+    });
+
+    it('doesnt add a new site candidate if already exists before', async () => {
+      const siteCandidateData = { baseURL: 'https://newsite.com' };
+      mockDynamoClient.getItem.returns(Promise.resolve(siteCandidateData));
+
+      await expect(exportedFunctions.addSiteCandidate(siteCandidateData))
+        .to.be.rejectedWith('Site candidate with base url https://newsite.com already exists');
+      expect(mockDynamoClient.getItem.calledOnce).to.be.true;
+      expect(mockDynamoClient.putItem.notCalled).to.be.true;
+    });
+
+    it('update site candidate throws an error if site candidate exists', async () => {
+      mockDynamoClient.getItem.returns(Promise.resolve(null));
+
+      const updatedSiteCandidate = createSiteCandidate({ baseURL: 'https://some-site.com' });
+
+      await expect(exportedFunctions.updateSiteCandidate(updatedSiteCandidate))
+        .to.be.rejectedWith('Site candidate with base url https://some-site.com does not exist');
+    });
+
+    it('updates an existing site candidate successfully', async () => {
+      const siteCandidateData = { baseURL: 'https://existingsite.com', status: SITE_CANDIDATE_STATUS.DISCOVERED };
+      mockDynamoClient.getItem.returns(Promise.resolve([siteCandidateData]));
+
+      const siteCandidate = createSiteCandidate({ baseURL: 'https://existingsite.com' });
+      siteCandidate.setStatus(SITE_CANDIDATE_STATUS.PENDING);
+
+      const result = await exportedFunctions.updateSiteCandidate(siteCandidate);
+      expect(mockDynamoClient.putItem.calledOnce).to.be.true;
+      expect(result.getBaseURL()).to.equal(siteCandidate.getBaseURL());
+      expect(result.getStatus()).to.equal(siteCandidate.getStatus());
+      expect(mockDynamoClient.getItem.calledOnce).to.be.true;
+      expect(mockDynamoClient.putItem.calledOnce).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
# Site Candidate Data Model

This PR introduces the Site Candidate Data Model to manage the site discovery flow. The primary objective is to maintain a comprehensive list of new sites and their respective statuses for potential inclusion in the Star Catalogue. The information is stored in the `site-candidates` table. The PR contains the data model itself, along with the access patterns and the functions which are used to add and modify of site candidates.

## Flow

1. Upon the discovery of a new site, Spacecat will check the `site-candidates` table to ascertain whether the site has been previously discovered.
  - If the site is found in the table, the candidate will be discarded.
  - If the site is not found, the candidate will be added to the `site-candidates` table with the status `PENDING`

2. Subsequently, Spacecat will dispatch a discovery slack message containing the URL of the newly discovered site. This message will include interactive options with `[Yes]` and `[Ignore]` buttons, enabling human decision-making regarding the addition of the site to the Star Catalogue.

3. If a user clicks `[Yes]`, Spacecat will further update the status to `APPROVED` and proceed with adding the site to the Star Catalogue.

4. If a user clicks `[Ignore]`, Spacecat will update the status to `IGNORED` and not add the site to Star Catalogue.

5. If any error happens during the process, Spacecat will update the status to `ERROR`
