### PR TITLE
feat: get and update configurations

### DIFF
--- a/packages/spacecat-shared-data-access/src/dto/configuration.js
+++ b/packages/spacecat-shared-data-access/src/dto/configuration.js
@@ -30,4 +30,16 @@ export const ConfigurationDto = {
 
     return createConfiguration(configurationData);
   },
+
+  /**
+     * Converts a Configuration object into a DynamoDB item.
+     * @param {Readonly<Configuration>} configuration - Configuration object.
+     * @returns {object} DynamoDB item.
+     */
+  toDynamoItem: (configuration) => ({
+    PK: 'ALL_CONFIGURATIONS',
+    version: configuration.getVersion(),
+    queues: configuration.getQueues(),
+    jobs: configuration.getJobs(),
+  }),
 };

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -443,8 +443,10 @@ export interface DataAccess {
   updateSiteCandidate: (siteCandidate: SiteCandidate) => Promise<SiteCandidate>;
 
   // configuration functions
-  getConfiguration: () => Promise<Configuration>
-  getConfigurationByVersion: (version: string) => Promise<Configuration>
+  getConfiguration: () => Promise<Readonly<Configuration>>
+  getConfigurations: () => Promise<Readonly<Configuration>[]>
+  getConfigurationByVersion: (version: string) => Promise<Readonly<Configuration>>
+  updateConfiguration: (configurationData: object) => Promise<Readonly<Configuration>>
 }
 
 interface DataAccessConfig {

--- a/packages/spacecat-shared-data-access/src/service/configurations/index.js
+++ b/packages/spacecat-shared-data-access/src/service/configurations/index.js
@@ -9,10 +9,19 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { getConfiguration, getConfigurationByVersion } from './accessPatterns.js';
+import {
+  getConfiguration,
+  getConfigurationByVersion,
+  getConfigurations,
+  updateConfiguration,
+} from './accessPatterns.js';
 
 export const configurationFunctions = (dynamoClient, config) => ({
   getConfiguration: () => getConfiguration(
+    dynamoClient,
+    config,
+  ),
+  getConfigurations: () => getConfigurations(
     dynamoClient,
     config,
   ),
@@ -20,5 +29,10 @@ export const configurationFunctions = (dynamoClient, config) => ({
     dynamoClient,
     config,
     version,
+  ),
+  updateConfiguration: (configurationData) => updateConfiguration(
+    dynamoClient,
+    config,
+    configurationData,
   ),
 });

--- a/packages/spacecat-shared-data-access/test/it/db.test.js
+++ b/packages/spacecat-shared-data-access/test/it/db.test.js
@@ -151,6 +151,28 @@ describe('DynamoDB Integration Test', async () => {
     expect(configuration.getVersion()).to.equal('v2');
   });
 
+  it('updates a configuration', async () => {
+    const configurationData = {
+      version: 'v2',
+      queues: {
+        audits: 'audits-queue',
+        imports: 'imports-queue',
+        reports: 'reports-queue',
+      },
+      jobs: [
+        { group: 'audits', interval: 'daily', type: 'some-audit' },
+        { group: 'reports', interval: 'daily', type: 'some-report' },
+      ],
+    };
+    const configuration = await dataAccess.updateConfiguration(configurationData);
+
+    expect(configuration).to.be.an('object');
+
+    expect(configuration.getVersion()).to.equal('v3');
+    expect(configuration.getQueues()).to.deep.equal(configurationData.queues);
+    expect(configuration.getJobs()).to.deep.equal(configurationData.jobs);
+  });
+
   it('gets organizations', async () => {
     const organizations = await dataAccess.getOrganizations();
 

--- a/packages/spacecat-shared-data-access/test/unit/service/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/index.test.js
@@ -60,8 +60,10 @@ describe('Data Access Object Tests', () => {
   ];
 
   const configurationFunctions = [
-    'getConfigurationByVersion',
     'getConfiguration',
+    'getConfigurations',
+    'getConfigurationByVersion',
+    'updateConfiguration',
   ];
 
   let dao;


### PR DESCRIPTION
Add retrieval of all configurations and updating of configurations as a consequence of #183 - to be used by PR in `api-service` implementing the API and leveraging the data access changes.