### PR TITLE
fix: resolving url when site has bot protection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18159,7 +18159,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "1.50.1",
+      "version": "1.52.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-dynamo": "1.3.47",
@@ -21514,7 +21514,7 @@
     },
     "packages/spacecat-shared-http-utils": {
       "name": "@adobe/spacecat-shared-http-utils",
-      "version": "1.6.18",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.9",

--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -88,7 +88,7 @@ async function composeAuditURL(url) {
   const resp = await fetch(urlWithScheme, {
     method: 'GET',
     headers: {
-      'User-Agent': 'curl/7.88.1', // Set the same User-Agent
+      'User-Agent': 'curl/7.88.1',
     },
   });
   const finalUrl = resp.url.split('://')[1];

--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -85,7 +85,12 @@ function composeBaseURL(domain) {
 
 async function composeAuditURL(url) {
   const urlWithScheme = prependSchema(url);
-  const resp = await fetch(urlWithScheme);
+  const resp = await fetch(urlWithScheme, {
+    method: 'GET',
+    headers: {
+      'User-Agent': 'curl/7.88.1', // Set the same User-Agent
+    },
+  });
   const finalUrl = resp.url.split('://')[1];
   return stripTrailingSlash(finalUrl);
 }


### PR DESCRIPTION
business.adobe.com has bot protection and we cannot resolve the audit url to run the broken-backlinks audit
