### PR TITLE
feat: Support import job deletion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18843,7 +18843,7 @@
     },
     "packages/spacecat-shared-content-client": {
       "name": "@adobe/spacecat-shared-content-client",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.0.6",

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -890,7 +890,6 @@ interface DataAccessConfig {
   indexNameAllOrganizationsByImsOrgId: string,
   indexNameAllImportJobsByStatus: string,
   indexNameAllImportJobsByDateRange: string,
-  indexNameAllImportUrlsByJobIdAndStatus: string,
   indexNameImportUrlsByJobIdAndStatus: string,
   indexNameApiKeyByHashedApiKey: string,
   pkAllSites: string;

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -891,6 +891,7 @@ interface DataAccessConfig {
   indexNameAllImportJobsByStatus: string,
   indexNameAllImportJobsByDateRange: string,
   indexNameAllImportUrlsByJobIdAndStatus: string,
+  indexNameImportUrlsByJobIdAndStatus: string,
   indexNameApiKeyByHashedApiKey: string,
   pkAllSites: string;
   pkAllLatestAudits: string;

--- a/packages/spacecat-shared-data-access/src/models/api-key.js
+++ b/packages/spacecat-shared-data-access/src/models/api-key.js
@@ -25,6 +25,7 @@ const scopeNames = [
   'audits.write_all',
   'imports.read',
   'imports.write',
+  'imports.delete',
   'imports.read_all',
   'imports.all_domains',
 ];

--- a/packages/spacecat-shared-data-access/src/service/import-job/index.js
+++ b/packages/spacecat-shared-data-access/src/service/import-job/index.js
@@ -16,6 +16,7 @@ import {
   getImportJobsByStatus,
   updateImportJob,
   getImportJobsByDateRange,
+  removeImportJob,
 } from './accessPatterns.js';
 
 export const importJobFunctions = (dynamoClient, config, log) => ({
@@ -44,10 +45,16 @@ export const importJobFunctions = (dynamoClient, config, log) => ({
     log,
     importJobData,
   ),
-  updateImportJob: (importJobData) => updateImportJob(
+  updateImportJob: (importJob) => updateImportJob(
     dynamoClient,
     config,
     log,
-    importJobData,
+    importJob,
+  ),
+  removeImportJob: (importJob) => removeImportJob(
+    dynamoClient,
+    config,
+    log,
+    importJob,
   ),
 });

--- a/packages/spacecat-shared-data-access/test/it/db.test.js
+++ b/packages/spacecat-shared-data-access/test/it/db.test.js
@@ -1086,6 +1086,32 @@ describe('DynamoDB Integration Test', async () => {
         const jobs = await dataAccess.getImportJobsByDateRange(startTime, endDate);
         expect(jobs.length).to.be.greaterThan(0);
       });
+
+      it('Verify removeImportJob', async () => {
+        const job = await createNewImportJob();
+        const jobId = job.getId();
+        const url = await createNewImportUrl(job);
+        const url2 = await createNewImportUrl(job);
+
+        expect(url.getId()).to.be.a('string');
+        expect(url.getJobId()).to.equal(jobId);
+        expect(url2.getJobId()).to.equal(jobId);
+
+        // Before we delete the job, there should be 2 URLs in the DB relating to this jobId
+        const importJobUrlsFromDb = await dataAccess.getImportUrlsByJobId(jobId);
+        expect(importJobUrlsFromDb.length).to.equal(2);
+
+        // Remove the new job
+        await dataAccess.removeImportJob(job);
+
+        // Try to find it in the DB
+        const deletedJob = await dataAccess.getImportJobByID(jobId);
+        expect(deletedJob).to.be.null;
+
+        // Try to find its URLs in the DB
+        const deletedJobImportUrls = await dataAccess.getImportUrlsByJobId(jobId);
+        expect(deletedJobImportUrls.length).to.equal(0);
+      });
     });
 
     describe('Import URL Tests', async () => {

--- a/packages/spacecat-shared-data-access/test/unit/models/api-key.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/api-key.test.js
@@ -22,10 +22,15 @@ const validApiKey = {
   imsOrgId: 'test-ims-org-id',
   expiresAt: '2024-05-29T14:26:00.000Z',
   revokedAt: '2024-05-29T14:26:00.000Z',
-  scopes: [{
-    name: 'imports.write',
-    domains: ['https://www.test.com'],
-  }],
+  scopes: [
+    {
+      name: 'imports.write',
+      domains: ['https://www.test.com'],
+    },
+    {
+      name: 'imports.delete',
+    },
+  ],
 };
 
 describe('ApiKey Model tests', () => {
@@ -130,6 +135,9 @@ describe('ApiKey Model tests', () => {
       expect(apiKey.getScopes()).to.deep.equal([{
         name: 'imports.write',
         domains: ['https://www.test.com'],
+      },
+      {
+        name: 'imports.delete',
       }]);
     });
   });

--- a/packages/spacecat-shared-data-access/test/unit/service/import-job/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-job/index.test.js
@@ -39,10 +39,9 @@ describe('Import Job Tests', () => {
         getItem: sinon.stub().resolves(),
         query: sinon.stub().resolves(null),
         putItem: sinon.stub().resolves(),
+        removeItem: sinon.stub().resolves(),
       };
-      mockLog = {
-        log: console,
-      };
+      mockLog = console;
       exportedFunctions = importJobFunctions(
         mockDynamoClient,
         TEST_DA_CONFIG,
@@ -149,6 +148,14 @@ describe('Import Job Tests', () => {
         const importJob = createImportJob(mockImportJob);
         const result = exportedFunctions.updateImportJob(importJob);
         expect(result).to.be.rejectedWith('Import Job with id:test-id does not exist');
+      });
+    });
+
+    describe('removeImportJob', () => {
+      it('should remove an existing ImportJob', async () => {
+        const importJob = createImportJob(mockImportJob);
+        await exportedFunctions.removeImportJob(importJob);
+        expect(mockDynamoClient.removeItem.calledOnce).to.be.true;
       });
     });
   });

--- a/packages/spacecat-shared-data-access/test/unit/service/import-job/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-job/index.test.js
@@ -152,10 +152,35 @@ describe('Import Job Tests', () => {
     });
 
     describe('removeImportJob', () => {
-      it('should remove an existing ImportJob', async () => {
+      it('should remove an existing ImportJob with no URLs', async () => {
         const importJob = createImportJob(mockImportJob);
         await exportedFunctions.removeImportJob(importJob);
         expect(mockDynamoClient.removeItem.calledOnce).to.be.true;
+      });
+
+      it('should remove an existing ImportJob with a couple of URLs', async () => {
+        mockDynamoClient.query.resolves([
+          {
+            id: 'test-url-1', url: 'https://www.example.com/resource-a', jobId: 'test-id', status: 'RUNNING',
+          },
+          {
+            id: 'test-url-2', url: 'https://www.example.com/resource-b', jobId: 'test-id', status: 'RUNNING',
+          },
+        ]);
+        const importJob = createImportJob(mockImportJob);
+        await exportedFunctions.removeImportJob(importJob);
+        // Note `calledThrice` — remove should be called on both URLs, then the import job
+        expect(mockDynamoClient.removeItem.calledThrice).to.be.true;
+        // Check the id's passed to removeItem
+        expect(mockDynamoClient.removeItem.getCall(0).args[1].id).to.equal('test-url-1');
+        expect(mockDynamoClient.removeItem.getCall(1).args[1].id).to.equal('test-url-2');
+        expect(mockDynamoClient.removeItem.getCall(2).args[1].id).to.equal('test-id');
+      });
+
+      it('should handle a Dynamo failure', async () => {
+        mockDynamoClient.removeItem = sinon.stub().rejects(new Error('Dynamo Error'));
+        const importJob = createImportJob(mockImportJob);
+        await expect(exportedFunctions.removeImportJob(importJob)).to.be.rejectedWith('Dynamo Error');
       });
     });
   });

--- a/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/import-url/index.test.js
@@ -19,6 +19,7 @@ import sinonChai from 'sinon-chai';
 import { importUrlFunctions } from '../../../../src/service/import-url/index.js';
 import { createImportUrl } from '../../../../src/models/importer/import-url.js';
 import { ImportJobStatus } from '../../../../src/index.js';
+import { removeUrlsForImportJob } from '../../../../src/service/import-url/accessPatterns.js';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -42,6 +43,7 @@ describe('Import Url Tests', () => {
       };
       mockLog = {
         log: sinon.stub(),
+        error: sinon.stub(),
       };
       exportedFunctions = importUrlFunctions(mockDynamoClient, TEST_DA_CONFIG, mockLog);
 
@@ -110,6 +112,13 @@ describe('Import Url Tests', () => {
         expect(result.length).to.equal(1);
         expect(result[0].getUrl()).to.equal('https://www.test.com');
         expect(result[0].getId()).to.equal('test-url-id');
+      });
+    });
+
+    describe('removeUrlsForImportJob', () => {
+      it('should handle a Dynamo error', async () => {
+        mockDynamoClient.query.rejects(new Error('Dynamo Error'));
+        await expect(removeUrlsForImportJob(mockDynamoClient, TEST_DA_CONFIG, mockLog, 'test-job-id')).to.be.rejectedWith('Dynamo Error');
       });
     });
   });

--- a/packages/spacecat-shared-data-access/test/unit/service/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/index.test.js
@@ -84,6 +84,7 @@ describe('Data Access Object Tests', () => {
     'createNewImportJob',
     'updateImportJob',
     'getImportJobsByDateRange',
+    'removeImportJob',
   ];
 
   const importUrlFunctions = [


### PR DESCRIPTION
Implements `removeImportJob`, which removes the import job and all associated import url entities.

Add new `imports.delete` scope to restrict import job deletion to API keys with the relevant scope.

## Related Issues

- [SITES-26088](https://jira.corp.adobe.com/browse/SITES-26088)