### PR TITLE
feat: introduce url inspect in google client

### DIFF
--- a/packages/spacecat-shared-google-client/src/index.d.ts
+++ b/packages/spacecat-shared-google-client/src/index.d.ts
@@ -64,6 +64,13 @@ export default class GoogleClient {
   ): Promise<JSON>;
 
   /**
+   * Retrieves the Google Search Console data for the specified url.
+   * @param url - The URL of the site to be inspected
+   * @returns {Promise<JSON>} The Google Search Console data.
+   */
+  urlInspect(url: string): Promise<JSON>;
+
+  /**
    * Lists all sites available to the authenticated user in Google Search Console.
    *
    * @returns {Promise<JSON>} A promise that resolves to the result of the list sites operation.

--- a/packages/spacecat-shared-google-client/src/utils.js
+++ b/packages/spacecat-shared-google-client/src/utils.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { context as h2, h1 } from '@adobe/fetch';
+
+/* c8 ignore next 3 */
+export const { fetch } = process.env.HELIX_FETCH_FORCE_HTTP1
+  ? h1()
+  : h2();


### PR DESCRIPTION
In context of [SITES-24087](https://jira.corp.adobe.com/browse/SITES-24087), introducing URL inspect to the Google Client