### PR TITLE
fix: Refactor createResponse Function to Handle Non-JSON Content-Types

### DIFF
--- a/packages/spacecat-shared-http-utils/src/index.js
+++ b/packages/spacecat-shared-http-utils/src/index.js
@@ -12,6 +12,11 @@
 
 import { Response } from '@adobe/fetch';
 
+const HEADER_CONTENT_TYPE = 'content-type';
+const HEADER_ERROR = 'x-error';
+
+const CONTENT_TYPE_JSON = 'application/json';
+
 /**
  * Creates a response with a JSON body if the content-type is JSON. Defaults to 200 status.
  * If a header is already defined and has a different content-type, it is handled accordingly.
@@ -24,13 +29,13 @@ export function createResponse(body, status = 200, headers = {}) {
   let responseBody = body;
 
   // Check if headers already contain a 'content-type' key
-  if (!headers['content-type']) {
+  if (!headers[HEADER_CONTENT_TYPE]) {
     // Set content-type to JSON if not already set
-    Object.assign(headers, { 'content-type': 'application/json; charset=utf-8' });
+    Object.assign(headers, { [HEADER_CONTENT_TYPE]: `${CONTENT_TYPE_JSON}; charset=utf-8` });
   }
 
   // Stringify body if content-type is JSON
-  if (headers['content-type'].includes('application/json')) {
+  if (headers[HEADER_CONTENT_TYPE].includes(CONTENT_TYPE_JSON)) {
     responseBody = body === '' ? '' : JSON.stringify(body);
   }
 
@@ -60,21 +65,21 @@ export function found(location, body = '') {
 
 export function badRequest(message = 'bad request', headers = {}) {
   return createResponse({ message }, 400, {
-    'x-error': message,
+    [HEADER_ERROR]: message,
     ...headers,
   });
 }
 
 export function notFound(message = 'not found', headers = {}) {
   return createResponse({ message }, 404, {
-    'x-error': message,
+    [HEADER_ERROR]: message,
     ...headers,
   });
 }
 
 export function internalServerError(message = 'internal server error', headers = {}) {
   return createResponse({ message }, 500, {
-    'x-error': message,
+    [HEADER_ERROR]: message,
     ...headers,
   });
 }

--- a/packages/spacecat-shared-http-utils/src/index.js
+++ b/packages/spacecat-shared-http-utils/src/index.js
@@ -13,21 +13,33 @@
 import { Response } from '@adobe/fetch';
 
 /**
- * Creates a response with a JSON body. Defaults to 200 status.
- * @param {object} body - JSON body.
- * @param {number} status - Optional status code.
- * @param {object} headers - Optional headers.
+ * Creates a response with a JSON body if the content-type is JSON. Defaults to 200 status.
+ * If a header is already defined and has a different content-type, it is handled accordingly.
+ * @param {object} body - Response body.
+ * @param {number} [status=200] - Optional status code.
+ * @param {object} [headers={}] - Optional headers.
  * @return {Response} Response.
  */
 export function createResponse(body, status = 200, headers = {}) {
-  return new Response(
-    body === '' ? '' : JSON.stringify(body),
-    {
-      headers: { 'content-type': 'application/json; charset=utf-8', ...headers },
-      status,
-    },
-  );
+  let responseBody = body;
+
+  // Check if headers already contain a 'content-type' key
+  if (!headers['content-type']) {
+    // Set content-type to JSON if not already set
+    Object.assign(headers, { 'content-type': 'application/json; charset=utf-8' });
+  }
+
+  // Stringify body if content-type is JSON
+  if (headers['content-type'].includes('application/json')) {
+    responseBody = body === '' ? '' : JSON.stringify(body);
+  }
+
+  return new Response(responseBody, {
+    headers,
+    status,
+  });
 }
+
 export function ok(body = '') {
   return createResponse(body, 200);
 }

--- a/packages/spacecat-shared-http-utils/test/index.test.js
+++ b/packages/spacecat-shared-http-utils/test/index.test.js
@@ -12,7 +12,7 @@
 /* eslint-env mocha */
 import { expect } from 'chai';
 import {
-  ok, badRequest, notFound, internalServerError, noContent, found, created,
+  ok, badRequest, notFound, internalServerError, noContent, found, created, createResponse,
 } from '../src/index.js';
 
 async function testMethod(response, expectedCode, expectedBody) {
@@ -22,6 +22,25 @@ async function testMethod(response, expectedCode, expectedBody) {
 }
 
 describe('HTTP Response Functions', () => {
+  it('createResponse should handle text/plain content type', async () => {
+    const body = 'text body';
+    const headers = { 'content-type': 'text/plain' };
+    const response = await createResponse(body, 200, headers);
+    expect(response.status).to.equal(200);
+    expect(response.headers.get('content-type')).to.equal('text/plain');
+    const responseBody = await response.text();
+    expect(responseBody).to.equal(body);
+  });
+
+  it('createResponse should handle application/json content type', async () => {
+    const body = { success: true };
+    const response = await createResponse(body);
+    expect(response.status).to.equal(200);
+    expect(response.headers.get('content-type')).to.equal('application/json; charset=utf-8');
+    const responseBody = await response.json();
+    expect(responseBody).to.deep.equal(body);
+  });
+
   it('ok should return a 200 OK response with default body', async () => {
     const response = await ok();
     await testMethod(response, 200, '');


### PR DESCRIPTION
This PR refactors the createResponse function to ensure proper handling of response bodies based on the content-type header. It also includes code improvements to enhance readability and maintainability.