### PR TITLE
fix: baseurl composition fixes

### DIFF
--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -63,8 +63,9 @@ function stripWWW(url) {
  * @returns {string} - The composed base URL.
  */
 function composeBaseURL(domain) {
-  let baseURL = stripTrailingDot(domain);
+  let baseURL = domain.toLowerCase();
   baseURL = stripPort(baseURL);
+  baseURL = stripTrailingDot(baseURL);
   baseURL = stripTrailingSlash(baseURL);
   baseURL = stripWWW(baseURL);
   baseURL = prependSchema(baseURL);

--- a/packages/spacecat-shared-utils/test/url-helpers.test.js
+++ b/packages/spacecat-shared-utils/test/url-helpers.test.js
@@ -94,6 +94,9 @@ describe('URL Utility Functions', () => {
       expect(composeBaseURL('https://example.com/')).to.equal('https://example.com');
       expect(composeBaseURL('http://example.com/')).to.equal('http://example.com');
       expect(composeBaseURL('example.com/')).to.equal('https://example.com');
+      expect(composeBaseURL('example.com.:123')).to.equal('https://example.com');
+      expect(composeBaseURL('WWW.example.com')).to.equal('https://example.com');
+      expect(composeBaseURL('WWW.example.com.:342')).to.equal('https://example.com');
     });
   });
 });


### PR DESCRIPTION
two more cases added:

1. CDN configurations may contain uppercase subdomains (ie WWW)
2. x-fw-host values coming from cdn logs might contain trailing dot **and** port
