### PR TITLE
fix: updating inferred start and end dates to reflect old and latest from RUM bundles

### DIFF
--- a/packages/spacecat-shared-rum-api-client/src/functions/experiment.js
+++ b/packages/spacecat-shared-rum-api-client/src/functions/experiment.js
@@ -55,31 +55,20 @@ function updateInferredStartAndEndDate(experimentObject, time) {
   const bundleDate = new Date(bundleTime);
   bundleDate.setHours(0, 0, 0, 0);
   if (!experimentObject.inferredStartDate && !experimentObject.inferredEndDate) {
-    // adding the inferredStartDate and inferredEndDate properties for the first time
     // eslint-disable-next-line no-param-reassign
     experimentObject.inferredStartDate = time;
-    // check if bundleTime is before yesterday
-    if (bundleDate < yesterday) {
-      // RUM data is delayed by a day, so if we don't have
-      // any RUM data for yesterday, so we can infer the endDate
-      // eslint-disable-next-line no-param-reassign
-      experimentObject.inferredEndDate = time;
-    } else {
-      // eslint-disable-next-line no-param-reassign
-      experimentObject.inferredEndDate = null;
-    }
+    // eslint-disable-next-line no-param-reassign
+    experimentObject.inferredEndDate = time;
   } else {
     const inferredStartDateObj = new Date(experimentObject.inferredStartDate);
+    const inferredEndDateObj = new Date(experimentObject.inferredEndDate);
     if (bundleTime < inferredStartDateObj) {
       // eslint-disable-next-line no-param-reassign
       experimentObject.inferredStartDate = time;
     }
-    if (bundleDate < yesterday) {
-      if (!experimentObject.inferredEndDate
-        || (bundleTime > new Date(experimentObject.inferredEndDate))) {
-        // eslint-disable-next-line no-param-reassign
-        experimentObject.inferredEndDate = time;
-      }
+    if (bundleTime > inferredEndDateObj) {
+      // eslint-disable-next-line no-param-reassign
+      experimentObject.inferredEndDate = time;
     }
   }
 }

--- a/packages/spacecat-shared-rum-api-client/src/functions/experiment.js
+++ b/packages/spacecat-shared-rum-api-client/src/functions/experiment.js
@@ -12,8 +12,7 @@
 
 const EXPERIMENT_CHECKPOINT = ['experiment'];
 const METRIC_CHECKPOINTS = ['click', 'convert', 'formsubmit'];
-const TOP_CHECKPOINT = ['top'];
-const CHECKPOINTS = [...TOP_CHECKPOINT, ...EXPERIMENT_CHECKPOINT, ...METRIC_CHECKPOINTS];
+const CHECKPOINTS = [...EXPERIMENT_CHECKPOINT, ...METRIC_CHECKPOINTS];
 
 function toClassName(name) {
   return typeof name === 'string'
@@ -74,32 +73,18 @@ function updateInferredStartAndEndDate(experimentObject, time) {
   }
 }
 
-/**
- * return the duplicate bundle if it exists
- * @param {*} bundles all the bundles
- * @param {*} bundle bundle to check for duplicates
- */
-function getDuplicateBundle(bundles, bundle) {
-  return bundles.find((b) => b.id === bundle.id && b.url !== bundle.url);
-}
-
 function handler(bundles) {
   const experimentInsights = {};
   for (const bundle of bundles) {
     const experimentEvent = bundle.events?.find((e) => e.checkpoint === 'experiment');
     if (experimentEvent) {
       const { url, weight, time } = bundle;
-      const duplicateBundle = getDuplicateBundle(bundles, bundle);
-      const experimentUrl = duplicateBundle ? duplicateBundle.url : url;
-      if (!experimentInsights[experimentUrl]) {
-        experimentInsights[experimentUrl] = [];
+      if (!experimentInsights[url]) {
+        experimentInsights[url] = [];
       }
       const experimentName = experimentEvent.source;
       const variantName = experimentEvent.target;
-      const experimentObject = getOrCreateExperimentObject(
-        experimentInsights[experimentUrl],
-        experimentName,
-      );
+      const experimentObject = getOrCreateExperimentObject(experimentInsights[url], experimentName);
       const variantObject = getOrCreateVariantObject(experimentObject.variants, variantName);
       updateInferredStartAndEndDate(experimentObject, time);
       variantObject.views += weight;

--- a/packages/spacecat-shared-rum-api-client/test/fixtures/bundles.json
+++ b/packages/spacecat-shared-rum-api-client/test/fixtures/bundles.json
@@ -1,23 +1,6 @@
 {
   "rumBundles": [
     {
-      "id": "future-bundle",
-      "host": "main--helix-website--adobe.aem.live",
-      "time": "2030-05-30T15:00:02.057Z",
-      "timeSlot": "2030-05-30T15:00:00.000Z",
-      "url": "https://www.aem.live/home",
-      "userAgent": "desktop:mac",
-      "weight": 100,
-      "events": [
-        {
-          "checkpoint": "experiment",
-          "target": "control",
-          "source": "short-home",
-          "timeDelta": 785
-        }
-      ]
-    },
-    {
       "id": "1Sdx",
       "host": "main--helix-website--adobe.aem.live",
       "time": "2024-05-31T00:00:05.017Z",

--- a/packages/spacecat-shared-rum-api-client/test/fixtures/bundles.json
+++ b/packages/spacecat-shared-rum-api-client/test/fixtures/bundles.json
@@ -691,7 +691,7 @@
       ]
     },
     {
-      "id": "",
+      "id": "lk23",
       "host": "main--helix-website--adobe.aem.live",
       "time": "2024-05-31T07:00:01.617Z",
       "timeSlot": "2024-05-31T07:00:00.000Z",
@@ -3014,7 +3014,7 @@
       ]
     },
     {
-      "id": "",
+      "id": "IDfa93a",
       "host": "main--helix-website--adobe.aem.live",
       "time": "2024-05-30T07:01:41.827Z",
       "timeSlot": "2024-05-30T07:00:00.000Z",
@@ -11658,7 +11658,7 @@
       ]
     },
     {
-      "id": "",
+      "id": "lkjd832",
       "host": "main--helix-website--adobe.aem.live",
       "time": "2024-05-28T06:00:00.362Z",
       "timeSlot": "2024-05-28T06:00:00.000Z",

--- a/packages/spacecat-shared-rum-api-client/test/fixtures/bundles.json
+++ b/packages/spacecat-shared-rum-api-client/test/fixtures/bundles.json
@@ -691,7 +691,7 @@
       ]
     },
     {
-      "id": "lk23",
+      "id": "",
       "host": "main--helix-website--adobe.aem.live",
       "time": "2024-05-31T07:00:01.617Z",
       "timeSlot": "2024-05-31T07:00:00.000Z",
@@ -3014,7 +3014,7 @@
       ]
     },
     {
-      "id": "IDfa93a",
+      "id": "",
       "host": "main--helix-website--adobe.aem.live",
       "time": "2024-05-30T07:01:41.827Z",
       "timeSlot": "2024-05-30T07:00:00.000Z",
@@ -11658,7 +11658,7 @@
       ]
     },
     {
-      "id": "lkjd832",
+      "id": "",
       "host": "main--helix-website--adobe.aem.live",
       "time": "2024-05-28T06:00:00.362Z",
       "timeSlot": "2024-05-28T06:00:00.000Z",

--- a/packages/spacecat-shared-rum-api-client/test/fixtures/cwv.json
+++ b/packages/spacecat-shared-rum-api-client/test/fixtures/cwv.json
@@ -9,7 +9,7 @@
     "inpCount": 3,
     "ttfb": 520.4500000476837,
     "ttfbCount": 18,
-    "pageviews": 2720
+    "pageviews": 2620
   },
   {
     "url": "https://www.aem.live/developer/block-collection",

--- a/packages/spacecat-shared-rum-api-client/test/fixtures/experiments.json
+++ b/packages/spacecat-shared-rum-api-client/test/fixtures/experiments.json
@@ -4,19 +4,6 @@
       "experiment": "short-home",
       "variants": [
         {
-          "name": "control",
-          "views": 900,
-          "click": {
-            ".hero .button": 100,
-            "*": 500,
-            ".header .button": 200,
-            ".header #navmenu-0": 200
-          },
-          "convert": {},
-          "formsubmit": {},
-          "interactionsCount": 500
-        },
-        {
           "name": "challenger-1",
           "views": 1300,
           "click": {
@@ -29,6 +16,19 @@
           "convert": {},
           "formsubmit": {},
           "interactionsCount": 400
+        },
+        {
+          "name": "control",
+          "views": 800,
+          "click": {
+            ".hero .button": 100,
+            "*": 500,
+            ".header .button": 200,
+            ".header #navmenu-0": 200
+          },
+          "convert": {},
+          "formsubmit": {},
+          "interactionsCount": 500
         }
       ],
       "inferredStartDate": "2024-05-26T03:00:02.380Z",

--- a/packages/spacecat-shared-rum-api-client/test/fixtures/trafficSources.json
+++ b/packages/spacecat-shared-rum-api-client/test/fixtures/trafficSources.json
@@ -1,11 +1,11 @@
 [
   {
     "url": "https://www.aem.live/home",
-    "total": 2720,
+    "total": 2620,
     "sources": [
       {
         "type": "owned:direct",
-        "views": 2320
+        "views": 2220
       },
       {
         "type": "earned:search",


### PR DESCRIPTION
inferred start and end dates will track the oldest and latest bundle dates so that audit can set the experiment status.

Fixes [SITES-23657](https://jira.corp.adobe.com/browse/SITES-23657)
