### PR TITLE
feat: Group email addresses by domain in the Slack ops invitation messages #182

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13745,7 +13745,7 @@
     },
     "packages/spacecat-shared-rum-api-client": {
       "name": "@adobe/spacecat-shared-rum-api-client",
-      "version": "1.6.8",
+      "version": "1.6.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.1",


### PR DESCRIPTION
Ticket: #182

Facilitate operation of the service by sorting email addresses by their domain.