### PR TITLE
Feat: add elevatedSlackClientWrapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13149,7 +13149,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "1.20.4",
+      "version": "1.20.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-dynamo": "1.2.5",
@@ -13655,7 +13655,7 @@
     },
     "packages/spacecat-shared-dynamo": {
       "name": "@adobe/spacecat-shared-dynamo",
-      "version": "1.3.13",
+      "version": "1.3.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.1.0",
@@ -13684,7 +13684,7 @@
     },
     "packages/spacecat-shared-gpt-client": {
       "name": "@adobe/spacecat-shared-gpt-client",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.1",
@@ -13720,7 +13720,7 @@
     },
     "packages/spacecat-shared-ims-client": {
       "name": "@adobe/spacecat-shared-ims-client",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.1",
@@ -13746,7 +13746,7 @@
     },
     "packages/spacecat-shared-rum-api-client": {
       "name": "@adobe/spacecat-shared-rum-api-client",
-      "version": "1.6.9",
+      "version": "1.6.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.1",
@@ -13770,7 +13770,7 @@
     },
     "packages/spacecat-shared-slack-client": {
       "name": "@adobe/spacecat-shared-slack-client",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "4.5.0",
@@ -13796,7 +13796,7 @@
     },
     "packages/spacecat-shared-utils": {
       "name": "@adobe/spacecat-shared-utils",
-      "version": "1.14.1",
+      "version": "1.14.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.1",

--- a/packages/spacecat-shared-slack-client/README.md
+++ b/packages/spacecat-shared-slack-client/README.md
@@ -87,6 +87,18 @@ const slackClient = BaseSlackClient.createFrom(context, target);
 const elevatedclient = ElevatedSlackClient.createFrom(context, target);
 ```
 
+Or, for an ElevatedSlackClient, use the `elevatedSlackClientWrapper`:
+
+```javascript
+import { elevatedSlackClientWrapper, SLACK_TARGETS } from '@adobe/spacecat-shared-slack-client';
+
+// .. Define `run` function ..
+
+export const main = wrap(run)
+  .with(elevatedSlackClientWrapper, { slackTarget: SLACK_TARGETS.WORKSPACE_EXTERNAL })
+  .with(secrets, { name: resolveSecretsName });
+```
+
 ### Posting a Message
 
 ```javascript

--- a/packages/spacecat-shared-slack-client/src/index.js
+++ b/packages/spacecat-shared-slack-client/src/index.js
@@ -12,6 +12,7 @@
 
 import BaseSlackClient from './clients/base-slack-client.js';
 import ElevatedSlackClient, { SLACK_STATUSES } from './clients/elevated-slack-client.js';
+import { elevatedSlackClientWrapper } from './wrappers/elevated-client-wrapper.js';
 
 const SLACK_TARGETS = {
   WORKSPACE_INTERNAL: 'WORKSPACE_INTERNAL',
@@ -23,4 +24,5 @@ export {
   SLACK_TARGETS,
   BaseSlackClient,
   ElevatedSlackClient,
+  elevatedSlackClientWrapper,
 };

--- a/packages/spacecat-shared-slack-client/src/wrappers/elevated-client-wrapper.js
+++ b/packages/spacecat-shared-slack-client/src/wrappers/elevated-client-wrapper.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import ElevatedSlackClient from '../clients/elevated-slack-client.js';
+
+/**
+ * Wrapper function to include an Elevated Slack client on the context object. Client will be
+ * available at `context.slack.elevatedClient`.
+ *
+ * @param {UniversalAction} fn
+ * @param {object} opts Options object. Must contain `slackTarget` indicating the target workspace
+ * @returns {function(object, UniversalContext): Promise<Response>}
+ */
+export function elevatedSlackClientWrapper(fn, opts = {}) {
+  return async (request, context) => {
+    const { slackTarget } = opts;
+    if (!context.slack?.elevatedClient) {
+      context.slack = context.slack || {};
+
+      context.slack.elevatedClient = ElevatedSlackClient.createFrom(
+        context,
+        slackTarget,
+      );
+    }
+
+    return fn(request, context);
+  };
+}

--- a/packages/spacecat-shared-slack-client/test/wrappers/elevated-client-wrapper.test.js
+++ b/packages/spacecat-shared-slack-client/test/wrappers/elevated-client-wrapper.test.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import {
+  elevatedSlackClientWrapper,
+} from '../../src/wrappers/elevated-client-wrapper.js';
+import { SLACK_TARGETS } from '../../src/index.js';
+
+chai.use(chaiAsPromised);
+
+const { expect } = chai;
+
+describe('Elevated Slack client action wrapper', () => {
+  let exampleHandler;
+  const baseEnv = {
+    SLACK_OPS_CHANNEL_WORKSPACE_EXTERNAL: 'mock-external-channel',
+    SLACK_TOKEN_WORKSPACE_INTERNAL_ELEVATED: 'mock-elevated-internal-token',
+    SLACK_TOKEN_WORKSPACE_EXTERNAL_ELEVATED: 'mock-elevated-external-token',
+  };
+
+  beforeEach(() => {
+    exampleHandler = sinon.spy(async () => new Response());
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should add an ElevatedSlackClient to context', async () => {
+    const opts = { slackTarget: SLACK_TARGETS.WORKSPACE_EXTERNAL };
+    await elevatedSlackClientWrapper(exampleHandler, opts)({}, { env: baseEnv });
+
+    expect(exampleHandler.calledOnce).to.be.true;
+    expect(exampleHandler.calledWith(sinon.match.any, sinon.match.has('slack'))).to.be.true;
+    expect(exampleHandler.calledWith(sinon.match.any, sinon.match.hasNested('slack.elevatedClient'))).to.be.true;
+    expect(exampleHandler.calledWith(sinon.match.any, sinon.match.hasNested('slack.elevatedClient.inviteUsersByEmail'))).to.be.true;
+  });
+
+  it('should not overwrite an existing ElevatedSlackClient', async () => {
+    let handlerWasChecked = false;
+
+    const opts = { slackTarget: SLACK_TARGETS.WORKSPACE_INTERNAL };
+    const baseContext = {
+      slack: { elevatedClient: 'existing' },
+      env: baseEnv,
+    };
+    await elevatedSlackClientWrapper(async (_, context) => {
+      expect(context.slack.elevatedClient).to.equal('existing');
+      handlerWasChecked = true;
+    }, opts)({}, baseContext);
+
+    expect(handlerWasChecked).to.be.true;
+  });
+
+  it('should throw an error if slackTarget is omitted from opts', async () => {
+    await expect(elevatedSlackClientWrapper(exampleHandler)({}, { env: baseEnv }))
+      .to.be.rejectedWith('Missing target for the Slack Client');
+  });
+});


### PR DESCRIPTION
Related ticket #207

Adds a wrapper for exposing an ElevatedSlackClient on the context at `context.slack.elevatedClient`.

Initial use case is to enable the API service to use an Elevated client in order to invite collab channel participants, in response to requests from Cloud Manager.