### PR TITLE
feat: Add API Key data attributes

### DIFF
--- a/packages/spacecat-shared-data-access/docs/schema.json
+++ b/packages/spacecat-shared-data-access/docs/schema.json
@@ -1135,6 +1135,87 @@
           }
         }
       }
+    },
+    {
+      "TableName": "spacecat-services-api-keys",
+      "KeyAttributes": {
+        "PartitionKey": {
+          "AttributeName": "id",
+          "AttributeType": "S"
+        }
+      },
+      "NonKeyAttributes": [
+        {
+          "AttributeName": "key",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "name",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "imsUserId",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "imsOrgId",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "createdAt",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "expiresAt",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "revokedAt",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "scopes",
+          "AttributeType": "M"
+        }
+      ],
+      "GlobalSecondaryIndexes": [
+      ],
+      "DataAccess": {
+        "MySql": {}
+      },
+      "SampleDataFormats": {
+        "id": [
+          "identifiers",
+          "UUID"
+        ]
+      },
+      "BillingMode": "PAY_PER_REQUEST",
+      "ProvisionedCapacitySettings": {
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": 0,
+          "WriteCapacityUnits": 0
+        },
+        "AutoScalingRead": {
+          "ScalableTargetRequest": {
+            "MinCapacity": 1,
+            "MaxCapacity": 10,
+            "ServiceRole": "AWSServiceRoleForApplicationAutoScaling_DynamoDBTable"
+          },
+          "ScalingPolicyConfiguration": {
+            "TargetValue": 70
+          }
+        },
+        "AutoScalingWrite": {
+          "ScalableTargetRequest": {
+            "MinCapacity": 1,
+            "MaxCapacity": 10,
+            "ServiceRole": "AWSServiceRoleForApplicationAutoScaling_DynamoDBTable"
+          },
+          "ScalingPolicyConfiguration": {
+            "TargetValue": 70
+          }
+        }
+      }
     }
   ]
 }

--- a/packages/spacecat-shared-data-access/docs/schema.json
+++ b/packages/spacecat-shared-data-access/docs/schema.json
@@ -1146,7 +1146,7 @@
       },
       "NonKeyAttributes": [
         {
-          "AttributeName": "key",
+          "AttributeName": "hashedKey",
           "AttributeType": "S"
         },
         {

--- a/packages/spacecat-shared-data-access/src/dto/api-key.js
+++ b/packages/spacecat-shared-data-access/src/dto/api-key.js
@@ -21,7 +21,7 @@ export const ApiKeyDto = {
      *          imsOrgId: *, expiresAt: *}}
      */
   toDynamoItem: (apiKey) => ({
-    key: apiKey.getKey(),
+    hashedKey: apiKey.getHashedKey(),
     name: apiKey.getName(),
     imsUserId: apiKey.getImsUserId(),
     imsOrgId: apiKey.getImsOrgId(),
@@ -38,7 +38,7 @@ export const ApiKeyDto = {
      */
   fromDynamoItem: (dynamoItem) => {
     const apiKeyData = {
-      key: dynamoItem.key,
+      hashedKey: dynamoItem.hashedKey,
       name: dynamoItem.name,
       imsUserId: dynamoItem.imsUserId,
       imsOrgId: dynamoItem.imsOrgId,

--- a/packages/spacecat-shared-data-access/src/dto/api-key.js
+++ b/packages/spacecat-shared-data-access/src/dto/api-key.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { createApiKey } from '../models/api-key.js';
+
+export const ApiKeyDto = {
+
+  /**
+     * Converts an ApiKey object into a DynamoDB item.
+     * @param apiKey
+     * @returns {{createdAt: *, name: *, imsUserId, scopes, revokedAt, key: *,
+     *          imsOrgId: *, expiresAt: *}}
+     */
+  toDynamoItem: (apiKey) => ({
+    key: apiKey.getKey(),
+    name: apiKey.getName(),
+    imsUserId: apiKey.getImsUserId(),
+    imsOrgId: apiKey.getImsOrgId(),
+    createdAt: apiKey.getCreatedAt(),
+    expiresAt: apiKey.getExpiresAt(),
+    revokedAt: apiKey.getRevokedAt(),
+    scopes: apiKey.getScopes(),
+  }),
+
+  /**
+     * Converts a DynamoDB item into an ApiKey object.
+     * @param dynamoItem
+     * @returns {ApiKey}
+     */
+  fromDynamoItem: (dynamoItem) => {
+    const apiKeyData = {
+      key: dynamoItem.key,
+      name: dynamoItem.name,
+      imsUserId: dynamoItem.imsUserId,
+      imsOrgId: dynamoItem.imsOrgId,
+      createdAt: dynamoItem.createdAt,
+      expiresAt: dynamoItem.expiresAt,
+      revokedAt: dynamoItem.revokedAt,
+      scopes: dynamoItem.scopes,
+    };
+
+    return createApiKey(apiKeyData);
+  },
+};

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -535,6 +535,57 @@ export interface ImportUrl {
 }
 
 /**
+ * Represents an API Key entity.
+ */
+export interface ApiKey {
+    /**
+     * Retrieves the ID of the API Key.
+     */
+    getId: () => string;
+
+    /**
+     * Retrieves the key of the API Key.
+     */
+    getKey: () => string;
+
+    /**
+     * Retrieves the name of the API Key.
+     */
+    getName: () => string;
+
+    /**
+    * Retrieves the imsUserId of the API Key.
+    */
+    getImsUserId: () => string;
+
+    /**
+    * Retrieves the imsOrgId of the API key
+    */
+    getImsOrgId: () => string;
+
+    /**
+     * Retrieves the createdAt of the API Key.
+     */
+    getCreatedAt: () => string;
+
+    /**
+     * Retrieves the expiresAt of the API Key.
+     */
+    getExpiresAt: () => string;
+
+    /**
+     * Retrieves the revokedAt of the API Key.
+     */
+    getRevokedAt: () => string;
+
+    /**
+     * Retrieves the scopes of the API Key.
+     */
+    getScopes: () => string;
+
+}
+
+/**
  * Represents an experiment entity.
  */
 export interface Experiment {
@@ -722,6 +773,12 @@ export interface DataAccess {
       jobId: string,
       status: string,
     ) => Promise<ImportUrl[]>;
+  getApiKeyById: (
+      id: string,
+    ) => Promise<ApiKey | null>;
+  createNewApiKey: (
+      apiKeyData: object,
+  ) => Promise<ApiKey>;
 
   // site candidate functions
   getSiteCandidateByBaseURL: (baseURL: string) => Promise<SiteCandidate>;
@@ -764,6 +821,7 @@ interface DataAccessConfig {
   tableNameImportJobs: string;
   tableNameImportUrls: string;
   tableNameExperiments: string;
+  tableNameApiKeys: string;
   indexNameAllKeyEventsBySiteId: string,
   indexNameAllSites: string;
   indexNameAllSitesOrganizations: string,

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -544,9 +544,9 @@ export interface ApiKey {
     getId: () => string;
 
     /**
-     * Retrieves the key of the API Key.
+     * Retrieves the hashed key value of the API Key.
      */
-    getKey: () => string;
+    getHashedKey: () => string;
 
     /**
      * Retrieves the name of the API Key.
@@ -773,8 +773,8 @@ export interface DataAccess {
       jobId: string,
       status: string,
     ) => Promise<ImportUrl[]>;
-  getApiKeyById: (
-      id: string,
+  getApiKeyByHashedKey: (
+      hashedKey: string,
     ) => Promise<ApiKey | null>;
   createNewApiKey: (
       apiKeyData: object,
@@ -832,6 +832,7 @@ interface DataAccessConfig {
   indexNameAllImportJobsByStatus: string,
   indexNameAllImportJobsByDateRange: string,
   indexNameAllImportUrlsByJobIdAndStatus: string,
+  indexNameApiKeyByHashedKey: string,
   pkAllSites: string;
   pkAllLatestAudits: string;
   pkAllOrganizations: string;

--- a/packages/spacecat-shared-data-access/src/index.js
+++ b/packages/spacecat-shared-data-access/src/index.js
@@ -25,6 +25,7 @@ const TABLE_NAME_SITE_TOP_PAGES = 'spacecat-services-site-top-pages-dev';
 const TABLE_NAME_IMPORT_JOBS = 'spacecat-services-import-jobs-dev';
 const TABLE_NAME_IMPORT_URLS = 'spacecat-services-import-urls-dev';
 const TABLE_NAME_EXPERIMENTS = 'spacecat-services-experiments-dev';
+const TABLE_NAME_API_KEYS = 'spacecat-services-api-keys-dev';
 
 const INDEX_NAME_ALL_KEY_EVENTS_BY_SITE_ID = 'spacecat-services-key-events-by-site-id';
 const INDEX_NAME_ALL_SITES = 'spacecat-services-all-sites-dev';
@@ -60,6 +61,7 @@ export default function dataAccessWrapper(fn) {
         DYNAMO_TABLE_NAME_IMPORT_JOBS = TABLE_NAME_IMPORT_JOBS,
         DYNAMO_TABLE_NAME_IMPORT_URLS = TABLE_NAME_IMPORT_URLS,
         DYNAMO_TABLE_NAME_EXPERIMENTS = TABLE_NAME_EXPERIMENTS,
+        DYNAMO_TABLE_NAME_API_KEYS = TABLE_NAME_API_KEYS,
         DYNAMO_INDEX_NAME_ALL_KEY_EVENTS_BY_SITE_ID = INDEX_NAME_ALL_KEY_EVENTS_BY_SITE_ID,
         DYNAMO_INDEX_NAME_ALL_SITES = INDEX_NAME_ALL_SITES,
         DYNAMO_INDEX_NAME_ALL_SITES_BY_DELIVERY_TYPE = INDEX_NAME_ALL_SITES_BY_DELIVERY_TYPE,
@@ -86,6 +88,7 @@ export default function dataAccessWrapper(fn) {
         tableNameImportJobs: DYNAMO_TABLE_NAME_IMPORT_JOBS,
         tableNameImportUrls: DYNAMO_TABLE_NAME_IMPORT_URLS,
         tableNameExperiments: DYNAMO_TABLE_NAME_EXPERIMENTS,
+        tableNameApiKeys: DYNAMO_TABLE_NAME_API_KEYS,
         indexNameAllKeyEventsBySiteId: DYNAMO_INDEX_NAME_ALL_KEY_EVENTS_BY_SITE_ID,
         indexNameAllSites: DYNAMO_INDEX_NAME_ALL_SITES,
         indexNameAllOrganizations: DYNAMO_INDEX_NAME_ALL_ORGANIZATIONS,

--- a/packages/spacecat-shared-data-access/src/index.js
+++ b/packages/spacecat-shared-data-access/src/index.js
@@ -37,6 +37,7 @@ const INDEX_NAME_ALL_SITES_ORGANIZATIONS = 'spacecat-services-all-sites-organiza
 const INDEX_NAME_ALL_IMPORT_JOBS_BY_STATUS = 'spacecat-services-all-import-jobs-by-status-dev';
 const INDEX_NAME_ALL_IMPORT_JOBS_BY_DATE_RANGE = 'spacecat-services-all-import-jobs-by-date-range-dev';
 const INDEX_NAME_ALL_IMPORT_URLS_BY_JOB_ID_AND_STATUS = 'spacecat-services-all-import-urls-by-job-id-and-status-dev';
+const INDEX_NAME_API_KEY_BY_HASHED_KEY = 'spacecat-services-api-key-by-hashed-key-dev';
 
 const PK_ALL_SITES = 'ALL_SITES';
 const PK_ALL_CONFIGURATIONS = 'ALL_CONFIGURATIONS';
@@ -74,6 +75,7 @@ export default function dataAccessWrapper(fn) {
         DYNAMO_INDEX_NAME_ALL_IMPORT_JOBS_BY_DATE_RANGE = INDEX_NAME_ALL_IMPORT_JOBS_BY_DATE_RANGE,
         DYNAMO_INDEX_NAME_ALL_IMPORT_URLS_BY_JOB_ID_AND_STATUS =
         INDEX_NAME_ALL_IMPORT_URLS_BY_JOB_ID_AND_STATUS,
+        DYNAMO_INDEX_NAME_API_KEY_BY_HASHED_KEY = INDEX_NAME_API_KEY_BY_HASHED_KEY,
       } = context.env;
 
       context.dataAccess = createDataAccess({
@@ -99,6 +101,7 @@ export default function dataAccessWrapper(fn) {
         indexNameAllImportJobsByStatus: DYNAMO_INDEX_NAME_ALL_IMPORT_JOBS_BY_STATUS,
         indexNameAllImportJobsByDateRange: DYNAMO_INDEX_NAME_ALL_IMPORT_JOBS_BY_DATE_RANGE,
         indexNameImportUrlsByJobIdAndStatus: DYNAMO_INDEX_NAME_ALL_IMPORT_URLS_BY_JOB_ID_AND_STATUS,
+        indexNameApiKeyByHashedKey: DYNAMO_INDEX_NAME_API_KEY_BY_HASHED_KEY,
         pkAllSites: PK_ALL_SITES,
         pkAllOrganizations: PK_ALL_ORGANIZATIONS,
         pkAllLatestAudits: PK_ALL_LATEST_AUDITS,

--- a/packages/spacecat-shared-data-access/src/models/api-key.js
+++ b/packages/spacecat-shared-data-access/src/models/api-key.js
@@ -11,14 +11,14 @@
  */
 
 import {
-  hasText, isIsoDate,
+  hasText, isIsoDate, isObject,
 } from '@adobe/spacecat-shared-utils';
 import { Base } from './base.js';
 
 const ApiKey = (data) => {
   const self = Base(data);
 
-  self.getKey = () => self.state.key;
+  self.getHashedKey = () => self.state.hashedKey;
   self.getName = () => self.state.name;
   self.getImsUserId = () => self.state.imsUserId;
   self.getImsOrgId = () => self.state.imsOrgId;
@@ -38,8 +38,8 @@ const ApiKey = (data) => {
 export const createApiKey = (data) => {
   const newState = { ...data };
 
-  if (!hasText(newState.key)) {
-    throw new Error(`Invalid Key: ${newState.key}`);
+  if (!hasText(newState.hashedKey)) {
+    throw new Error(`Invalid Hashed Key: ${newState.hashedKey}`);
   }
 
   if (!hasText(newState.name)) {
@@ -64,6 +64,16 @@ export const createApiKey = (data) => {
 
   if (!Array.isArray(newState.scopes)) {
     throw new Error(`Invalid scopes: ${newState.scopes}`);
+  }
+
+  for (const scope of newState.scopes) {
+    if (!isObject(scope)) {
+      throw new Error(`Invalid scope: ${scope}`);
+    }
+
+    if (!hasText(scope.name)) {
+      throw new Error(`Invalid scope name: ${scope.name}`);
+    }
   }
 
   return ApiKey(newState);

--- a/packages/spacecat-shared-data-access/src/models/api-key.js
+++ b/packages/spacecat-shared-data-access/src/models/api-key.js
@@ -17,6 +17,7 @@ import { Base } from './base.js';
 
 const scopeNames = ['sites.read_all', 'sites.write_all', 'organizations.read_all', 'organizations.write_all',
   'audits.read_all', 'audits.write_all', 'imports.read', 'imports.write', 'imports.read_all'];
+
 const ApiKey = (data) => {
   const self = Base(data);
 

--- a/packages/spacecat-shared-data-access/src/models/api-key.js
+++ b/packages/spacecat-shared-data-access/src/models/api-key.js
@@ -11,10 +11,12 @@
  */
 
 import {
-  hasText, isIsoDate, isObject,
+  hasText, isIsoDate, isObject, isValidUrl,
 } from '@adobe/spacecat-shared-utils';
 import { Base } from './base.js';
 
+const scopeNames = ['sites.read', 'sites.write', 'organizations.read', 'organizations.write',
+  'audits.read', 'audits.write', 'imports.read', 'imports.write', 'imports.read_all'];
 const ApiKey = (data) => {
   const self = Base(data);
 
@@ -73,6 +75,19 @@ export const createApiKey = (data) => {
 
     if (!hasText(scope.name)) {
       throw new Error(`Invalid scope name: ${scope.name}`);
+    }
+
+    if (!scopeNames.includes(scope.name)) {
+      throw new Error(`Scope name is not part of the pre-defined scopes: ${scope.name}`);
+    }
+
+    if (hasText(scope.domains) && !Array.isArray(scope.domains)) {
+      throw new Error(`Scope domains should be an array: ${scope.domains}`);
+    }
+    for (const domain of scope.domains) {
+      if (!isValidUrl(domain)) {
+        throw new Error(`Invalid domain: ${domain}`);
+      }
     }
   }
 

--- a/packages/spacecat-shared-data-access/src/models/api-key.js
+++ b/packages/spacecat-shared-data-access/src/models/api-key.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  hasText, isIsoDate,
+} from '@adobe/spacecat-shared-utils';
+import { Base } from './base.js';
+
+const ApiKey = (data) => {
+  const self = Base(data);
+
+  self.getKey = () => self.state.key;
+  self.getName = () => self.state.name;
+  self.getImsUserId = () => self.state.imsUserId;
+  self.getImsOrgId = () => self.state.imsOrgId;
+  self.getCreatedAt = () => self.state.createdAt;
+  self.getExpiresAt = () => self.state.expiresAt;
+  self.getRevokedAt = () => self.state.revokedAt;
+  self.getScopes = () => self.state.scopes;
+
+  return Object.freeze(self);
+};
+
+/**
+ * Creates a new ApiKey object.
+ * @param {Object} apiKeyData - The data for the ApiKey object.
+ * @returns {ApiKey} The new ApiKey object.
+ */
+export const createApiKey = (data) => {
+  const newState = { ...data };
+
+  if (!hasText(newState.key)) {
+    throw new Error(`Invalid Key: ${newState.key}`);
+  }
+
+  if (!hasText(newState.name)) {
+    throw new Error(`Invalid Name: ${newState.name}`);
+  }
+
+  if (hasText(newState.createdAt) && !isIsoDate(newState.createdAt)) {
+    throw new Error(`createdAt should be a valid ISO 8601 string: ${newState.createdAt}`);
+  }
+
+  if (!hasText(newState.createdAt)) {
+    newState.createdAt = new Date().toISOString();
+  }
+
+  if (hasText(newState.expiresAt) && !isIsoDate(newState.expiresAt)) {
+    throw new Error(`expiresAt should be a valid ISO 8601 string: ${newState.expiresAt}`);
+  }
+
+  if (hasText(newState.revokedAt) && !isIsoDate(newState.revokedAt)) {
+    throw new Error(`revokedAt should be a valid ISO 8601 string: ${newState.revokedAt}`);
+  }
+
+  if (!Array.isArray(newState.scopes)) {
+    throw new Error(`Invalid scopes: ${newState.scopes}`);
+  }
+
+  return ApiKey(newState);
+};

--- a/packages/spacecat-shared-data-access/src/models/api-key.js
+++ b/packages/spacecat-shared-data-access/src/models/api-key.js
@@ -15,8 +15,8 @@ import {
 } from '@adobe/spacecat-shared-utils';
 import { Base } from './base.js';
 
-const scopeNames = ['sites.read', 'sites.write', 'organizations.read', 'organizations.write',
-  'audits.read', 'audits.write', 'imports.read', 'imports.write', 'imports.read_all'];
+const scopeNames = ['sites.read_all', 'sites.write_all', 'organizations.read_all', 'organizations.write_all',
+  'audits.read_all', 'audits.write_all', 'imports.read', 'imports.write', 'imports.read_all'];
 const ApiKey = (data) => {
   const self = Base(data);
 

--- a/packages/spacecat-shared-data-access/src/service/api-key/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/api-key/accessPatterns.js
@@ -13,16 +13,27 @@
 import { ApiKeyDto } from '../../dto/api-key.js';
 
 /**
- * Get ApiKey by ID
- * @param {string} id
+ * Get ApiKey by Hashed Key
+ * @param {string} hashedKey
  * @param {DynamoClient} dynamoClient
  * @param {Object} config
  * @param {Logger} log
  * @returns {Promise<ApiKeyDto>}
  */
-export const getApiKeyById = async (id, dynamoClient, config, log) => {
-  const item = await dynamoClient.getItem(config.tableNameApiKeys, { id }, log);
-  return ApiKeyDto.fromDynamoItem(item);
+export const getApiKeyByHashedKey = async (hashedKey, dynamoClient, log, config) => {
+  const item = await dynamoClient.query({
+    TableName: config.tableNameApiKeys,
+    IndexName: config.indexNameApiKeyByHashedKey,
+    KeyConditionExpression: '#hashedKey = :hashedKey',
+    ExpressionAttributeNames: {
+      '#hashedKey': 'hashedKey',
+    },
+    ExpressionAttributeValues: {
+      ':gsi1pk': config.pkApiKey,
+      ':hashedKey': hashedKey,
+    },
+  });
+  ApiKeyDto.fromDynamoItem(item);
 };
 
 /**

--- a/packages/spacecat-shared-data-access/src/service/api-key/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/api-key/accessPatterns.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { ApiKeyDto } from '../../dto/api-key.js';
+
+/**
+ * Get ApiKey by ID
+ * @param {string} id
+ * @param {DynamoClient} dynamoClient
+ * @param {Object} config
+ * @param {Logger} log
+ * @returns {Promise<ApiKeyDto>}
+ */
+export const getApiKeyById = async (id, dynamoClient, config, log) => {
+  const item = await dynamoClient.getItem(config.tableNameApiKeys, { id }, log);
+  return ApiKeyDto.fromDynamoItem(item);
+};
+
+/**
+ * Create new ApiKey
+ * @param {ApiKey} apiKey
+ * @param {DynamoClient} dynamoClient
+ * @param {Object} config
+ * @param {Logger} log
+ * @returns {Promise<ApiKeyDto>}
+ */
+export const createNewApiKey = async (apiKey, dynamoClient, config, log) => {
+  const item = ApiKeyDto.toDynamoItem(apiKey);
+  await dynamoClient.putItem(config.tableNameApiKeys, item, log);
+  return item;
+};

--- a/packages/spacecat-shared-data-access/src/service/api-key/index.js
+++ b/packages/spacecat-shared-data-access/src/service/api-key/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { createNewApiKey, getApiKeyById } from './accessPatterns.js';
+
+export const apiKeyFunctions = (dynamoClient, config, log) => ({
+  getApiKeyById: (id) => getApiKeyById(id, dynamoClient, config, log),
+  createNewApiKey: (apiKey) => createNewApiKey(apiKey, dynamoClient, config, log),
+});

--- a/packages/spacecat-shared-data-access/src/service/api-key/index.js
+++ b/packages/spacecat-shared-data-access/src/service/api-key/index.js
@@ -10,9 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import { createNewApiKey, getApiKeyById } from './accessPatterns.js';
+import { createNewApiKey, getApiKeyByHashedKey } from './accessPatterns.js';
 
 export const apiKeyFunctions = (dynamoClient, config, log) => ({
-  getApiKeyById: (id) => getApiKeyById(id, dynamoClient, config, log),
+  getApiKeyByHashedKey: (hashedKey) => getApiKeyByHashedKey(hashedKey, dynamoClient, log, config),
   createNewApiKey: (apiKey) => createNewApiKey(apiKey, dynamoClient, config, log),
 });

--- a/packages/spacecat-shared-data-access/src/service/index.js
+++ b/packages/spacecat-shared-data-access/src/service/index.js
@@ -21,6 +21,7 @@ import { siteTopPagesFunctions } from './site-top-pages/index.js';
 import { importJobFunctions } from './import-job/index.js';
 import { importUrlFunctions } from './import-url/index.js';
 import { experimentFunctions } from './experiments/index.js';
+import { apiKeyFunctions } from './api-key/index.js';
 
 /**
  * Creates a data access object.
@@ -48,6 +49,7 @@ export const createDataAccess = (config, log = console) => {
   const importJobFuncs = importJobFunctions(dynamoClient, config, log);
   const importUrlFuncs = importUrlFunctions(dynamoClient, config, log);
   const experimentFuncs = experimentFunctions(dynamoClient, config, log);
+  const apiKeyFuncs = apiKeyFunctions(dynamoClient, config, log);
 
   return {
     ...auditFuncs,
@@ -60,5 +62,6 @@ export const createDataAccess = (config, log = console) => {
     ...importJobFuncs,
     ...importUrlFuncs,
     ...experimentFuncs,
+    ...apiKeyFuncs,
   };
 };

--- a/packages/spacecat-shared-data-access/test/unit/models/api-key.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/api-key.test.js
@@ -16,7 +16,7 @@ import { expect } from 'chai';
 import { createApiKey } from '../../../src/models/api-key.js';
 
 const validApiKey = {
-  key: 'test',
+  hashedKey: 'test',
   name: 'test-name',
   imsUserId: 'test-ims-user-id',
   imsOrgId: 'test-ims-org-id',
@@ -31,7 +31,7 @@ const validApiKey = {
 describe('ApiKey Model tests', () => {
   describe('Validation Tests', () => {
     it('throws an error if key is not a valid string', () => {
-      expect(() => createApiKey({ ...validApiKey, key: 123 })).to.throw('Invalid Key: 123');
+      expect(() => createApiKey({ ...validApiKey, hashedKey: 123 })).to.throw('Invalid Hashed Key: 123');
     });
 
     it('throws an error if name is not a valid string', () => {
@@ -61,6 +61,14 @@ describe('ApiKey Model tests', () => {
     it('throws an error if scopes is not an array', () => {
       expect(() => createApiKey({ ...validApiKey, scopes: 'invalid-scopes' })).to.throw('Invalid scopes: invalid-scopes');
     });
+
+    it('throws an error if scope is not an object', () => {
+      expect(() => createApiKey({ ...validApiKey, scopes: ['invalid-scope'] })).to.throw('Invalid scope: invalid-scope');
+    });
+
+    it('throws an error if scope does not have the name attribute', () => {
+      expect(() => createApiKey({ ...validApiKey, scopes: [{ domains: ['https://www.test.com'] }] })).to.throw('Invalid scope name: undefined');
+    });
   });
   describe('ApiKey Functionality Tests', () => {
     let apiKey;
@@ -68,8 +76,8 @@ describe('ApiKey Model tests', () => {
       apiKey = createApiKey({ ...validApiKey });
     });
 
-    it('gets key', () => {
-      expect(apiKey.getKey()).to.equal('test');
+    it('gets hashed key', () => {
+      expect(apiKey.getHashedKey()).to.equal('test');
     });
 
     it('gets name', () => {

--- a/packages/spacecat-shared-data-access/test/unit/models/api-key.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/api-key.test.js
@@ -23,7 +23,7 @@ const validApiKey = {
   expiresAt: '2024-05-29T14:26:00.000Z',
   revokedAt: '2024-05-29T14:26:00.000Z',
   scopes: [{
-    name: 'import.write',
+    name: 'imports.write',
     domains: ['https://www.test.com'],
   }],
 };
@@ -69,6 +69,18 @@ describe('ApiKey Model tests', () => {
     it('throws an error if scope does not have the name attribute', () => {
       expect(() => createApiKey({ ...validApiKey, scopes: [{ domains: ['https://www.test.com'] }] })).to.throw('Invalid scope name: undefined');
     });
+
+    it('throws an error if scope is not part of the predefined scopes', () => {
+      expect(() => createApiKey({ ...validApiKey, scopes: [{ name: 'invalid-scope', domains: ['https://www.test.com'] }] })).to.throw('Scope name is not part of the pre-defined scopes: invalid-scope');
+    });
+
+    it('throws an error if domains is not an array', () => {
+      expect(() => createApiKey({ ...validApiKey, scopes: [{ name: 'imports.write', domains: 'https://www.test.com' }] })).to.throw('Scope domains should be an array: https://www.test.com');
+    });
+
+    it('throws an error if domains does not have a valid url', () => {
+      expect(() => createApiKey({ ...validApiKey, scopes: [{ name: 'imports.write', domains: ['random-domain'] }] })).to.throw('Invalid domain: random-domain');
+    });
   });
   describe('ApiKey Functionality Tests', () => {
     let apiKey;
@@ -106,7 +118,7 @@ describe('ApiKey Model tests', () => {
 
     it('gets scopes', () => {
       expect(apiKey.getScopes()).to.deep.equal([{
-        name: 'import.write',
+        name: 'imports.write',
         domains: ['https://www.test.com'],
       }]);
     });

--- a/packages/spacecat-shared-data-access/test/unit/models/api-key.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/api-key.test.js
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { expect } from 'chai';
+import { createApiKey } from '../../../src/models/api-key.js';
+
+const validApiKey = {
+  key: 'test',
+  name: 'test-name',
+  imsUserId: 'test-ims-user-id',
+  imsOrgId: 'test-ims-org-id',
+  expiresAt: '2024-05-29T14:26:00.000Z',
+  revokedAt: '2024-05-29T14:26:00.000Z',
+  scopes: [{
+    name: 'import.write',
+    domains: ['https://www.test.com'],
+  }],
+};
+
+describe('ApiKey Model tests', () => {
+  describe('Validation Tests', () => {
+    it('throws an error if key is not a valid string', () => {
+      expect(() => createApiKey({ ...validApiKey, key: 123 })).to.throw('Invalid Key: 123');
+    });
+
+    it('throws an error if name is not a valid string', () => {
+      expect(() => createApiKey({ ...validApiKey, name: 123 })).to.throw('Invalid Name: 123');
+    });
+
+    it('throws an error if createdAt is not a valid date', () => {
+      expect(() => createApiKey({ ...validApiKey, createdAt: 'invalid-date' })).to.throw('createdAt should be a valid ISO 8601 string: invalid-date');
+    });
+
+    it('throws an error if expiresAt is not a valid date', () => {
+      expect(() => createApiKey({
+        ...validApiKey,
+        expiresAt: 'invalid-date',
+      })).to.throw('expiresAt should be a valid ISO 8601 string: invalid-date');
+    });
+
+    it('creates an ApiKey object with a createdAt date', () => {
+      const apiKey = createApiKey({ ...validApiKey, createdAt: '' });
+      expect(apiKey.getCreatedAt()).is.not.empty;
+    });
+
+    it('throws an error if revokedAt is not a valid date', () => {
+      expect(() => createApiKey({ ...validApiKey, revokedAt: 'invalid-date' })).to.throw('revokedAt should be a valid ISO 8601 string: invalid-date');
+    });
+
+    it('throws an error if scopes is not an array', () => {
+      expect(() => createApiKey({ ...validApiKey, scopes: 'invalid-scopes' })).to.throw('Invalid scopes: invalid-scopes');
+    });
+  });
+  describe('ApiKey Functionality Tests', () => {
+    let apiKey;
+    beforeEach(() => {
+      apiKey = createApiKey({ ...validApiKey });
+    });
+
+    it('gets key', () => {
+      expect(apiKey.getKey()).to.equal('test');
+    });
+
+    it('gets name', () => {
+      expect(apiKey.getName()).to.equal('test-name');
+    });
+
+    it('gets imsUserId', () => {
+      expect(apiKey.getImsUserId()).to.equal('test-ims-user-id');
+    });
+
+    it('gets imsOrgId', () => {
+      expect(apiKey.getImsOrgId()).to.equal('test-ims-org-id');
+    });
+
+    it('gets createdAt', () => {
+      expect(apiKey.getCreatedAt()).is.not.empty;
+    });
+
+    it('gets expiresAt', () => {
+      expect(apiKey.getExpiresAt()).to.equal('2024-05-29T14:26:00.000Z');
+    });
+
+    it('gets revokedAt', () => {
+      expect(apiKey.getRevokedAt()).to.equal('2024-05-29T14:26:00.000Z');
+    });
+
+    it('gets scopes', () => {
+      expect(apiKey.getScopes()).to.deep.equal([{
+        name: 'import.write',
+        domains: ['https://www.test.com'],
+      }]);
+    });
+  });
+});

--- a/packages/spacecat-shared-data-access/test/unit/service/api-key/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/api-key/index.test.js
@@ -60,7 +60,7 @@ describe('Api Key Tests', () => {
           expiresAt: '2024-05-29T14:26:00.000Z',
           revokedAt: '2024-05-29T14:26:00.000Z',
           scopes: [{
-            name: 'import.write',
+            name: 'imports.write',
             domains: ['https://www.test.com'],
           }],
         };
@@ -83,7 +83,7 @@ describe('Api Key Tests', () => {
           expiresAt: '2024-05-29T14:26:00.000Z',
           revokedAt: '2024-05-29T14:26:00.000Z',
           scopes: [{
-            name: 'import.write',
+            name: 'imports.write',
             domains: ['https://www.test.com'],
           }],
         });

--- a/packages/spacecat-shared-data-access/test/unit/service/api-key/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/api-key/index.test.js
@@ -53,7 +53,7 @@ describe('Api Key Tests', () => {
     describe('getApiKeyByKey', () => {
       it('should return an ApiKeyDto when an item is found', async () => {
         const mockApiKey = {
-          key: 'test-key',
+          hashedKey: 'test-key',
           name: 'test-name',
           imsUserId: 'test-ims-user-id',
           imsOrgId: 'test-ims-org-id',
@@ -64,19 +64,19 @@ describe('Api Key Tests', () => {
             domains: ['https://www.test.com'],
           }],
         };
-        mockDynamoClient.getItem.resolves(mockApiKey);
+        mockDynamoClient.query.resolves(mockApiKey);
 
-        const apiKey = await exportedFunctions.getApiKeyById('test-key');
+        const apiKey = await exportedFunctions.getApiKeyByHashedKey('test-key');
 
         expect(apiKey).to.be.not.null;
-        expect(mockDynamoClient.getItem).to.have.been.calledOnce;
+        expect(mockDynamoClient.query).to.have.been.calledOnce;
       });
     });
 
     describe('createNewApiKey', () => {
       it('should create a new ApiKey', async () => {
         const apiKey = createApiKey({
-          key: 'test-key',
+          hashedKey: 'test-key',
           name: 'test-name',
           imsUserId: 'test-ims-user-id',
           imsOrgId: 'test-ims-org-id',

--- a/packages/spacecat-shared-data-access/test/unit/service/api-key/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/api-key/index.test.js
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { apiKeyFunctions } from '../../../../src/service/api-key/index.js';
+import { createApiKey } from '../../../../src/models/api-key.js';
+
+chai.use(sinonChai);
+chai.use(chaiAsPromised);
+
+const { expect } = chai;
+
+const TEST_DA_CONFIG = {
+  tableNameApiKeys: 'test-api-keys',
+};
+
+describe('Api Key Tests', () => {
+  describe('Api Key Functions', () => {
+    let mockDynamoClient;
+    let mockLog;
+    let exportedFunctions;
+
+    beforeEach(() => {
+      mockDynamoClient = {
+        getItem: sinon.stub().resolves(),
+        query: sinon.stub().resolves(null),
+        putItem: sinon.stub().resolves(),
+      };
+      mockLog = {
+        log: console,
+      };
+      exportedFunctions = apiKeyFunctions(
+        mockDynamoClient,
+        TEST_DA_CONFIG,
+        mockLog,
+      );
+    });
+
+    describe('getApiKeyByKey', () => {
+      it('should return an ApiKeyDto when an item is found', async () => {
+        const mockApiKey = {
+          key: 'test-key',
+          name: 'test-name',
+          imsUserId: 'test-ims-user-id',
+          imsOrgId: 'test-ims-org-id',
+          expiresAt: '2024-05-29T14:26:00.000Z',
+          revokedAt: '2024-05-29T14:26:00.000Z',
+          scopes: [{
+            name: 'import.write',
+            domains: ['https://www.test.com'],
+          }],
+        };
+        mockDynamoClient.getItem.resolves(mockApiKey);
+
+        const apiKey = await exportedFunctions.getApiKeyById('test-key');
+
+        expect(apiKey).to.be.not.null;
+        expect(mockDynamoClient.getItem).to.have.been.calledOnce;
+      });
+    });
+
+    describe('createNewApiKey', () => {
+      it('should create a new ApiKey', async () => {
+        const apiKey = createApiKey({
+          key: 'test-key',
+          name: 'test-name',
+          imsUserId: 'test-ims-user-id',
+          imsOrgId: 'test-ims-org-id',
+          expiresAt: '2024-05-29T14:26:00.000Z',
+          revokedAt: '2024-05-29T14:26:00.000Z',
+          scopes: [{
+            name: 'import.write',
+            domains: ['https://www.test.com'],
+          }],
+        });
+
+        mockDynamoClient.putItem.resolves(apiKey);
+
+        const result = await exportedFunctions.createNewApiKey(apiKey);
+
+        expect(result).to.be.not.null;
+        expect(mockDynamoClient.putItem).to.have.been.calledOnce;
+      });
+    });
+  });
+});

--- a/packages/spacecat-shared-data-access/test/unit/service/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/index.test.js
@@ -100,7 +100,7 @@ describe('Data Access Object Tests', () => {
   ];
 
   const apiKeyFunctions = [
-    'getApiKeyById',
+    'getApiKeyByHashedKey',
     'createNewApiKey',
   ];
 

--- a/packages/spacecat-shared-data-access/test/unit/service/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/index.test.js
@@ -152,7 +152,7 @@ describe('Data Access Object Tests', () => {
     });
   });
 
-  it('contains all knows apiKey functions', () => {
+  it('contains all known apiKey functions', () => {
     apiKeyFunctions.forEach((funcName) => {
       expect(dao).to.have.property(funcName);
     });

--- a/packages/spacecat-shared-data-access/test/unit/service/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/index.test.js
@@ -99,6 +99,11 @@ describe('Data Access Object Tests', () => {
     'getExperiment',
   ];
 
+  const apiKeyFunctions = [
+    'getApiKeyById',
+    'createNewApiKey',
+  ];
+
   let dao;
 
   before(() => {
@@ -147,6 +152,12 @@ describe('Data Access Object Tests', () => {
     });
   });
 
+  it('contains all knows apiKey functions', () => {
+    apiKeyFunctions.forEach((funcName) => {
+      expect(dao).to.have.property(funcName);
+    });
+  });
+
   it('does not contain any unexpected functions', () => {
     const expectedFunctions = new Set([
       ...auditFunctions,
@@ -158,7 +169,8 @@ describe('Data Access Object Tests', () => {
       ...siteTopPagesFunctions,
       ...importJobFunctions,
       ...importUrlFunctions,
-      ...experimentFunctions]);
+      ...experimentFunctions,
+      ...apiKeyFunctions]);
     Object.keys(dao).forEach((funcName) => {
       expect(expectedFunctions).to.include(funcName);
     });


### PR DESCRIPTION


## Related Issues
[SITES-23627](https://jira.corp.adobe.com/browse/SITES-23627)

Setup the dynamo DB table with the following attributes:
```
{  
"id": "298987DC-DEBC-45D2-9054-10053BF15F5E",  
"key": "(encrypted with crypto package)",  
"name": "Bruce's key",  
"imsUserId": "AD5E1C3F650AAAF30A495FD9@b13a68e1650aa8c6495ffe.e",  
"imsOrgId": "86DF666465096C340A495E89@AdobeOrg",
"createdAt": "2024-07-16T18:59:14.435Z",
"expiresAt": "2024-10-16T18:59:14.435Z",
"revokedAt": null,
"scopes": [    
     {      "name": "import.write",
            "domains": [        
                "https://adobe.com"      
            ]    
      }  
      ]
}
```
