### PR TITLE
fix: handle missing 'sites' and 'orgs' in enabled/disabled configuraions safely

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/configuration.js
+++ b/packages/spacecat-shared-data-access/src/models/configuration.js
@@ -37,12 +37,15 @@ const Configuration = (data = {}) => {
     const orgId = site.getOrganizationId();
 
     if (handler.enabled) {
-      return handler.enabled.sites.includes(siteId) || handler.enabled.orgs.includes(orgId);
+      const sites = handler.enabled.sites || [];
+      const orgs = handler.enabled.orgs || [];
+      return sites.includes(siteId) || orgs.includes(orgId);
     }
 
     if (handler.disabled) {
-      return !((handler.disabled.sites && handler.disabled.sites.includes(siteId))
-          || (handler.disabled.orgs && handler.disabled.orgs.includes(orgId)));
+      const sites = handler.disabled.sites || [];
+      const orgs = handler.disabled.orgs || [];
+      return !(sites.includes(siteId) || orgs.includes(orgId));
     }
 
     return handler.enabledByDefault;

--- a/packages/spacecat-shared-data-access/test/unit/models/configuration.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/configuration.test.js
@@ -58,6 +58,22 @@ const validData = {
     cwv: {
       enabledByDefault: true,
     },
+    'handler-configuration-without-orgs': {
+      enabledByDefault: false,
+      enabled: {
+        sites: [
+          'site0-id',
+        ],
+      },
+    },
+    'handler-configuration-without-sites': {
+      enabledByDefault: false,
+      enabled: {
+        orgs: [
+          'org0-id',
+        ],
+      },
+    },
   },
   queues: {
     audits: 'sqs://.../spacecat-services-audit-jobs',
@@ -163,6 +179,26 @@ describe('Configuration Model Tests', () => {
     const isEnabled = configuration.isHandlerEnabledForOrg('cwv', { getId: () => 'org3' });
     expect(isEnabled).to.be.a('boolean');
     expect(isEnabled).to.be.true;
+  });
+
+  it('Checks if a handler configuration is missing sites key', () => {
+    const configuration = createConfiguration(validData);
+    const isEnabled = configuration.isHandlerEnabledForSite(
+      'handler-configuration-without-sites',
+      { getId: () => 'site1-id', getOrganizationId: () => 'org2' },
+    );
+    expect(isEnabled).to.be.a('boolean');
+    expect(isEnabled).to.be.false;
+  });
+
+  it('Checks if a handler configuration is missing orgs ke', () => {
+    const configuration = createConfiguration(validData);
+    const isEnabled = configuration.isHandlerEnabledForSite(
+      'handler-configuration-without-orgs',
+      { getId: () => 'site1-id', getOrganizationId: () => 'org2' },
+    );
+    expect(isEnabled).to.be.a('boolean');
+    expect(isEnabled).to.be.false;
   });
 
   it('checks if a handler type is enabled for an organization', () => {


### PR DESCRIPTION
Currently, some audit data in the database has an incomplete structure.
For example, broken-internal-links:
```
"broken-backlinks-internal": {
      "enabledByDefault": true,
      "disabled": {
        "sites": [
          "site-id",
        ],
        // missed orgs
      },
    },
```

The absence of the "orgs/sites" key leads to an error in
https://github.com/adobe/spacecat-shared/blob/main/packages/spacecat-shared-data-access/src/models/configuration.js#L39-L45
https://spacecat.coralogix.com/#/query-new/logs?id=qzf80Nda2AaKpjA4VSTle&page=0
```
TypeError: Cannot read properties of undefined (reading 'includes')
at Configuration.self.isHandlerEnabledForSite (/var/task/index.js:8360:77)
```

This PR includes the corrected logic to handle such cases.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
