### PR TITLE
feat: introduce organic keywords for ahrefs client and top keyword in top pages

### DIFF
--- a/packages/spacecat-shared-ahrefs-client/src/index.d.ts
+++ b/packages/spacecat-shared-ahrefs-client/src/index.d.ts
@@ -70,4 +70,10 @@ export default class AhrefsAPIClient {
      */
   getBacklinks(url: string, limit?: number):
       Promise<{ result: object, fullAuditRef: string }>;
+
+  /**
+   * Asynchronous method to get organic keywords.
+   */
+  getOrganicKeywords(url: string, limit?: number):
+      Promise<{ result: object, fullAuditRef: string }>;
 }

--- a/packages/spacecat-shared-ahrefs-client/src/index.d.ts
+++ b/packages/spacecat-shared-ahrefs-client/src/index.d.ts
@@ -74,6 +74,6 @@ export default class AhrefsAPIClient {
   /**
    * Asynchronous method to get organic keywords.
    */
-  getOrganicKeywords(url: string, limit?: number):
+  getOrganicKeywords(url: string, country?: string, keywordFilter?: string[], limit?: number):
       Promise<{ result: object, fullAuditRef: string }>;
 }

--- a/packages/spacecat-shared-ahrefs-client/src/index.js
+++ b/packages/spacecat-shared-ahrefs-client/src/index.js
@@ -192,9 +192,14 @@ export default class AhrefsAPIClient {
       output: 'json',
     };
     if (keywordFilter.length > 0) {
-      queryParams.where = JSON.stringify({
-        or: keywordFilter.map((keyword) => ({ field: 'keyword', is: ['iphrase_match', keyword] })),
-      });
+      try {
+        queryParams.where = JSON.stringify({
+          or: keywordFilter.map((keyword) => ({ field: 'keyword', is: ['iphrase_match', keyword] })),
+        });
+      } catch (e) {
+        this.log.error(`Error parsing keyword filter: ${e.message}`);
+        throw new Error(`Error parsing keyword filter: ${e.message}`);
+      }
     }
 
     return this.sendRequest('/site-explorer/organic-keywords', queryParams);

--- a/packages/spacecat-shared-ahrefs-client/src/index.js
+++ b/packages/spacecat-shared-ahrefs-client/src/index.js
@@ -174,4 +174,26 @@ export default class AhrefsAPIClient {
 
     return this.sendRequest('/site-explorer/metrics-history', queryParams);
   }
+
+  async getOrganicKeywords(url, country = 'us', keywordFilter = [], limit = 200) {
+    const queryParams = {
+      country,
+      date: new Date().toISOString().split('T')[0],
+      select: [
+        'keyword',
+        'sum_traffic',
+        'best_position_url',
+      ].join(','),
+      order_by: 'sum_traffic:desc',
+      target: url,
+      limit: getLimit(limit, 2000),
+      mode: 'prefix',
+      where: JSON.stringify({
+        or: keywordFilter.map((keyword) => ({ field: 'keyword', is: ['iphrase_match', keyword] })),
+      }),
+      output: 'json',
+    };
+
+    return this.sendRequest('/site-explorer/organic-keywords', queryParams);
+  }
 }

--- a/packages/spacecat-shared-ahrefs-client/src/index.js
+++ b/packages/spacecat-shared-ahrefs-client/src/index.js
@@ -120,6 +120,7 @@ export default class AhrefsAPIClient {
       select: [
         'url',
         'sum_traffic',
+        'top_keyword',
       ].join(','),
       order_by: 'sum_traffic',
       date: new Date().toISOString().split('T')[0],

--- a/packages/spacecat-shared-ahrefs-client/src/index.js
+++ b/packages/spacecat-shared-ahrefs-client/src/index.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { isValidUrl } from '@adobe/spacecat-shared-utils';
+import { hasText, isValidUrl, isArray } from '@adobe/spacecat-shared-utils';
 import { context as h2, h1 } from '@adobe/fetch';
 
 /* c8 ignore next 3 */
@@ -177,6 +177,18 @@ export default class AhrefsAPIClient {
   }
 
   async getOrganicKeywords(url, country = 'us', keywordFilter = [], limit = 200) {
+    if (!hasText(url)) {
+      throw new Error(`Invalid URL: ${url}`);
+    }
+    if (!hasText(country)) {
+      throw new Error(`Invalid country: ${country}`);
+    }
+    if (!isArray(keywordFilter)) {
+      throw new Error(`Invalid keyword filter: ${keywordFilter}`);
+    }
+    if (!Number.isInteger(limit) || limit < 1) {
+      throw new Error(`Invalid limit: ${limit}`);
+    }
     const queryParams = {
       country,
       date: new Date().toISOString().split('T')[0],

--- a/packages/spacecat-shared-ahrefs-client/src/index.js
+++ b/packages/spacecat-shared-ahrefs-client/src/index.js
@@ -188,11 +188,13 @@ export default class AhrefsAPIClient {
       target: url,
       limit: getLimit(limit, 2000),
       mode: 'prefix',
-      where: JSON.stringify({
-        or: keywordFilter.map((keyword) => ({ field: 'keyword', is: ['iphrase_match', keyword] })),
-      }),
       output: 'json',
     };
+    if (keywordFilter.length > 0) {
+      queryParams.where = JSON.stringify({
+        or: keywordFilter.map((keyword) => ({ field: 'keyword', is: ['iphrase_match', keyword] })),
+      });
+    }
 
     return this.sendRequest('/site-explorer/organic-keywords', queryParams);
   }

--- a/packages/spacecat-shared-ahrefs-client/test/index.test.js
+++ b/packages/spacecat-shared-ahrefs-client/test/index.test.js
@@ -320,13 +320,13 @@ describe('AhrefsAPIClient', () => {
           target: 'test-site.com',
           limit: 200,
           mode: 'prefix',
+          output: 'json',
           where: JSON.stringify({
             or: [
               { field: 'keyword', is: ['iphrase_match', 'keyword1'] },
               { field: 'keyword', is: ['iphrase_match', 'keyword2'] },
             ],
           }),
-          output: 'json',
         })
         .reply(200, organicKeywordsResponse);
 
@@ -337,7 +337,37 @@ describe('AhrefsAPIClient', () => {
         .deep
         .equal({
           result: organicKeywordsResponse,
-          fullAuditRef: 'https://example.com/site-explorer/organic-keywords?country=us&date=2023-03-12&select=keyword%2Csum_traffic%2Cbest_position_url&order_by=sum_traffic%3Adesc&target=test-site.com&limit=200&mode=prefix&where=%7B%22or%22%3A%5B%7B%22field%22%3A%22keyword%22%2C%22is%22%3A%5B%22iphrase_match%22%2C%22keyword1%22%5D%7D%2C%7B%22field%22%3A%22keyword%22%2C%22is%22%3A%5B%22iphrase_match%22%2C%22keyword2%22%5D%7D%5D%7D&output=json',
+          fullAuditRef: 'https://example.com/site-explorer/organic-keywords?country=us&date=2023-03-12&select=keyword%2Csum_traffic%2Cbest_position_url&order_by=sum_traffic%3Adesc&target=test-site.com&limit=200&mode=prefix&output=json&where=%7B%22or%22%3A%5B%7B%22field%22%3A%22keyword%22%2C%22is%22%3A%5B%22iphrase_match%22%2C%22keyword1%22%5D%7D%2C%7B%22field%22%3A%22keyword%22%2C%22is%22%3A%5B%22iphrase_match%22%2C%22keyword2%22%5D%7D%5D%7D',
+        });
+    });
+
+    it('sends API request with no keyword filter if none are specified', async () => {
+      nock(config.apiBaseUrl)
+        .get('/site-explorer/organic-keywords')
+        .query({
+          country: 'us',
+          date: new Date().toISOString().split('T')[0],
+          select: [
+            'keyword',
+            'sum_traffic',
+            'best_position_url',
+          ].join(','),
+          order_by: 'sum_traffic:desc',
+          target: 'test-site.com',
+          limit: 200,
+          mode: 'prefix',
+          output: 'json',
+        })
+        .reply(200, organicKeywordsResponse);
+
+      const result = await client.getOrganicKeywords('test-site.com');
+
+      expect(result)
+        .to
+        .deep
+        .equal({
+          result: organicKeywordsResponse,
+          fullAuditRef: 'https://example.com/site-explorer/organic-keywords?country=us&date=2023-03-12&select=keyword%2Csum_traffic%2Cbest_position_url&order_by=sum_traffic%3Adesc&target=test-site.com&limit=200&mode=prefix&output=json',
         });
     });
   });

--- a/packages/spacecat-shared-ahrefs-client/test/index.test.js
+++ b/packages/spacecat-shared-ahrefs-client/test/index.test.js
@@ -52,10 +52,12 @@ describe('AhrefsAPIClient', () => {
       {
         url: 'page-url-1',
         sum_traffic: 100,
+        top_keyword: 'keyword1',
       },
       {
         url: 'page-url-2',
         sum_traffic: 300,
+        top_keyword: 'keyword2',
       },
     ],
   };
@@ -218,6 +220,7 @@ describe('AhrefsAPIClient', () => {
         select: [
           'url',
           'sum_traffic',
+          'top_keyword',
         ].join(','),
         where: JSON.stringify(filter),
         order_by: 'sum_traffic',
@@ -236,7 +239,7 @@ describe('AhrefsAPIClient', () => {
       const result = await client.getTopPages(target, specifiedLimit);
       expect(result).to.deep.equal({
         result: topPagesResponse,
-        fullAuditRef: `https://example.com/site-explorer/top-pages?select=url%2Csum_traffic&order_by=sum_traffic&date=${date}&target=${target}&limit=${specifiedLimit}&mode=prefix&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22sum_traffic%22%2C%22is%22%3A%5B%22gt%22%2C0%5D%7D%5D%7D`,
+        fullAuditRef: `https://example.com/site-explorer/top-pages?select=url%2Csum_traffic%2Ctop_keyword&order_by=sum_traffic&date=${date}&target=${target}&limit=${specifiedLimit}&mode=prefix&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22sum_traffic%22%2C%22is%22%3A%5B%22gt%22%2C0%5D%7D%5D%7D`,
       });
     });
   });

--- a/packages/spacecat-shared-ahrefs-client/test/index.test.js
+++ b/packages/spacecat-shared-ahrefs-client/test/index.test.js
@@ -373,5 +373,10 @@ describe('AhrefsAPIClient', () => {
           fullAuditRef: 'https://example.com/site-explorer/organic-keywords?country=us&date=2023-03-12&select=keyword%2Csum_traffic%2Cbest_position_url&order_by=sum_traffic%3Adesc&target=test-site.com&limit=200&mode=prefix&output=json',
         });
     });
+
+    it('throws error when keyword filter is not an array', async () => {
+      const result = client.getOrganicKeywords('test-site.com', 'us', 'keyword1');
+      await expect(result).to.be.rejectedWith('Error parsing keyword filter: keywordFilter.map is not a function');
+    });
   });
 });

--- a/packages/spacecat-shared-ahrefs-client/test/index.test.js
+++ b/packages/spacecat-shared-ahrefs-client/test/index.test.js
@@ -115,15 +115,11 @@ describe('AhrefsAPIClient', () => {
 
   describe('constructor', () => {
     it('throws error when api base url is missing', () => {
-      expect(() => new AhrefsAPIClient({}))
-        .to
-        .throw('Invalid Ahrefs API Base URL: undefined');
+      expect(() => new AhrefsAPIClient({})).to.throw('Invalid Ahrefs API Base URL: undefined');
     });
 
     it('throws error when fetch is not a function', () => {
-      expect(() => new AhrefsAPIClient(config, 'fetch'))
-        .to
-        .throw('"fetchAPI" must be a function');
+      expect(() => new AhrefsAPIClient(config, 'fetch')).to.throw('"fetchAPI" must be a function');
     });
   });
 
@@ -137,10 +133,7 @@ describe('AhrefsAPIClient', () => {
       };
 
       const ahrefsAPIClient = AhrefsAPIClient.createFrom(context);
-      expect(ahrefsAPIClient)
-        .to
-        .be
-        .instanceOf(AhrefsAPIClient);
+      expect(ahrefsAPIClient).to.be.instanceOf(AhrefsAPIClient);
     });
   });
 
@@ -151,13 +144,10 @@ describe('AhrefsAPIClient', () => {
         .reply(200, backlinksResponse);
 
       const result = await client.sendRequest('/some-endpoint');
-      expect(result)
-        .to
-        .deep
-        .equal({
-          result: backlinksResponse,
-          fullAuditRef: 'https://example.com/some-endpoint',
-        });
+      expect(result).to.deep.equal({
+        result: backlinksResponse,
+        fullAuditRef: 'https://example.com/some-endpoint',
+      });
     });
 
     it('throw error when API response is not ok', async () => {
@@ -165,10 +155,7 @@ describe('AhrefsAPIClient', () => {
         .get(/.*/)
         .reply(400, 'Bad Request');
 
-      await expect(client.sendRequest('/some-endpoint'))
-        .to
-        .be
-        .rejectedWith('Ahrefs API request failed with status: 400');
+      await expect(client.sendRequest('/some-endpoint')).to.be.rejectedWith('Ahrefs API request failed with status: 400');
     });
 
     it('throw error when API response body cannot be parsed as JSON', async () => {
@@ -176,10 +163,7 @@ describe('AhrefsAPIClient', () => {
         .get(/.*/)
         .reply(200, 'invalid-json');
 
-      await expect(client.sendRequest('/some-endpoint'))
-        .to
-        .be
-        .rejectedWith('Error parsing Ahrefs API response:');
+      await expect(client.sendRequest('/some-endpoint')).to.be.rejectedWith('Error parsing Ahrefs API response:');
     });
   });
 
@@ -201,39 +185,21 @@ describe('AhrefsAPIClient', () => {
           output: 'json',
           where: JSON.stringify({
             and: [
-              {
-                field: 'is_dofollow',
-                is: ['eq', 1],
-              },
-              {
-                field: 'is_content',
-                is: ['eq', 1],
-              },
-              {
-                field: 'domain_rating_source',
-                is: ['gte', 29.5],
-              },
-              {
-                field: 'traffic_domain',
-                is: ['gte', 500],
-              },
-              {
-                field: 'links_external',
-                is: ['lte', 300],
-              },
+              { field: 'is_dofollow', is: ['eq', 1] },
+              { field: 'is_content', is: ['eq', 1] },
+              { field: 'domain_rating_source', is: ['gte', 29.5] },
+              { field: 'traffic_domain', is: ['gte', 500] },
+              { field: 'links_external', is: ['lte', 300] },
             ],
           }),
         })
         .reply(200, backlinksResponse);
 
       const result = await client.getBrokenBacklinks('test-site.com');
-      expect(result)
-        .to
-        .deep
-        .equal({
-          result: backlinksResponse,
-          fullAuditRef: 'https://example.com/site-explorer/broken-backlinks?select=title%2Curl_from%2Curl_to%2Ctraffic_domain&limit=50&mode=prefix&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=test-site.com&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D',
-        });
+      expect(result).to.deep.equal({
+        result: backlinksResponse,
+        fullAuditRef: 'https://example.com/site-explorer/broken-backlinks?select=title%2Curl_from%2Curl_to%2Ctraffic_domain&limit=50&mode=prefix&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=test-site.com&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D',
+      });
     });
   });
 
@@ -245,10 +211,7 @@ describe('AhrefsAPIClient', () => {
       const date = mockDate.split('T')[0];
       const filter = {
         and: [
-          {
-            field: 'sum_traffic',
-            is: ['gt', 0],
-          },
+          { field: 'sum_traffic', is: ['gt', 0] },
         ],
       };
       const queryParams = {
@@ -271,13 +234,10 @@ describe('AhrefsAPIClient', () => {
         .reply(200, topPagesResponse);
 
       const result = await client.getTopPages(target, specifiedLimit);
-      expect(result)
-        .to
-        .deep
-        .equal({
-          result: topPagesResponse,
-          fullAuditRef: `https://example.com/site-explorer/top-pages?select=url%2Csum_traffic&order_by=sum_traffic&date=${date}&target=${target}&limit=${specifiedLimit}&mode=prefix&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22sum_traffic%22%2C%22is%22%3A%5B%22gt%22%2C0%5D%7D%5D%7D`,
-        });
+      expect(result).to.deep.equal({
+        result: topPagesResponse,
+        fullAuditRef: `https://example.com/site-explorer/top-pages?select=url%2Csum_traffic&order_by=sum_traffic&date=${date}&target=${target}&limit=${specifiedLimit}&mode=prefix&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22sum_traffic%22%2C%22is%22%3A%5B%22gt%22%2C0%5D%7D%5D%7D`,
+      });
     });
   });
 
@@ -300,39 +260,21 @@ describe('AhrefsAPIClient', () => {
           output: 'json',
           where: JSON.stringify({
             and: [
-              {
-                field: 'is_dofollow',
-                is: ['eq', 1],
-              },
-              {
-                field: 'is_content',
-                is: ['eq', 1],
-              },
-              {
-                field: 'domain_rating_source',
-                is: ['gte', 29.5],
-              },
-              {
-                field: 'traffic_domain',
-                is: ['gte', 500],
-              },
-              {
-                field: 'links_external',
-                is: ['lte', 300],
-              },
+              { field: 'is_dofollow', is: ['eq', 1] },
+              { field: 'is_content', is: ['eq', 1] },
+              { field: 'domain_rating_source', is: ['gte', 29.5] },
+              { field: 'traffic_domain', is: ['gte', 500] },
+              { field: 'links_external', is: ['lte', 300] },
             ],
           }),
         })
         .reply(200, backlinksResponse);
 
       const result = await client.getBacklinks('test-site.com', upperLimit * 3);
-      expect(result)
-        .to
-        .deep
-        .equal({
-          result: backlinksResponse,
-          fullAuditRef: `https://example.com/site-explorer/all-backlinks?select=title%2Curl_from%2Curl_to&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=test-site.com&limit=${upperLimit}&mode=prefix&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D`,
-        });
+      expect(result).to.deep.equal({
+        result: backlinksResponse,
+        fullAuditRef: `https://example.com/site-explorer/all-backlinks?select=title%2Curl_from%2Curl_to&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=test-site.com&limit=${upperLimit}&mode=prefix&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D`,
+      });
     });
   });
 
@@ -355,13 +297,10 @@ describe('AhrefsAPIClient', () => {
         .reply(200, organicTrafficMetricsResponse);
 
       const result = await client.getOrganicTraffic('test-site.com', startDate, endDate);
-      expect(result)
-        .to
-        .deep
-        .equal({
-          result: organicTrafficMetricsResponse,
-          fullAuditRef: 'https://example.com/site-explorer/metrics-history?target=test-site.com&date_from=2024-01-29&date_to=2024-02-05&history_grouping=weekly&volume_mode=average&mode=prefix&output=json',
-        });
+      expect(result).to.deep.equal({
+        result: organicTrafficMetricsResponse,
+        fullAuditRef: 'https://example.com/site-explorer/metrics-history?target=test-site.com&date_from=2024-01-29&date_to=2024-02-05&history_grouping=weekly&volume_mode=average&mode=prefix&output=json',
+      });
     });
   });
 

--- a/packages/spacecat-shared-ahrefs-client/test/index.test.js
+++ b/packages/spacecat-shared-ahrefs-client/test/index.test.js
@@ -374,9 +374,29 @@ describe('AhrefsAPIClient', () => {
         });
     });
 
+    it('throws error when keyword filter does not contain appropriate keyword items', async () => {
+      const result = client.getOrganicKeywords('test-site.com', 'us', [BigInt(123)]);
+      await expect(result).to.be.rejectedWith('Error parsing keyword filter: Do not know how to serialize a BigInt');
+    });
+
     it('throws error when keyword filter is not an array', async () => {
       const result = client.getOrganicKeywords('test-site.com', 'us', 'keyword1');
-      await expect(result).to.be.rejectedWith('Error parsing keyword filter: keywordFilter.map is not a function');
+      await expect(result).to.be.rejectedWith('Invalid keyword filter: keyword1');
+    });
+
+    it('throws error when url is not a string', async () => {
+      const result = client.getOrganicKeywords(123);
+      await expect(result).to.be.rejectedWith('Invalid URL: 123');
+    });
+
+    it('throws error when country is not a string', async () => {
+      const result = client.getOrganicKeywords('test-site.com', 123);
+      await expect(result).to.be.rejectedWith('Invalid country: 123');
+    });
+
+    it('throws error when limit is not an integer', async () => {
+      const result = client.getOrganicKeywords('test-site.com', 'us', [], 1.5);
+      await expect(result).to.be.rejectedWith('Invalid limit: 1.5');
     });
   });
 });

--- a/packages/spacecat-shared-ahrefs-client/test/index.test.js
+++ b/packages/spacecat-shared-ahrefs-client/test/index.test.js
@@ -79,6 +79,21 @@ describe('AhrefsAPIClient', () => {
     ],
   };
 
+  const organicKeywordsResponse = {
+    keywords: [
+      {
+        keyword: 'keyword1',
+        sum_traffic: 100,
+        best_position_url: 'url1',
+      },
+      {
+        keyword: 'keyword2',
+        sum_traffic: 200,
+        best_position_url: 'url2',
+      },
+    ],
+  };
+
   before('setup', function () {
     this.clock = sandbox.useFakeTimers({
       now: new Date(mockDate).getTime(),
@@ -100,11 +115,15 @@ describe('AhrefsAPIClient', () => {
 
   describe('constructor', () => {
     it('throws error when api base url is missing', () => {
-      expect(() => new AhrefsAPIClient({})).to.throw('Invalid Ahrefs API Base URL: undefined');
+      expect(() => new AhrefsAPIClient({}))
+        .to
+        .throw('Invalid Ahrefs API Base URL: undefined');
     });
 
     it('throws error when fetch is not a function', () => {
-      expect(() => new AhrefsAPIClient(config, 'fetch')).to.throw('"fetchAPI" must be a function');
+      expect(() => new AhrefsAPIClient(config, 'fetch'))
+        .to
+        .throw('"fetchAPI" must be a function');
     });
   });
 
@@ -118,7 +137,10 @@ describe('AhrefsAPIClient', () => {
       };
 
       const ahrefsAPIClient = AhrefsAPIClient.createFrom(context);
-      expect(ahrefsAPIClient).to.be.instanceOf(AhrefsAPIClient);
+      expect(ahrefsAPIClient)
+        .to
+        .be
+        .instanceOf(AhrefsAPIClient);
     });
   });
 
@@ -129,10 +151,13 @@ describe('AhrefsAPIClient', () => {
         .reply(200, backlinksResponse);
 
       const result = await client.sendRequest('/some-endpoint');
-      expect(result).to.deep.equal({
-        result: backlinksResponse,
-        fullAuditRef: 'https://example.com/some-endpoint',
-      });
+      expect(result)
+        .to
+        .deep
+        .equal({
+          result: backlinksResponse,
+          fullAuditRef: 'https://example.com/some-endpoint',
+        });
     });
 
     it('throw error when API response is not ok', async () => {
@@ -140,7 +165,10 @@ describe('AhrefsAPIClient', () => {
         .get(/.*/)
         .reply(400, 'Bad Request');
 
-      await expect(client.sendRequest('/some-endpoint')).to.be.rejectedWith('Ahrefs API request failed with status: 400');
+      await expect(client.sendRequest('/some-endpoint'))
+        .to
+        .be
+        .rejectedWith('Ahrefs API request failed with status: 400');
     });
 
     it('throw error when API response body cannot be parsed as JSON', async () => {
@@ -148,7 +176,10 @@ describe('AhrefsAPIClient', () => {
         .get(/.*/)
         .reply(200, 'invalid-json');
 
-      await expect(client.sendRequest('/some-endpoint')).to.be.rejectedWith('Error parsing Ahrefs API response:');
+      await expect(client.sendRequest('/some-endpoint'))
+        .to
+        .be
+        .rejectedWith('Error parsing Ahrefs API response:');
     });
   });
 
@@ -170,21 +201,39 @@ describe('AhrefsAPIClient', () => {
           output: 'json',
           where: JSON.stringify({
             and: [
-              { field: 'is_dofollow', is: ['eq', 1] },
-              { field: 'is_content', is: ['eq', 1] },
-              { field: 'domain_rating_source', is: ['gte', 29.5] },
-              { field: 'traffic_domain', is: ['gte', 500] },
-              { field: 'links_external', is: ['lte', 300] },
+              {
+                field: 'is_dofollow',
+                is: ['eq', 1],
+              },
+              {
+                field: 'is_content',
+                is: ['eq', 1],
+              },
+              {
+                field: 'domain_rating_source',
+                is: ['gte', 29.5],
+              },
+              {
+                field: 'traffic_domain',
+                is: ['gte', 500],
+              },
+              {
+                field: 'links_external',
+                is: ['lte', 300],
+              },
             ],
           }),
         })
         .reply(200, backlinksResponse);
 
       const result = await client.getBrokenBacklinks('test-site.com');
-      expect(result).to.deep.equal({
-        result: backlinksResponse,
-        fullAuditRef: 'https://example.com/site-explorer/broken-backlinks?select=title%2Curl_from%2Curl_to%2Ctraffic_domain&limit=50&mode=prefix&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=test-site.com&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D',
-      });
+      expect(result)
+        .to
+        .deep
+        .equal({
+          result: backlinksResponse,
+          fullAuditRef: 'https://example.com/site-explorer/broken-backlinks?select=title%2Curl_from%2Curl_to%2Ctraffic_domain&limit=50&mode=prefix&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=test-site.com&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D',
+        });
     });
   });
 
@@ -196,7 +245,10 @@ describe('AhrefsAPIClient', () => {
       const date = mockDate.split('T')[0];
       const filter = {
         and: [
-          { field: 'sum_traffic', is: ['gt', 0] },
+          {
+            field: 'sum_traffic',
+            is: ['gt', 0],
+          },
         ],
       };
       const queryParams = {
@@ -219,10 +271,13 @@ describe('AhrefsAPIClient', () => {
         .reply(200, topPagesResponse);
 
       const result = await client.getTopPages(target, specifiedLimit);
-      expect(result).to.deep.equal({
-        result: topPagesResponse,
-        fullAuditRef: `https://example.com/site-explorer/top-pages?select=url%2Csum_traffic&order_by=sum_traffic&date=${date}&target=${target}&limit=${specifiedLimit}&mode=prefix&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22sum_traffic%22%2C%22is%22%3A%5B%22gt%22%2C0%5D%7D%5D%7D`,
-      });
+      expect(result)
+        .to
+        .deep
+        .equal({
+          result: topPagesResponse,
+          fullAuditRef: `https://example.com/site-explorer/top-pages?select=url%2Csum_traffic&order_by=sum_traffic&date=${date}&target=${target}&limit=${specifiedLimit}&mode=prefix&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22sum_traffic%22%2C%22is%22%3A%5B%22gt%22%2C0%5D%7D%5D%7D`,
+        });
     });
   });
 
@@ -245,21 +300,39 @@ describe('AhrefsAPIClient', () => {
           output: 'json',
           where: JSON.stringify({
             and: [
-              { field: 'is_dofollow', is: ['eq', 1] },
-              { field: 'is_content', is: ['eq', 1] },
-              { field: 'domain_rating_source', is: ['gte', 29.5] },
-              { field: 'traffic_domain', is: ['gte', 500] },
-              { field: 'links_external', is: ['lte', 300] },
+              {
+                field: 'is_dofollow',
+                is: ['eq', 1],
+              },
+              {
+                field: 'is_content',
+                is: ['eq', 1],
+              },
+              {
+                field: 'domain_rating_source',
+                is: ['gte', 29.5],
+              },
+              {
+                field: 'traffic_domain',
+                is: ['gte', 500],
+              },
+              {
+                field: 'links_external',
+                is: ['lte', 300],
+              },
             ],
           }),
         })
         .reply(200, backlinksResponse);
 
       const result = await client.getBacklinks('test-site.com', upperLimit * 3);
-      expect(result).to.deep.equal({
-        result: backlinksResponse,
-        fullAuditRef: `https://example.com/site-explorer/all-backlinks?select=title%2Curl_from%2Curl_to&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=test-site.com&limit=${upperLimit}&mode=prefix&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D`,
-      });
+      expect(result)
+        .to
+        .deep
+        .equal({
+          result: backlinksResponse,
+          fullAuditRef: `https://example.com/site-explorer/all-backlinks?select=title%2Curl_from%2Curl_to&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=test-site.com&limit=${upperLimit}&mode=prefix&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D`,
+        });
     });
   });
 
@@ -282,10 +355,51 @@ describe('AhrefsAPIClient', () => {
         .reply(200, organicTrafficMetricsResponse);
 
       const result = await client.getOrganicTraffic('test-site.com', startDate, endDate);
-      expect(result).to.deep.equal({
-        result: organicTrafficMetricsResponse,
-        fullAuditRef: 'https://example.com/site-explorer/metrics-history?target=test-site.com&date_from=2024-01-29&date_to=2024-02-05&history_grouping=weekly&volume_mode=average&mode=prefix&output=json',
-      });
+      expect(result)
+        .to
+        .deep
+        .equal({
+          result: organicTrafficMetricsResponse,
+          fullAuditRef: 'https://example.com/site-explorer/metrics-history?target=test-site.com&date_from=2024-01-29&date_to=2024-02-05&history_grouping=weekly&volume_mode=average&mode=prefix&output=json',
+        });
+    });
+  });
+
+  describe('getOrganicKeywords', () => {
+    it('sends API request with appropriate endpoint query params', async () => {
+      nock(config.apiBaseUrl)
+        .get('/site-explorer/organic-keywords')
+        .query({
+          country: 'us',
+          date: new Date().toISOString().split('T')[0],
+          select: [
+            'keyword',
+            'sum_traffic',
+            'best_position_url',
+          ].join(','),
+          order_by: 'sum_traffic:desc',
+          target: 'test-site.com',
+          limit: 200,
+          mode: 'prefix',
+          where: JSON.stringify({
+            or: [
+              { field: 'keyword', is: ['iphrase_match', 'keyword1'] },
+              { field: 'keyword', is: ['iphrase_match', 'keyword2'] },
+            ],
+          }),
+          output: 'json',
+        })
+        .reply(200, organicKeywordsResponse);
+
+      const result = await client.getOrganicKeywords('test-site.com', 'us', ['keyword1', 'keyword2']);
+
+      expect(result)
+        .to
+        .deep
+        .equal({
+          result: organicKeywordsResponse,
+          fullAuditRef: 'https://example.com/site-explorer/organic-keywords?country=us&date=2023-03-12&select=keyword%2Csum_traffic%2Cbest_position_url&order_by=sum_traffic%3Adesc&target=test-site.com&limit=200&mode=prefix&where=%7B%22or%22%3A%5B%7B%22field%22%3A%22keyword%22%2C%22is%22%3A%5B%22iphrase_match%22%2C%22keyword1%22%5D%7D%2C%7B%22field%22%3A%22keyword%22%2C%22is%22%3A%5B%22iphrase_match%22%2C%22keyword2%22%5D%7D%5D%7D&output=json',
+        });
     });
   });
 });

--- a/packages/spacecat-shared-data-access/src/dto/site-top-page.js
+++ b/packages/spacecat-shared-data-access/src/dto/site-top-page.js
@@ -26,6 +26,7 @@ export const SiteTopPageDto = {
     siteId: siteTopPage.getSiteId(),
     url: siteTopPage.getURL(),
     traffic: siteTopPage.getTraffic(),
+    topKeyword: siteTopPage.getTopKeyword(),
     source: siteTopPage.getSource(),
     geo: siteTopPage.getGeo(),
     importedAt: siteTopPage.getImportedAt(),
@@ -34,13 +35,16 @@ export const SiteTopPageDto = {
 
   /**
    * Converts a DynamoDB item into a SiteTopPage object.
-   * @param {{siteId, url, traffic, source, geo, importedAt, SK: string}} item - DynamoDB item.
+   * @param {
+   *   {siteId, url, traffic, topKeyword, source, geo, importedAt, SK: string}
+   * } item - DynamoDB item.
    * @returns {SiteTopPage}
    */
   fromDynamoItem: (item) => createSiteTopPage({
     siteId: item.siteId,
     url: item.url,
     traffic: item.traffic,
+    topKeyword: item.topKeyword,
     source: item.source,
     geo: item.geo,
     importedAt: item.importedAt,

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -348,6 +348,12 @@ export interface SiteTopPage {
   getTraffic: () => number;
 
   /**
+   * Retrieves the keyword that brings the most organic traffic to the page.
+   * @returns {string} The keyword.
+   */
+  getTopKeyword: () => string;
+
+  /**
    * Retrieves the source of the site top page.
    * @returns {string} The source.
    */

--- a/packages/spacecat-shared-data-access/src/models/site-top-page.js
+++ b/packages/spacecat-shared-data-access/src/models/site-top-page.js
@@ -50,10 +50,6 @@ export const createSiteTopPage = (data) => {
     throw new Error('Source must be provided');
   }
 
-  if (!hasText(newState.topKeyword)) {
-    throw new Error('Top keyword must be provided');
-  }
-
   if (!hasText(newState.geo)) {
     newState.geo = DEFAULT_GEO;
   }

--- a/packages/spacecat-shared-data-access/src/models/site-top-page.js
+++ b/packages/spacecat-shared-data-access/src/models/site-top-page.js
@@ -23,6 +23,7 @@ const SiteTopPage = (data = {}) => {
   self.getSiteId = () => self.state.siteId;
   self.getURL = () => self.state.url;
   self.getTraffic = () => self.state.traffic;
+  self.getTopKeyword = () => self.state.topKeyword;
   self.getSource = () => self.state.source.toLowerCase();
   self.getGeo = () => self.state.geo;
   self.getImportedAt = () => self.state.importedAt;
@@ -47,6 +48,10 @@ export const createSiteTopPage = (data) => {
 
   if (!hasText(newState.source)) {
     throw new Error('Source must be provided');
+  }
+
+  if (!hasText(newState.topKeyword)) {
+    throw new Error('Top keyword must be provided');
   }
 
   if (!hasText(newState.geo)) {

--- a/packages/spacecat-shared-data-access/test/it/db.test.js
+++ b/packages/spacecat-shared-data-access/test/it/db.test.js
@@ -82,6 +82,7 @@ function checkSiteTopPage(siteTopPage) {
   expect(siteTopPage.getSiteId()).to.be.a('string');
   expect(siteTopPage.getURL()).to.be.a('string');
   expect(siteTopPage.getTraffic()).to.be.a('number');
+  expect(siteTopPage.getTopKeyword()).to.be.a('string');
   expect(siteTopPage.getSource()).to.be.a('string');
   expect(siteTopPage.getGeo()).to.be.a('string');
   expect(isIsoDate(siteTopPage.getImportedAt())).to.be.true;
@@ -767,6 +768,7 @@ describe('DynamoDB Integration Test', async () => {
       siteId,
       url: 'https://example12345.com/page-12345',
       traffic: 360420000,
+      topKeyword: 'keyword12345',
       source: 'rum',
       geo: 'au',
       importedAt: new Date().toISOString(),

--- a/packages/spacecat-shared-data-access/test/it/generateSampleData.js
+++ b/packages/spacecat-shared-data-access/test/it/generateSampleData.js
@@ -324,6 +324,7 @@ export default async function generateSampleData(
       SK: `ahrefs#global#${String(traffic).padStart(12, '0')}`,
       url: `${sites[i % numberOfSites].baseURL}/page-${i}`,
       traffic,
+      topKeyword: `keyword-${i}`,
       source: 'ahrefs',
       geo: 'global',
       importedAt: nowIso,

--- a/packages/spacecat-shared-data-access/test/unit/models/site-top-page.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site-top-page.test.js
@@ -19,6 +19,7 @@ const validData = {
   siteId: 'site123',
   url: 'https://www.example.com',
   traffic: 1000,
+  topKeyword: 'keyword',
   source: 'rum',
   geo: 'au',
   importedAt: new Date().toISOString(),
@@ -49,6 +50,11 @@ describe('SiteTopPage Model Tests', () => {
     it('throws an error if importedAt is not a valid ISO date', () => {
       expect(() => createSiteTopPage({ ...validData, importedAt: 'invalid-date' }))
         .to.throw('Imported at must be a valid ISO date');
+    });
+
+    it('throws an error if top keyword is not provided', () => {
+      expect(() => createSiteTopPage({ ...validData, topKeyword: '' }))
+        .to.throw('Top keyword must be provided');
     });
 
     it('creates a SiteTopPage object with valid data', () => {

--- a/packages/spacecat-shared-data-access/test/unit/models/site-top-page.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site-top-page.test.js
@@ -52,11 +52,6 @@ describe('SiteTopPage Model Tests', () => {
         .to.throw('Imported at must be a valid ISO date');
     });
 
-    it('throws an error if top keyword is not provided', () => {
-      expect(() => createSiteTopPage({ ...validData, topKeyword: '' }))
-        .to.throw('Top keyword must be provided');
-    });
-
     it('creates a SiteTopPage object with valid data', () => {
       const siteTopPage = createSiteTopPage(validData);
       expect(siteTopPage).to.be.an('object');

--- a/packages/spacecat-shared-data-access/test/unit/service/site-top-pages/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/site-top-pages/index.test.js
@@ -75,6 +75,7 @@ describe('Site Top Pages Access Pattern Tests', () => {
         url: 'https://www.example.com',
         traffic: 1000,
         source: 'gsc',
+        topKeyword: 'keyword',
         geo: 'au',
         importedAt: new Date().toISOString(),
       };
@@ -93,6 +94,7 @@ describe('Site Top Pages Access Pattern Tests', () => {
       expect(result[0].getSiteId()).to.equal(siteTopPageData.siteId);
       expect(result[0].getURL()).to.equal(siteTopPageData.url);
       expect(result[0].getTraffic()).to.equal(siteTopPageData.traffic);
+      expect(result[0].getTopKeyword()).to.equal(siteTopPageData.topKeyword);
       expect(result[0].getSource()).to.equal(siteTopPageData.source);
       expect(result[0].getGeo()).to.equal(siteTopPageData.geo);
       expect(result[0].getImportedAt()).to.equal(siteTopPageData.importedAt);
@@ -103,6 +105,7 @@ describe('Site Top Pages Access Pattern Tests', () => {
         siteId: 'site123',
         url: 'https://www.example.com',
         traffic: 1000,
+        topKeyword: 'keyword',
         source: 'gsc',
         geo: 'au',
         importedAt: new Date().toISOString(),
@@ -122,6 +125,7 @@ describe('Site Top Pages Access Pattern Tests', () => {
       expect(result[0].getSiteId()).to.equal(siteTopPageData.siteId);
       expect(result[0].getURL()).to.equal(siteTopPageData.url);
       expect(result[0].getTraffic()).to.equal(siteTopPageData.traffic);
+      expect(result[0].getTopKeyword()).to.equal(siteTopPageData.topKeyword);
       expect(result[0].getSource()).to.equal(siteTopPageData.source);
       expect(result[0].getGeo()).to.equal(siteTopPageData.geo);
       expect(result[0].getImportedAt()).to.equal(siteTopPageData.importedAt);
@@ -147,6 +151,7 @@ describe('Site Top Pages Access Pattern Tests', () => {
         siteId: 'site123',
         url: 'https://www.example.com',
         traffic: 1000,
+        topKeyword: 'keyword',
         source: 'rum',
         geo: 'us',
         importedAt: new Date().toISOString(),
@@ -162,6 +167,7 @@ describe('Site Top Pages Access Pattern Tests', () => {
       expect(result.getSiteId()).to.equal(siteTopPageData.siteId);
       expect(result.getURL()).to.equal(siteTopPageData.url);
       expect(result.getTraffic()).to.equal(siteTopPageData.traffic);
+      expect(result.getTopKeyword()).to.equal(siteTopPageData.topKeyword);
       expect(result.getSource()).to.equal(siteTopPageData.source);
       expect(result.getGeo()).to.equal(siteTopPageData.geo);
       expect(result.getImportedAt()).to.equal(siteTopPageData.importedAt);
@@ -172,6 +178,7 @@ describe('Site Top Pages Access Pattern Tests', () => {
         siteId: 'site123',
         url: 'https://www.example.com',
         traffic: 1000,
+        topKeyword: 'keyword',
         source: 'rum',
         geo: 'us',
         importedAt: new Date().toISOString(),


### PR DESCRIPTION
In context for [SITES-22601](https://jira.corp.adobe.com/browse/SITES-22601) (auto fix broken backlinks), we need access to the keywords of a page to determine the best possible alternate url (as suggested [by research](https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=AEMSites&title=SEO+%7C+Broken+Backlinks+Auto-Suggest)) 

### Cost estimation for the API consumption:

- **Request per page:**
Worst Case:
Each row in the query costs 12 Units (_sum_traffic_: 10, _keyword_: 1, _best_position_url_: 1)
Using a limit of 200 rows per request: 2400 Units (12 x 200).
For 200 broken backlinks: **480k Units** (2400 x 200)

- **For import:**
How many keywords should be imported?
For example, page with 20k keywords (with traffic):
Getting all keywords: **240k Units** (12 x 20 000)
Getting top 2k keywords: **24k Units** (12 x 2000)
