### PR TITLE
feat: Expire URLs automatically after set period of time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18699,7 +18699,7 @@
     },
     "packages/spacecat-shared-content-client": {
       "name": "@adobe/spacecat-shared-content-client",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.0.6",

--- a/packages/spacecat-shared-data-access/docs/schema.json
+++ b/packages/spacecat-shared-data-access/docs/schema.json
@@ -1089,6 +1089,10 @@
       },
       "NonKeyAttributes": [
         {
+          "AttributeName": "expiresAt",
+          "AttributeType": "S"
+        },
+        {
           "AttributeName": "file",
           "AttributeType": "S"
         },

--- a/packages/spacecat-shared-data-access/docs/schema.json
+++ b/packages/spacecat-shared-data-access/docs/schema.json
@@ -1090,7 +1090,7 @@
       "NonKeyAttributes": [
         {
           "AttributeName": "expiresAt",
-          "AttributeType": "S"
+          "AttributeType": "N"
         },
         {
           "AttributeName": "file",

--- a/packages/spacecat-shared-data-access/src/dto/audit.js
+++ b/packages/spacecat-shared-data-access/src/dto/audit.js
@@ -13,15 +13,7 @@
 import { isObject } from '@adobe/spacecat-shared-utils';
 
 import { createAudit } from '../models/audit.js';
-
-function parseEpochToDate(epochInSeconds) {
-  const milliseconds = epochInSeconds * 1000;
-  return new Date(milliseconds);
-}
-
-function convertDateToEpochSeconds(date) {
-  return Math.floor(date.getTime() / 1000);
-}
+import { convertDateToEpochSeconds, parseEpochToDate } from './dto-utils.js';
 
 /**
  * Data transfer object for Audit.

--- a/packages/spacecat-shared-data-access/src/dto/dto-utils.js
+++ b/packages/spacecat-shared-data-access/src/dto/dto-utils.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Parse the given Epoch timestamp, in seconds, to a Date object.
+ * @param {number} epochInSeconds - The Epoch timestamp in seconds.
+ * @returns {Date} A new Date object set to the given timestamp.
+ */
+export function parseEpochToDate(epochInSeconds) {
+  const milliseconds = epochInSeconds * 1000;
+  return new Date(milliseconds);
+}
+
+/**
+ * Convert the given Date object to an Epoch timestamp, in seconds.
+ * @param {Date} date - The Date object to convert.
+ * @returns {number} The Epoch timestamp in seconds.
+ */
+export function convertDateToEpochSeconds(date) {
+  return Math.floor(date.getTime() / 1000);
+}

--- a/packages/spacecat-shared-data-access/src/dto/import-url.js
+++ b/packages/spacecat-shared-data-access/src/dto/import-url.js
@@ -11,6 +11,7 @@
  */
 
 import { createImportUrl } from '../models/importer/import-url.js';
+import { convertDateToEpochSeconds, parseEpochToDate } from './dto-utils.js';
 
 /**
  * The ImportUrlDto is a helper that can convert an ImportUrl object to a DynamoDB item and
@@ -30,6 +31,7 @@ export const ImportUrlDto = {
     reason: importUrl.getReason(),
     path: importUrl.getPath(),
     file: importUrl.getFile(),
+    expiresAt: convertDateToEpochSeconds(importUrl.getExpiresAt()),
   }),
 
   /**
@@ -46,6 +48,7 @@ export const ImportUrlDto = {
       reason: dynamoItem.reason,
       path: dynamoItem.path,
       file: dynamoItem.file,
+      expiresAt: parseEpochToDate(dynamoItem.expiresAt),
     };
     return createImportUrl(importUrlData);
   },

--- a/packages/spacecat-shared-data-access/src/models/importer/import-url.js
+++ b/packages/spacecat-shared-data-access/src/models/importer/import-url.js
@@ -14,6 +14,8 @@ import { hasText, isValidUrl } from '@adobe/spacecat-shared-utils';
 import { Base } from '../base.js';
 import { ImportUrlStatus } from './import-constants.js';
 
+const EXPIRES_IN_DAYS = 30;
+
 /**
  * Creates a new ImportUrl object
  *
@@ -31,6 +33,11 @@ const ImportUrl = (data) => {
   self.getPath = () => self.state.path;
   // Resulting path and filename of the imported .docx file
   self.getFile = () => self.state.file;
+
+  if (!self.expiresAt) {
+    self.expiresAt = new Date();
+    self.expiresAt.setDate(self.expiresAt.getDate() + EXPIRES_IN_DAYS);
+  }
 
   /**
    * Updates the state of the ImportJob.

--- a/packages/spacecat-shared-data-access/src/models/importer/import-url.js
+++ b/packages/spacecat-shared-data-access/src/models/importer/import-url.js
@@ -14,7 +14,7 @@ import { hasText, isValidUrl } from '@adobe/spacecat-shared-utils';
 import { Base } from '../base.js';
 import { ImportUrlStatus } from './import-constants.js';
 
-const EXPIRES_IN_DAYS = 30;
+export const IMPORT_URL_EXPIRES_IN_DAYS = 30;
 
 /**
  * Creates a new ImportUrl object
@@ -33,11 +33,8 @@ const ImportUrl = (data) => {
   self.getPath = () => self.state.path;
   // Resulting path and filename of the imported .docx file
   self.getFile = () => self.state.file;
-
-  if (!self.expiresAt) {
-    self.expiresAt = new Date();
-    self.expiresAt.setDate(self.expiresAt.getDate() + EXPIRES_IN_DAYS);
-  }
+  // Expiration date for the URL
+  self.getExpiresAt = () => self.state.expiresAt;
 
   /**
    * Updates the state of the ImportJob.
@@ -107,6 +104,11 @@ export const createImportUrl = (data) => {
 
   if (!Object.values(ImportUrlStatus).includes(newState.status)) {
     throw new Error(`Invalid Import URL status: ${newState.status}`);
+  }
+
+  if (!newState.expiresAt) {
+    newState.expiresAt = new Date();
+    newState.expiresAt.setDate(newState.expiresAt.getDate() + IMPORT_URL_EXPIRES_IN_DAYS);
   }
 
   return ImportUrl(newState);

--- a/packages/spacecat-shared-data-access/test/it/db.test.js
+++ b/packages/spacecat-shared-data-access/test/it/db.test.js
@@ -34,6 +34,7 @@ import {
 import { KEY_EVENT_TYPES } from '../../src/models/key-event.js';
 import { ConfigurationDto } from '../../src/dto/configuration.js';
 import { ImportJobStatus, ImportOptions, ImportUrlStatus } from '../../src/index.js';
+import { IMPORT_URL_EXPIRES_IN_DAYS } from '../../src/models/importer/import-url.js';
 
 use(chaiAsPromised);
 
@@ -1094,6 +1095,12 @@ describe('DynamoDB Integration Test', async () => {
 
         expect(url.getId()).to.be.a('string');
         expect(url.getJobId()).to.equal(job.getId());
+
+        // Check that expiresAt was set correctly
+        const expectedExpiresAtDate = new Date();
+        expectedExpiresAtDate.setDate(expectedExpiresAtDate.getDate() + IMPORT_URL_EXPIRES_IN_DAYS);
+
+        expect(url.getExpiresAt().toDateString()).to.equal(expectedExpiresAtDate.toDateString());
       });
 
       it('Verify getImportUrlById', async () => {


### PR DESCRIPTION
Adds an `expiresAt` field to import-url entities which will be leveraged by Dynamo to automatically remove items after their TTL has elapsed.

## Related Issues

- [SITES-23373](https://jira.corp.adobe.com/browse/SITES-23373)
