### PR TITLE
fix(rum-api-client): point to the new rum bundler host

### DIFF
--- a/packages/spacecat-shared-rum-api-client/src/common/rum-bundler-client.js
+++ b/packages/spacecat-shared-rum-api-client/src/common/rum-bundler-client.js
@@ -15,7 +15,7 @@ import { hasText } from '@adobe/spacecat-shared-utils';
 import { fetch } from '../utils.js';
 import { GRANULARITY } from './constants.js';
 
-const BASE_URL = 'https://rum.fastly-aem.page/bundles';
+const BASE_URL = 'https://bundles.aem.page/bundles';
 const HOURS_IN_DAY = 24;
 const ONE_HOUR = 1000 * 60 * 60;
 const ONE_DAY = ONE_HOUR * HOURS_IN_DAY;

--- a/packages/spacecat-shared-rum-api-client/test/common/rum-bundler-client.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/common/rum-bundler-client.test.js
@@ -20,7 +20,7 @@ import { generateDailyDates, generateHourlyDates, generateRumBundles } from '../
 
 use(chaiAsPromised);
 
-const BASE_URL = 'https://rum.fastly-aem.page';
+const BASE_URL = 'https://bundles.aem.page';
 describe('Rum bundler client', () => {
   let sandbox;
 

--- a/packages/spacecat-shared-rum-api-client/test/index.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/index.test.js
@@ -19,6 +19,8 @@ import RUMAPIClient from '../src/index.js';
 
 use(chaiAsPromised);
 
+const RUM_BUNDLER_API_HOST = 'https://bundles.aem.page';
+
 describe('RUMAPIClient', () => {
   const context = {};
   const rumApiClient = RUMAPIClient.createFrom(context);
@@ -42,7 +44,7 @@ describe('RUMAPIClient', () => {
 
     const queryUrl = `/bundles${constructUrl('space.cat', new Date(), 'some-domain-key')}`;
 
-    nock('https://rum.fastly-aem.page')
+    nock(RUM_BUNDLER_API_HOST)
       .get(queryUrl)
       .reply(200, { rumBundles: [] });
 
@@ -75,7 +77,7 @@ describe('RUMAPIClient', () => {
 
     const queryUrl = `/bundles${constructUrl('space.cat', new Date(), 'some-domain-key')}`;
 
-    nock('https://rum.fastly-aem.page')
+    nock(RUM_BUNDLER_API_HOST)
       .get(queryUrl)
       .reply(200, { rumBundles: [] });
 


### PR DESCRIPTION
as per https://cq-dev.slack.com/archives/C07198KKQ07/p1736898652490009
