### PR TITLE
fix: gracefully handle config in case handler is not defined

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -57,14 +57,14 @@ export const Config = (data = {}) => {
   const state = { ...validConfig };
   const self = { state };
   self.getSlackConfig = () => state.slack;
-  self.getSlackMentions = (type) => state?.handlers[type]?.mentions?.slack;
-  self.getHandlerConfig = (type) => state?.handlers[type];
+  self.getSlackMentions = (type) => state?.handlers?.[type]?.mentions?.slack;
+  self.getHandlerConfig = (type) => state?.handlers?.[type];
   self.getHandlers = () => state.handlers;
   self.getImports = () => state.imports;
-  self.getExcludedURLs = (type) => state?.handlers[type]?.excludedURLs;
-  self.getManualOverwrites = (type) => state?.handlers[type]?.manualOverwrites;
-  self.getFixedURLs = (type) => state?.handlers[type]?.fixedURLs;
-  self.getIncludedURLs = (type) => state?.handlers[type]?.includedURLs;
+  self.getExcludedURLs = (type) => state?.handlers?.[type]?.excludedURLs;
+  self.getManualOverwrites = (type) => state?.handlers?.[type]?.manualOverwrites;
+  self.getFixedURLs = (type) => state?.handlers?.[type]?.fixedURLs;
+  self.getIncludedURLs = (type) => state?.handlers?.[type]?.includedURLs;
 
   self.updateSlackConfig = (channel, workspace, invitedUserCount) => {
     state.slack = {

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -132,6 +132,16 @@ describe('Config Tests', () => {
       const updatedImports = config.getImports();
       expect(updatedImports).to.deep.equal(imports);
     });
+
+    it('should fail gracefully if handler is not present in the configuration', () => {
+      const config = Config();
+      expect(config.getSlackMentions('404')).to.be.undefined;
+      expect(config.getHandlerConfig('404')).to.be.undefined;
+      expect(config.getExcludedURLs('404')).to.be.undefined;
+      expect(config.getManualOverwrites('404')).to.be.undefined;
+      expect(config.getFixedURLs('404')).to.be.undefined;
+      expect(config.getIncludedURLs('404')).to.be.undefined;
+    });
   });
 
   describe('fromDynamoItem Static Method', () => {


### PR DESCRIPTION
Fix a bug where an undefined handler config would throw an error.
https://cq-dev.slack.com/archives/C06AVLUPML5/p1728172881655109