### PR TITLE
feat: add organic traffic audit type (SITES-18661)

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/audit.js
+++ b/packages/spacecat-shared-data-access/src/models/audit.js
@@ -16,6 +16,7 @@ import { Base } from './base.js';
 export const AUDIT_TYPE_404 = '404';
 export const AUDIT_TYPE_BROKEN_BACKLINKS = 'broken-backlinks';
 export const AUDIT_TYPE_ORGANIC_KEYWORDS = 'organic-keywords';
+export const AUDIT_TYPE_ORGANIC_TRAFFIC = 'organic-traffic';
 export const AUDIT_TYPE_CWV = 'cwv';
 export const AUDIT_TYPE_LHS_DESKTOP = 'lhs-desktop';
 export const AUDIT_TYPE_LHS_MOBILE = 'lhs-mobile';
@@ -26,6 +27,7 @@ const AUDIT_TYPE_PROPERTIES = {
   [AUDIT_TYPE_404]: [],
   [AUDIT_TYPE_BROKEN_BACKLINKS]: [],
   [AUDIT_TYPE_ORGANIC_KEYWORDS]: [],
+  [AUDIT_TYPE_ORGANIC_TRAFFIC]: [],
   [AUDIT_TYPE_CWV]: [],
   [AUDIT_TYPE_LHS_DESKTOP]: ['performance', 'seo', 'accessibility', 'best-practices'],
   [AUDIT_TYPE_LHS_MOBILE]: ['performance', 'seo', 'accessibility', 'best-practices'],

--- a/packages/spacecat-shared-data-access/src/models/site/audit-config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/audit-config.js
@@ -14,11 +14,13 @@ import AuditConfigType from './audit-config-type.js';
 import {
   AUDIT_TYPE_BROKEN_BACKLINKS,
   AUDIT_TYPE_ORGANIC_KEYWORDS,
+  AUDIT_TYPE_ORGANIC_TRAFFIC,
 } from '../audit.js';
 
 const AUDIT_TYPE_DISABLED_DEFAULTS = {
   [AUDIT_TYPE_BROKEN_BACKLINKS]: true,
   [AUDIT_TYPE_ORGANIC_KEYWORDS]: true,
+  [AUDIT_TYPE_ORGANIC_TRAFFIC]: true,
 };
 
 function getAuditTypeConfigs(auditTypeConfigs, auditsDisabled) {
@@ -26,6 +28,7 @@ function getAuditTypeConfigs(auditTypeConfigs, auditsDisabled) {
     return {
       [AUDIT_TYPE_BROKEN_BACKLINKS]: AuditConfigType({ disabled: true }),
       [AUDIT_TYPE_ORGANIC_KEYWORDS]: AuditConfigType({ disabled: true }),
+      [AUDIT_TYPE_ORGANIC_TRAFFIC]: AuditConfigType({ disabled: true }),
     };
   }
   return Object.entries(auditTypeConfigs || {}).reduce((acc, [key, value]) => {

--- a/packages/spacecat-shared-data-access/test/unit/models/site/audit-config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/audit-config.test.js
@@ -15,7 +15,9 @@
 import { expect } from 'chai';
 
 import AuditConfig from '../../../../src/models/site/audit-config.js';
-import { AUDIT_TYPE_BROKEN_BACKLINKS } from '../../../../src/models/audit.js';
+import {
+  AUDIT_TYPE_BROKEN_BACKLINKS, AUDIT_TYPE_ORGANIC_KEYWORDS, AUDIT_TYPE_ORGANIC_TRAFFIC,
+} from '../../../../src/models/audit.js';
 
 describe('AuditConfig Tests', () => {
   describe('AuditConfig Creation', () => {
@@ -25,6 +27,10 @@ describe('AuditConfig Tests', () => {
       const auditTypeConfigs = auditConfig.getAuditTypeConfigs();
       expect(auditTypeConfigs[AUDIT_TYPE_BROKEN_BACKLINKS]).to.be.an('object');
       expect(auditTypeConfigs[AUDIT_TYPE_BROKEN_BACKLINKS].disabled()).to.be.true;
+      expect(auditTypeConfigs[AUDIT_TYPE_ORGANIC_KEYWORDS]).to.be.an('object');
+      expect(auditTypeConfigs[AUDIT_TYPE_ORGANIC_KEYWORDS].disabled()).to.be.true;
+      expect(auditTypeConfigs[AUDIT_TYPE_ORGANIC_TRAFFIC]).to.be.an('object');
+      expect(auditTypeConfigs[AUDIT_TYPE_ORGANIC_TRAFFIC].disabled()).to.be.true;
     });
 
     it('creates an AuditConfig with provided data', () => {


### PR DESCRIPTION
Add organic traffic audit type, which is by default disabled

## Related Issues
https://jira.corp.adobe.com/browse/SITES-18661
