### PR TITLE
feat: use ims-client for auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15418,6 +15418,7 @@
       "dependencies": {
         "@adobe/fetch": "4.1.2",
         "@adobe/helix-universal": "4.5.2",
+        "@adobe/spacecat-shared-ims-client": "^1.3.4",
         "@adobe/spacecat-shared-utils": "1.7.2"
       },
       "devDependencies": {
@@ -16495,6 +16496,7 @@
       "requires": {
         "@adobe/fetch": "4.1.2",
         "@adobe/helix-universal": "4.5.2",
+        "@adobe/spacecat-shared-ims-client": "^1.3.4",
         "@adobe/spacecat-shared-utils": "1.7.2",
         "chai": "4.4.1",
         "chai-as-promised": "7.1.1",

--- a/packages/spacecat-shared-gpt-client/README.md
+++ b/packages/spacecat-shared-gpt-client/README.md
@@ -7,11 +7,17 @@ The `FirefallClient` library offers a streamlined way to interact with the Firef
 To use the `FirefallClient`, you need to configure it with the following parameters:
 
 - `FIREFALL_API_ENDPOINT`: The endpoint URL for the Firefall API.
-- `FIREFALL_IMS_ORG`: Your IMS organization ID for Firefall.
 - `FIREFALL_API_KEY`: Your API key for accessing the Firefall API.
-- `FIREFALL_API_AUTH`: Your Bearer authorization token for the Firefall API.
+- `FIREFALL_API_CAPABILITY_NAME`: The capability name for the Firefall API.
 
 These parameters can be set through environment variables or passed directly to the `FirefallClient.createFrom` method.
+
+Additionally, the configuration for the `@adobe/spacecat-shared-ims-client` library is required to fetch the service access token from the IMS API:
+
+- `IMS_HOST`: The hostname of the IMS API.
+- `IMS_CLIENT_ID`: Your IMS client ID.
+- `IMS_CLIENT_CODE`: Your IMS client code, used for authentication.
+- `IMS_CLIENT_SECRET`: Your IMS client secret, used for authentication.
 
 ## Usage Examples
 
@@ -42,9 +48,12 @@ async function fetchInsights(prompt) {
     const client = FirefallClient.createFrom({
       env: {
         FIREFALL_API_ENDPOINT: 'https://api.firefall.example.com',
-        FIREFALL_IMS_ORG: 'yourImsOrgId',
         FIREFALL_API_KEY: 'yourApiKey',
-        FIREFALL_API_AUTH: 'yourApiAuth',
+        FIREFALL_API_CAPABILITY_NAME: 'yourCapabilityName',
+        IMS_HOST: 'ims.example.com',
+        IMS_CLIENT_ID: 'yourClientId',
+        IMS_CLIENT_CODE: 'yourClientCode',
+        IMS_CLIENT_SECRET: 'yourClientSecret',
       },
       log: console,
     });

--- a/packages/spacecat-shared-gpt-client/package.json
+++ b/packages/spacecat-shared-gpt-client/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@adobe/fetch": "4.1.2",
     "@adobe/helix-universal": "4.5.2",
+    "@adobe/spacecat-shared-ims-client": "1.3.4",
     "@adobe/spacecat-shared-utils": "1.7.2"
   },
   "devDependencies": {

--- a/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
+++ b/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
@@ -11,6 +11,7 @@
  */
 
 import { createUrl } from '@adobe/fetch';
+import { ImsClient } from '@adobe/spacecat-shared-ims-client';
 import { hasText, isObject, isValidUrl } from '@adobe/spacecat-shared-utils';
 
 import { fetch as httpFetch } from '../utils.js';
@@ -27,11 +28,12 @@ function validateFirefallResponse(response) {
 export default class FirefallClient {
   static createFrom(context) {
     const { log = console } = context;
+    const imsClient = ImsClient.createFrom(context);
+
     const {
       FIREFALL_API_ENDPOINT: apiEndpoint,
-      FIREFALL_IMS_ORG: imsOrg,
+      IMS_CLIENT_ID: imsOrg,
       FIREFALL_API_KEY: apiKey,
-      FIREFALL_API_AUTH: apiAuth,
       FIREFALL_API_POLL_INTERVAL: pollInterval = 2000,
       FIREFALL_API_CAPABILITY_NAME: capabilityName = 'gpt4_32k_completions_capability',
     } = context.env;
@@ -40,23 +42,15 @@ export default class FirefallClient {
       throw new Error('Missing Firefall API endpoint');
     }
 
-    if (!hasText(imsOrg)) {
-      throw new Error('Missing Firefall IMS Org');
-    }
-
     if (!hasText(apiKey)) {
       throw new Error('Missing Firefall API key');
     }
 
-    if (!hasText(apiAuth)) {
-      throw new Error('Missing Firefall API auth');
-    }
-
     return new FirefallClient({
-      apiAuth,
       apiEndpoint,
       apiKey,
       capabilityName,
+      imsClient,
       imsOrg,
       pollInterval,
     }, log);
@@ -66,10 +60,10 @@ export default class FirefallClient {
    * Creates a new Firefall client
    *
    * @param {Object} config - The configuration object.
-   * @param {string} config.apiAuth - The Bearer authorization token for Firefall.
    * @param {string} config.apiEndpoint - The API endpoint for Firefall.
    * @param {string} config.apiKey - The API Key for Firefall.
    * @param {string} config.capabilityName - The capability name for Firefall.
+   * @param {ImsClient} config.imsClient - The IMS Client.
    * @param {string} config.imsOrg - The IMS Org for Firefall.
    * @param {number} config.pollInterval - The interval to poll for job status.
    * @param {Object} log - The Logger.
@@ -78,6 +72,15 @@ export default class FirefallClient {
   constructor(config, log) {
     this.config = config;
     this.log = log;
+    this.imsClient = config.imsClient;
+    this.apiAuth = null;
+  }
+
+  async #getApiAuth() {
+    if (!this.apiAuth) {
+      this.apiAuth = await this.imsClient.getServiceAccessToken();
+    }
+    return this.apiAuth;
   }
 
   #logDuration(message, startTime) {
@@ -87,6 +90,8 @@ export default class FirefallClient {
   }
 
   async #submitJob(prompt) {
+    const apiAuth = await this.#getApiAuth();
+
     const body = JSON.stringify({
       input: prompt,
       capability_name: this.config.capabilityName,
@@ -97,7 +102,7 @@ export default class FirefallClient {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.config.apiAuth}`,
+        Authorization: `Bearer ${apiAuth}`,
         'x-api-key': this.config.apiKey,
         'x-gw-ims-org-id': this.config.imsOrg,
       },
@@ -113,6 +118,8 @@ export default class FirefallClient {
 
   /* eslint-disable no-await-in-loop */
   async #pollJobStatus(jobId) {
+    const apiAuth = await this.#getApiAuth();
+
     let jobStatusResponse;
     do {
       await new Promise(
@@ -124,7 +131,7 @@ export default class FirefallClient {
         {
           method: 'GET',
           headers: {
-            Authorization: `Bearer ${this.config.apiAuth}`,
+            Authorization: `Bearer ${apiAuth}`,
             'x-api-key': this.config.apiKey,
             'x-gw-ims-org-id': this.config.imsOrg,
           },


### PR DESCRIPTION
Right now the firefall client requires a manually generated, expiring access token to be provided. This was done in the prototype stage. In order to use the client with proper ims authentication, this PR switches to using the ims client.

- [x] Use IMS Client for lazy authentication
- [x] Remove manually provided access token (API_AUTH) config
- [x] Adjust readme
- [x] Update tests