### PR TITLE
feat: Add update queries for import-job and import-url entites

### DIFF
--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -610,11 +610,17 @@ export interface DataAccess {
   createNewImportJob: (
     importJobData: object,
     ) => Promise<ImportJob>;
+  updateImportJob: (
+    importJob: ImportJob,
+    ) => Promise<ImportJob>;
   getImportUrlByID: (
     id: string,
     ) => Promise<ImportUrl | null>;
   createNewImportUrl: (
     importUrlData: object,
+    ) => Promise<ImportUrl>;
+  updateImportUrl: (
+    importUrl: ImportUrl,
     ) => Promise<ImportUrl>;
 
   // site candidate functions

--- a/packages/spacecat-shared-data-access/src/models/importer/import-job.js
+++ b/packages/spacecat-shared-data-access/src/models/importer/import-job.js
@@ -30,7 +30,6 @@ export const IMPORT_JOB_STATUS = {
 const ImportJob = (data) => {
   const self = Base(data);
 
-  self.getId = () => self.state.id;
   self.getBaseURL = () => self.state.baseURL;
   self.getApiKey = () => self.state.apiKey;
   self.getOptions = () => self.state.options;

--- a/packages/spacecat-shared-data-access/src/models/importer/import-job.js
+++ b/packages/spacecat-shared-data-access/src/models/importer/import-job.js
@@ -30,6 +30,7 @@ export const IMPORT_JOB_STATUS = {
 const ImportJob = (data) => {
   const self = Base(data);
 
+  self.getId = () => self.state.id;
   self.getBaseURL = () => self.state.baseURL;
   self.getApiKey = () => self.state.apiKey;
   self.getOptions = () => self.state.options;

--- a/packages/spacecat-shared-data-access/src/service/import-job/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/import-job/accessPatterns.js
@@ -76,7 +76,7 @@ export const updateImportJob = async (dynamoClient, config, log, importJob) => {
   const existingImportJob = await getImportJobByID(dynamoClient, config, log, importJob.getId());
 
   if (!isObject(existingImportJob)) {
-    throw new Error(`Import Job with id:${importJob.getId()} does not exist`);
+    throw new Error(`Import Job with id: ${importJob.getId()} does not exist`);
   }
 
   await dynamoClient.putItem(config.tableNameImportJobs, ImportJobDto.toDynamoItem(importJob));

--- a/packages/spacecat-shared-data-access/src/service/import-job/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/import-job/accessPatterns.js
@@ -76,7 +76,7 @@ export const updateImportJob = async (dynamoClient, config, log, importJob) => {
   const existingImportJob = await getImportJobByID(dynamoClient, config, log, importJob.getId());
 
   if (!isObject(existingImportJob)) {
-    throw new Error('Import Job does not exist');
+    throw new Error(`Import Job with id:${importJob.getId()} does not exist`);
   }
 
   await dynamoClient.putItem(config.tableNameImportJobs, ImportJobDto.toDynamoItem(importJob));

--- a/packages/spacecat-shared-data-access/src/service/import-job/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/import-job/accessPatterns.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import { isObject } from '@adobe/spacecat-shared-utils';
 import { ImportJobDto } from '../../dto/import-job.js';
 import { createImportJob } from '../../models/importer/import-job.js';
 
@@ -61,5 +62,24 @@ export const getImportJobsByStatus = async (dynamoClient, config, log, status) =
 export const createNewImportJob = async (dynamoClient, config, log, importJobData) => {
   const importJob = createImportJob(importJobData);
   await dynamoClient.putItem(config.tableNameImportJobs, ImportJobDto.toDynamoItem(importJob));
+  return importJob;
+};
+
+/**
+ * Updates an Import Job
+ * @param {DynamoClient} dynamoClient
+ * @param {Object} config
+ * @param {Logger} log
+ * @param {ImportJobDto} importJob
+ */
+export const updateImportJob = async (dynamoClient, config, log, importJob) => {
+  const existingImportJob = await getImportJobByID(dynamoClient, config, log, importJob.getId());
+
+  if (!isObject(existingImportJob)) {
+    throw new Error('Import Job does not exist');
+  }
+
+  await dynamoClient.putItem(config.tableNameImportJobs, ImportJobDto.toDynamoItem(importJob));
+
   return importJob;
 };

--- a/packages/spacecat-shared-data-access/src/service/import-job/index.js
+++ b/packages/spacecat-shared-data-access/src/service/import-job/index.js
@@ -14,6 +14,7 @@ import {
   createNewImportJob,
   getImportJobByID,
   getImportJobsByStatus,
+  updateImportJob,
 } from './accessPatterns.js';
 
 export const importJobFunctions = (dynamoClient, config, log) => ({
@@ -30,6 +31,12 @@ export const importJobFunctions = (dynamoClient, config, log) => ({
     status,
   ),
   createNewImportJob: (importJobData) => createNewImportJob(
+    dynamoClient,
+    config,
+    log,
+    importJobData,
+  ),
+  updateImportJob: (importJobData) => updateImportJob(
     dynamoClient,
     config,
     log,

--- a/packages/spacecat-shared-data-access/src/service/import-url/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/import-url/accessPatterns.js
@@ -67,7 +67,7 @@ export const updateImportUrl = async (dynamoClient, config, log, importUrl) => {
     throw new Error(`Import Url with ID:${importUrlData.getId()} does not exist`);
   }
 
-  await dynamoClient.putItem(config.tableNameImportUrls, ImportUrlDto.toDynamoItem(importUrlData));
+  await dynamoClient.putItem(config.tableNameImportUrls, ImportUrlDto.toDynamoItem(importUrl));
 
-  return importUrlData;
+  return importUrl;
 };

--- a/packages/spacecat-shared-data-access/src/service/import-url/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/import-url/accessPatterns.js
@@ -52,15 +52,15 @@ export const createNewImportUrl = async (dynamoClient, config, log, importUrlDat
  * @param {DynamoClient} dynamoClient
  * @param {Object} config
  * @param {Logger} log
- * @param {Object} importUrlData
+ * @param {Object} importUrl
  * @returns {ImportUrlDto}
  */
-export const updateImportUrl = async (dynamoClient, config, log, importUrlData) => {
+export const updateImportUrl = async (dynamoClient, config, log, importUrl) => {
   const existingImportUrl = await getImportUrlById(
     dynamoClient,
     config,
     log,
-    importUrlData.getId(),
+    importUrl.getId(),
   );
 
   if (!isObject(existingImportUrl)) {

--- a/packages/spacecat-shared-data-access/src/service/import-url/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/import-url/accessPatterns.js
@@ -64,7 +64,7 @@ export const updateImportUrl = async (dynamoClient, config, log, importUrl) => {
   );
 
   if (!isObject(existingImportUrl)) {
-    throw new Error(`Import Url with ID:${importUrlData.getId()} does not exist`);
+    throw new Error(`Import Url with ID:${importUrl.getId()} does not exist`);
   }
 
   await dynamoClient.putItem(config.tableNameImportUrls, ImportUrlDto.toDynamoItem(importUrl));

--- a/packages/spacecat-shared-data-access/src/service/import-url/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/import-url/accessPatterns.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import { isObject } from '@adobe/spacecat-shared-utils';
 import { ImportUrlDto } from '../../dto/import-url.js';
 import { createImportUrl } from '../../models/importer/import-url.js';
 
@@ -44,4 +45,29 @@ export const createNewImportUrl = async (dynamoClient, config, log, importUrlDat
     ImportUrlDto.toDynamoItem(importUrl),
   );
   return importUrl;
+};
+
+/**
+ * Update an existing Import Url
+ * @param {DynamoClient} dynamoClient
+ * @param {Object} config
+ * @param {Logger} log
+ * @param {Object} importUrlData
+ * @returns {ImportUrlDto}
+ */
+export const updateImportUrl = async (dynamoClient, config, log, importUrlData) => {
+  const existingImportUrl = await getImportUrlById(
+    dynamoClient,
+    config,
+    log,
+    importUrlData.getId(),
+  );
+
+  if (!isObject(existingImportUrl)) {
+    throw new Error(`Import Url with ID:${importUrlData.getId()} does not exist`);
+  }
+
+  await dynamoClient.putItem(config.tableNameImportUrls, ImportUrlDto.toDynamoItem(importUrlData));
+
+  return importUrlData;
 };

--- a/packages/spacecat-shared-data-access/src/service/import-url/index.js
+++ b/packages/spacecat-shared-data-access/src/service/import-url/index.js
@@ -10,7 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
-import { getImportUrlById, createNewImportUrl } from './accessPatterns.js';
+import {
+  getImportUrlById,
+  createNewImportUrl,
+  updateImportUrl,
+} from './accessPatterns.js';
 
 export const importUrlFunctions = (dynamoClient, config, log) => ({
   getImportUrlById: (id) => getImportUrlById(
@@ -20,6 +24,12 @@ export const importUrlFunctions = (dynamoClient, config, log) => ({
     id,
   ),
   createNewImportUrl: (importUrlData) => createNewImportUrl(
+    dynamoClient,
+    config,
+    log,
+    importUrlData,
+  ),
+  updateImportUrl: (importUrlData) => updateImportUrl(
     dynamoClient,
     config,
     log,

--- a/packages/spacecat-shared-data-access/src/service/import-url/index.js
+++ b/packages/spacecat-shared-data-access/src/service/import-url/index.js
@@ -29,10 +29,10 @@ export const importUrlFunctions = (dynamoClient, config, log) => ({
     log,
     importUrlData,
   ),
-  updateImportUrl: (importUrlData) => updateImportUrl(
+  updateImportUrl: (importUrl) => updateImportUrl(
     dynamoClient,
     config,
     log,
-    importUrlData,
+    importUrl,
   ),
 });

--- a/packages/spacecat-shared-data-access/test/unit/service/import-job/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-job/index.test.js
@@ -146,6 +146,7 @@ describe('Import Job Tests', () => {
         expect(mockDynamoClient.putItem).to.have.been.calledOnce;
         expect(result.getStatus()).to.equal('COMPLETE');
       });
+
       it('should throw an error if the ImportJob does not exist', async () => {
         const mockImportJobData = {
           id: 'test-id',

--- a/packages/spacecat-shared-data-access/test/unit/service/import-job/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-job/index.test.js
@@ -156,7 +156,7 @@ describe('Import Job Tests', () => {
         };
         const importJob = createImportJob(mockImportJobData);
         const result = exportedFunctions.updateImportJob(importJob);
-        expect(result).to.be.rejectedWith('Import Job does not exist');
+        expect(result).to.be.rejectedWith('Import Job with id:test-id does not exist');
       });
     });
   });

--- a/packages/spacecat-shared-data-access/test/unit/service/import-job/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-job/index.test.js
@@ -43,7 +43,7 @@ describe('Import Job Tests', () => {
         putItem: sinon.stub().resolves(),
       };
       mockLog = {
-        log: sinon.stub(),
+        log: console,
       };
       exportedFunctions = importJobFunctions(
         mockDynamoClient,

--- a/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
@@ -95,6 +95,7 @@ describe('Import Url Tests', () => {
         expect(mockDynamoClient.putItem).to.have.been.calledOnce;
         expect(result.getStatus()).to.equal('COMPLETE');
       });
+
       it('should throw an error when the importUrl does not exist', async () => {
         const mockImportUrl = {
           id: 'test-id',

--- a/packages/spacecat-shared-data-access/test/unit/service/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/index.test.js
@@ -82,11 +82,13 @@ describe('Data Access Object Tests', () => {
     'getImportJobByID',
     'getImportJobsByStatus',
     'createNewImportJob',
+    'updateImportJob',
   ];
 
   const importUrlFunctions = [
     'getImportUrlById',
     'createNewImportUrl',
+    'updateImportUrl',
   ];
 
   let dao;


### PR DESCRIPTION


## Related Issues
[SITES-22578](https://jira.corp.adobe.com/browse/SITES-22578)

Add the following queries to import-url and import-job entities:

- updateImportUrl
- updateImportJob