### PR TITLE
fix: expose traffic_domain in the broken backlinks audit data (SITES-22464)

### DIFF
--- a/packages/spacecat-shared-ahrefs-client/src/index.js
+++ b/packages/spacecat-shared-ahrefs-client/src/index.js
@@ -96,6 +96,7 @@ export default class AhrefsAPIClient {
         'title',
         'url_from',
         'url_to',
+        'traffic_domain',
       ].join(','),
       limit: getLimit(limit, 100),
       mode: 'prefix',

--- a/packages/spacecat-shared-ahrefs-client/test/index.test.js
+++ b/packages/spacecat-shared-ahrefs-client/test/index.test.js
@@ -161,6 +161,7 @@ describe('AhrefsAPIClient', () => {
             'title',
             'url_from',
             'url_to',
+            'traffic_domain',
           ].join(','),
           limit: 50,
           mode: 'prefix',
@@ -182,7 +183,7 @@ describe('AhrefsAPIClient', () => {
       const result = await client.getBrokenBacklinks('test-site.com');
       expect(result).to.deep.equal({
         result: backlinksResponse,
-        fullAuditRef: 'https://example.com/site-explorer/broken-backlinks?select=title%2Curl_from%2Curl_to&limit=50&mode=prefix&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=test-site.com&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D',
+        fullAuditRef: 'https://example.com/site-explorer/broken-backlinks?select=title%2Curl_from%2Curl_to%2Ctraffic_domain&limit=50&mode=prefix&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=test-site.com&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D',
       });
     });
   });


### PR DESCRIPTION
Fix: https://jira.corp.adobe.com/browse/SITES-22464

Expose `traffic_domain `- integer (10 units) - The referring domain's estimated monthly organic traffic from search
in order to have the "Est. traffic" value (see https://cq-dev.slack.com/archives/C05A45JBP9N/p1717513501293899?thread_ts=1717155663.015079&cid=C05A45JBP9N).

No additional cost, since we already include the property in the filter and order clause.