### PR TITLE
fix: SITES-26948 [Import Assistant] Allow calls to Firefall to use specified ims org id

### DIFF
--- a/packages/spacecat-shared-gpt-client/README.md
+++ b/packages/spacecat-shared-gpt-client/README.md
@@ -10,6 +10,11 @@ To use the `FirefallClient`, you need to configure it with the following paramet
 - `FIREFALL_API_KEY`: Your API key for accessing the Firefall API.
 - `FIREFALL_API_CAPABILITY_NAME`: The capability name for the Firefall API.
 
+Optionally, you can specify the IMS ORG ID to use when calling the Firefall APIs.  If this value is not specified, the IMS_CLIENT_ID (see below) will
+be used for the header's value:
+
+- `FIREFALL_IMS_ORG_ID`: The IMS ORG ID to use when calling the Firefall APIs and tracking the request.
+
 These parameters can be set through environment variables or passed directly to the `FirefallClient.createFrom` method.
 
 Additionally, the configuration for the `@adobe/spacecat-shared-ims-client` library is required to fetch the service access token from the IMS API:

--- a/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
+++ b/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
@@ -50,7 +50,7 @@ export default class FirefallClient {
 
     const {
       FIREFALL_API_ENDPOINT: apiEndpoint,
-      IMS_CLIENT_ID: imsOrg,
+      IMS_CLIENT_ID: imsClientId,
       FIREFALL_IMS_ORG_ID: firefallImsOrgId,
       FIREFALL_API_KEY: apiKey,
       FIREFALL_API_POLL_INTERVAL: pollInterval = 2000,
@@ -70,7 +70,7 @@ export default class FirefallClient {
       apiKey,
       capabilityName,
       imsClient,
-      imsOrg: firefallImsOrgId || imsOrg,
+      imsOrg: firefallImsOrgId || imsClientId,
       pollInterval,
     }, log);
   }
@@ -188,7 +188,6 @@ export default class FirefallClient {
    *          - imageUrls: An array of URLs of the images to provide to Firefall
    *          - model: LLM Model to use (default: gpt-4-turbo).  Use 'gpt-4-vision' with images.
    *          - responseFormat: The response format to request from Firefall (accepts: json_object)
-   *          - imsOrgId: The IMS Org id to send with Firefall prompts (optional)
    * @returns {Object} - AI response
    */
   async fetchChatCompletion(prompt, options = {}) {

--- a/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
+++ b/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
@@ -51,7 +51,7 @@ export default class FirefallClient {
     const {
       FIREFALL_API_ENDPOINT: apiEndpoint,
       IMS_CLIENT_ID: imsOrg,
-      FIREFALL_IMS_ORG: firefallImsOrg,
+      FIREFALL_IMS_ORG_ID: firefallImsOrgId,
       FIREFALL_API_KEY: apiKey,
       FIREFALL_API_POLL_INTERVAL: pollInterval = 2000,
       FIREFALL_API_CAPABILITY_NAME: capabilityName = 'gpt4_32k_completions_capability',
@@ -70,7 +70,7 @@ export default class FirefallClient {
       apiKey,
       capabilityName,
       imsClient,
-      imsOrg: firefallImsOrg || imsOrg,
+      imsOrg: firefallImsOrgId || imsOrg,
       pollInterval,
     }, log);
   }

--- a/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
+++ b/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
@@ -51,6 +51,7 @@ export default class FirefallClient {
     const {
       FIREFALL_API_ENDPOINT: apiEndpoint,
       IMS_CLIENT_ID: imsOrg,
+      FIREFALL_IMS_ORG: firefallImsOrg,
       FIREFALL_API_KEY: apiKey,
       FIREFALL_API_POLL_INTERVAL: pollInterval = 2000,
       FIREFALL_API_CAPABILITY_NAME: capabilityName = 'gpt4_32k_completions_capability',
@@ -69,7 +70,7 @@ export default class FirefallClient {
       apiKey,
       capabilityName,
       imsClient,
-      imsOrg,
+      imsOrg: firefallImsOrg || imsOrg,
       pollInterval,
     }, log);
   }
@@ -111,10 +112,9 @@ export default class FirefallClient {
    * Submit a prompt to the Firefall API.
    * @param body The body of the request.
    * @param path The Firefall API path.
-   * @param imsOrgId An optional IMS Org ID, to override the config default.
    * @returns {Promise<unknown>}
    */
-  async #submitPrompt(body, path, imsOrgId = undefined) {
+  async #submitPrompt(body, path) {
     const apiAuth = await this.#getApiAuth();
 
     const url = createUrl(`${this.config.apiEndpoint}${path}`);
@@ -122,7 +122,7 @@ export default class FirefallClient {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${apiAuth}`,
       'x-api-key': this.config.apiKey,
-      'x-gw-ims-org-id': imsOrgId ?? this.config.imsOrg,
+      'x-gw-ims-org-id': this.config.imsOrg,
     };
 
     this.log.info(`URL: ${url}, Headers: ${JSON.stringify(headers)}`);
@@ -195,7 +195,6 @@ export default class FirefallClient {
     const {
       imageUrls,
       responseFormat,
-      imsOrgId,
       model: llmModel = 'gpt-4-turbo',
     } = options || {};
     const hasImageUrls = imageUrls && imageUrls.length > 0;
@@ -259,11 +258,7 @@ export default class FirefallClient {
       const startTime = process.hrtime.bigint();
       const body = getBody();
 
-      chatSubmissionResponse = await this.#submitPrompt(
-        JSON.stringify(body),
-        '/v2/chat/completions',
-        imsOrgId,
-      );
+      chatSubmissionResponse = await this.#submitPrompt(JSON.stringify(body), '/v2/chat/completions');
       this.#logDuration('Firefall API Chat Completion call', startTime);
     } catch (error) {
       this.log.error('Error while fetching data from Firefall chat API: ', error.message);

--- a/packages/spacecat-shared-gpt-client/test/clients/firefall-client.test.js
+++ b/packages/spacecat-shared-gpt-client/test/clients/firefall-client.test.js
@@ -246,6 +246,7 @@ describe('FirefallClient', () => {
         imageUrls: [base64ImageUrl],
         model: 'gpt-4-turbo',
         responseFormat: 'json_object',
+        imsOrgId: 'ImsOrgId',
       };
 
       await expect(client.fetchChatCompletion('Test prompt', options))

--- a/packages/spacecat-shared-gpt-client/test/clients/firefall-client.test.js
+++ b/packages/spacecat-shared-gpt-client/test/clients/firefall-client.test.js
@@ -218,6 +218,8 @@ describe('FirefallClient', () => {
     });
 
     it('should handle no options', async () => {
+      mockContext.env.FIREFALL_IMS_ORG = 'myOrgId@adobe.com';
+      client = FirefallClient.createFrom(mockContext);
       nock(mockContext.env.FIREFALL_API_ENDPOINT)
         .post(chatPath)
         .reply(200, chatResponse);
@@ -246,7 +248,6 @@ describe('FirefallClient', () => {
         imageUrls: [base64ImageUrl],
         model: 'gpt-4-turbo',
         responseFormat: 'json_object',
-        imsOrgId: 'ImsOrgId',
       };
 
       await expect(client.fetchChatCompletion('Test prompt', options))


### PR DESCRIPTION
The context's IMS_CLIENT_ID value is used in 2 places:
- IMSClient: IMS Token fetch (as an IMS Client Id)
- GPTClient: Firefall call as the `x-gw-ims-org-id` header value

This PR is to allow the `x-gw-ims-org-id` to use a specified, optional value.

## Related Issues
https://jira.corp.adobe.com/browse/SITES-26948
