### PR TITLE
feat: SITES-26591 [Import Assistant] Expand GPT client to user chat endpoint

### DIFF
--- a/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
+++ b/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
@@ -177,8 +177,10 @@ export default class FirefallClient {
   /**
    * Fetches data from Firefall Chat Completion API.
    * @param prompt The text prompt to provide to Firefall
-   * @param options The options for the call:
-   *                - imageUrls: An array of URLs of the images to provide to Firefall
+   * @param options The options for the call, with optional properties:
+   *          - imageUrls: An array of URLs of the images to provide to Firefall
+   *          - model: LLM Model to use (default: gpt-4-turbo).  Use 'gpt-4-vision' with images.
+   *          - responseFormat: The response format to request from Firefall (accepts: json_object)
    * @returns {Object} - AI response
    */
   async fetchChatCompletion(prompt, options = {}) {


### PR DESCRIPTION
My PR did not have the `feat` prefix and so it wasn't deployed.  I didn't realize that was the mechanism.  Is that worth a description in `pull_request_template.md`?

This is a quick correction to some JavaDocs but essentially is to have the GPT package deployed.

## Related Issues
https://jira.corp.adobe.com/browse/SITES-26591
PR: https://github.com/adobe/spacecat-shared/pull/422

