### PR TITLE
fix: #268 Import URL entities need a REDIRECT status, and additional properties for reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22086,7 +22086,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "1.29.0",
+      "version": "1.29.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-dynamo": "1.2.5",
@@ -22601,7 +22601,7 @@
     },
     "packages/spacecat-shared-dynamo": {
       "name": "@adobe/spacecat-shared-dynamo",
-      "version": "1.3.23",
+      "version": "1.3.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.1.0",
@@ -22630,7 +22630,7 @@
     },
     "packages/spacecat-shared-google-client": {
       "name": "@adobe/spacecat-shared-google-client",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",
@@ -24313,7 +24313,7 @@
     },
     "packages/spacecat-shared-slack-client": {
       "name": "@adobe/spacecat-shared-slack-client",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.0.5",
@@ -24360,7 +24360,7 @@
     },
     "packages/spacecat-shared-utils": {
       "name": "@adobe/spacecat-shared-utils",
-      "version": "1.15.8",
+      "version": "1.15.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",

--- a/packages/spacecat-shared-data-access/src/dto/import-url.js
+++ b/packages/spacecat-shared-data-access/src/dto/import-url.js
@@ -26,6 +26,9 @@ export const ImportUrlDto = {
     jobId: importUrl.getJobId(),
     url: importUrl.getUrl(),
     status: importUrl.getStatus(),
+    reason: importUrl.getReason(),
+    path: importUrl.getPath(),
+    file: importUrl.getFile(),
   }),
 
   /**
@@ -37,6 +40,9 @@ export const ImportUrlDto = {
       jobId: dynamoItem.jobId,
       url: dynamoItem.url,
       status: dynamoItem.status,
+      reason: dynamoItem.reason,
+      path: dynamoItem.path,
+      file: dynamoItem.file,
     };
     return createImportUrl(importUrlData);
   },

--- a/packages/spacecat-shared-data-access/src/models/importer/import-url.js
+++ b/packages/spacecat-shared-data-access/src/models/importer/import-url.js
@@ -10,12 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-import { isValidUrl } from '@adobe/spacecat-shared-utils';
+import { hasText, isValidUrl } from '@adobe/spacecat-shared-utils';
 import { Base } from '../base.js';
 import { ImportJobStatus } from './import-job.js';
 
 export const ImportUrlStatus = {
   PENDING: 'PENDING',
+  REDIRECT: 'REDIRECT',
   ...ImportJobStatus,
 };
 
@@ -31,11 +32,16 @@ const ImportUrl = (data) => {
   self.getJobId = () => self.state.jobId;
   self.getUrl = () => self.state.url;
   self.getStatus = () => self.state.status;
+  self.getReason = () => self.state.reason;
+  // Absolute path to the resource that is being imported for the given URL
+  self.getPath = () => self.state.path;
+  // Resulting path and filename of the imported .docx file
+  self.getFile = () => self.state.file;
 
   /**
-     * Updates the status of the ImportUrl
-     */
-  self.updateStatus = (status) => {
+   * Updates the status of the ImportUrl
+   */
+  self.setStatus = (status) => {
     if (!Object.values(ImportUrlStatus).includes(status)) {
       throw new Error(`Invalid Import URL status during update: ${status}`);
     }
@@ -45,6 +51,47 @@ const ImportUrl = (data) => {
 
     return self;
   };
+
+  /**
+   * Updates the reason that the import of this URL was not successful
+   */
+  self.setReason = (reason) => {
+    if (!hasText(reason)) {
+      return self; // no-op
+    }
+
+    self.state.reason = reason;
+    self.touch();
+    return self;
+  };
+
+  /**
+   * Updates the path of the ImportUrl
+   */
+  self.setPath = (path) => {
+    if (!hasText(path)) {
+      return self; // no-op
+    }
+
+    self.state.path = path;
+    self.touch();
+    return self;
+  };
+
+  /**
+   * Updates the file of the ImportUrl. This is the path and file name of the file which
+   * was imported.
+   */
+  self.setFile = (file) => {
+    if (!hasText(file)) {
+      return self; // no-op
+    }
+
+    self.state.file = file;
+    self.touch();
+    return self;
+  };
+
   return Object.freeze(self);
 };
 

--- a/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
@@ -88,7 +88,7 @@ describe('Import Url Tests', () => {
         mockDynamoClient.getItem.resolves(mockImportUrl);
 
         const importUrl = await exportedFunctions.getImportUrlById('test-id');
-        importUrl.updateStatus('COMPLETE');
+        importUrl.setStatus('COMPLETE');
         const result = await exportedFunctions.updateImportUrl(importUrl);
 
         expect(result).to.be.not.null;


### PR DESCRIPTION
## Related Issues

- #268 

In order to support generating the import-report.xlsx file for an import job, we need the ability to track if a URL was skipped because it was a redirect, or if it failed for another reason.

Screenshot from an example import-report included below:

![image](https://github.com/adobe/spacecat-shared/assets/1048207/34e25174-8ea5-4c12-b704-98ec87698ad4)

To support this, I'm proposing that we add the following properties to the import-url entities, in addition to the existing status:

```
reason: the reason that the import of a URL failed (could be the redirect destination in the case of a redirect)
path: absolute path to the resource that is being imported for the given URL
file: resulting path and filename of the imported .docx file
```

An additional status REDIRECT will also be added to `ImportUrlStatus` to facilitate generation of this report.


