### PR TITLE
fix: Click count is artificially inflating the conversion rate

### DIFF
--- a/packages/spacecat-shared-rum-api-client/src/functions/experiment.js
+++ b/packages/spacecat-shared-rum-api-client/src/functions/experiment.js
@@ -62,14 +62,49 @@ function handler(bundles) {
       const variantObject = getOrCreateVariantObject(experimentObject.variants, variantName);
       variantObject.views += weight;
 
+      const metrics = {};
+      for (const checkpoint of METRIC_CHECKPOINTS) {
+        metrics[checkpoint] = {};
+      }
       for (const event of bundle.events) {
         if (METRIC_CHECKPOINTS.includes(event.checkpoint)) {
           const { source, checkpoint } = event;
+          if (!metrics[checkpoint][source]) {
+            metrics[checkpoint][source] = weight;
+          } else {
+            metrics[checkpoint][source] += weight;
+          }
+        }
+      }
+      // combine metrics and variantObject, considering the interaction events
+      // only once during the session
+      for (const checkpoint of METRIC_CHECKPOINTS) {
+        // eslint-disable-next-line no-restricted-syntax
+        for (const source in metrics[checkpoint]) {
           if (!variantObject[checkpoint][source]) {
             variantObject[checkpoint][source] = weight;
           } else {
             variantObject[checkpoint][source] += weight;
           }
+        }
+      }
+      // add each metric to the variantObject's * count by weight
+      for (const checkpoint of Object.keys(metrics)) {
+        if (Object.keys(metrics[checkpoint]).length > 0) {
+          if (!variantObject[checkpoint]['*']) {
+            variantObject[checkpoint]['*'] = weight;
+          } else {
+            variantObject[checkpoint]['*'] += weight;
+          }
+        }
+      }
+      // add global interactionsCount if there's any interaction
+      const hasInteraction = Object.values(metrics).some((m) => Object.keys(m).length > 0);
+      if (hasInteraction) {
+        if (!variantObject.interactionsCount) {
+          variantObject.interactionsCount = weight;
+        } else {
+          variantObject.interactionsCount += weight;
         }
       }
     }

--- a/packages/spacecat-shared-rum-api-client/test/fixtures/bundles.json
+++ b/packages/spacecat-shared-rum-api-client/test/fixtures/bundles.json
@@ -16503,6 +16503,12 @@
           "target": "https://www.aem.live/docs",
           "source": ".header #navmenu-0",
           "timeDelta": 6317.60009765625
+        },
+        {
+          "checkpoint": "click",
+          "target": "https://www.aem.live/docs",
+          "source": ".header #navmenu-0",
+          "timeDelta": 7613.60009765625
         }
       ]
     },

--- a/packages/spacecat-shared-rum-api-client/test/fixtures/experiments.json
+++ b/packages/spacecat-shared-rum-api-client/test/fixtures/experiments.json
@@ -8,23 +8,27 @@
           "views": 1300,
           "click": {
             ".hero": 100,
+            "*": 400,
             ".header #navmenu-0": 100,
             ".roi-calculator .button": 100,
             ".hero .button": 100
           },
           "convert": {},
-          "formsubmit": {}
+          "formsubmit": {},
+          "interactionsCount": 400
         },
         {
           "name": "control",
           "views": 800,
           "click": {
             ".hero .button": 100,
+            "*": 500,
             ".header .button": 200,
             ".header #navmenu-0": 200
           },
           "convert": {},
-          "formsubmit": {}
+          "formsubmit": {},
+          "interactionsCount": 500
         }
       ]
     }


### PR DESCRIPTION
- click/convert/formsubmit metrics - each session can add 0/1 * (weight) at max to the metric count per selector - This answers which CTA was clicked
- add * to each metric, each session adding 0/1 * (weight), but with out selector - this answers whether there's click/convert/formsubmit event at all on the page, with out considering where it happened
- interactionsCount - a global property, 0/1 * (weight), if there's at least one click/convert/formsubmit per session

The example json from the test
```
{
  "https://www.aem.live/home": [
    {
      "experiment": "short-home",
      "variants": [
        {
          "name": "challenger-1",
          "views": 1300,
          "click": {
            ".hero": 100,
            "*": 400,
            ".header #navmenu-0": 100,
            ".roi-calculator .button": 100,
            ".hero .button": 100
          },
          "convert": {},
          "formsubmit": {},
          "interactionsCount": 400
        },
        {
          "name": "control",
          "views": 800,
          "click": {
            ".hero .button": 100,
            "*": 500,
            ".header .button": 200,
            ".header #navmenu-0": 200
          },
          "convert": {},
          "formsubmit": {},
          "interactionsCount": 500
        }
      ]
    }
  ],
  "https://www.aem.live/new-exp-page": [
    {
      "experiment": "",
      "variants": [
        {
          "name": "https://www.aem.live/some-other-page",
          "views": 100,
          "click": {},
          "convert": {},
          "formsubmit": {}
        }
      ]
    }
  ]
}
```

## Related Issues
[SITES-22951](https://jira.corp.adobe.com/browse/SITES-22951)

Thanks for contributing!
