### PR TITLE
fix: proper http data for x-ray trace

### DIFF
--- a/packages/spacecat-shared-utils/src/tracing-fetch.js
+++ b/packages/spacecat-shared-utils/src/tracing-fetch.js
@@ -9,35 +9,140 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+import { Request } from '@adobe/fetch';
 import AWSXRay from 'aws-xray-sdk';
 
 import { fetch as adobeFetch } from './adobe-fetch.js';
+import { isNumber } from './functions.js';
 
-export async function tracingFetch(url, options = {}) {
+/**
+ * Creates a subsegment for a given hostname based on whether the parent segment is traced or not.
+ * @param {Object} parentSegment - The parent X-Ray segment.
+ * @param {string} hostname - The hostname to associate with the subsegment.
+ * @returns {Object} The created subsegment.
+ */
+const createSubsegment = (parentSegment, hostname) => (parentSegment.notTraced
+  ? parentSegment.addNewSubsegmentWithoutSampling(hostname)
+  : parentSegment.addNewSubsegment(hostname));
+
+/**
+ * Sets the AWS X-Ray trace headers on the request object.
+ * @param {Request} request - The request object on which headers are set.
+ * @param {Object} parentSegment - The parent X-Ray segment.
+ * @param {Object} subSegment - The subsegment to include in the headers.
+ */
+const setTraceHeaders = (request, parentSegment, subSegment) => {
+  const effectiveParentSegment = parentSegment.segment || parentSegment;
+  request.headers.set(
+    'X-Amzn-Trace-Id',
+    `Root=${effectiveParentSegment.trace_id};Parent=${subSegment.id};Sampled=0`,
+  );
+};
+
+/**
+ * Adds flags to the given subsegment based on the status code of the response.
+ * @param {Object} subSegment - The X-Ray subsegment to which flags are added.
+ * @param {number} status - The status code of the response.
+ */
+const setSubSegmentFlagsByStatusCode = (
+  subSegment,
+  status,
+) => { /* eslint-disable no-param-reassign */
+  if (status === 429) {
+    subSegment.throttled = true;
+    return;
+  }
+  if (status >= 400 && status < 500) {
+    subSegment.error = true;
+    return;
+  }
+  if (status >= 500 && status < 600) {
+    subSegment.fault = true;
+  }
+};
+
+/**
+ * Adds request and response data to the given segment for AWS X-Ray tracing.
+ * @param {Object} segment - The X-Ray segment to which request and response data are added.
+ * @param {Request} request - The original request object.
+ * @param {Response} [response] - The response object (if available).
+ */
+const addFetchRequestDataToSegment = (
+  segment,
+  request,
+  response,
+) => { /* eslint-disable no-param-reassign */
+  const { url, method } = request;
+  segment.http = {
+    request: { url, method },
+  };
+
+  if (!response) {
+    return;
+  }
+
+  segment.http.response = {
+    status: response.status,
+  };
+
+  const contentLength = Number.parseInt(response.headers.get('content-length'), 10);
+  if (isNumber(contentLength)) {
+    segment.http.response.content_length = contentLength;
+  }
+};
+
+/**
+ * Adds error data to the given segment for AWS X-Ray tracing.
+ * @param {Object} subSegment - The X-Ray subsegment to which error data is added.
+ * @param {Request} request - The original request object.
+ * @param {Error} error - The error object.
+ */
+const handleSubSegmentError = (subSegment, request, error) => {
+  subSegment.addErrorFlag();
+  addFetchRequestDataToSegment(subSegment, request);
+  subSegment.addAnnotation('errorMessage', error.message);
+  subSegment.addAnnotation('errorStack', error.stack);
+  subSegment.close(error);
+};
+
+/**
+ * Performs a fetch request and adds AWS X-Ray tracing, including request/response tracking.
+ * @param {string} url - The URL for the request.
+ * @param {Object} options - Options to be passed to the fetch call.
+ * @returns {Promise<Response>} The response from the fetch request.
+ */
+export async function tracingFetch(url, options) {
   const parentSegment = AWSXRay.getSegment();
 
   if (!parentSegment) {
     return adobeFetch(url, options);
   }
 
-  const method = options.method || 'GET';
-  const subsegment = parentSegment.addNewSubsegment(`HTTP ${method} ${url}`);
+  const request = new Request(url, options);
+  const { hostname } = new URL(request.url);
+  const subSegment = createSubsegment(parentSegment, hostname);
 
-  try {
-    subsegment.addAnnotation('url', url);
-    subsegment.addAnnotation('method', method);
+  subSegment.namespace = 'remote';
 
-    const response = await adobeFetch(url, options);
-
-    subsegment.addMetadata('statusCode', response.status);
-
-    subsegment.close();
-
-    return response;
-  } catch (error) {
-    subsegment.addError(error);
-    subsegment.close();
-
-    throw error;
+  if (!parentSegment.noOp) {
+    setTraceHeaders(request, parentSegment, subSegment);
   }
+
+  const capturedAdobeFetch = async () => {
+    let response = null;
+    try {
+      response = await adobeFetch(request);
+    } catch (e) {
+      handleSubSegmentError(subSegment, request, e);
+      throw e;
+    }
+
+    setSubSegmentFlagsByStatusCode(subSegment, response.status);
+
+    addFetchRequestDataToSegment(subSegment, request, response);
+    subSegment.close();
+    return response;
+  };
+
+  return capturedAdobeFetch();
 }

--- a/packages/spacecat-shared-utils/test/functions.test.js
+++ b/packages/spacecat-shared-utils/test/functions.test.js
@@ -308,6 +308,7 @@ describe('Shared functions', () => {
     const sevenDaysLaterExpected = '2023-12-04T12:30:01.124Z';
     const sevenDaysEarlierExpected = '2023-11-20T12:30:01.124Z';
 
+    // eslint-disable-next-line func-names
     before('setup', function () {
       this.clock = sandbox.useFakeTimers({
         now: new Date(mockDate).getTime(),

--- a/packages/spacecat-shared-utils/test/sqs.test.js
+++ b/packages/spacecat-shared-utils/test/sqs.test.js
@@ -14,6 +14,7 @@
 
 import { SQSClient } from '@aws-sdk/client-sqs';
 import wrap from '@adobe/helix-shared-wrap';
+import AWSXRay from 'aws-xray-sdk';
 import sinon from 'sinon';
 import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
@@ -30,6 +31,7 @@ const sandbox = sinon.createSandbox();
 describe('SQS', () => {
   describe('SQS class', () => {
     let context;
+    AWSXRay.enableManualMode();
 
     beforeEach('setup', () => {
       context = {


### PR DESCRIPTION
By looking at the AWS XRay fetch instrumentation (which we could not use, see https://github.com/adobe/spacecat-shared/pull/409) i noticed that there's better ways to fit the request/response data into a trace.