### PR TITLE
feat: add initiatedBy attribute to import job

### DIFF
--- a/packages/spacecat-shared-data-access/docs/schema.json
+++ b/packages/spacecat-shared-data-access/docs/schema.json
@@ -978,6 +978,10 @@
         {
           "AttributeName": "urlCount",
           "AttributeType": "N"
+        },
+        {
+          "AttributeName": "initiatedBy",
+          "AttributeType": "M"
         }
       ],
       "GlobalSecondaryIndexes": [

--- a/packages/spacecat-shared-data-access/src/dto/import-job.js
+++ b/packages/spacecat-shared-data-access/src/dto/import-job.js
@@ -38,6 +38,7 @@ export const ImportJobDto = {
     successCount: importJob.getSuccessCount(),
     failedCount: importJob.getFailedCount(),
     importQueueId: importJob.getImportQueueId(),
+    initiatedBy: importJob.getInitiatedBy(),
     GSI1PK: 'ALL_IMPORT_JOBS',
   }),
 
@@ -58,6 +59,7 @@ export const ImportJobDto = {
       successCount: dynamoItem.successCount,
       failedCount: dynamoItem.failedCount,
       importQueueId: dynamoItem.importQueueId,
+      initiatedBy: dynamoItem.initiatedBy,
     };
 
     return createImportJob(importJobData);

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -510,6 +510,11 @@ export interface ImportJob {
    */
   getImportQueueId: () => string;
 
+  /**
+   * Retrieves the initiatedBy (name, imsOrgId, imsUserId, userAgent) of the import job.
+   */
+  getInitiatedBy: () => object;
+
 }
 
 export interface ImportUrl {

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -511,7 +511,7 @@ export interface ImportJob {
   getImportQueueId: () => string;
 
   /**
-   * Retrieves the initiatedBy (name, imsOrgId, imsUserId, userAgent) of the import job.
+   * Retrieves the initiatedBy metadata (name, imsOrgId, imsUserId, userAgent) of the import job.
    */
   getInitiatedBy: () => object;
 

--- a/packages/spacecat-shared-data-access/src/models/importer/import-job.js
+++ b/packages/spacecat-shared-data-access/src/models/importer/import-job.js
@@ -189,9 +189,5 @@ export const createImportJob = (data) => {
     throw new Error(`Invalid options: ${newState.options}`);
   }
 
-  if (!isObject(newState.initiatedBy)) {
-    throw new Error(`Invalid initiatedBy: ${newState.initiatedBy}`);
-  }
-
   return ImportJob(newState);
 };

--- a/packages/spacecat-shared-data-access/src/models/importer/import-job.js
+++ b/packages/spacecat-shared-data-access/src/models/importer/import-job.js
@@ -41,6 +41,7 @@ const ImportJob = (data) => {
   self.getSuccessCount = () => self.state.successCount;
   self.getFailedCount = () => self.state.failedCount;
   self.getImportQueueId = () => self.state.importQueueId;
+  self.getInitiatedBy = () => self.state.initiatedBy;
 
   /**
      * Updates the end time of the ImportJob.
@@ -186,6 +187,10 @@ export const createImportJob = (data) => {
 
   if (!isObject(newState.options)) {
     throw new Error(`Invalid options: ${newState.options}`);
+  }
+
+  if (!isObject(newState.initiatedBy)) {
+    throw new Error(`Invalid initiatedBy: ${newState.initiatedBy}`);
   }
 
   return ImportJob(newState);

--- a/packages/spacecat-shared-data-access/test/unit/models/importer/import-job.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/importer/import-job.test.js
@@ -26,7 +26,7 @@ const validImportJob = {
     enableCss: true,
   },
   initiatedBy: {
-    name: 'test',
+    apiKeyName: 'test',
   },
 };
 describe('ImportJob Model tests', () => {

--- a/packages/spacecat-shared-data-access/test/unit/models/importer/import-job.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/importer/import-job.test.js
@@ -51,10 +51,6 @@ describe('ImportJob Model tests', () => {
       expect(() => createImportJob({ ...validImportJob, hashedApiKey: 123 })).to.throw('Invalid API key: 123');
     });
 
-    it('throws an error if initiatedBy is not a valid object', () => {
-      expect(() => createImportJob({ ...validImportJob, initiatedBy: 'invalid-initiatedBy' })).to.throw('Invalid initiatedBy: invalid-initiatedBy');
-    });
-
     it('creates an import job object with a startTime', () => {
       const importJob = createImportJob({ ...validImportJob, startTime: '' });
       expect(importJob.getStartTime()).to.match(/^20/);

--- a/packages/spacecat-shared-data-access/test/unit/models/importer/import-job.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/importer/import-job.test.js
@@ -25,6 +25,9 @@ const validImportJob = {
     enableJavascript: true,
     enableCss: true,
   },
+  initiatedBy: {
+    name: 'test',
+  },
 };
 describe('ImportJob Model tests', () => {
   describe('Validation Tests', () => {
@@ -48,9 +51,13 @@ describe('ImportJob Model tests', () => {
       expect(() => createImportJob({ ...validImportJob, hashedApiKey: 123 })).to.throw('Invalid API key: 123');
     });
 
+    it('throws an error if initiatedBy is not a valid object', () => {
+      expect(() => createImportJob({ ...validImportJob, initiatedBy: 'invalid-initiatedBy' })).to.throw('Invalid initiatedBy: invalid-initiatedBy');
+    });
+
     it('creates an import job object with a startTime', () => {
       const importJob = createImportJob({ ...validImportJob, startTime: '' });
-      expect(importJob.getStartTime()).is.not.empty;
+      expect(importJob.getStartTime()).to.match(/^20/);
     });
   });
 

--- a/packages/spacecat-shared-data-access/test/unit/service/import-job/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-job/index.test.js
@@ -60,7 +60,7 @@ describe('Import Job Tests', () => {
           hashedApiKey: '4c806362b613f7496abf284146efd31da90e4b16169fe001841ca17290f427c4',
           importQueueId: 'test-import-queue-id',
           initiatedBy: {
-            name: 'test-user',
+            apiKeyName: 'test-user',
             imsUserId: 'test-ims-user-id',
             imsOrgId: 'test-ims-org-id',
             userAgent: 'test-user-agent',
@@ -92,7 +92,7 @@ describe('Import Job Tests', () => {
           startTime: '2024-05-28T14:26:00.000Z',
           importQueueId: 'test-import-queue-id',
           initiatedBy: {
-            name: 'test-user',
+            apiKeyName: 'test-user',
             imsUserId: 'test-ims-user-id',
             imsOrgId: 'test-ims-org-id',
             userAgent: 'test-user-agent',
@@ -107,7 +107,7 @@ describe('Import Job Tests', () => {
           startTime: '2024-06-01T14:26:00.000Z',
           importQueueId: 'test-import-queue-id-1',
           initiatedBy: {
-            name: 'test-user',
+            apiKeyName: 'test-user',
             imsUserId: 'test-ims-user-id',
             imsOrgId: 'test-ims-org-id',
             userAgent: 'test-user-agent',
@@ -131,7 +131,7 @@ describe('Import Job Tests', () => {
           hashedApiKey: '4c806362b613f7496abf284146efd31da90e4b16169fe001841ca17290f427c4',
           importQueueId: 'test-import-queue-id',
           initiatedBy: {
-            name: 'test-user',
+            apiKeyName: 'test-user',
             imsUserId: 'test-ims-user-id',
             imsOrgId: 'test-ims-org-id',
             userAgent: 'test-user-agent',
@@ -145,7 +145,7 @@ describe('Import Job Tests', () => {
           hashedApiKey: '5c806362b613f7496abf284146efd31da90e4b16169fe001841ca17290f427c4',
           importQueueId: 'test-import-queue-id-1',
           initiatedBy: {
-            name: 'test-user',
+            apiKeyName: 'test-user',
             imsUserId: 'test-ims-user-id',
             imsOrgId: 'test-ims-org-id',
             userAgent: 'test-user-agent',
@@ -169,7 +169,7 @@ describe('Import Job Tests', () => {
           hashedApiKey: '4c806362b613f7496abf284146efd31da90e4b16169fe001841ca17290f427c4',
           importQueueId: 'test-import-queue-id',
           initiatedBy: {
-            name: 'test-user',
+            apiKeyName: 'test-user',
             imsUserId: 'test-ims-user-id',
             imsOrgId: 'test-ims-org-id',
             userAgent: 'test-user-agent',
@@ -179,7 +179,7 @@ describe('Import Job Tests', () => {
           mockImportJobData,
         );
 
-        expect(result.state.initiatedBy.name).to.equal('test-user');
+        expect(result.state.initiatedBy.apiKeyName).to.equal('test-user');
         expect(result.state.baseURL).to.equal('https://www.test.com');
       });
     });
@@ -194,7 +194,7 @@ describe('Import Job Tests', () => {
           hashedApiKey: '4c806362b613f7496abf284146efd31da90e4b16169fe001841ca17290f427c4',
           importQueueId: 'test-import-queue-id',
           initiatedBy: {
-            name: 'test-user',
+            apiKeyName: 'test-user',
             imsUserId: 'test-ims-user-id',
             imsOrgId: 'test-ims-org-id',
             userAgent: 'test-user-agent',
@@ -218,7 +218,7 @@ describe('Import Job Tests', () => {
           options: {},
           baseURL: 'https://www.test.com',
           initiatedBy: {
-            name: 'test-user',
+            apiKeyName: 'test-user',
             imsUserId: 'test-ims-user-id',
             imsOrgId: 'test-ims-org-id',
             userAgent: 'test-user-agent',

--- a/packages/spacecat-shared-data-access/test/unit/service/import-job/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-job/index.test.js
@@ -59,13 +59,17 @@ describe('Import Job Tests', () => {
           baseURL: 'https://www.test.com',
           hashedApiKey: '4c806362b613f7496abf284146efd31da90e4b16169fe001841ca17290f427c4',
           importQueueId: 'test-import-queue-id',
+          initiatedBy: {
+            name: 'test-user',
+            imsUserId: 'test-ims-user-id',
+            imsOrgId: 'test-ims-org-id',
+            userAgent: 'test-user-agent',
+          },
         };
         mockDynamoClient.getItem.resolves(mockImportJob);
         const result = await exportedFunctions.getImportJobByID('test-id');
 
-        expect(result).to.be.not.null;
         expect(result.state.id).to.equal('test-id');
-        expect(mockDynamoClient.getItem).to.have.been.calledOnce;
       });
 
       it('should return null if item is not found', async () => {
@@ -73,7 +77,7 @@ describe('Import Job Tests', () => {
 
         const result = await exportedFunctions.getImportJobByID('test-id');
 
-        expect(result).to.be.null;
+        expect(result).to.equal(null);
       });
     });
 
@@ -87,6 +91,12 @@ describe('Import Job Tests', () => {
           hashedApiKey: '4c806362b613f7496abf284146efd31da90e4b16169fe001841ca17290f427c4',
           startTime: '2024-05-28T14:26:00.000Z',
           importQueueId: 'test-import-queue-id',
+          initiatedBy: {
+            name: 'test-user',
+            imsUserId: 'test-ims-user-id',
+            imsOrgId: 'test-ims-org-id',
+            userAgent: 'test-user-agent',
+          },
         },
         {
           id: 'test-id-1',
@@ -96,6 +106,12 @@ describe('Import Job Tests', () => {
           hashedApiKey: '5c806362b613f7496abf284146efd31da90e4b16169fe001841ca17290f427c4',
           startTime: '2024-06-01T14:26:00.000Z',
           importQueueId: 'test-import-queue-id-1',
+          initiatedBy: {
+            name: 'test-user',
+            imsUserId: 'test-ims-user-id',
+            imsOrgId: 'test-ims-org-id',
+            userAgent: 'test-user-agent',
+          },
         }];
         mockDynamoClient.query.resolves(mockImportJobs);
 
@@ -114,6 +130,12 @@ describe('Import Job Tests', () => {
           baseURL: 'https://www.test.com',
           hashedApiKey: '4c806362b613f7496abf284146efd31da90e4b16169fe001841ca17290f427c4',
           importQueueId: 'test-import-queue-id',
+          initiatedBy: {
+            name: 'test-user',
+            imsUserId: 'test-ims-user-id',
+            imsOrgId: 'test-ims-org-id',
+            userAgent: 'test-user-agent',
+          },
         },
         {
           id: 'test-id-1',
@@ -122,6 +144,12 @@ describe('Import Job Tests', () => {
           baseURL: 'https://www.test1.com',
           hashedApiKey: '5c806362b613f7496abf284146efd31da90e4b16169fe001841ca17290f427c4',
           importQueueId: 'test-import-queue-id-1',
+          initiatedBy: {
+            name: 'test-user',
+            imsUserId: 'test-ims-user-id',
+            imsOrgId: 'test-ims-org-id',
+            userAgent: 'test-user-agent',
+          },
         }];
         mockDynamoClient.query.resolves(mockImportJobs);
 
@@ -140,13 +168,19 @@ describe('Import Job Tests', () => {
           baseURL: 'https://www.test.com',
           hashedApiKey: '4c806362b613f7496abf284146efd31da90e4b16169fe001841ca17290f427c4',
           importQueueId: 'test-import-queue-id',
+          initiatedBy: {
+            name: 'test-user',
+            imsUserId: 'test-ims-user-id',
+            imsOrgId: 'test-ims-org-id',
+            userAgent: 'test-user-agent',
+          },
         };
         const result = await exportedFunctions.createNewImportJob(
           mockImportJobData,
         );
 
-        expect(result).to.be.not.null;
-        expect(mockDynamoClient.putItem.calledOnce).to.be.true;
+        expect(result.state.initiatedBy.name).to.equal('test-user');
+        expect(result.state.baseURL).to.equal('https://www.test.com');
       });
     });
 
@@ -159,6 +193,12 @@ describe('Import Job Tests', () => {
           baseURL: 'https://www.test.com',
           hashedApiKey: '4c806362b613f7496abf284146efd31da90e4b16169fe001841ca17290f427c4',
           importQueueId: 'test-import-queue-id',
+          initiatedBy: {
+            name: 'test-user',
+            imsUserId: 'test-ims-user-id',
+            imsOrgId: 'test-ims-org-id',
+            userAgent: 'test-user-agent',
+          },
         };
         mockDynamoClient.getItem.resolves(mockImportJobData);
 
@@ -167,9 +207,6 @@ describe('Import Job Tests', () => {
         const result = await exportedFunctions.updateImportJob(
           importJob,
         );
-
-        expect(result).to.be.not.null;
-        expect(mockDynamoClient.putItem).to.have.been.calledOnce;
         expect(result.getStatus()).to.equal('COMPLETE');
       });
 
@@ -180,6 +217,12 @@ describe('Import Job Tests', () => {
           hashedApiKey: '4c806362b613f7496abf284146efd31da90e4b16169fe001841ca17290f427c4',
           options: {},
           baseURL: 'https://www.test.com',
+          initiatedBy: {
+            name: 'test-user',
+            imsUserId: 'test-ims-user-id',
+            imsOrgId: 'test-ims-org-id',
+            userAgent: 'test-user-agent',
+          },
         };
         const importJob = createImportJob(mockImportJobData);
         const result = exportedFunctions.updateImportJob(importJob);


### PR DESCRIPTION
## Related Issues
[SITES-23126](https://jira.corp.adobe.com/browse/SITES-23126)

Adding initiatedBy attribute to the importJob for analytics - to keep track of the jobs started by a user.
```
{
	"id": "b6f08173-0e76-41d6-a7c8-213edee64353",
	"baseURL": "https://www.canadiantire.ca",
	"options": {
		"enableJavascript": false,
		"scrollToBottom": true
	},
	"startTime": "2024-08-19T20:15:37.121Z",
	"status": "RUNNING",
	"urlCount": 1,
	"importQueueId": "spacecat-import-queue-1",
         "initiatedBy": {
            "name": 'test-user',
            "imsUserId": 'test-ims-user-id',
            "imsOrgId": 'test-ims-org-id',
            "userAgent": 'Mozilla/5.0',
          },
}
```