### PR TITLE
fix: ahrefs api call order_by

### DIFF
--- a/packages/spacecat-shared-ahrefs-client/src/index.js
+++ b/packages/spacecat-shared-ahrefs-client/src/index.js
@@ -120,7 +120,7 @@ export default class AhrefsAPIClient {
         'url',
         'sum_traffic',
       ].join(','),
-      order_by: 'sum_traffic_merged',
+      order_by: 'sum_traffic',
       date: new Date().toISOString().split('T')[0],
       target: url,
       limit: getLimit(limit, 2000),

--- a/packages/spacecat-shared-ahrefs-client/test/index.test.js
+++ b/packages/spacecat-shared-ahrefs-client/test/index.test.js
@@ -183,7 +183,7 @@ describe('AhrefsAPIClient', () => {
           'sum_traffic',
         ].join(','),
         where: JSON.stringify(filter),
-        order_by: 'sum_traffic_merged',
+        order_by: 'sum_traffic',
         date,
         target,
         limit: specifiedLimit,
@@ -199,7 +199,7 @@ describe('AhrefsAPIClient', () => {
       const result = await client.getTopPages(target, specifiedLimit);
       expect(result).to.deep.equal({
         result: topPagesResponse,
-        fullAuditRef: `https://example.com/site-explorer/top-pages?select=url%2Csum_traffic&order_by=sum_traffic_merged&date=${date}&target=${target}&limit=${specifiedLimit}&mode=prefix&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22sum_traffic%22%2C%22is%22%3A%5B%22gt%22%2C0%5D%7D%5D%7D`,
+        fullAuditRef: `https://example.com/site-explorer/top-pages?select=url%2Csum_traffic&order_by=sum_traffic&date=${date}&target=${target}&limit=${specifiedLimit}&mode=prefix&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22sum_traffic%22%2C%22is%22%3A%5B%22gt%22%2C0%5D%7D%5D%7D`,
       });
     });
   });


### PR DESCRIPTION
`sum_traffic_merged` can be used in the `order_by` only when we also set a `date_compared`, which we won't need/use
