### PR TITLE
SITES-24645: [Importer] Add validation check for jobId while creating an import URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17811,7 +17811,7 @@
     },
     "packages/spacecat-shared-ahrefs-client": {
       "name": "@adobe/spacecat-shared-ahrefs-client",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",
@@ -19265,7 +19265,7 @@
     },
     "packages/spacecat-shared-content-client": {
       "name": "@adobe/spacecat-shared-content-client",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.0.5",
@@ -19692,7 +19692,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "1.44.0",
+      "version": "1.44.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-dynamo": "1.2.5",
@@ -20762,7 +20762,7 @@
     },
     "packages/spacecat-shared-dynamo": {
       "name": "@adobe/spacecat-shared-dynamo",
-      "version": "1.3.35",
+      "version": "1.3.36",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.1.0",
@@ -20799,7 +20799,7 @@
     },
     "packages/spacecat-shared-google-client": {
       "name": "@adobe/spacecat-shared-google-client",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",
@@ -22961,7 +22961,7 @@
     },
     "packages/spacecat-shared-gpt-client": {
       "name": "@adobe/spacecat-shared-gpt-client",
-      "version": "1.2.12",
+      "version": "1.2.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",
@@ -23058,7 +23058,7 @@
     },
     "packages/spacecat-shared-http-utils": {
       "name": "@adobe/spacecat-shared-http-utils",
-      "version": "1.6.8",
+      "version": "1.6.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",
@@ -29088,7 +29088,7 @@
     },
     "packages/spacecat-shared-ims-client": {
       "name": "@adobe/spacecat-shared-ims-client",
-      "version": "1.3.13",
+      "version": "1.3.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",
@@ -29151,7 +29151,7 @@
     },
     "packages/spacecat-shared-rum-api-client": {
       "name": "@adobe/spacecat-shared-rum-api-client",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",
@@ -29181,7 +29181,7 @@
     },
     "packages/spacecat-shared-slack-client": {
       "name": "@adobe/spacecat-shared-slack-client",
-      "version": "1.3.14",
+      "version": "1.3.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.0.5",
@@ -29245,7 +29245,7 @@
     },
     "packages/spacecat-shared-utils": {
       "name": "@adobe/spacecat-shared-utils",
-      "version": "1.19.7",
+      "version": "1.19.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.8",

--- a/packages/spacecat-shared-data-access/src/models/importer/import-url.js
+++ b/packages/spacecat-shared-data-access/src/models/importer/import-url.js
@@ -105,6 +105,10 @@ export const createImportUrl = (data) => {
     throw new Error(`Invalid Url: ${newState.url}`);
   }
 
+  if (!hasText(newState.jobId)) {
+    throw new Error(`Invalid Job ID: ${newState.jobId}`);
+  }
+
   if (!Object.values(ImportUrlStatus).includes(newState.status)) {
     throw new Error(`Invalid Import URL status: ${newState.status}`);
   }

--- a/packages/spacecat-shared-data-access/test/unit/models/importer/import-url.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/importer/import-url.test.js
@@ -42,6 +42,10 @@ describe('ImportUrl Model tests', () => {
     it('throws an error if status is invalid', () => {
       expect(() => createImportUrl({ ...validImportUrlData, status: 'invalid' })).to.throw('Invalid Import URL status: invalid');
     });
+
+    it('throws an error if jobId is not a valid string', () => {
+      expect(() => createImportUrl({ ...validImportUrlData, jobId: null })).to.throw('Invalid Job ID: null');
+    });
   });
   describe('Import URL Functionality Tests', () => {
     let importUrl;

--- a/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
@@ -69,6 +69,7 @@ describe('Import Url Tests', () => {
         const mockImportUrl = {
           id: 'test-id',
           status: 'RUNNING',
+          jobId: 'test-job-id',
           url: 'https://www.test.com',
         };
         await exportedFunctions.createNewImportUrl(mockImportUrl);
@@ -80,6 +81,7 @@ describe('Import Url Tests', () => {
       it('should update an existing importUrl with the correct status', async () => {
         const mockImportUrl = {
           id: 'test-id',
+          jobId: 'test-job-id',
           status: 'RUNNING',
           url: 'https://www.test.com',
         };
@@ -97,6 +99,7 @@ describe('Import Url Tests', () => {
       it('should throw an error when the importUrl does not exist', async () => {
         const mockImportUrl = {
           id: 'test-id',
+          jobId: 'test-job-id',
           status: 'RUNNING',
           url: 'https://www.test.com',
         };


### PR DESCRIPTION
## Related Issues
[SITES-24645](https://jira.corp.adobe.com/browse/SITES-24645)

We want to add a validation check for jobId in spacecat-shared while creating an import-url.
We do not want an import-url entry in the DB without the jobId attribute.

