### PR TITLE
feat: update broken backlinks filter for ahrefs

### DIFF
--- a/packages/spacecat-shared-ahrefs-client/src/index.js
+++ b/packages/spacecat-shared-ahrefs-client/src/index.js
@@ -137,8 +137,6 @@ export default class AhrefsAPIClient {
   async getBacklinks(url, limit = 200) {
     const filter = {
       and: [
-        { field: 'is_dofollow', is: ['eq', 1] },
-        { field: 'is_content', is: ['eq', 1] },
         { field: 'domain_rating_source', is: ['gte', 29.5] },
         { field: 'traffic_domain', is: ['gte', 500] },
         { field: 'links_external', is: ['lte', 300] },

--- a/packages/spacecat-shared-ahrefs-client/test/index.test.js
+++ b/packages/spacecat-shared-ahrefs-client/test/index.test.js
@@ -263,8 +263,6 @@ describe('AhrefsAPIClient', () => {
           output: 'json',
           where: JSON.stringify({
             and: [
-              { field: 'is_dofollow', is: ['eq', 1] },
-              { field: 'is_content', is: ['eq', 1] },
               { field: 'domain_rating_source', is: ['gte', 29.5] },
               { field: 'traffic_domain', is: ['gte', 500] },
               { field: 'links_external', is: ['lte', 300] },
@@ -276,7 +274,7 @@ describe('AhrefsAPIClient', () => {
       const result = await client.getBacklinks('test-site.com', upperLimit * 3);
       expect(result).to.deep.equal({
         result: backlinksResponse,
-        fullAuditRef: `https://example.com/site-explorer/all-backlinks?select=title%2Curl_from%2Curl_to&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=test-site.com&limit=${upperLimit}&mode=prefix&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D`,
+        fullAuditRef: `https://example.com/site-explorer/all-backlinks?select=title%2Curl_from%2Curl_to&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=test-site.com&limit=${upperLimit}&mode=prefix&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D`,
       });
     });
   });


### PR DESCRIPTION
Update Ahrefs broken backlinks filter to include links that where found outside the biggest piece of content on the page and links that have a nofollow attribute.