### PR TITLE
feat: get organization by IMS org ID

### DIFF
--- a/packages/spacecat-shared-data-access/src/service/organizations/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/organizations/accessPatterns.js
@@ -51,6 +51,27 @@ export const getOrganizationByID = async (
 };
 
 /**
+ * Retrieves an organization by its IMS org ID.
+ *
+ * @param {DynamoDbClient} dynamoClient - The DynamoDB client.
+ * @param {DataAccessConfig} config - The data access config.
+ * @param {string} imsOrgId - Organization identifier on IMS, in the format of {id}@AdobeOrg
+ * @returns {Promise<Readonly<Organization>>} A promise that resolves to an organization, if found.
+ */
+export const getOrganizationByImsOrgID = async (
+  dynamoClient,
+  config,
+  imsOrgId,
+) => {
+  const dynamoItem = await dynamoClient.getItem(
+    config.tableNameOrganizations,
+    { imsOrgId },
+  );
+
+  return isObject(dynamoItem) ? OrganizationDto.fromDynamoItem(dynamoItem) : null;
+};
+
+/**
  * Adds an organization.
  *
  * @param {DynamoDbClient} dynamoClient - The DynamoDB client.

--- a/packages/spacecat-shared-data-access/src/service/organizations/index.js
+++ b/packages/spacecat-shared-data-access/src/service/organizations/index.js
@@ -15,6 +15,7 @@ import {
   addOrganization,
   updateOrganization,
   removeOrganization,
+  getOrganizationByImsOrgID,
 } from './accessPatterns.js';
 
 export const organizationFunctions = (dynamoClient, config, log) => ({
@@ -23,6 +24,11 @@ export const organizationFunctions = (dynamoClient, config, log) => ({
     dynamoClient,
     config,
     organizationId,
+  ),
+  getOrganizationByImsOrgID: (imsOrgId) => getOrganizationByImsOrgID(
+    dynamoClient,
+    config,
+    imsOrgId,
   ),
   addOrganization: (organizationData) => addOrganization(
     dynamoClient,

--- a/packages/spacecat-shared-data-access/test/unit/service/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/index.test.js
@@ -56,6 +56,7 @@ describe('Data Access Object Tests', () => {
     'addOrganization',
     'updateOrganization',
     'removeOrganization',
+    'getOrganizationByImsOrgID',
   ];
 
   let dao;

--- a/packages/spacecat-shared-data-access/test/unit/service/organization/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/organization/index.test.js
@@ -52,6 +52,12 @@ describe('Organization Access Pattern Tests', () => {
     let mockLog;
     let exportedFunctions;
 
+    const mockOrgData = {
+      id: 'organization1',
+      name: 'Organization1',
+      imsOrgId: '1234567890ABCDEF12345678@AdobeOrg',
+    };
+
     beforeEach(() => {
       mockDynamoClient = {
         query: sinon.stub().returns(Promise.resolve([])),
@@ -75,11 +81,6 @@ describe('Organization Access Pattern Tests', () => {
     });
 
     it('calls getOrganizationByID and returns site', async () => {
-      const mockOrgData = {
-        id: 'organization1',
-        name: 'Organization1',
-      };
-
       mockDynamoClient.getItem.onFirstCall().resolves(mockOrgData);
 
       const result = await exportedFunctions.getOrganizationByID();
@@ -87,6 +88,26 @@ describe('Organization Access Pattern Tests', () => {
       expect(result).to.be.an('object');
       expect(result.getId()).to.equal(mockOrgData.id);
       expect(result.getName()).to.equal(mockOrgData.name);
+      expect(mockDynamoClient.getItem.called).to.be.true;
+    });
+
+    it('should return null when an organization is not found by IMS org ID', async () => {
+      mockDynamoClient.getItem.onFirstCall().resolves(null);
+
+      const result = await exportedFunctions.getOrganizationByImsOrgID('notfoundorg123@AdobeOrg');
+
+      expect(result).to.be.null;
+      expect(mockDynamoClient.getItem.called).to.be.true;
+    });
+
+    it('should return an organization by IMS org ID', async () => {
+      mockDynamoClient.getItem.onFirstCall().resolves(mockOrgData);
+
+      const result = await exportedFunctions.getOrganizationByImsOrgID('1234567890ABCDEF12345678@AdobeOrg');
+
+      expect(result).to.be.an('object');
+      expect(result.getId()).to.equal(mockOrgData.id);
+      expect(result.getImsOrgId()).to.equal(mockOrgData.imsOrgId);
       expect(mockDynamoClient.getItem.called).to.be.true;
     });
 


### PR DESCRIPTION
In support of tickets SITES-19428 and SITES-19427.

Implements `getOrganizationByImsOrgID` function.

TODO: Create a GSI which uses `imsOrgId` as the partition key (tracked in SITES-19842).