### PR TITLE
feat: update redirects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6898,6 +6898,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/graph-data-structure": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/graph-data-structure/-/graph-data-structure-4.0.0.tgz",
+      "integrity": "sha512-QQaIgq8nQmSxDdYT7F/bmn/5tmB17VPY0Vz+9nGL4QtvkcDphboq3pcwLL4k0cX7nK+UWMScnNPf47vPNCPCFQ==",
+      "license": "MIT"
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "dev": true,
@@ -17763,7 +17769,8 @@
       "dependencies": {
         "@adobe/helix-universal": "5.0.5",
         "@adobe/spacecat-helix-content-sdk": "1.1.7",
-        "@adobe/spacecat-shared-utils": "1.19.6"
+        "@adobe/spacecat-shared-utils": "1.19.6",
+        "graph-data-structure": "4.0.0"
       },
       "devDependencies": {
         "chai": "5.1.1",
@@ -18185,7 +18192,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "1.43.4",
+      "version": "1.44.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-dynamo": "1.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -253,10 +253,9 @@
       }
     },
     "node_modules/@adobe/spacecat-helix-content-sdk": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-helix-content-sdk/-/spacecat-helix-content-sdk-1.1.7.tgz",
-      "integrity": "sha512-b305seiD9shMgNBb+vnGLUvPqQ9YiqftJk+OhtrkveOBKU+SU12TtyZ09MdSBR9YN71alZl4RwCMn/yHPXTTeg==",
-      "license": "Apache-2.0",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-helix-content-sdk/-/spacecat-helix-content-sdk-1.1.8.tgz",
+      "integrity": "sha512-8Aw3SUjM6dG/e/yXeSawn7I+XoagPNTQVxVnIuctqxdGzD7DSrQBBz/LuwP9w3zjAe1NQkEke2nP2U6vrc1amw==",
       "dependencies": {
         "@adobe/fetch": "4.1.8",
         "@adobe/helix-docx2md": "1.6.6",
@@ -14726,7 +14725,6 @@
       "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-4.0.0.tgz",
       "integrity": "sha512-cWqO7O2I4XfJDWyWElAQ9D/dtdh5Mo0RHndsfiiYyjWnlPzBJdIvjCVURO4EjyYaC3BjV+ISNXCfTXPXTEIEWA==",
       "dev": true,
-      "license": "(BSD-2-Clause OR WTFPL)",
       "peerDependencies": {
         "chai": "^5.0.0",
         "sinon": ">=4.0.0"
@@ -17768,7 +17766,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.0.5",
-        "@adobe/spacecat-helix-content-sdk": "1.1.7",
+        "@adobe/spacecat-helix-content-sdk": "1.1.8",
         "@adobe/spacecat-shared-utils": "1.19.6",
         "graph-data-structure": "4.0.0"
       },
@@ -17778,7 +17776,7 @@
         "esmock": "2.6.7",
         "nock": "13.5.4",
         "sinon": "18.0.0",
-        "sinon-chai": "4.0.0",
+        "sinon-chai": "^4.0.0",
         "typescript": "5.5.4"
       },
       "engines": {

--- a/packages/spacecat-shared-content-client/package.json
+++ b/packages/spacecat-shared-content-client/package.json
@@ -36,7 +36,8 @@
   "dependencies": {
     "@adobe/helix-universal": "5.0.5",
     "@adobe/spacecat-helix-content-sdk": "1.1.7",
-    "@adobe/spacecat-shared-utils": "1.19.6"
+    "@adobe/spacecat-shared-utils": "1.19.6",
+    "graph-data-structure": "4.0.0"
   },
   "devDependencies": {
     "chai": "5.1.1",

--- a/packages/spacecat-shared-content-client/package.json
+++ b/packages/spacecat-shared-content-client/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@adobe/helix-universal": "5.0.5",
-    "@adobe/spacecat-helix-content-sdk": "1.1.7",
+    "@adobe/spacecat-helix-content-sdk": "1.1.8",
     "@adobe/spacecat-shared-utils": "1.19.6",
     "graph-data-structure": "4.0.0"
   },

--- a/packages/spacecat-shared-content-client/src/clients/content-client.js
+++ b/packages/spacecat-shared-content-client/src/clients/content-client.js
@@ -170,7 +170,7 @@ const removeRedirectLoops = (currentRedirects, newRedirects, log) => {
     }
   });
   if (newRedirects.length !== noCycleRedirects.length) {
-    this.log.info(`Removed ${newRedirects.length - noCycleRedirects.length} redirect loops`);
+    log.info(`Removed ${newRedirects.length - noCycleRedirects.length} redirect loops`);
   }
   return noCycleRedirects;
 };

--- a/packages/spacecat-shared-content-client/src/clients/content-client.js
+++ b/packages/spacecat-shared-content-client/src/clients/content-client.js
@@ -158,7 +158,7 @@ const removeRedirectLoops = (currentRedirects, newRedirects, log) => {
   const noCycleRedirects = [];
   currentRedirects.forEach((r) => redirectsGraph.addEdge(r.from, r.to));
   if (hasCycle(redirectsGraph)) {
-    throw new Error('Redirect cycle detected');
+    throw new Error('Redirect cycle detected in current redirects');
   }
   newRedirects.forEach((r) => {
     redirectsGraph.addEdge(r.from, r.to);

--- a/packages/spacecat-shared-content-client/src/clients/content-client.js
+++ b/packages/spacecat-shared-content-client/src/clients/content-client.js
@@ -99,7 +99,7 @@ const validateMetadata = (metadata) => {
 };
 
 const validateRedirects = (redirects) => {
-  const pathRegex = /^\/(?:[a-zA-Z0-9\-._~%!$&'()*+,;=:@]+\/?)*$/;
+  const pathRegex = /^\/[a-zA-Z0-9\-._~%!$&'()*+,;=:@/]*$/;
   if (!Array.isArray(redirects)) {
     throw new Error('Redirects must be an array');
   }

--- a/packages/spacecat-shared-content-client/src/clients/content-client.js
+++ b/packages/spacecat-shared-content-client/src/clients/content-client.js
@@ -99,6 +99,7 @@ const validateMetadata = (metadata) => {
 };
 
 const validateRedirects = (redirects) => {
+  const pathRegex = /^\/(?:[a-zA-Z0-9\-._~%!$&'()*+,;=:@]+\/?)*$/;
   if (!Array.isArray(redirects)) {
     throw new Error('Redirects must be an array');
   }
@@ -120,12 +121,12 @@ const validateRedirects = (redirects) => {
       throw new Error('Redirect must have a valid to path');
     }
 
-    if (!redirect.from.startsWith('/')) {
-      throw new Error('Redirect from path must start with a slash');
+    if (!pathRegex.test(redirect.from)) {
+      throw new Error(`Invalid redirect from path: ${redirect.from}`);
     }
 
-    if (!redirect.to.startsWith('/')) {
-      throw new Error('Redirect to path must start with a slash');
+    if (!pathRegex.test(redirect.to)) {
+      throw new Error(`Invalid redirect to path: ${redirect.to}`);
     }
 
     if (redirect.from === redirect.to) {

--- a/packages/spacecat-shared-content-client/test/clients/content-client.test.js
+++ b/packages/spacecat-shared-content-client/test/clients/content-client.test.js
@@ -419,6 +419,16 @@ describe('ContentClient', () => {
       const client = ContentClient.createFrom(context, siteConfigGoogleDrive);
       await expect(client.updateRedirects(newRedirects)).to.be.rejectedWith('Redirect cycle detected');
     });
+    it('does not call rawClient when all redirects are duplicates', async () => {
+      const newRedirects = [
+        { from: '/test-A', to: '/test-B' },
+        { from: '/test-C', to: '/test-D' },
+      ];
+      ContentClient = await createContentClientForRedirects(existingRedirects);
+      const client = ContentClient.createFrom(context, siteConfigGoogleDrive);
+      await client.updateRedirects(newRedirects);
+      await expect(client.rawClient.appendRedirects).to.not.have.been.called;
+    });
     it('does not call rawClient when there are no valid redirects', async () => {
       const newRedirects = [
         { from: '/test-D', to: '/test-A' },

--- a/packages/spacecat-shared-content-client/test/clients/content-client.test.js
+++ b/packages/spacecat-shared-content-client/test/clients/content-client.test.js
@@ -43,6 +43,12 @@ describe('ContentClient', () => {
     ['keywords', 'test, metadata'],
   ]);
 
+  const existingRedirects = [
+    { from: '/test-A', to: '/test-B' },
+    { from: '/test-C', to: '/test-D' },
+    { from: '/test-B', to: '/test-D' },
+  ];
+
   const createContentClient = async (getPageMetadata) => {
     const contentSDK = sinon.stub().returns({
       getPageMetadata: sinon.stub().resolves(getPageMetadata),
@@ -59,6 +65,20 @@ describe('ContentClient', () => {
       getPageMetadata: getError
         ? sinon.stub().rejects(new Error(errorMessage)) : sinon.stub().resolves(new Map()),
       updatePageMetadata: sinon.stub().resolves(updateError ? { status: 500 } : { status: 200 }),
+      getRedirects: getError
+        ? sinon.stub().rejects(new Error(errorMessage)) : sinon.stub().resolves(existingRedirects),
+      appendRedirects: sinon.stub().resolves(updateError ? { status: 500 } : { status: 200 }),
+    });
+
+    return esmock('../../src/clients/content-client.js', {
+      '@adobe/spacecat-helix-content-sdk': { createFrom: contentSDK },
+    });
+  };
+
+  const createContentClientForRedirects = async (getRedirects) => {
+    const contentSDK = sinon.stub().returns({
+      getRedirects: sinon.stub().resolves(getRedirects),
+      appendRedirects: sinon.stub().resolves({ status: 200 }),
     });
 
     return esmock('../../src/clients/content-client.js', {
@@ -325,6 +345,62 @@ describe('ContentClient', () => {
 
       expect(updatedMetadata).to.deep.equal(expectedMetadata);
       expect(client.rawClient.updatePageMetadata.calledOnceWith('/test-path', expectedMetadata)).to.be.true;
+    });
+  });
+
+  describe('updateRedirects', () => {
+    it('throws an error if raw client has non-200 status', async () => {
+      ContentClient = await createErrorContentClient(false, true, 'Error updating redirects');
+      const client = ContentClient.createFrom(context, siteConfigGoogleDrive);
+      await expect(client.updateRedirects([{ from: '/A', to: '/B' }])).to.be.rejectedWith('Failed to update redirects');
+    });
+    it('throws an error if new redirects are not an array', async () => {
+      const client = ContentClient.createFrom(context, siteConfigGoogleDrive);
+      await expect(client.updateRedirects({})).to.be.rejectedWith('Redirects must be an array');
+    });
+    it('throws an error if new redirects are an empty array', async () => {
+      const client = ContentClient.createFrom(context, siteConfigGoogleDrive);
+      await expect(client.updateRedirects([])).to.be.rejectedWith('Redirects must not be empty');
+    });
+    it('throws an error if new redirects contains an invalid entry', async () => {
+      const client = ContentClient.createFrom(context, siteConfigGoogleDrive);
+      await expect(client.updateRedirects([{ from: '/A', to: '/B' }, 'malformed-redirect'])).to.be.rejectedWith('Redirect must be an object');
+      await expect(client.updateRedirects([{ from: '/A', to: '/B' }, { from: '', to: '/B' }])).to.be.rejectedWith('Redirect must have a valid from path');
+      await expect(client.updateRedirects([{ from: '/A', to: '/B' }, { from: '/A', to: '' }])).to.be.rejectedWith('Redirect must have a valid to path');
+      await expect(client.updateRedirects([{ from: 'A', to: '/B' }, { from: '/A', to: '/C' }])).to.be.rejectedWith('Redirect from path must start with a slash');
+      await expect(client.updateRedirects([{ from: '/A', to: 'B' }, { from: '/A', to: '/C' }])).to.be.rejectedWith('Redirect to path must start with a slash');
+      await expect(client.updateRedirects([{ from: '/A', to: '/B' }, { from: '/A', to: '/A' }])).to.be.rejectedWith('Redirect from and to paths must be different');
+    });
+    it('update success', async () => {
+      const newRedirects = [
+        { from: '/test-X', to: '/test-Y' },
+      ];
+
+      ContentClient = await createContentClientForRedirects(existingRedirects);
+      const client = ContentClient.createFrom(context, siteConfigGoogleDrive);
+      await client.updateRedirects(newRedirects);
+      await expect(client.rawClient.appendRedirects.calledOnceWith(sinon.match([{ from: '/test-X', to: '/test-Y' }]))).to.be.true;
+    });
+    it('update success ignores duplicates', async () => {
+      const newRedirects = [
+        { from: '/test-A', to: '/test-B' },
+        { from: '/test-X', to: '/test-Y' },
+        { from: '/test-B', to: '/test-D' },
+        { from: '/test-X', to: '/test-Y' },
+      ];
+
+      ContentClient = await createContentClientForRedirects(existingRedirects);
+      const client = ContentClient.createFrom(context, siteConfigGoogleDrive);
+      await client.updateRedirects(newRedirects);
+      await expect(client.rawClient.appendRedirects.calledOnceWith(sinon.match([{ from: '/test-X', to: '/test-Y' }]))).to.be.true;
+    });
+    it('detect cycles', async () => {
+      const newRedirects = [
+        { from: '/test-D', to: '/test-A' },
+      ];
+      ContentClient = await createContentClientForRedirects(existingRedirects);
+      const client = ContentClient.createFrom(context, siteConfigGoogleDrive);
+      await expect(client.updateRedirects(newRedirects)).to.be.rejectedWith('Redirect cycle detected');
     });
   });
 });

--- a/packages/spacecat-shared-content-client/test/clients/content-client.test.js
+++ b/packages/spacecat-shared-content-client/test/clients/content-client.test.js
@@ -369,8 +369,8 @@ describe('ContentClient', () => {
       await expect(client.updateRedirects([{ from: '/A', to: '/B' }, 'malformed-redirect'])).to.be.rejectedWith('Redirect must be an object');
       await expect(client.updateRedirects([{ from: '/A', to: '/B' }, { from: '', to: '/B' }])).to.be.rejectedWith('Redirect must have a valid from path');
       await expect(client.updateRedirects([{ from: '/A', to: '/B' }, { from: '/A', to: '' }])).to.be.rejectedWith('Redirect must have a valid to path');
-      await expect(client.updateRedirects([{ from: 'A', to: '/B' }, { from: '/A', to: '/C' }])).to.be.rejectedWith('Redirect from path must start with a slash');
-      await expect(client.updateRedirects([{ from: '/A', to: 'B' }, { from: '/A', to: '/C' }])).to.be.rejectedWith('Redirect to path must start with a slash');
+      await expect(client.updateRedirects([{ from: 'A', to: '/B' }, { from: '/A', to: '/C' }])).to.be.rejectedWith('Invalid redirect from path: A');
+      await expect(client.updateRedirects([{ from: '/A', to: 'B' }, { from: '/A', to: '/C' }])).to.be.rejectedWith('Invalid redirect to path: B');
       await expect(client.updateRedirects([{ from: '/A', to: '/B' }, { from: '/A', to: '/A' }])).to.be.rejectedWith('Redirect from and to paths must be different');
     });
     it('update success', async () => {


### PR DESCRIPTION
Feature to update redirects spreadsheet for an Edge Delivery Services website.
Receives a list of new redirects, validates them, ensuring they have the right format, and that they will not duplicate or create cycles with the existing redirect rules, and appends them to the existing rules in the spreadsheet.