### PR TITLE
feat: support FIFO queues with the SQS sendMessage helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22599,7 +22599,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "1.49.1",
+      "version": "1.49.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-dynamo": "1.3.42",

--- a/packages/spacecat-shared-utils/src/sqs.js
+++ b/packages/spacecat-shared-utils/src/sqs.js
@@ -32,7 +32,7 @@ class SQS {
    * @param {string} messageGroupId - (Optional) The message group ID for FIFO queues.
    * @return {Promise<void>}
    */
-  async sendMessage(queueUrl, message, messageGroupId) {
+  async sendMessage(queueUrl, message, messageGroupId = undefined) {
     const body = {
       ...message,
       timestamp: new Date().toISOString(),

--- a/packages/spacecat-shared-utils/test/sqs.test.js
+++ b/packages/spacecat-shared-utils/test/sqs.test.js
@@ -12,6 +12,7 @@
 
 /* eslint-env mocha */
 
+import { SQSClient } from '@aws-sdk/client-sqs';
 import wrap from '@adobe/helix-shared-wrap';
 import sinon from 'sinon';
 import { expect, use } from 'chai';
@@ -105,8 +106,30 @@ describe('SQS', () => {
   });
 
   describe('SQS helpers', () => {
-    const exampleHandler = sinon.spy(async (message, context) => {
-      const { log } = context;
+    let sqsClientStub;
+    let sendStub;
+    let context;
+
+    beforeEach(() => {
+      // Stub the AWS SQS client so we can inspect the arguments we send it
+      sqsClientStub = sandbox.createStubInstance(SQSClient);
+      sendStub = sandbox.stub().callsFake(() => ({ MessageId: '12345' }));
+      sandbox.stub(SQSClient.prototype, 'constructor').callsFake(() => sqsClientStub);
+      sandbox.stub(SQSClient.prototype, 'send').callsFake(sendStub);
+      context = {
+        log: console,
+        runtime: {
+          region: 'us-east-1',
+        },
+      };
+    });
+
+    afterEach('clean', () => {
+      sandbox.restore();
+    });
+
+    const exampleHandler = sandbox.spy(async (message, ctx) => {
+      const { log } = ctx;
       const messageStr = JSON.stringify(message);
       log.info(`Handling message ${messageStr}`);
       return new Response(messageStr);
@@ -127,7 +150,7 @@ describe('SQS', () => {
     });
 
     it('should handle a valid context with an event record', async () => {
-      const context = {
+      const ctx = {
         log: console,
         invocation: {
           event: {
@@ -142,12 +165,42 @@ describe('SQS', () => {
       };
 
       const handler = sqsEventAdapter(exampleHandler);
-      const response = await handler(emptyRequest, context);
+      const response = await handler(emptyRequest, ctx);
 
       expect(response.status).to.equal(200);
       const result = await response.json();
       expect(result.id).to.equal('1234567890');
       expect(exampleHandler.calledWith({ id: '1234567890' })).to.be.true;
+    });
+
+    it('should not include a MessageGroupId when one is not provided', async () => {
+      const action = wrap(async (req, ctx) => {
+        await ctx.sqs.sendMessage('queue-url', { key: 'value' });
+      }).with(sqsWrapper);
+
+      await action({}, context);
+
+      const firstSendArg = sendStub.getCall(0).args[0];
+      expect(Object.keys(firstSendArg.input)).to.deep.equal([
+        'MessageBody',
+        'QueueUrl',
+      ]);
+    });
+
+    it('should include a MessageGroupId when provided', async () => {
+      const action = wrap(async (req, ctx) => {
+        await ctx.sqs.sendMessage('queue-url', { key: 'value' }, 'job-id');
+      }).with(sqsWrapper);
+
+      await action({}, context);
+
+      const firstSendArg = sendStub.getCall(0).args[0];
+      expect(Object.keys(firstSendArg.input)).to.deep.equal([
+        'MessageBody',
+        'QueueUrl',
+        'MessageGroupId',
+      ]);
+      expect(firstSendArg.input.MessageGroupId).to.equal('job-id');
     });
   });
 });


### PR DESCRIPTION
Add support for passing a `MessageGroupId` to the `sqsClient.send(..)` method to enable the use of FIFO queues.

Without this property we see the following error in the logs:

```
...failed with error: MissingParameter: The request must contain the parameter MessageGroupId.
```

## Related Issues

- [SITES-26422](https://jira.corp.adobe.com/browse/SITES-26422) Migrate all import queues to FIFO SQS queues

