### PR TITLE
fix: Fix the getFailedCount function in importJob interface

### DIFF
--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -491,7 +491,7 @@ export interface ImportJob {
   /**
    * Retrieves the failure count of the import job.
    */
-  getFailureCount: () => number;
+  getFailedCount: () => number;
 
   /**
    * Retrieves the importQueueId of the import job.


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
[SITES-23346](https://jira.corp.adobe.com/browse/SITES-23346
)

For consistency, would like to keep the export as getFailedCount().
Reference: https://github.com/adobe/spacecat-shared/blob/main/packages/spacecat-shared-data-access/src/dto/import-job.js#L39

