### PR TITLE
fix: strip slash only for / path

### DIFF
--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -44,12 +44,17 @@ function stripTrailingDot(url) {
 }
 
 /**
- * Strips the trailing slash from the end of the URL.
+ * Strips the trailing slash from the end of the URL if the path is '/'.
  * @param {string} url - The URL to modify.
  * @returns {string} - The URL with the trailing slash removed.
  */
 function stripTrailingSlash(url) {
-  return url.endsWith('/') ? url.slice(0, -1) : url;
+  // remove the scheme (if any) to simplify the slash check
+  const schemelessUrl = url.split('://')[1] || url;
+
+  return schemelessUrl.endsWith('/') && schemelessUrl.split('/').length === 2
+    ? url.slice(0, -1)
+    : url;
 }
 
 /**

--- a/packages/spacecat-shared-utils/test/url-helpers.test.js
+++ b/packages/spacecat-shared-utils/test/url-helpers.test.js
@@ -60,11 +60,13 @@ describe('URL Utility Functions', () => {
   });
 
   describe('stripTrailingSlash', () => {
-    it('should remove trailing slash from the end of the URL', () => {
+    it('should remove trailing slash from the end of the URL if path = /', () => {
       expect(stripTrailingSlash('example.com/')).to.equal('example.com');
-      expect(stripTrailingSlash('example.com//')).to.equal('example.com/');
-      expect(stripTrailingSlash('/example.com/')).to.equal('/example.com');
-      expect(stripTrailingSlash('example.com/abc/')).to.equal('example.com/abc');
+      expect(stripTrailingSlash('https://example.com/')).to.equal('https://example.com');
+      expect(stripTrailingSlash('example.com//')).to.equal('example.com//');
+      expect(stripTrailingSlash('/example.com/')).to.equal('/example.com/');
+      expect(stripTrailingSlash('example.com/abc/')).to.equal('example.com/abc/');
+      expect(stripTrailingSlash('https://example.com/abc/')).to.equal('https://example.com/abc/');
     });
 
     it('should not modify the URL if no trailing slash present', () => {
@@ -110,7 +112,11 @@ describe('URL Utility Functions', () => {
       nock('https://abc.com')
         .get('/')
         .reply(200);
+      nock('https://abc.com')
+        .get('/us/en/')
+        .reply(200);
       await expect(composeAuditURL('https://abc.com')).to.eventually.equal('abc.com');
+      await expect(composeAuditURL('https://abc.com/us/en/')).to.eventually.equal('abc.com/us/en/');
     });
     it('should follow redirect when composing audit URL', async () => {
       nock('https://abc.com')


### PR DESCRIPTION
Only remove the ending `/` for root page.