### PR TITLE
feat(rum-api-client): campaign performance measurement for meta campaigns

### DIFF
--- a/packages/spacecat-shared-rum-api-client/src/functions/campaign-performance.js
+++ b/packages/spacecat-shared-rum-api-client/src/functions/campaign-performance.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* c8 ignore start */
+
+import { DataChunks, series } from '@adobe/rum-distiller';
+import { loadBundles } from '../utils.js';
+
+function handler(bundles) {
+  const dataChunks = new DataChunks();
+  loadBundles(bundles, dataChunks);
+
+  const campaignIdFacet = (bundle) => (bundle.events.some((e) => e.checkpoint === 'paid' && e.source === 'facebook')
+    ? bundle.events.find((e) => e.checkpoint === 'utm' && e.source === 'utm_campaign')?.target
+    : null);
+  dataChunks.addFacet('traffic', campaignIdFacet);
+
+  dataChunks.addSeries('ctr', (bundle) => (bundle.events.some((e) => e.checkpoint === 'click')
+    ? bundle.weight
+    : 0));
+  dataChunks.addSeries('lcp', series.lcp);
+  dataChunks.addSeries('views', series.pageViews);
+
+  return dataChunks.facets.traffic.map((traffic) => {
+    const campaignId = traffic.value;
+    const { ctr, lcp, views } = traffic.metrics;
+
+    return {
+      campaignId,
+      ctr: (ctr.sum / ctr.weight).toFixed(4),
+      lcp: lcp.percentile(75),
+      views: views.weight,
+    };
+  }).sort((a, b) => b.views - a.views);
+}
+
+export default {
+  handler,
+  checkpoints: [
+    'click',
+    'cwv-lcp',
+    'utm',
+    'paid',
+    'email',
+    'enter',
+  ],
+};
+/* c8 ignore end */


### PR DESCRIPTION
### Summary
This PR introduces the `campaign-performance` query which is used to evaluate the performance of marketing campaigns by analyzing RUM data. The query first filters RUM bundles where the source of a paid checkpoint is identified as `facebook` (see explanation below). Then it groups the RUM bundles by the `utm_campaign` so that each campaign's performance can be calculated. Finally it calculates some business KPIs such as CTR and pageviews for each campaign.

**Example Query Response:**

```json
[
  {
    "campaignId": "120213168952980692",
    "ctr": "0.0699",
    "lcp": 2342,
    "views": 118800
  },
  {
    "campaignId": "120211829416530209",
    "ctr": "0.0809",
    "lcp": 7079,
    "views": 30900
  },
  {
    "campaignId": "23855478306050731",
    "ctr": "0.2917",
    "lcp": 6129,
    "views": 26400
  }
]
```

### Details
[RUM Enhancer](https://github.com/adobe/helix-rum-enhancer/) collects hints about the sources of acquired traffic. One of the primary indicators is `utm` parameters, where:

- `utm_source` and `utm_medium` provide information about the traffic source.
- `utm_campaign` identifies the specific marketing or advertising campaign responsible for driving the traffic.

In addition to `utm` parameters, other hints are collected as well such as `email` and `paid` checkpoints. A `paid` checkpoint is triggered when a specific hint in the URL tells the traffic source. For example, if the URL contains a `fbclid` query parameter, RUM Enhancer fires a `paid` checkpoint event with `facebook` as the source and `fbclid` as the target.