### PR TITLE
feat: introduce missing audit id property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25315,7 +25315,7 @@
     },
     "packages/spacecat-shared-rum-api-client": {
       "name": "@adobe/spacecat-shared-rum-api-client",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.9",

--- a/packages/spacecat-shared-data-access/src/dto/audit.js
+++ b/packages/spacecat-shared-data-access/src/dto/audit.js
@@ -43,6 +43,7 @@ export const AuditDto = {
     } : {};
 
     return {
+      id: audit.getId(),
       siteId: audit.getSiteId(),
       auditedAt: audit.getAuditedAt(),
       auditResult: audit.getAuditResult(),
@@ -62,6 +63,7 @@ export const AuditDto = {
    */
   fromDynamoItem: (dynamoItem) => {
     const auditData = {
+      id: dynamoItem.id,
       siteId: dynamoItem.siteId,
       auditedAt: dynamoItem.auditedAt,
       auditResult: dynamoItem.auditResult,

--- a/packages/spacecat-shared-data-access/src/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/index.d.ts
@@ -33,6 +33,12 @@ export declare const ImportUrlStatus: {
  * Represents an individual audit of a site.
  */
 export interface Audit {
+
+  /**
+   * Retrieves the ID of the audit.
+   * @returns {string} The audit ID.
+   */
+  getId: () => string;
   /**
    * Retrieves the site ID associated with this audit.
    * @returns {string} The site ID.

--- a/packages/spacecat-shared-data-access/test/unit/service/audits/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/audits/index.test.js
@@ -164,6 +164,7 @@ describe('Audit Access Pattern Tests', () => {
     let exportedFunctions;
 
     const auditData = {
+      id: 'test-audit-id',
       siteId: 'site1',
       auditType: 'lhs-mobile',
       auditedAt: new Date().toISOString(),
@@ -196,6 +197,7 @@ describe('Audit Access Pattern Tests', () => {
       const result = await exportedFunctions.addAudit(auditData);
       // Once for 'audits' and once for 'latest_audits'
       expect(mockDynamoClient.putItem.calledTwice).to.be.true;
+      expect(result.getId()).to.equal(auditData.id);
       expect(result.getSiteId()).to.equal(auditData.siteId);
       expect(result.getAuditType()).to.equal(auditData.auditType);
       expect(result.getAuditedAt()).to.equal(auditData.auditedAt);


### PR DESCRIPTION
In context of the new opportunity and suggestions data model, it is a requirement for the audits to have an ID in order to link them to an opportunity.