### PR TITLE
feat: Add unauthorized and forbidden to https status codes

### DIFF
--- a/packages/spacecat-shared-http-utils/src/index.js
+++ b/packages/spacecat-shared-http-utils/src/index.js
@@ -74,6 +74,20 @@ export function badRequest(message = 'bad request', headers = {}) {
   });
 }
 
+export function unauthorized(message = 'unauthorized', headers = {}) {
+  return createResponse({ message }, 401, {
+    [HEADER_ERROR]: message,
+    ...headers,
+  });
+}
+
+export function forbidden(message = 'forbidden', headers = {}) {
+  return createResponse({ message }, 403, {
+    [HEADER_ERROR]: message,
+    ...headers,
+  });
+}
+
 export function notFound(message = 'not found', headers = {}) {
   return createResponse({ message }, 404, {
     [HEADER_ERROR]: message,

--- a/packages/spacecat-shared-http-utils/test/index.test.js
+++ b/packages/spacecat-shared-http-utils/test/index.test.js
@@ -12,7 +12,8 @@
 /* eslint-env mocha */
 import { expect } from 'chai';
 import {
-  ok, badRequest, notFound, internalServerError, noContent, found, created, createResponse,
+  ok, badRequest, notFound, internalServerError,
+  noContent, found, created, createResponse, unauthorized, forbidden,
 } from '../src/index.js';
 
 async function testMethod(response, expectedCode, expectedBody) {
@@ -96,6 +97,24 @@ describe('HTTP Response Functions', () => {
     expect(response.headers.get('custom-header')).to.equal('value');
     const responseBody = await response.json();
     expect(responseBody).to.deep.equal({ message: 'Invalid input' });
+  });
+
+  it('unauthorized should return a 401 Unauthorized response with custom message and headers', async () => {
+    const response = await unauthorized('Unauthorized access', { 'custom-header': 'value' });
+    expect(response.status).to.equal(401);
+    expect(response.headers.get('x-error')).to.equal('Unauthorized access');
+    expect(response.headers.get('custom-header')).to.equal('value');
+    const responseBody = await response.json();
+    expect(responseBody).to.deep.equal({ message: 'Unauthorized access' });
+  });
+
+  it('forbidden should return a 403 Forbidden response with custom message and headers', async () => {
+    const response = await forbidden('Forbidden access', { 'custom-header': 'value' });
+    expect(response.status).to.equal(403);
+    expect(response.headers.get('x-error')).to.equal('Forbidden access');
+    expect(response.headers.get('custom-header')).to.equal('value');
+    const responseBody = await response.json();
+    expect(responseBody).to.deep.equal({ message: 'Forbidden access' });
   });
 
   it('notFound should return a 404 Not Found response with default message and headers', async () => {


### PR DESCRIPTION


## Related Issues
[SITES-25915](https://jira.corp.adobe.com/browse/SITES-25915)

Add unauthorized and forbidden to the http status code as discussed in this comment: https://github.com/adobe/spacecat-api-service/pull/569/files#r1841073366
