### PR TITLE
fix: add property to include specific urls in the site config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15518,7 +15518,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "1.42.0",
+      "version": "1.43.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-dynamo": "1.2.5",
@@ -19097,7 +19097,7 @@
     },
     "packages/spacecat-shared-http-utils": {
       "name": "@adobe/spacecat-shared-http-utils",
-      "version": "1.6.7",
+      "version": "1.6.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",

--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -30,7 +30,7 @@ export const configSchema = Joi.object({
       brokenTargetURL: Joi.string().optional(),
       targetURL: Joi.string().optional(),
     })).optional(),
-    productDetailPages: Joi.array().items(Joi.string()),
+    includedURLs: Joi.array().items(Joi.string()),
   }).unknown(true)).unknown(true),
 }).unknown(true);
 
@@ -64,7 +64,7 @@ export const Config = (data = {}) => {
   self.getExcludedURLs = (type) => state?.handlers[type]?.excludedURLs;
   self.getManualOverwrites = (type) => state?.handlers[type]?.manualOverwrites;
   self.getFixedURLs = (type) => state?.handlers[type]?.fixedURLs;
-  self.getProductDetailPages = (type) => state?.handlers[type]?.productDetailPages;
+  self.getIncludedURLs = (type) => state?.handlers[type]?.includedURLs;
 
   self.updateSlackConfig = (channel, workspace, invitedUserCount) => {
     state.slack = {


### PR DESCRIPTION
Upon several naming discussions, we decided to change the name from product detail pages so something more generic. 
