### PR TITLE
fix(sqs-wrapper): decrease error log level

### DIFF
--- a/packages/spacecat-shared-utils/src/sqs.js
+++ b/packages/spacecat-shared-utils/src/sqs.js
@@ -96,7 +96,7 @@ export function sqsEventAdapter(fn) {
       message = JSON.parse(records[0]?.body);
       log.info(`Received message with id: ${records[0]?.messageId}`);
     } catch (e) {
-      log.error('Function was not invoked properly, message body is not a valid JSON', e);
+      log.warn('Function was not invoked properly, message body is not a valid JSON', e);
       return new Response('', {
         status: 400,
         headers: {


### PR DESCRIPTION
"_Function was not invoked properly, message body is not a valid JSON_" errors are not actual errors creating unnecessary noise in the ops alerts

hence, decreasing the level to warn