### PR TITLE
fix: Add id to api-key DTO

### DIFF
--- a/packages/spacecat-shared-data-access/src/dto/api-key.js
+++ b/packages/spacecat-shared-data-access/src/dto/api-key.js
@@ -21,6 +21,7 @@ export const ApiKeyDto = {
      *          imsOrgId: *, expiresAt: *}}
      */
   toDynamoItem: (apiKey) => ({
+    id: apiKey.getId(),
     hashedApiKey: apiKey.getHashedApiKey(),
     name: apiKey.getName(),
     imsUserId: apiKey.getImsUserId(),
@@ -38,6 +39,7 @@ export const ApiKeyDto = {
      */
   fromDynamoItem: (dynamoItem) => {
     const apiKeyData = {
+      id: dynamoItem.id,
       hashedApiKey: dynamoItem.hashedApiKey,
       name: dynamoItem.name,
       imsUserId: dynamoItem.imsUserId,

--- a/packages/spacecat-shared-http-utils/src/auth/handlers/scoped-api-key.js
+++ b/packages/spacecat-shared-http-utils/src/auth/handlers/scoped-api-key.js
@@ -37,6 +37,7 @@ export default class ScopedApiKeyHandler extends AbstractHandler {
 
     // Keys are stored by their hash, so we need to hash the key to look it up
     const hashedApiKey = hashWithSHA256(apiKeyFromHeader);
+    this.log(`Checking for API key with hash: ${hashedApiKey}`, 'debug');
     const apiKeyEntity = await dataAccess.getApiKeyByHashedApiKey(hashedApiKey);
 
     if (!apiKeyEntity) {


### PR DESCRIPTION


## Related Issues

Add `id` to ApiKeyDto. This might resolve the issue we are seeing with ApiKeys. ScopedApiKeyHandler abruptly stops.
Reference logs:
```

  | 2024-08-16T15:08:41.483Z | START RequestId: 64726ea5-b32b-4008-87a6-e072891f8460 Version: 1376
-- | -- | --
  | 2024-08-16T15:08:41.487Z | 2024-08-16T15:08:41.487Z 64726ea5-b32b-4008-87a6-e072891f8460 DEBUG Trying to authenticate with legacyApiKey
  | 2024-08-16T15:08:41.487Z | 2024-08-16T15:08:41.487Z 64726ea5-b32b-4008-87a6-e072891f8460 DEBUG Failed to authenticate with legacyApiKey
  | 2024-08-16T15:08:41.487Z | 2024-08-16T15:08:41.487Z 64726ea5-b32b-4008-87a6-e072891f8460 DEBUG Trying to authenticate with scopedApiKey
  | 2024-08-16T15:08:41.489Z | END RequestId: 64726ea5-b32b-4008-87a6-e072891f8460


```
