### PR TITLE
feat: fulfillable items support on Organization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13567,7 +13567,7 @@
     },
     "packages/spacecat-shared-example": {
       "name": "@adobe/spacecat-shared-example",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.1",
@@ -13579,7 +13579,7 @@
     },
     "packages/spacecat-shared-gpt-client": {
       "name": "@adobe/spacecat-shared-gpt-client",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.1",
@@ -13615,7 +13615,7 @@
     },
     "packages/spacecat-shared-ims-client": {
       "name": "@adobe/spacecat-shared-ims-client",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.1",
@@ -13641,7 +13641,7 @@
     },
     "packages/spacecat-shared-rum-api-client": {
       "name": "@adobe/spacecat-shared-rum-api-client",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.1",
@@ -13665,7 +13665,7 @@
     },
     "packages/spacecat-shared-slack-client": {
       "name": "@adobe/spacecat-shared-slack-client",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "4.5.0",

--- a/packages/spacecat-shared-data-access/src/dto/organization.js
+++ b/packages/spacecat-shared-data-access/src/dto/organization.js
@@ -30,6 +30,7 @@ export const OrganizationDto = {
     updatedAt: organization.getUpdatedAt(),
     GSI1PK: 'ALL_ORGANIZATIONS',
     config: Config.toDynamoItem(organization.getConfig()),
+    fulfillableItems: organization.getFulfillableItems(),
   }),
 
   /**
@@ -45,6 +46,7 @@ export const OrganizationDto = {
       createdAt: dynamoItem.createdAt,
       updatedAt: dynamoItem.updatedAt,
       config: dynamoItem.config,
+      fulfillableItems: dynamoItem.fulfillableItems,
     };
 
     return createOrganization(organizationData);

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -100,6 +100,10 @@ export interface Config {
 
 }
 
+export interface FulfillableItems {
+  items: string[];
+}
+
 /**
  * AuditConfig defines the structure for the overall audit configuration of a site.
  */
@@ -313,6 +317,12 @@ export interface Organization {
    * @returns {Config} The current audit configuration.
    */
   getConfig: () => Config;
+
+  /**
+   * Retrieves the fulfillable items object for the org.
+   * @returns {FulfillableItems} The current fulfillable items object.
+   */
+  getFulfillableItems: () => FulfillableItems;
 }
 
 export interface Configuration {

--- a/packages/spacecat-shared-data-access/src/models/organization.js
+++ b/packages/spacecat-shared-data-access/src/models/organization.js
@@ -29,6 +29,7 @@ const Organization = (data = {}) => {
   self.getConfig = () => self.state.config;
   self.getName = () => self.state.name;
   self.getImsOrgId = () => self.state.imsOrgId;
+  self.getFulfillableItems = () => self.state.fulfillableItems;
 
   /**
      * Updates the IMS Org ID belonging to the organization.
@@ -77,6 +78,18 @@ const Organization = (data = {}) => {
 
     return self;
   };
+
+  self.updateFulfillableItems = (fulfillableItems) => {
+    if (!isObject(fulfillableItems)) {
+      throw new Error('Fulfillable items object must be provided');
+    }
+
+    self.state.fulfillableItems = fulfillableItems;
+    self.touch();
+
+    return self;
+  };
+
   return Object.freeze(self);
 };
 

--- a/packages/spacecat-shared-data-access/test/unit/models/organization.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/organization.test.js
@@ -147,5 +147,41 @@ describe('Organization Model Tests', () => {
 
       expect(organization.getUpdatedAt()).to.not.equal(initialUpdatedAt);
     });
+
+    it('updates fulfillable items correctly', () => {
+      let fulfillableItemsData = {
+        items: [
+          'dx_example_solution',
+          'dx_aem_another_solution',
+        ],
+      };
+      organization.updateFulfillableItems(fulfillableItemsData);
+      let updatedFIs = organization.getFulfillableItems();
+      expect(updatedFIs).to.be.an('object');
+      expect(updatedFIs.items).to.be.an('array');
+      expect(updatedFIs.items[0]).to.equal('dx_example_solution');
+      expect(updatedFIs.items[1]).to.equal('dx_aem_another_solution');
+
+      // Next, clear out items
+      fulfillableItemsData = {
+        items: [],
+      };
+      organization.updateFulfillableItems(fulfillableItemsData);
+      updatedFIs = organization.getFulfillableItems();
+      expect(updatedFIs).to.be.an('object');
+      expect(updatedFIs.items).to.be.an('array');
+      expect(updatedFIs.items.length).to.equal(0);
+    });
+
+    it('should handle invalid fulfillable items', () => {
+      let fulfillableItemsData = 'not-correct';
+      expect(() => organization.updateFulfillableItems(fulfillableItemsData)).to.throw('Fulfillable items object must be provided');
+
+      fulfillableItemsData = null;
+      expect(() => organization.updateFulfillableItems(fulfillableItemsData)).to.throw('Fulfillable items object must be provided');
+
+      fulfillableItemsData = ['thing_one'];
+      expect(() => organization.updateFulfillableItems(fulfillableItemsData)).to.throw('Fulfillable items object must be provided');
+    });
   });
 });


### PR DESCRIPTION
Add accessors to support the `fulfillableItems` property defined on `Organization`: https://lucid.app/lucidchart/f5480d07-626d-42e8-8eb5-39b0e9a1c75f/edit?invitationId=inv_c77bd463-5df8-4973-b70b-a8028a6ee21a&page=0_0#

Includes: 

- Model & DTO updates
- Type updates
- Test coverage