### PR TITLE
feat: SITES-26835 [Import Assistant] Introduce imports.assistant api key scope

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/api-key/api-key.js
+++ b/packages/spacecat-shared-data-access/src/models/api-key/api-key.js
@@ -28,6 +28,7 @@ const scopeNames = [
   'imports.delete',
   'imports.read_all',
   'imports.all_domains',
+  'imports.assistant',
 ];
 
 const ApiKey = (data) => {
@@ -121,8 +122,8 @@ const ApiKey = (data) => {
  * @param {Object} apiKeyData - The data for the ApiKey object.
  * @returns {ApiKey} The new ApiKey object.
  */
-export const createApiKey = (data) => {
-  const newState = { ...data };
+export const createApiKey = (apiKeyData) => {
+  const newState = { ...apiKeyData };
 
   if (!hasText(newState.hashedApiKey)) {
     throw new Error(`Invalid Hashed API Key: ${newState.hashedApiKey}`);

--- a/packages/spacecat-shared-data-access/test/unit/models/api-key.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/api-key.test.js
@@ -69,6 +69,11 @@ describe('ApiKey Model tests', () => {
       expect(apiKey.getScopes()).to.deep.equal([{ name: 'imports.write', domains: ['https://adobe.com', 'https://test.com'] }]);
     });
 
+    it('creates an ApiKey object for a user with scope - imports.assistant', () => {
+      const apiKey = createApiKey({ ...validApiKey, scopes: [{ name: 'imports.assistant' }] });
+      expect(apiKey.getScopes()).to.deep.equal([{ name: 'imports.assistant' }]);
+    });
+
     it('throws an error if revokedAt is not a valid date', () => {
       expect(() => createApiKey({ ...validApiKey, revokedAt: 'invalid-date' })).to.throw('revokedAt should be a valid ISO 8601 string: invalid-date');
     });


### PR DESCRIPTION
Introduce the `imports.assistant` scope for the API key to enable calls to the assistant, providing help when creating Import JS.

## Related Issues
Jira: https://jira.corp.adobe.com/browse/SITES-26835

