### PR TITLE
fix(audits): extend expiry date for audits from 1 to 6 months

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/audit.js
+++ b/packages/spacecat-shared-data-access/src/models/audit.js
@@ -25,7 +25,7 @@ export const AUDIT_TYPE_LHS_MOBILE = 'lhs-mobile';
 export const AUDIT_TYPE_EXPERIMENTATION_ESS_MONTHLY = 'experimentation-ess-monthly';
 export const AUDIT_TYPE_EXPERIMENTATION_ESS_DAILY = 'experimentation-ess-daily';
 
-const EXPIRES_IN_DAYS = 30;
+const EXPIRES_IN_DAYS = 30 * 6;
 
 const AUDIT_TYPE_PROPERTIES = {
   [AUDIT_TYPE_LHS_DESKTOP]: ['performance', 'seo', 'accessibility', 'best-practices'],

--- a/packages/spacecat-shared-data-access/test/unit/models/audit.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/audit.test.js
@@ -109,7 +109,7 @@ describe('Audit Model Tests', () => {
       const audit = createAudit(validData);
       expect(audit.getExpiresAt()).to.be.a('Date');
       const expectedDate = new Date(validData.auditedAt);
-      expectedDate.setDate(expectedDate.getDate() + 30);
+      expectedDate.setDate(expectedDate.getDate() + 30 * 6);
       expect(audit.getExpiresAt().toDateString()).to.equal(expectedDate.toDateString());
     });
   });


### PR DESCRIPTION
Extend expiry date for audits from 1 to 6 months.
Temporarily until we clarify how to rollup and summarize the data based on reporting use cases.