### PR TITLE
feat: Add an additional scope to all imports on all domains

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/api-key.js
+++ b/packages/spacecat-shared-data-access/src/models/api-key.js
@@ -26,6 +26,7 @@ const scopeNames = [
   'imports.read',
   'imports.write',
   'imports.read_all',
+  'imports.write_all_domains',
 ];
 
 const ApiKey = (data) => {


### PR DESCRIPTION
## Related Issues

[SITES-22756](https://jira.corp.adobe.com/browse/SITES-22756)

Add an additional scope `'imports.write_all_domains'` to allow imports on all domains.