### PR TITLE
fix: composeAuditURL user agent failing for some sites

### DIFF
--- a/packages/spacecat-shared-utils/src/index.d.ts
+++ b/packages/spacecat-shared-utils/src/index.d.ts
@@ -99,10 +99,11 @@ declare function composeBaseURL(domain: string): string;
 
 /**
  * Composes an audit URL by applying a series of transformations to the given url.
- * @param url - The url to compose the audit URL from.
+ * @param {string} url - The url to compose the audit URL from.
+ * @param {string} [userAgent] - Optional user agent to use in the audit URL.
  * @returns a promise that resolves the composed audit URL.
  */
-declare function composeAuditURL(url: string): Promise<string>;
+declare function composeAuditURL(url: string, userAgent: string): Promise<string>;
 
 /**
  * Resolves the name of the secret based on the function version.

--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -83,12 +83,12 @@ function composeBaseURL(domain) {
   return baseURL;
 }
 
-async function composeAuditURL(url) {
+async function composeAuditURL(url, userAgent = '') {
   const urlWithScheme = prependSchema(url);
   const resp = await fetch(urlWithScheme, {
     method: 'GET',
     headers: {
-      'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+      'User-Agent': userAgent,
     },
   });
   const finalUrl = resp.url.split('://')[1];

--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -83,13 +83,23 @@ function composeBaseURL(domain) {
   return baseURL;
 }
 
-async function composeAuditURL(url, userAgent = '') {
+/**
+ * Composes an audit URL by applying a series of transformations to the given url.
+ * @param {string} url - The url to compose the audit URL from.
+ * @param {string} [userAgent] - Optional user agent to use in the audit URL.
+ * @returns a promise that resolves the composed audit URL.
+ */
+async function composeAuditURL(url, userAgent) {
   const urlWithScheme = prependSchema(url);
+
+  const headers = {};
+  if (userAgent) {
+    headers['User-Agent'] = userAgent;
+  }
+
   const resp = await fetch(urlWithScheme, {
     method: 'GET',
-    headers: {
-      'User-Agent': userAgent,
-    },
+    headers,
   });
   const finalUrl = resp.url.split('://')[1];
   return stripTrailingSlash(finalUrl);

--- a/packages/spacecat-shared-utils/test/url-helpers.test.js
+++ b/packages/spacecat-shared-utils/test/url-helpers.test.js
@@ -118,6 +118,18 @@ describe('URL Utility Functions', () => {
       await expect(composeAuditURL('https://abc.com')).to.eventually.equal('abc.com');
       await expect(composeAuditURL('https://abc.com/us/en/')).to.eventually.equal('abc.com/us/en/');
     });
+
+    it('should compose audit URL with customed user agent', async () => {
+      nock('https://abc.com', {
+        reqheaders: {
+          'User-Agent': 'customed user agent',
+        },
+      })
+        .get('/')
+        .reply(200);
+      await expect(composeAuditURL('https://abc.com', 'customed user agent')).to.eventually.equal('abc.com');
+    });
+
     it('should follow redirect when composing audit URL', async () => {
       nock('https://abc.com')
         .get('/')


### PR DESCRIPTION
There are pages that need to specify a user agent, others fail when there is a custom user agent:
https://spacecat.coralogix.com/#/query-new/logs?id=hAC93giMyiLuiHMxw9VW3&page=0

The idea is to add the user agent to the site configuration, then the consumer of the function can decide weather to add a user agent or not