### PR TITLE
feat: Enable retrieval of a user's email address from IMS given an access token #193

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 .idea/*
 .vscode/*
 coverage/*
+*DO-NOT-COMMIT*

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ junit
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Files deliberately excluded from version control
+*DO-NOT-COMMIT*

--- a/packages/spacecat-shared-ims-client/src/clients/ims-client.js
+++ b/packages/spacecat-shared-ims-client/src/clients/ims-client.js
@@ -330,14 +330,14 @@ export default class ImsClient {
         throw new Error(`IMS getImsUserProfile request failed with status: ${profileResponse.status}`);
       }
 
-      const profile = await profileResponse.json();
+      const { userId, email, roles } = await profileResponse.json();
 
       this.#logDuration('IMS getImsUserProfile request', startTime);
 
       return {
-        userId: profile.userId,
-        email: profile.email,
-        organizations: getOrganizationList(profile.roles),
+        userId,
+        email,
+        organizations: getOrganizationList(roles),
       };
     } catch (error) {
       this.log.error('Error fetching user profile data from IMS: ', error.message);

--- a/packages/spacecat-shared-ims-client/src/clients/ims-client.js
+++ b/packages/spacecat-shared-ims-client/src/clients/ims-client.js
@@ -14,11 +14,16 @@ import { createUrl } from '@adobe/fetch';
 import { hasText, isObject } from '@adobe/spacecat-shared-utils';
 
 import {
-  createFormData, emailAddressIsAllowed,
+  createFormData,
+  emailAddressIsAllowed,
   extractIdAndAuthSource,
-  fetch as httpFetch, getGroupMembersEndpoint,
+  fetch as httpFetch,
+  getGroupMembersEndpoint,
   getImsOrgsApiPath,
-  IMS_PRODUCT_CONTEXT_BY_ORG_ENDPOINT, IMS_TOKEN_ENDPOINT, IMS_TOKEN_ENDPOINT_V3,
+  IMS_PRODUCT_CONTEXT_BY_ORG_ENDPOINT,
+  IMS_PROFILE_ENDPOINT,
+  IMS_TOKEN_ENDPOINT,
+  IMS_TOKEN_ENDPOINT_V3,
 } from '../utils.js';
 
 export default class ImsClient {
@@ -296,5 +301,47 @@ export default class ImsClient {
       countryCode: orgDetails?.countryCode,
       admins,
     };
+  }
+
+  /**
+   * Fetch a subset of properties from a user's IMS profile, given their access token.
+   * @param {string} imsAccessToken A valid IMS user access token
+   * @returns {Promise<{userId, email, organizations: string[]}>} Fields from the user's profile
+   */
+  async getImsUserProfile(imsAccessToken) {
+    // Helper to pull the unique organization ID values from an array of role entries
+    function getOrganizationList(roles) {
+      return [...new Set(roles.map((roleEntry) => roleEntry.organization))];
+    }
+
+    try {
+      const startTime = process.hrtime.bigint();
+
+      const profileResponse = await httpFetch(
+        `https://${this.config.imsHost}${IMS_PROFILE_ENDPOINT}`,
+        {
+          headers: {
+            Authorization: `Bearer ${imsAccessToken}`,
+          },
+        },
+      );
+
+      if (!profileResponse.ok) {
+        throw new Error(`IMS getImsUserProfile request failed with status: ${profileResponse.status}`);
+      }
+
+      const profile = await profileResponse.json();
+
+      this.#logDuration('IMS getImsUserProfile request', startTime);
+
+      return {
+        userId: profile.userId,
+        email: profile.email,
+        organizations: getOrganizationList(profile.roles),
+      };
+    } catch (error) {
+      this.log.error('Error fetching user profile data from IMS: ', error.message);
+      throw error;
+    }
   }
 }

--- a/packages/spacecat-shared-ims-client/src/utils.js
+++ b/packages/spacecat-shared-ims-client/src/utils.js
@@ -22,6 +22,7 @@ export const IMS_TOKEN_ENDPOINT = '/ims/token/v4';
 export const IMS_TOKEN_ENDPOINT_V3 = '/ims/token/v3';
 export const IMS_PRODUCT_CONTEXT_BY_ORG_ENDPOINT = '/ims/fetch_pc_by_org/v1';
 export const IMS_ORGANIZATIONS_ENDPOINT = '/ims/organizations';
+export const IMS_PROFILE_ENDPOINT = '/ims/profile/v1';
 
 /**
  * Creates and populates a FormData object from key-value pairs.

--- a/packages/spacecat-shared-ims-client/test/clients/ims-client.test.js
+++ b/packages/spacecat-shared-ims-client/test/clients/ims-client.test.js
@@ -281,4 +281,22 @@ describe('ImsClient', () => {
       expect(orgDetails.admins).to.have.length(0);
     });
   });
+
+  describe('getImsUserProfile', () => {
+    let client;
+
+    beforeEach(() => {
+      client = ImsClient.createFrom(mockContext);
+    });
+
+    it('should fail for edge cases: no token', async () => {
+      nock(`https://${DUMMY_HOST}`)
+        .get('/ims/profile/v1')
+        .reply(401, {
+          error: 'invalid_token',
+          error_description: 'Invalid or expired token.',
+        });
+      await expect(client.getImsUserProfile(null)).to.be.rejectedWith('IMS getImsUserProfile request failed with status: 401');
+    });
+  });
 });


### PR DESCRIPTION
Ticket: #193

Proposed addition of a new method to the ImsClient, `getImsUserProfile(imsAccessToken)`.

Currently we deal directly with email addresses from the IMS group members API. However, to support the Cloud Manager use case, we need to adapt to support project collaboration channel requests via access token. This method will bridge the gap from IMS user token to a user's email address, which we can then use to send them a Slack invitation.