### PR TITLE
feat: query for URLs for a given jobID matching status

### DIFF
--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -622,6 +622,10 @@ export interface DataAccess {
   updateImportUrl: (
     importUrl: ImportUrl,
     ) => Promise<ImportUrl>;
+  getImportUrlsByJobIDAndStatus: (
+      jobId: string,
+      status: string,
+    ) => Promise<ImportUrl[]>;
 
   // site candidate functions
   getSiteCandidateByBaseURL: (baseURL: string) => Promise<SiteCandidate>;
@@ -666,6 +670,7 @@ interface DataAccessConfig {
   indexNameAllOrganizations: string,
   indexNameAllOrganizationsByImsOrgId: string,
   indexNameAllImportJobsByStatus: string,
+  indexNameAllImportUrlsByJobIdAndStatus: string,
   pkAllSites: string;
   pkAllLatestAudits: string;
   pkAllOrganizations: string;

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -622,7 +622,7 @@ export interface DataAccess {
   updateImportUrl: (
     importUrl: ImportUrl,
     ) => Promise<ImportUrl>;
-  getImportUrlsByJobIDAndStatus: (
+  getImportUrlsByJobIdAndStatus: (
       jobId: string,
       status: string,
     ) => Promise<ImportUrl[]>;

--- a/packages/spacecat-shared-data-access/src/index.js
+++ b/packages/spacecat-shared-data-access/src/index.js
@@ -33,6 +33,7 @@ const INDEX_NAME_ALL_SITES_BY_DELIVERY_TYPE = 'spacecat-services-all-sites-by-de
 const INDEX_NAME_ALL_LATEST_AUDIT_SCORES = 'spacecat-services-all-latest-audit-scores-dev';
 const INDEX_NAME_ALL_SITES_ORGANIZATIONS = 'spacecat-services-all-sites-organizations-dev';
 const INDEX_NAME_ALL_IMPORT_JOBS_BY_STATUS = 'spacecat-services-all-import-jobs-by-status-dev';
+const INDEX_NAME_ALL_IMPORT_URLS_BY_JOB_ID_AND_STATUS = 'spacecat-services-all-import-urls-by-job-id-and-status-dev';
 
 const PK_ALL_SITES = 'ALL_SITES';
 const PK_ALL_CONFIGURATIONS = 'ALL_CONFIGURATIONS';
@@ -65,6 +66,8 @@ export default function dataAccessWrapper(fn) {
         DYNAMO_INDEX_NAME_ALL_ORGANIZATIONS_BY_IMS_ORG_ID = INDEX_NAME_ALL_ORGANIZATIONS_BY_IMS_ORG_ID,
         DYNAMO_INDEX_NAME_ALL_SITES_ORGANIZATIONS = INDEX_NAME_ALL_SITES_ORGANIZATIONS,
         DYNAMO_INDEX_NAME_ALL_IMPORT_JOBS_BY_STATUS = INDEX_NAME_ALL_IMPORT_JOBS_BY_STATUS,
+        DYNAMO_INDEX_NAME_ALL_IMPORT_URLS_BY_JOB_ID_AND_STATUS =
+        INDEX_NAME_ALL_IMPORT_URLS_BY_JOB_ID_AND_STATUS,
       } = context.env;
 
       context.dataAccess = createDataAccess({
@@ -86,6 +89,7 @@ export default function dataAccessWrapper(fn) {
         indexNameAllLatestAuditScores: DYNAMO_INDEX_NAME_ALL_LATEST_AUDIT_SCORES,
         indexNameAllSitesOrganizations: DYNAMO_INDEX_NAME_ALL_SITES_ORGANIZATIONS,
         indexNameAllImportJobsByStatus: DYNAMO_INDEX_NAME_ALL_IMPORT_JOBS_BY_STATUS,
+        indexNameImportUrlsByJobIdAndStatus: DYNAMO_INDEX_NAME_ALL_IMPORT_URLS_BY_JOB_ID_AND_STATUS,
         pkAllSites: PK_ALL_SITES,
         pkAllOrganizations: PK_ALL_ORGANIZATIONS,
         pkAllLatestAudits: PK_ALL_LATEST_AUDITS,

--- a/packages/spacecat-shared-data-access/src/service/import-url/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/import-url/accessPatterns.js
@@ -71,3 +71,28 @@ export const updateImportUrl = async (dynamoClient, config, log, importUrl) => {
 
   return importUrl;
 };
+
+/**
+ * Get Import Urls by Job ID and Status
+ * @param {DynamoClient} dynamoClient
+ * @param {Object} config
+ * @param {Logger} log
+ * @param {string} jobId
+ * @param {string} status
+ * @returns {Promise<ImportUrlDto[]>}
+ */
+export const getImportUrlsByJobIdAndStatus = async (dynamoClient, config, log, jobId, status) => {
+  const items = await dynamoClient.query({
+    TableName: config.tableNameImportUrls,
+    IndexName: config.indexNameImportUrlsByJobIdAndStatus,
+    KeyConditionExpression: 'jobId = :jobId AND #status = :status',
+    ExpressionAttributeNames: {
+      '#status': 'status',
+    },
+    ExpressionAttributeValues: {
+      ':jobId': jobId,
+      ':status': status,
+    },
+  });
+  return items.map((item) => ImportUrlDto.fromDynamoItem(item));
+};

--- a/packages/spacecat-shared-data-access/src/service/import-url/index.js
+++ b/packages/spacecat-shared-data-access/src/service/import-url/index.js
@@ -14,6 +14,7 @@ import {
   getImportUrlById,
   createNewImportUrl,
   updateImportUrl,
+  getImportUrlsByJobIdAndStatus,
 } from './accessPatterns.js';
 
 export const importUrlFunctions = (dynamoClient, config, log) => ({
@@ -34,5 +35,12 @@ export const importUrlFunctions = (dynamoClient, config, log) => ({
     config,
     log,
     importUrl,
+  ),
+  getImportUrlsByJobIdAndStatus: (jobId, status) => getImportUrlsByJobIdAndStatus(
+    dynamoClient,
+    config,
+    log,
+    jobId,
+    status,
   ),
 });

--- a/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
@@ -108,5 +108,19 @@ describe('Import Url Tests', () => {
         await expect(result).to.be.rejectedWith('Import Url with ID:test-id does not exist');
       });
     });
+
+    describe('getImportUrlsByJobIdAndStatus', () => {
+      it('should return an array of ImportUrlDto when items are found', async () => {
+        const mockImportUrl = {
+          id: 'test-id',
+          status: 'RUNNING',
+          url: 'https://www.test.com',
+          jobId: 'test-job-id',
+        };
+        mockDynamoClient.query.resolves([mockImportUrl]);
+        const result = await exportedFunctions.getImportUrlsByJobIdAndStatus('test-job-id', 'RUNNING');
+        expect(result.length).to.equal(1);
+      });
+    });
   });
 });

--- a/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
@@ -120,6 +120,7 @@ describe('Import Url Tests', () => {
         mockDynamoClient.query.resolves([mockImportUrl]);
         const result = await exportedFunctions.getImportUrlsByJobIdAndStatus('test-job-id', 'RUNNING');
         expect(result.length).to.equal(1);
+        expect(result[0].getUrl()).to.equal('https://www.test.com');
       });
     });
   });

--- a/packages/spacecat-shared-data-access/test/unit/service/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/index.test.js
@@ -89,6 +89,7 @@ describe('Data Access Object Tests', () => {
     'getImportUrlById',
     'createNewImportUrl',
     'updateImportUrl',
+    'getImportUrlsByJobIdAndStatus',
   ];
 
   let dao;


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
[SITES-22580](https://jira.corp.adobe.com/browse/SITES-22580)

Query the import-url table for entries matching:

JobID
Status
