### PR TITLE
fix: refactor hashed api key and query to retrieve API key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15390,7 +15390,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "1.41.0",
+      "version": "1.41.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-dynamo": "1.2.5",
@@ -16464,7 +16464,7 @@
     },
     "packages/spacecat-shared-dynamo": {
       "name": "@adobe/spacecat-shared-dynamo",
-      "version": "1.3.31",
+      "version": "1.3.32",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.1.0",
@@ -16481,7 +16481,7 @@
     },
     "packages/spacecat-shared-example": {
       "name": "@adobe/spacecat-shared-example",
-      "version": "1.2.12",
+      "version": "1.2.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",
@@ -16493,7 +16493,7 @@
     },
     "packages/spacecat-shared-google-client": {
       "name": "@adobe/spacecat-shared-google-client",
-      "version": "1.1.17",
+      "version": "1.1.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",
@@ -18744,11 +18744,11 @@
     },
     "packages/spacecat-shared-http-utils": {
       "name": "@adobe/spacecat-shared-http-utils",
-      "version": "1.5.0",
+      "version": "1.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",
-        "@adobe/spacecat-shared-data-access": "1.39.0",
+        "@adobe/spacecat-shared-data-access": "1.41.2",
         "@adobe/spacecat-shared-utils": "1.19.1",
         "jose": "5.6.3"
       },
@@ -18757,20 +18757,6 @@
         "chai": "4.5.0",
         "chai-as-promised": "8.0.0",
         "sinon": "18.0.0"
-      }
-    },
-    "packages/spacecat-shared-http-utils/node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-1.39.0.tgz",
-      "integrity": "sha512-nhqs0dpyUBtknMDstlSfJQOBny1+eqhbvU8xHkgijXmeUlo8Nkus22icoKlxjTLWwE8/0poSsyymelBnqH6SNg==",
-      "dependencies": {
-        "@adobe/spacecat-shared-dynamo": "1.2.5",
-        "@adobe/spacecat-shared-utils": "1.2.0",
-        "@aws-sdk/client-dynamodb": "3.620.0",
-        "@aws-sdk/lib-dynamodb": "3.620.0",
-        "@types/joi": "17.2.3",
-        "joi": "17.13.3",
-        "uuid": "10.0.0"
       }
     },
     "packages/spacecat-shared-http-utils/node_modules/@adobe/spacecat-shared-data-access/node_modules/@adobe/spacecat-shared-utils": {
@@ -24614,7 +24600,7 @@
     },
     "packages/spacecat-shared-rum-api-client": {
       "name": "@adobe/spacecat-shared-rum-api-client",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",
@@ -24700,7 +24686,7 @@
     },
     "packages/spacecat-shared-utils": {
       "name": "@adobe/spacecat-shared-utils",
-      "version": "1.19.2",
+      "version": "1.19.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",

--- a/packages/spacecat-shared-data-access/docs/schema.json
+++ b/packages/spacecat-shared-data-access/docs/schema.json
@@ -1146,7 +1146,7 @@
       },
       "NonKeyAttributes": [
         {
-          "AttributeName": "hashedKey",
+          "AttributeName": "hashedApiKey",
           "AttributeType": "S"
         },
         {

--- a/packages/spacecat-shared-data-access/src/dto/api-key.js
+++ b/packages/spacecat-shared-data-access/src/dto/api-key.js
@@ -21,7 +21,7 @@ export const ApiKeyDto = {
      *          imsOrgId: *, expiresAt: *}}
      */
   toDynamoItem: (apiKey) => ({
-    hashedApiKey: apiKey.gethashedApiKey(),
+    hashedApiKey: apiKey.getHashedApiKey(),
     name: apiKey.getName(),
     imsUserId: apiKey.getImsUserId(),
     imsOrgId: apiKey.getImsOrgId(),

--- a/packages/spacecat-shared-data-access/src/dto/api-key.js
+++ b/packages/spacecat-shared-data-access/src/dto/api-key.js
@@ -21,7 +21,7 @@ export const ApiKeyDto = {
      *          imsOrgId: *, expiresAt: *}}
      */
   toDynamoItem: (apiKey) => ({
-    hashedKey: apiKey.getHashedKey(),
+    hashedApiKey: apiKey.gethashedApiKey(),
     name: apiKey.getName(),
     imsUserId: apiKey.getImsUserId(),
     imsOrgId: apiKey.getImsOrgId(),
@@ -38,7 +38,7 @@ export const ApiKeyDto = {
      */
   fromDynamoItem: (dynamoItem) => {
     const apiKeyData = {
-      hashedKey: dynamoItem.hashedKey,
+      hashedApiKey: dynamoItem.hashedApiKey,
       name: dynamoItem.name,
       imsUserId: dynamoItem.imsUserId,
       imsOrgId: dynamoItem.imsOrgId,

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -546,7 +546,7 @@ export interface ApiKey {
     /**
      * Retrieves the hashed key value of the API Key.
      */
-    getHashedKey: () => string;
+    gethashedApiKey: () => string;
 
     /**
      * Retrieves the name of the API Key.
@@ -773,8 +773,8 @@ export interface DataAccess {
       jobId: string,
       status: string,
     ) => Promise<ImportUrl[]>;
-  getApiKeyByHashedKey: (
-      hashedKey: string,
+  getApiKeyByhashedApiKey: (
+      hashedApiKey: string,
     ) => Promise<ApiKey | null>;
   createNewApiKey: (
       apiKeyData: object,
@@ -832,7 +832,7 @@ interface DataAccessConfig {
   indexNameAllImportJobsByStatus: string,
   indexNameAllImportJobsByDateRange: string,
   indexNameAllImportUrlsByJobIdAndStatus: string,
-  indexNameApiKeyByHashedKey: string,
+  indexNameApiKeyByhashedApiKey: string,
   pkAllSites: string;
   pkAllLatestAudits: string;
   pkAllOrganizations: string;

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -773,7 +773,7 @@ export interface DataAccess {
       jobId: string,
       status: string,
     ) => Promise<ImportUrl[]>;
-  getApiKeyByhashedApiKey: (
+  getApiKeyByHashedApiKey: (
       hashedApiKey: string,
     ) => Promise<ApiKey | null>;
   createNewApiKey: (
@@ -832,7 +832,7 @@ interface DataAccessConfig {
   indexNameAllImportJobsByStatus: string,
   indexNameAllImportJobsByDateRange: string,
   indexNameAllImportUrlsByJobIdAndStatus: string,
-  indexNameApiKeyByhashedApiKey: string,
+  indexNameApiKeyByHashedApiKey: string,
   pkAllSites: string;
   pkAllLatestAudits: string;
   pkAllOrganizations: string;

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -546,7 +546,7 @@ export interface ApiKey {
     /**
      * Retrieves the hashed key value of the API Key.
      */
-    gethashedApiKey: () => string;
+    getHashedApiKey: () => string;
 
     /**
      * Retrieves the name of the API Key.

--- a/packages/spacecat-shared-data-access/src/index.js
+++ b/packages/spacecat-shared-data-access/src/index.js
@@ -101,7 +101,7 @@ export default function dataAccessWrapper(fn) {
         indexNameAllImportJobsByStatus: DYNAMO_INDEX_NAME_ALL_IMPORT_JOBS_BY_STATUS,
         indexNameAllImportJobsByDateRange: DYNAMO_INDEX_NAME_ALL_IMPORT_JOBS_BY_DATE_RANGE,
         indexNameImportUrlsByJobIdAndStatus: DYNAMO_INDEX_NAME_ALL_IMPORT_URLS_BY_JOB_ID_AND_STATUS,
-        indexNameApiKeyByHashedKey: DYNAMO_INDEX_NAME_API_KEY_BY_HASHED_KEY,
+        indexNameApiKeyByhashedApiKey: DYNAMO_INDEX_NAME_API_KEY_BY_HASHED_KEY,
         pkAllSites: PK_ALL_SITES,
         pkAllOrganizations: PK_ALL_ORGANIZATIONS,
         pkAllLatestAudits: PK_ALL_LATEST_AUDITS,

--- a/packages/spacecat-shared-data-access/src/index.js
+++ b/packages/spacecat-shared-data-access/src/index.js
@@ -37,7 +37,7 @@ const INDEX_NAME_ALL_SITES_ORGANIZATIONS = 'spacecat-services-all-sites-organiza
 const INDEX_NAME_ALL_IMPORT_JOBS_BY_STATUS = 'spacecat-services-all-import-jobs-by-status-dev';
 const INDEX_NAME_ALL_IMPORT_JOBS_BY_DATE_RANGE = 'spacecat-services-all-import-jobs-by-date-range-dev';
 const INDEX_NAME_ALL_IMPORT_URLS_BY_JOB_ID_AND_STATUS = 'spacecat-services-all-import-urls-by-job-id-and-status-dev';
-const INDEX_NAME_API_KEY_BY_HASHED_KEY = 'spacecat-services-api-key-by-hashed-key-dev';
+const INDEX_NAME_API_KEY_BY_HASHED_API_KEY = 'spacecat-services-api-key-by-hashed-api-key-dev';
 
 const PK_ALL_SITES = 'ALL_SITES';
 const PK_ALL_CONFIGURATIONS = 'ALL_CONFIGURATIONS';
@@ -75,7 +75,7 @@ export default function dataAccessWrapper(fn) {
         DYNAMO_INDEX_NAME_ALL_IMPORT_JOBS_BY_DATE_RANGE = INDEX_NAME_ALL_IMPORT_JOBS_BY_DATE_RANGE,
         DYNAMO_INDEX_NAME_ALL_IMPORT_URLS_BY_JOB_ID_AND_STATUS =
         INDEX_NAME_ALL_IMPORT_URLS_BY_JOB_ID_AND_STATUS,
-        DYNAMO_INDEX_NAME_API_KEY_BY_HASHED_KEY = INDEX_NAME_API_KEY_BY_HASHED_KEY,
+        DYNAMO_INDEX_NAME_API_KEY_BY_HASHED_API_KEY = INDEX_NAME_API_KEY_BY_HASHED_API_KEY,
       } = context.env;
 
       context.dataAccess = createDataAccess({
@@ -101,7 +101,7 @@ export default function dataAccessWrapper(fn) {
         indexNameAllImportJobsByStatus: DYNAMO_INDEX_NAME_ALL_IMPORT_JOBS_BY_STATUS,
         indexNameAllImportJobsByDateRange: DYNAMO_INDEX_NAME_ALL_IMPORT_JOBS_BY_DATE_RANGE,
         indexNameImportUrlsByJobIdAndStatus: DYNAMO_INDEX_NAME_ALL_IMPORT_URLS_BY_JOB_ID_AND_STATUS,
-        indexNameApiKeyByhashedApiKey: DYNAMO_INDEX_NAME_API_KEY_BY_HASHED_KEY,
+        indexNameApiKeyByHashedApiKey: DYNAMO_INDEX_NAME_API_KEY_BY_HASHED_API_KEY,
         pkAllSites: PK_ALL_SITES,
         pkAllOrganizations: PK_ALL_ORGANIZATIONS,
         pkAllLatestAudits: PK_ALL_LATEST_AUDITS,

--- a/packages/spacecat-shared-data-access/src/models/api-key.js
+++ b/packages/spacecat-shared-data-access/src/models/api-key.js
@@ -21,7 +21,7 @@ const scopeNames = ['sites.read_all', 'sites.write_all', 'organizations.read_all
 const ApiKey = (data) => {
   const self = Base(data);
 
-  self.gethashedApiKey = () => self.state.hashedApiKey;
+  self.getHashedApiKey = () => self.state.hashedApiKey;
   self.getName = () => self.state.name;
   self.getImsUserId = () => self.state.imsUserId;
   self.getImsOrgId = () => self.state.imsOrgId;

--- a/packages/spacecat-shared-data-access/src/models/api-key.js
+++ b/packages/spacecat-shared-data-access/src/models/api-key.js
@@ -42,7 +42,7 @@ export const createApiKey = (data) => {
   const newState = { ...data };
 
   if (!hasText(newState.hashedApiKey)) {
-    throw new Error(`Invalid Hashed Key: ${newState.hashedApiKey}`);
+    throw new Error(`Invalid Hashed API Key: ${newState.hashedApiKey}`);
   }
 
   if (!hasText(newState.name)) {

--- a/packages/spacecat-shared-data-access/src/models/api-key.js
+++ b/packages/spacecat-shared-data-access/src/models/api-key.js
@@ -21,7 +21,7 @@ const scopeNames = ['sites.read_all', 'sites.write_all', 'organizations.read_all
 const ApiKey = (data) => {
   const self = Base(data);
 
-  self.getHashedKey = () => self.state.hashedKey;
+  self.gethashedApiKey = () => self.state.hashedApiKey;
   self.getName = () => self.state.name;
   self.getImsUserId = () => self.state.imsUserId;
   self.getImsOrgId = () => self.state.imsOrgId;
@@ -41,8 +41,8 @@ const ApiKey = (data) => {
 export const createApiKey = (data) => {
   const newState = { ...data };
 
-  if (!hasText(newState.hashedKey)) {
-    throw new Error(`Invalid Hashed Key: ${newState.hashedKey}`);
+  if (!hasText(newState.hashedApiKey)) {
+    throw new Error(`Invalid Hashed Key: ${newState.hashedApiKey}`);
   }
 
   if (!hasText(newState.name)) {

--- a/packages/spacecat-shared-data-access/src/service/api-key/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/api-key/accessPatterns.js
@@ -23,7 +23,7 @@ import { ApiKeyDto } from '../../dto/api-key.js';
 export const getApiKeyByHashedApiKey = async (hashedApiKey, dynamoClient, log, config) => {
   const items = await dynamoClient.query({
     TableName: config.tableNameApiKeys,
-    IndexName: config.indexNameApiKeyByhashedApiKey,
+    IndexName: config.indexNameApiKeyByHashedApiKey,
     KeyConditionExpression: '#hashedApiKey = :hashedApiKey',
     ExpressionAttributeNames: {
       '#hashedApiKey': 'hashedApiKey',

--- a/packages/spacecat-shared-data-access/src/service/api-key/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/api-key/accessPatterns.js
@@ -14,25 +14,26 @@ import { ApiKeyDto } from '../../dto/api-key.js';
 
 /**
  * Get ApiKey by Hashed Key
- * @param {string} hashedKey
+ * @param {string} hashedApiKey
  * @param {DynamoClient} dynamoClient
  * @param {Object} config
  * @param {Logger} log
  * @returns {Promise<ApiKeyDto>}
  */
-export const getApiKeyByHashedKey = async (hashedKey, dynamoClient, log, config) => {
-  const item = await dynamoClient.query({
+export const getApiKeyByHashedApiKey = async (hashedApiKey, dynamoClient, log, config) => {
+  const items = await dynamoClient.query({
     TableName: config.tableNameApiKeys,
-    IndexName: config.indexNameApiKeyByHashedKey,
-    KeyConditionExpression: '#hashedKey = :hashedKey',
+    IndexName: config.indexNameApiKeyByhashedApiKey,
+    KeyConditionExpression: '#hashedApiKey = :hashedApiKey',
     ExpressionAttributeNames: {
-      '#hashedKey': 'hashedKey',
+      '#hashedApiKey': 'hashedApiKey',
     },
     ExpressionAttributeValues: {
-      ':hashedKey': hashedKey,
+      ':hashedApiKey': hashedApiKey,
     },
+    Limit: 1,
   });
-  return item ? ApiKeyDto.fromDynamoItem(item) : null;
+  return items.length > 0 ? ApiKeyDto.fromDynamoItem(items[0]) : null;
 };
 
 /**

--- a/packages/spacecat-shared-data-access/src/service/api-key/index.js
+++ b/packages/spacecat-shared-data-access/src/service/api-key/index.js
@@ -10,9 +10,14 @@
  * governing permissions and limitations under the License.
  */
 
-import { createNewApiKey, getApiKeyByHashedKey } from './accessPatterns.js';
+import { createNewApiKey, getApiKeyByHashedApiKey } from './accessPatterns.js';
 
 export const apiKeyFunctions = (dynamoClient, config, log) => ({
-  getApiKeyByHashedKey: (hashedKey) => getApiKeyByHashedKey(hashedKey, dynamoClient, log, config),
+  getApiKeyByHashedApiKey: (hashedApiKey) => getApiKeyByHashedApiKey(
+    hashedApiKey,
+    dynamoClient,
+    log,
+    config,
+  ),
   createNewApiKey: (apiKey) => createNewApiKey(apiKey, dynamoClient, config, log),
 });

--- a/packages/spacecat-shared-data-access/test/unit/models/api-key.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/api-key.test.js
@@ -89,7 +89,7 @@ describe('ApiKey Model tests', () => {
     });
 
     it('gets hashed key', () => {
-      expect(apiKey.gethashedApiKey()).to.equal('test');
+      expect(apiKey.getHashedApiKey()).to.equal('test');
     });
 
     it('gets name', () => {

--- a/packages/spacecat-shared-data-access/test/unit/models/api-key.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/api-key.test.js
@@ -31,7 +31,7 @@ const validApiKey = {
 describe('ApiKey Model tests', () => {
   describe('Validation Tests', () => {
     it('throws an error if key is not a valid string', () => {
-      expect(() => createApiKey({ ...validApiKey, hashedApiKey: 123 })).to.throw('Invalid Hashed Key: 123');
+      expect(() => createApiKey({ ...validApiKey, hashedApiKey: 123 })).to.throw('Invalid Hashed API Key: 123');
     });
 
     it('throws an error if name is not a valid string', () => {

--- a/packages/spacecat-shared-data-access/test/unit/models/api-key.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/api-key.test.js
@@ -16,7 +16,7 @@ import { expect } from 'chai';
 import { createApiKey } from '../../../src/models/api-key.js';
 
 const validApiKey = {
-  hashedKey: 'test',
+  hashedApiKey: 'test',
   name: 'test-name',
   imsUserId: 'test-ims-user-id',
   imsOrgId: 'test-ims-org-id',
@@ -31,7 +31,7 @@ const validApiKey = {
 describe('ApiKey Model tests', () => {
   describe('Validation Tests', () => {
     it('throws an error if key is not a valid string', () => {
-      expect(() => createApiKey({ ...validApiKey, hashedKey: 123 })).to.throw('Invalid Hashed Key: 123');
+      expect(() => createApiKey({ ...validApiKey, hashedApiKey: 123 })).to.throw('Invalid Hashed Key: 123');
     });
 
     it('throws an error if name is not a valid string', () => {
@@ -89,7 +89,7 @@ describe('ApiKey Model tests', () => {
     });
 
     it('gets hashed key', () => {
-      expect(apiKey.getHashedKey()).to.equal('test');
+      expect(apiKey.gethashedApiKey()).to.equal('test');
     });
 
     it('gets name', () => {

--- a/packages/spacecat-shared-data-access/test/unit/service/api-key/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/api-key/index.test.js
@@ -53,7 +53,7 @@ describe('Api Key Tests', () => {
     describe('getApiKeyByKey', () => {
       it('should return an ApiKeyDto when an item is found', async () => {
         const mockApiKey = {
-          hashedKey: 'test-key',
+          hashedApiKey: 'test-key',
           name: 'test-name',
           imsUserId: 'test-ims-user-id',
           imsOrgId: 'test-ims-org-id',
@@ -66,7 +66,7 @@ describe('Api Key Tests', () => {
         };
         mockDynamoClient.query.resolves(mockApiKey);
 
-        const apiKey = await exportedFunctions.getApiKeyByHashedKey('test-key');
+        const apiKey = await exportedFunctions.getApiKeyByhashedApiKey('test-key');
 
         expect(apiKey).to.be.not.null;
         expect(mockDynamoClient.query).to.have.been.calledOnce;
@@ -76,7 +76,7 @@ describe('Api Key Tests', () => {
     describe('createNewApiKey', () => {
       it('should create a new ApiKey', async () => {
         const apiKey = createApiKey({
-          hashedKey: 'test-key',
+          hashedApiKey: 'test-key',
           name: 'test-name',
           imsUserId: 'test-ims-user-id',
           imsOrgId: 'test-ims-org-id',

--- a/packages/spacecat-shared-data-access/test/unit/service/api-key/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/api-key/index.test.js
@@ -64,9 +64,9 @@ describe('Api Key Tests', () => {
             domains: ['https://www.test.com'],
           }],
         };
-        mockDynamoClient.query.resolves(mockApiKey);
+        mockDynamoClient.query.resolves([mockApiKey]);
 
-        const apiKey = await exportedFunctions.getApiKeyByhashedApiKey('test-key');
+        const apiKey = await exportedFunctions.getApiKeyByHashedApiKey('test-key');
 
         expect(apiKey).to.be.not.null;
         expect(mockDynamoClient.query).to.have.been.calledOnce;

--- a/packages/spacecat-shared-data-access/test/unit/service/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/index.test.js
@@ -100,7 +100,7 @@ describe('Data Access Object Tests', () => {
   ];
 
   const apiKeyFunctions = [
-    'getApiKeyByhashedApiKey',
+    'getApiKeyByHashedApiKey',
     'createNewApiKey',
   ];
 

--- a/packages/spacecat-shared-data-access/test/unit/service/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/index.test.js
@@ -100,7 +100,7 @@ describe('Data Access Object Tests', () => {
   ];
 
   const apiKeyFunctions = [
-    'getApiKeyByHashedKey',
+    'getApiKeyByhashedApiKey',
     'createNewApiKey',
   ];
 

--- a/packages/spacecat-shared-http-utils/package.json
+++ b/packages/spacecat-shared-http-utils/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@adobe/fetch": "4.1.8",
     "@adobe/spacecat-shared-utils": "1.19.1",
-    "@adobe/spacecat-shared-data-access": "1.39.0",
+    "@adobe/spacecat-shared-data-access": "1.41.2",
     "jose": "5.6.3"
   },
   "devDependencies": {

--- a/packages/spacecat-shared-http-utils/src/auth/handlers/scoped-api-key.js
+++ b/packages/spacecat-shared-http-utils/src/auth/handlers/scoped-api-key.js
@@ -37,7 +37,7 @@ export default class ScopedApiKeyHandler extends AbstractHandler {
 
     // Keys are stored by their hash, so we need to hash the key to look it up
     const hashedKey = hashWithSHA256(apiKeyFromHeader);
-    const apiKeyEntity = await dataAccess.getApiKeyByHashedApiKey(hashedKey);
+    const apiKeyEntity = await dataAccess.getApiKeyByHashedKey(hashedKey);
 
     if (!apiKeyEntity) {
       this.log(`No API key entity found in the data layer for the provided API key: ${apiKeyFromHeader}`, 'error');

--- a/packages/spacecat-shared-http-utils/src/auth/handlers/scoped-api-key.js
+++ b/packages/spacecat-shared-http-utils/src/auth/handlers/scoped-api-key.js
@@ -37,7 +37,7 @@ export default class ScopedApiKeyHandler extends AbstractHandler {
 
     // Keys are stored by their hash, so we need to hash the key to look it up
     const hashedKey = hashWithSHA256(apiKeyFromHeader);
-    const apiKeyEntity = await dataAccess.getApiKeyByHashedKey(hashedKey);
+    const apiKeyEntity = await dataAccess.getApiKeyByHashedApiKey(hashedKey);
 
     if (!apiKeyEntity) {
       this.log(`No API key entity found in the data layer for the provided API key: ${apiKeyFromHeader}`, 'error');

--- a/packages/spacecat-shared-http-utils/test/auth/auth-wrapper.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/auth-wrapper.test.js
@@ -55,7 +55,7 @@ describe('auth wrapper', () => {
       dataAccess: {},
     };
     mockApiKey = createApiKey({
-      hashedKey: '372c6ba5a67b01a8d6c45e5ade6b41db9586ca06c77f0ef7795dfe895111fd0b',
+      hashedApiKey: '372c6ba5a67b01a8d6c45e5ade6b41db9586ca06c77f0ef7795dfe895111fd0b',
       name: 'Test API key name',
       scopes: [
         {
@@ -120,7 +120,7 @@ describe('auth wrapper', () => {
     const scopedAction = wrap(() => 42)
       .with(authWrapper, { authHandlers: [ScopedApiKeyHandler] })
       .with(enrichPathInfo);
-    context.dataAccess.getApiKeyByHashedKey = async () => mockApiKey;
+    context.dataAccess.getApiKeyByHashedApiKey = async () => mockApiKey;
 
     const resp = await scopedAction(new Request('https://space.cat/', {
       headers: { 'x-api-key': 'test-api-key' },

--- a/packages/spacecat-shared-http-utils/test/auth/auth-wrapper.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/auth-wrapper.test.js
@@ -55,7 +55,7 @@ describe('auth wrapper', () => {
       dataAccess: {},
     };
     mockApiKey = createApiKey({
-      hashedApiKey: '372c6ba5a67b01a8d6c45e5ade6b41db9586ca06c77f0ef7795dfe895111fd0b',
+      hashedKey: '372c6ba5a67b01a8d6c45e5ade6b41db9586ca06c77f0ef7795dfe895111fd0b',
       name: 'Test API key name',
       scopes: [
         {
@@ -120,7 +120,7 @@ describe('auth wrapper', () => {
     const scopedAction = wrap(() => 42)
       .with(authWrapper, { authHandlers: [ScopedApiKeyHandler] })
       .with(enrichPathInfo);
-    context.dataAccess.getApiKeyByHashedApiKey = async () => mockApiKey;
+    context.dataAccess.getApiKeyByHashedKey = async () => mockApiKey;
 
     const resp = await scopedAction(new Request('https://space.cat/', {
       headers: { 'x-api-key': 'test-api-key' },

--- a/packages/spacecat-shared-http-utils/test/auth/handlers/scoped-api-key.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/handlers/scoped-api-key.test.js
@@ -16,7 +16,6 @@ import chai from 'chai';
 import sinon from 'sinon';
 import chaiAsPromised from 'chai-as-promised';
 
-import { createApiKey } from '@adobe/spacecat-shared-data-access/src/models/api-key.js';
 import AbstractHandler from '../../../src/auth/handlers/abstract.js';
 import AuthInfo from '../../../src/auth/auth-info.js';
 import ScopedApiKeyHandler from '../../../src/auth/handlers/scoped-api-key.js';
@@ -30,11 +29,14 @@ describe('ScopedApiKeyHandler', () => {
   let handler;
 
   let mockContext;
+  let createApiKeyStub;
 
   const baseApiKeyData = {
     hashedKey: '372c6ba5a67b01a8d6c45e5ade6b41db9586ca06c77f0ef7795dfe895111fd0b',
     id: '1C4ED8DE-8ECD-42E1-9812-AF34082FB1B4',
     name: 'Test api key',
+    expiredAt: '2025-01-01T16:23:00.000Z',
+    revokedAt: null,
     scopes: [
       {
         name: 'imports.write',
@@ -57,7 +59,7 @@ describe('ScopedApiKeyHandler', () => {
 
     mockContext = {
       dataAccess: {
-        getApiKeyByHashedKey: sinon.stub().resolves(createApiKey(baseApiKeyData)),
+        getApiKeyByHashedKey: sinon.stub().resolves(createApiKeyStub),
       },
       pathInfo: {
         headers: {
@@ -65,6 +67,15 @@ describe('ScopedApiKeyHandler', () => {
         },
       },
     };
+
+    createApiKeyStub = sinon.stub().returns({
+      getId: () => baseApiKeyData.id,
+      getHashedKey: () => baseApiKeyData.hashedKey,
+      getName: () => baseApiKeyData.name,
+      getExpiresAt: () => baseApiKeyData.expiredAt,
+      getRevokedAt: () => baseApiKeyData.revokedAt,
+      getScopes: () => baseApiKeyData.scopes,
+    });
   });
 
   afterEach(() => {
@@ -116,9 +127,9 @@ describe('ScopedApiKeyHandler', () => {
   });
 
   it('should return null if the API key has expired', async () => {
-    mockContext.dataAccess.getApiKeyByHashedKey = sinon.stub().resolves(createApiKey({
+    baseApiKeyData.expiredAt = '2024-01-01T16:23:00.000Z';
+    mockContext.dataAccess.getApiKeyByHashedKey = sinon.stub().resolves(createApiKeyStub({
       ...baseApiKeyData,
-      expiresAt: '2024-01-01T16:23:00.000Z',
     }));
 
     const result = await handler.checkAuth({}, mockContext);
@@ -129,9 +140,10 @@ describe('ScopedApiKeyHandler', () => {
   });
 
   it('should return null if the API key has been revoked', async () => {
-    mockContext.dataAccess.getApiKeyByHashedKey = sinon.stub().resolves(createApiKey({
+    baseApiKeyData.expiredAt = '2025-01-01T16:23:00.000Z';
+    baseApiKeyData.revokedAt = '2024-01-01T16:23:00.000Z';
+    mockContext.dataAccess.getApiKeyByHashedKey = sinon.stub().resolves(createApiKeyStub({
       ...baseApiKeyData,
-      revokedAt: '2024-08-01T10:00:00.000Z',
     }));
 
     const result = await handler.checkAuth({}, mockContext);
@@ -142,6 +154,10 @@ describe('ScopedApiKeyHandler', () => {
   });
 
   it('should return an AuthInfo object for a valid key', async () => {
+    baseApiKeyData.revokedAt = null;
+    mockContext.dataAccess.getApiKeyByHashedKey = sinon.stub().resolves(createApiKeyStub({
+      ...baseApiKeyData,
+    }));
     const result = await handler.checkAuth({}, mockContext);
     expect(result).to.be.instanceof(AuthInfo);
     expect(result.type).to.equal('scopedApiKey');

--- a/packages/spacecat-shared-http-utils/test/auth/handlers/scoped-api-key.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/handlers/scoped-api-key.test.js
@@ -32,7 +32,7 @@ describe('ScopedApiKeyHandler', () => {
   let mockContext;
 
   const baseApiKeyData = {
-    hashedKey: '372c6ba5a67b01a8d6c45e5ade6b41db9586ca06c77f0ef7795dfe895111fd0b',
+    hashedApiKey: '372c6ba5a67b01a8d6c45e5ade6b41db9586ca06c77f0ef7795dfe895111fd0b',
     id: '1C4ED8DE-8ECD-42E1-9812-AF34082FB1B4',
     name: 'Test api key',
     scopes: [
@@ -57,7 +57,7 @@ describe('ScopedApiKeyHandler', () => {
 
     mockContext = {
       dataAccess: {
-        getApiKeyByHashedKey: sinon.stub().resolves(createApiKey(baseApiKeyData)),
+        getApiKeyByHashedApiKey: sinon.stub().resolves(createApiKey(baseApiKeyData)),
       },
       pathInfo: {
         headers: {
@@ -106,7 +106,7 @@ describe('ScopedApiKeyHandler', () => {
     const context = {
       ...mockContext,
       dataAccess: {
-        getApiKeyByHashedKey: sinon.stub().resolves(null),
+        getApiKeyByHashedApiKey: sinon.stub().resolves(null),
       },
     };
 
@@ -116,7 +116,7 @@ describe('ScopedApiKeyHandler', () => {
   });
 
   it('should return null if the API key has expired', async () => {
-    mockContext.dataAccess.getApiKeyByHashedKey = sinon.stub().resolves(createApiKey({
+    mockContext.dataAccess.getApiKeyByHashedApiKey = sinon.stub().resolves(createApiKey({
       ...baseApiKeyData,
       expiresAt: '2024-01-01T16:23:00.000Z',
     }));
@@ -129,7 +129,7 @@ describe('ScopedApiKeyHandler', () => {
   });
 
   it('should return null if the API key has been revoked', async () => {
-    mockContext.dataAccess.getApiKeyByHashedKey = sinon.stub().resolves(createApiKey({
+    mockContext.dataAccess.getApiKeyByHashedApiKey = sinon.stub().resolves(createApiKey({
       ...baseApiKeyData,
       revokedAt: '2024-08-01T10:00:00.000Z',
     }));
@@ -159,6 +159,6 @@ describe('ScopedApiKeyHandler', () => {
     expect(result.getProfile().getId()).to.equal('1C4ED8DE-8ECD-42E1-9812-AF34082FB1B4');
     expect(result.getProfile().getScopes()[0].name).to.equal('imports.write');
     expect(result.getProfile().getScopes()[1].name).to.equal('sites.read_all');
-    expect(result.getProfile().getHashedKey()).to.equal('372c6ba5a67b01a8d6c45e5ade6b41db9586ca06c77f0ef7795dfe895111fd0b');
+    expect(result.getProfile().getHashedApiKey()).to.equal('372c6ba5a67b01a8d6c45e5ade6b41db9586ca06c77f0ef7795dfe895111fd0b');
   });
 });

--- a/packages/spacecat-shared-http-utils/test/auth/handlers/scoped-api-key.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/handlers/scoped-api-key.test.js
@@ -32,7 +32,7 @@ describe('ScopedApiKeyHandler', () => {
   let mockContext;
 
   const baseApiKeyData = {
-    hashedApiKey: '372c6ba5a67b01a8d6c45e5ade6b41db9586ca06c77f0ef7795dfe895111fd0b',
+    hashedKey: '372c6ba5a67b01a8d6c45e5ade6b41db9586ca06c77f0ef7795dfe895111fd0b',
     id: '1C4ED8DE-8ECD-42E1-9812-AF34082FB1B4',
     name: 'Test api key',
     scopes: [
@@ -57,7 +57,7 @@ describe('ScopedApiKeyHandler', () => {
 
     mockContext = {
       dataAccess: {
-        getApiKeyByHashedApiKey: sinon.stub().resolves(createApiKey(baseApiKeyData)),
+        getApiKeyByHashedKey: sinon.stub().resolves(createApiKey(baseApiKeyData)),
       },
       pathInfo: {
         headers: {
@@ -106,7 +106,7 @@ describe('ScopedApiKeyHandler', () => {
     const context = {
       ...mockContext,
       dataAccess: {
-        getApiKeyByHashedApiKey: sinon.stub().resolves(null),
+        getApiKeyByHashedKey: sinon.stub().resolves(null),
       },
     };
 
@@ -116,7 +116,7 @@ describe('ScopedApiKeyHandler', () => {
   });
 
   it('should return null if the API key has expired', async () => {
-    mockContext.dataAccess.getApiKeyByHashedApiKey = sinon.stub().resolves(createApiKey({
+    mockContext.dataAccess.getApiKeyByHashedKey = sinon.stub().resolves(createApiKey({
       ...baseApiKeyData,
       expiresAt: '2024-01-01T16:23:00.000Z',
     }));
@@ -129,7 +129,7 @@ describe('ScopedApiKeyHandler', () => {
   });
 
   it('should return null if the API key has been revoked', async () => {
-    mockContext.dataAccess.getApiKeyByHashedApiKey = sinon.stub().resolves(createApiKey({
+    mockContext.dataAccess.getApiKeyByHashedKey = sinon.stub().resolves(createApiKey({
       ...baseApiKeyData,
       revokedAt: '2024-08-01T10:00:00.000Z',
     }));
@@ -159,6 +159,6 @@ describe('ScopedApiKeyHandler', () => {
     expect(result.getProfile().getId()).to.equal('1C4ED8DE-8ECD-42E1-9812-AF34082FB1B4');
     expect(result.getProfile().getScopes()[0].name).to.equal('imports.write');
     expect(result.getProfile().getScopes()[1].name).to.equal('sites.read_all');
-    expect(result.getProfile().getHashedApiKey()).to.equal('372c6ba5a67b01a8d6c45e5ade6b41db9586ca06c77f0ef7795dfe895111fd0b');
+    expect(result.getProfile().getHashedKey()).to.equal('372c6ba5a67b01a8d6c45e5ade6b41db9586ca06c77f0ef7795dfe895111fd0b');
   });
 });


### PR DESCRIPTION

## Related Issues
[SITES-23633](https://jira.corp.adobe.com/browse/SITES-23633)

- Refactor hashedKey to hashedApiKey for consistency with spacecat-api-service
- Modify the unit tests spacecat-shared-http-utils to remove dependency on spacecat-data-shared methods
- Modify the query - `getApiKeyByHashedApiKey` to return the first element of an array
