### PR TITLE
fix(ahrefs-client): enhance organic keywords query to use in HOTLCTR opportunity

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
     "typescriptreact"
   ],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "source.fixAll.eslint": true
   },
   "editor.formatOnSave": true,
   "javascript.format.enable": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
     "typescriptreact"
   ],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.formatOnSave": true,
   "javascript.format.enable": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20156,7 +20156,7 @@
     },
     "packages/spacecat-shared-content-client": {
       "name": "@adobe/spacecat-shared-content-client",
-      "version": "1.3.22",
+      "version": "1.3.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.0.8",

--- a/packages/spacecat-shared-ahrefs-client/src/index.d.ts
+++ b/packages/spacecat-shared-ahrefs-client/src/index.d.ts
@@ -73,7 +73,13 @@ export default class AhrefsAPIClient {
 
   /**
    * Asynchronous method to get organic keywords.
+   * @param url
+   * @param country
+   * @param keywordFilter
+   * @param limit
+   * @param mode
    */
-  getOrganicKeywords(url: string, country?: string, keywordFilter?: string[], limit?: number):
+  getOrganicKeywords(url: string, country?: string, keywordFilter?: string[],
+                     limit?: number, mode?: string):
       Promise<{ result: object, fullAuditRef: string }>;
 }

--- a/packages/spacecat-shared-ahrefs-client/src/index.js
+++ b/packages/spacecat-shared-ahrefs-client/src/index.js
@@ -172,7 +172,7 @@ export default class AhrefsAPIClient {
     return this.sendRequest('/site-explorer/metrics-history', queryParams);
   }
 
-  async getOrganicKeywords(url, country = 'us', keywordFilter = [], limit = 200) {
+  async getOrganicKeywords(url, country = 'us', keywordFilter = [], limit = 10, mode = 'prefix') {
     if (!hasText(url)) {
       throw new Error(`Invalid URL: ${url}`);
     }
@@ -185,18 +185,25 @@ export default class AhrefsAPIClient {
     if (!Number.isInteger(limit) || limit < 1) {
       throw new Error(`Invalid limit: ${limit}`);
     }
+    if (!['prefix', 'exact'].includes(mode)) {
+      throw new Error(`Invalid mode: ${mode}`);
+    }
+
     const queryParams = {
       country,
       date: new Date().toISOString().split('T')[0],
       select: [
         'keyword',
         'sum_traffic',
-        'best_position_url',
+        'volume',
+        'best_position',
+        'cpc',
+        'is_branded',
       ].join(','),
       order_by: 'sum_traffic:desc',
       target: url,
-      limit: getLimit(limit, 2000),
-      mode: 'prefix',
+      limit: getLimit(limit, 100),
+      mode,
       output: 'json',
     };
     if (keywordFilter.length > 0) {


### PR DESCRIPTION
Implements: https://jira.corp.adobe.com/browse/SITES-28786

I didn't find any consumer for the existing organic keywords query/import, so I propose to adjust/enhance it with the requirements we have for HOTLCTR opportunity.

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
