### PR TITLE
feat: introduce fixed URLs in audit type config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21603,7 +21603,7 @@
     },
     "packages/spacecat-shared-ahrefs-client": {
       "name": "@adobe/spacecat-shared-ahrefs-client",
-      "version": "1.2.6",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",
@@ -22086,7 +22086,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "1.29.1",
+      "version": "1.32.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-dynamo": "1.2.5",
@@ -24288,7 +24288,7 @@
     },
     "packages/spacecat-shared-rum-api-client": {
       "name": "@adobe/spacecat-shared-rum-api-client",
-      "version": "2.0.3",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",
@@ -24360,7 +24360,7 @@
     },
     "packages/spacecat-shared-utils": {
       "name": "@adobe/spacecat-shared-utils",
-      "version": "1.15.10",
+      "version": "1.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",

--- a/packages/spacecat-shared-data-access/src/models/site/audit-config-type.js
+++ b/packages/spacecat-shared-data-access/src/models/site/audit-config-type.js
@@ -15,6 +15,7 @@ const AuditConfigType = (data = {}) => {
     disabled: data.disabled || false,
     excludedURLs: data.excludedURLs || [],
     manualOverwrites: data.manualOverwrites || [],
+    fixedURLs: data.fixedURLs || [],
   };
 
   const self = {
@@ -26,6 +27,10 @@ const AuditConfigType = (data = {}) => {
     getManualOverwrites: () => state.manualOverwrites,
     updateManualOverwrites: (manualOverwrites) => {
       state.manualOverwrites = manualOverwrites;
+    },
+    getFixedURLs: () => state.fixedURLs,
+    updateFixedURLs: (fixedURLs) => {
+      state.fixedURLs = fixedURLs;
     },
     updateDisabled: (newValue) => {
       state.disabled = newValue;
@@ -40,6 +45,7 @@ AuditConfigType.fromDynamoItem = (dynamoItem) => {
     disabled: dynamoItem.disabled,
     excludedURLs: dynamoItem.excludedURLs,
     manualOverwrites: dynamoItem.manualOverwrites,
+    fixedURLs: dynamoItem.fixedURLs,
   };
   return AuditConfigType(auditConfigTypeData);
 };
@@ -48,6 +54,7 @@ AuditConfigType.toDynamoItem = (auditConfigType) => ({
   disabled: auditConfigType.disabled(),
   excludedURLs: auditConfigType.getExcludedURLs(),
   manualOverwrites: auditConfigType.getManualOverwrites(),
+  fixedURLs: auditConfigType.getFixedURLs(),
 });
 
 export default AuditConfigType;

--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -35,6 +35,10 @@ export const configSchema = Joi.object({
           brokenTargetURL: Joi.string().optional(),
           targetURL: Joi.string().optional(),
         })).optional(),
+        fixedURLs: Joi.array().items(Joi.object({
+          brokenTargetURL: Joi.string().optional(),
+          targetURL: Joi.string().optional(),
+        })).optional(),
       }).unknown(true),
     ).unknown(true),
   }).unknown(true),

--- a/packages/spacecat-shared-data-access/test/unit/models/site/audit-config-type.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/audit-config-type.test.js
@@ -140,4 +140,26 @@ describe('AuditConfigType Tests', () => {
       expect(auditConfigType.getManualOverwrites()).to.be.an('array').that.is.empty;
     });
   });
+
+  describe('updateFixedURLs Method', () => {
+    it('updates the updateFixedURLs array', () => {
+      const auditConfigType = AuditConfigType();
+      const newFixedURLs = [
+        { brokenTargetURL: 'https://broken.co', targetURL: 'https://fixed.co' },
+        { brokenTargetURL: 'https://broken.link.co', targetURL: 'https://fixed.link.co' },
+      ];
+      auditConfigType.updateFixedURLs(newFixedURLs);
+      expect(auditConfigType.getFixedURLs()).to.eql(newFixedURLs);
+    });
+
+    it('updates the fixedURLs array to an empty array', () => {
+      const fixedURLs = [
+        { brokenTargetURL: 'https://broken.co', targetURL: 'https://fixed.co' },
+        { brokenTargetURL: 'https://broken.link.co', targetURL: 'https://fixed.link.co' },
+      ];
+      const auditConfigType = AuditConfigType({ fixedURLs });
+      auditConfigType.updateFixedURLs([]);
+      expect(auditConfigType.getFixedURLs()).to.be.an('array').that.is.empty;
+    });
+  });
 });


### PR DESCRIPTION
This PR introduces the stored fixes of the broken backlinks so they can be shown in the UI and dowloaded by the user.

Implements: https://jira.corp.adobe.com/browse/SITES-22925