### PR TITLE
fix(sqs): Support both standard and FIFO SQS queues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21223,7 +21223,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "1.58.2",
+      "version": "1.59.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-dynamo": "1.4.0",

--- a/packages/spacecat-shared-utils/src/sqs.js
+++ b/packages/spacecat-shared-utils/src/sqs.js
@@ -26,6 +26,15 @@ class SQS {
   }
 
   /**
+   * Check if the queue is a FIFO queue by examining its URL.
+   * @param {string} queueUrl - the URL of the SQS queue
+   * @returns {boolean} true if the queue is a FIFO queue, false otherwise
+   */
+  static #isFifoQueue(queueUrl) {
+    return hasText(queueUrl) && queueUrl.toLowerCase().endsWith('.fifo');
+  }
+
+  /**
    * Send a message to an SQS queue. For FIFO queues, messageGroupId is required.
    * @param {string} queueUrl - The URL of the SQS queue.
    * @param {object} message - The message body to send.
@@ -43,8 +52,8 @@ class SQS {
       QueueUrl: queueUrl,
     };
 
-    if (hasText(messageGroupId)) {
-      // MessageGroupId is required for FIFO queues
+    // Only include MessageGroupId if the queue is a FIFO queue
+    if (SQS.#isFifoQueue(queueUrl) && hasText(messageGroupId)) {
       params.MessageGroupId = messageGroupId;
     }
 


### PR DESCRIPTION
Currently, sending an SQS message to a standard (non-FIFO) queue will fail if the `messageGroupId` param is provided to the `sendMessage` function. The function should only include this param when it is sending a message to a FIFO queue.

## Related Issues

- #489 

