### PR TITLE
feat: isNonEmptyObject

### DIFF
--- a/packages/spacecat-shared-utils/src/functions.js
+++ b/packages/spacecat-shared-utils/src/functions.js
@@ -67,6 +67,15 @@ function isObject(value) {
 }
 
 /**
+ * Checks if the given value is an object and contains properties of its own.
+ * @param {*} value - The value to check.
+ * @return {boolean} True if the value is a non-empty object, false otherwise.
+ */
+function isNonEmptyObject(value) {
+  return isObject(value) && Object.keys(value).length > 0;
+}
+
+/**
  * Determines if the given parameter is a string.
  *
  * @param {*} value - The value to check.
@@ -196,6 +205,7 @@ export {
   isIsoTimeOffsetsDate,
   isNumber,
   isObject,
+  isNonEmptyObject,
   isString,
   toBoolean,
   isValidUrl,

--- a/packages/spacecat-shared-utils/src/index.d.ts
+++ b/packages/spacecat-shared-utils/src/index.d.ts
@@ -29,6 +29,8 @@ export function isNumber(value: unknown): boolean;
 
 export function isObject(value: unknown): boolean;
 
+export function isNonEmptyObject(value: unknown): boolean;
+
 export function isString(value: unknown): boolean;
 
 export function toBoolean(value: unknown): boolean;

--- a/packages/spacecat-shared-utils/test/functions.test.js
+++ b/packages/spacecat-shared-utils/test/functions.test.js
@@ -26,6 +26,7 @@ import {
   isIsoTimeOffsetsDate,
   isNumber,
   isObject,
+  isNonEmptyObject,
   isString,
   toBoolean,
   arrayEquals,
@@ -188,6 +189,23 @@ describe('Shared functions', () => {
 
       expect(isObject({})).to.be.true;
       expect(isObject({ asd: 'dsa' })).to.be.true;
+    });
+
+    it('non empty object', () => {
+      const invalidObjects = [
+        null,
+        undefined,
+        123,
+        'dasd',
+        [],
+        ['dasd'],
+        {},
+      ];
+
+      invalidObjects.forEach((value) => expect(isNonEmptyObject(value)).to.be.false);
+
+      expect(isNonEmptyObject({})).to.be.false;
+      expect(isNonEmptyObject({ asd: 'dsa' })).to.be.true;
     });
 
     it('is string', () => {


### PR DESCRIPTION
Introduce `isNonEmptyObject` method, which checks whether an object is an object and has properties of its own.