### PR TITLE
feat: Add a query to get all import urls by jobId

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17758,7 +17758,7 @@
     },
     "packages/spacecat-shared-content-client": {
       "name": "@adobe/spacecat-shared-content-client",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.0.5",

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -779,6 +779,9 @@ export interface DataAccess {
       jobId: string,
       status: string,
     ) => Promise<ImportUrl[]>;
+  getImportUrlsByJobId: (
+      jobId: string,
+    ) => Promise<ImportUrl[]>;
   getApiKeyByHashedApiKey: (
       hashedApiKey: string,
     ) => Promise<ApiKey | null>;

--- a/packages/spacecat-shared-data-access/src/service/import-url/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/import-url/accessPatterns.js
@@ -96,3 +96,23 @@ export const getImportUrlsByJobIdAndStatus = async (dynamoClient, config, log, j
   });
   return items.map((item) => ImportUrlDto.fromDynamoItem(item));
 };
+
+/**
+ * Get Import Urls by Job ID
+ * @param {DynamoClient} dynamoClient
+ * @param {Object} config
+ * @param {Logger} log
+ * @param {string} jobId
+ * @returns {Promise<ImportUrlDto[]>}
+ */
+export const getImportUrlsByJobId = async (dynamoClient, config, log, jobId) => {
+  const items = await dynamoClient.query({
+    TableName: config.tableNameImportUrls,
+    IndexName: config.indexNameImportUrlsByJobIdAndStatus,
+    KeyConditionExpression: 'jobId = :jobId',
+    ExpressionAttributeValues: {
+      ':jobId': jobId,
+    },
+  });
+  return items.map((item) => ImportUrlDto.fromDynamoItem(item));
+};

--- a/packages/spacecat-shared-data-access/src/service/import-url/accessPatterns.js
+++ b/packages/spacecat-shared-data-access/src/service/import-url/accessPatterns.js
@@ -79,7 +79,7 @@ export const updateImportUrl = async (dynamoClient, config, log, importUrl) => {
  * @param {Logger} log
  * @param {string} jobId
  * @param {string} status
- * @returns {Promise<ImportUrlDto[]>}
+ * @returns {Promise<ImportUrl[]>}
  */
 export const getImportUrlsByJobIdAndStatus = async (dynamoClient, config, log, jobId, status) => {
   const items = await dynamoClient.query({
@@ -103,7 +103,7 @@ export const getImportUrlsByJobIdAndStatus = async (dynamoClient, config, log, j
  * @param {Object} config
  * @param {Logger} log
  * @param {string} jobId
- * @returns {Promise<ImportUrlDto[]>}
+ * @returns {Promise<ImportUrl[]>}
  */
 export const getImportUrlsByJobId = async (dynamoClient, config, log, jobId) => {
   const items = await dynamoClient.query({

--- a/packages/spacecat-shared-data-access/src/service/import-url/index.js
+++ b/packages/spacecat-shared-data-access/src/service/import-url/index.js
@@ -14,7 +14,8 @@ import {
   getImportUrlById,
   createNewImportUrl,
   updateImportUrl,
-  getImportUrlsByJobIdAndStatus, getImportUrlsByJobId,
+  getImportUrlsByJobIdAndStatus,
+  getImportUrlsByJobId,
 } from './accessPatterns.js';
 
 export const importUrlFunctions = (dynamoClient, config, log) => ({

--- a/packages/spacecat-shared-data-access/src/service/import-url/index.js
+++ b/packages/spacecat-shared-data-access/src/service/import-url/index.js
@@ -14,7 +14,7 @@ import {
   getImportUrlById,
   createNewImportUrl,
   updateImportUrl,
-  getImportUrlsByJobIdAndStatus,
+  getImportUrlsByJobIdAndStatus, getImportUrlsByJobId,
 } from './accessPatterns.js';
 
 export const importUrlFunctions = (dynamoClient, config, log) => ({
@@ -42,5 +42,11 @@ export const importUrlFunctions = (dynamoClient, config, log) => ({
     log,
     jobId,
     status,
+  ),
+  getImportUrlsByJobId: (jobId) => getImportUrlsByJobId(
+    dynamoClient,
+    config,
+    log,
+    jobId,
   ),
 });

--- a/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
@@ -72,7 +72,7 @@ describe('Import Url Tests', () => {
           url: 'https://www.test.com',
         };
         await exportedFunctions.createNewImportUrl(mockImportUrl);
-        expect(mockDynamoClient.putItem.calledOnce).to.equal(true);
+        expect(mockDynamoClient.putItem.calledOnce).to.be.true;
       });
     });
 

--- a/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
@@ -60,7 +60,7 @@ describe('Import Url Tests', () => {
       it('should return null when an item is not found', async () => {
         mockDynamoClient.getItem.resolves(null);
         const result = await exportedFunctions.getImportUrlById('test-id');
-        expect(result).to.equal(null);
+        expect(result).to.be.null;
       });
     });
 

--- a/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
@@ -123,18 +123,18 @@ describe('Import Url Tests', () => {
     });
 
     describe('getImportUrlsByJobId', () => {
-      it('should return an array of ImportUrlDto when items are found', async () => {
+      it('should return an array of ImportUrl when items are found', async () => {
         const mockImportUrl = {
-          id: 'test-job-id',
+          id: 'test-url-id',
           status: 'RUNNING',
           url: 'https://www.test.com',
           jobId: 'test-job-id',
         };
         mockDynamoClient.query.resolves([mockImportUrl]);
-        const result = await exportedFunctions.getImportUrlsByJobId('test-job-id');
+        const result = await exportedFunctions.getImportUrlsByJobId('test-url-id');
         expect(result.length).to.equal(1);
         expect(result[0].getUrl()).to.equal('https://www.test.com');
-        expect(result[0].getId()).to.equal('test-job-id');
+        expect(result[0].getId()).to.equal('test-url-id');
       });
     });
   });

--- a/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
@@ -60,7 +60,7 @@ describe('Import Url Tests', () => {
       it('should return null when an item is not found', async () => {
         mockDynamoClient.getItem.resolves(null);
         const result = await exportedFunctions.getImportUrlById('test-id');
-        expect(result).to.be.null;
+        expect(result).to.equal(null);
       });
     });
 
@@ -72,7 +72,7 @@ describe('Import Url Tests', () => {
           url: 'https://www.test.com',
         };
         await exportedFunctions.createNewImportUrl(mockImportUrl);
-        expect(mockDynamoClient.putItem.calledOnce).to.be.true;
+        expect(mockDynamoClient.putItem.calledOnce).to.equal(true);
       });
     });
 
@@ -89,8 +89,8 @@ describe('Import Url Tests', () => {
         importUrl.setStatus('COMPLETE');
         const result = await exportedFunctions.updateImportUrl(importUrl);
 
-        expect(result).to.be.not.null;
-        expect(mockDynamoClient.putItem).to.have.been.calledOnce;
+        expect(result).to.not.equal(null);
+        expect(mockDynamoClient.putItem.callCount).to.equal(1);
         expect(result.getStatus()).to.equal('COMPLETE');
       });
 
@@ -119,6 +119,22 @@ describe('Import Url Tests', () => {
         const result = await exportedFunctions.getImportUrlsByJobIdAndStatus('test-job-id', 'RUNNING');
         expect(result.length).to.equal(1);
         expect(result[0].getUrl()).to.equal('https://www.test.com');
+      });
+    });
+
+    describe('getImportUrlsByJobId', () => {
+      it('should return an array of ImportUrlDto when items are found', async () => {
+        const mockImportUrl = {
+          id: 'test-job-id',
+          status: 'RUNNING',
+          url: 'https://www.test.com',
+          jobId: 'test-job-id',
+        };
+        mockDynamoClient.query.resolves([mockImportUrl]);
+        const result = await exportedFunctions.getImportUrlsByJobId('test-job-id');
+        expect(result.length).to.equal(1);
+        expect(result[0].getUrl()).to.equal('https://www.test.com');
+        expect(result[0].getId()).to.equal('test-job-id');
       });
     });
   });

--- a/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
@@ -89,8 +89,8 @@ describe('Import Url Tests', () => {
         importUrl.setStatus('COMPLETE');
         const result = await exportedFunctions.updateImportUrl(importUrl);
 
-        expect(result).to.not.equal(null);
-        expect(mockDynamoClient.putItem.callCount).to.equal(1);
+        expect(result).to.be.not.null;
+        expect(mockDynamoClient.putItem).to.have.been.calledOnce;
         expect(result.getStatus()).to.equal('COMPLETE');
       });
 

--- a/packages/spacecat-shared-data-access/test/unit/service/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/index.test.js
@@ -91,6 +91,7 @@ describe('Data Access Object Tests', () => {
     'createNewImportUrl',
     'updateImportUrl',
     'getImportUrlsByJobIdAndStatus',
+    'getImportUrlsByJobId',
   ];
 
   const experimentFunctions = [


### PR DESCRIPTION
## Related Issues
[SITES-24337](https://jira.corp.adobe.com/browse/SITES-24337)

We want to add a query to retrieve all URLs based on a jobId to generate an import report.
The discussion started here: https://github.com/adobe/spacecat-content-processor/pull/143#discussion_r1754542157
for this PR.