### PR TITLE
fix: allow domain properties for organic search data

### DIFF
--- a/packages/spacecat-shared-google-client/src/index.js
+++ b/packages/spacecat-shared-google-client/src/index.js
@@ -89,8 +89,8 @@ export default class GoogleClient {
   }
 
   async getOrganicSearchData(startDate, endDate, dimensions = ['date'], rowLimit = 1000, startRow = 0) {
-    if (!isValidUrl(this.siteUrl)) {
-      throw new Error('Error retrieving organic search data from Google API: Invalid site URL in secret');
+    if (!isValidUrl(this.siteUrl) && !this.siteUrl.startsWith('sc-domain')) {
+      throw new Error(`Error retrieving organic search data from Google API: Invalid site URL in secret (${this.siteUrl})`);
     }
     if (!isValidDate(startDate) || !isValidDate(endDate)) {
       throw new Error('Error retrieving organic search data from Google API: Invalid date format');


### PR DESCRIPTION
This PR enables the google client to fetch domain properties from GSC for organic search data