### PR TITLE
feat: util for reading .query static files, modeled after getPrompt

### DIFF
--- a/packages/spacecat-shared-utils/package.json
+++ b/packages/spacecat-shared-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/spacecat-shared-utils",
-  "version": "1.30.2",
+  "version": "1.30.3",
   "description": "Shared modules of the Spacecat Services - utils",
   "type": "module",
   "engines": {

--- a/packages/spacecat-shared-utils/package.json
+++ b/packages/spacecat-shared-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/spacecat-shared-utils",
-  "version": "1.30.3",
+  "version": "1.30.2",
   "description": "Shared modules of the Spacecat Services - utils",
   "type": "module",
   "engines": {

--- a/packages/spacecat-shared-utils/src/helpers.js
+++ b/packages/spacecat-shared-utils/src/helpers.js
@@ -131,3 +131,23 @@ export async function getPrompt(placeholders, filename, log = console) {
     return null;
   }
 }
+
+/**
+ * Reads the content of a query file asynchronously and replaces any placeholders
+ * with the corresponding values. Logs the error and returns null in case of an error.
+ *
+ * @param {Object} placeholders - A JSON object containing values to replace in the query content.
+ * @param {String} filename - The filename of the query file.
+ * @param {Object} log - The logger
+ * @returns {Promise<string|null>} - A promise that resolves to a string with the query content,
+ * or null if an error occurs.
+ */
+export async function getQuery(placeholders, filename, log = console) {
+  try {
+    const queryContent = await fs.readFile(`./static/queries/${filename}.query`, { encoding: 'utf8' });
+    return replacePlaceholders(queryContent, placeholders);
+  } catch (error) {
+    log.error('Error reading query file:', error.message);
+    return null;
+  }
+}

--- a/packages/spacecat-shared-utils/src/helpers.js
+++ b/packages/spacecat-shared-utils/src/helpers.js
@@ -11,7 +11,6 @@
  */
 
 import { Parser } from '@json2csv/plainjs';
-import { GetSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 import { promises as fs } from 'fs';
 import { isString } from './functions.js';
 
@@ -53,30 +52,6 @@ export function resolveCustomerSecretsName(baseURL, ctx) {
     throw new Error('Invalid baseURL: must be a valid URL');
   }
   return resolveSecretsName({}, ctx, `${basePath}/${customer}`);
-}
-
-/**
- * Retrieves the RUM domain key for the specified base URL from the customer secrets.
- *
- * @param {string} baseURL - The base URL for which the RUM domain key is to be retrieved.
- * @param {UniversalContext} context - Helix Universal Context. See https://github.com/adobe/helix-universal/blob/main/src/adapter.d.ts#L120
- * @returns {Promise<string>} - A promise that resolves to the RUM domain key.
- * @throws {Error} Throws an error if no domain key is found for the specified base URL.
- */
-export async function getRUMDomainKey(baseURL, context) {
-  const customerSecretName = resolveCustomerSecretsName(baseURL, context);
-  const { runtime } = context;
-
-  try {
-    const client = new SecretsManagerClient({ region: runtime.region });
-    const command = new GetSecretValueCommand({
-      SecretId: customerSecretName,
-    });
-    const response = await client.send(command);
-    return JSON.parse(response.SecretString)?.RUM_DOMAIN_KEY;
-  } catch (error) {
-    throw new Error(`Error retrieving the domain key for ${baseURL}. Error: ${error.message}`);
-  }
 }
 
 /**

--- a/packages/spacecat-shared-utils/src/helpers.js
+++ b/packages/spacecat-shared-utils/src/helpers.js
@@ -88,6 +88,19 @@ export function replacePlaceholders(content, placeholders) {
 }
 
 /**
+ * Internal function to support reading static file
+ * and replace placeholder strings with values.
+ *
+ * @param {Object} placeholders - A JSON object containing values to replace in the prompt content.
+ * @param {String} filename - The path of the prompt file.
+ * @returns {Promise<string|null>} - A promise that resolves to a string with the prompt content.
+ */
+async function getStaticContent(placeholders, filename) {
+  const fileContent = await fs.readFile(filename, { encoding: 'utf8' });
+  return replacePlaceholders(fileContent, placeholders);
+}
+
+/**
  * Reads the content of a prompt file asynchronously and replaces any placeholders
  * with the corresponding values. Logs the error and returns null in case of an error.
  *
@@ -99,8 +112,7 @@ export function replacePlaceholders(content, placeholders) {
  */
 export async function getPrompt(placeholders, filename, log = console) {
   try {
-    const promptContent = await fs.readFile(`./static/prompts/${filename}.prompt`, { encoding: 'utf8' });
-    return replacePlaceholders(promptContent, placeholders);
+    return await getStaticContent(placeholders, `./static/prompts/${filename}.prompt`);
   } catch (error) {
     log.error('Error reading prompt file:', error.message);
     return null;
@@ -119,8 +131,7 @@ export async function getPrompt(placeholders, filename, log = console) {
  */
 export async function getQuery(placeholders, filename, log = console) {
   try {
-    const queryContent = await fs.readFile(`./static/queries/${filename}.query`, { encoding: 'utf8' });
-    return replacePlaceholders(queryContent, placeholders);
+    return await getStaticContent(placeholders, `./static/queries/${filename}.query`);
   } catch (error) {
     log.error('Error reading query file:', error.message);
     return null;

--- a/packages/spacecat-shared-utils/src/index.d.ts
+++ b/packages/spacecat-shared-utils/src/index.d.ts
@@ -167,6 +167,19 @@ declare function getPrompt(placeholders: object, filename: string, log: object):
   Promise<string | null>;
 
 /**
+ * Reads the content of a query file asynchronously and replaces any placeholders
+ * with the corresponding values. Logs the error and returns null in case of an error.
+ *
+ * @param {Object} placeholders - A JSON object containing values to replace in the query content.
+ * @param {String} filename - The filename of the query file.
+ * @param {Object} log - The logger
+ * @returns {Promise<string|null>} - A promise that resolves to a string with the query content,
+ * or null if an error occurs.
+ */
+declare function getQuery(placeholders: object, filename: string, log: object):
+  Promise<string | null>;
+
+/**
  * Retrieves the high-form-view-low-form-conversion metrics from the provided array of form vitals.
  * @param {Object[]} formVitals - An array of form vitals.
  * @param {number} interval - The interval in days.
@@ -181,7 +194,7 @@ declare function getHighFormViewsLowConversionMetrics(formVitals: object[], inte
  * @returns {Object[]} - An array of high-page-view-low-form-view metrics.
  */
 declare function getHighPageViewsLowFormViewsMetrics(formVitals: object[], interval: number):
-    object[];
+  object[];
 
 /**
  * Retrieves the high-page-view-low-form-ctr metrics from the provided array of form vitals.
@@ -189,7 +202,7 @@ declare function getHighPageViewsLowFormViewsMetrics(formVitals: object[], inter
  * @returns {Object[]} - An array of high-page-view-low-form-ctr metrics.
  */
 declare function getHighPageViewsLowFormCtrMetrics(formVitals: object[], interval: number):
-    object[];
+  object[];
 
 /**
  * Retrieves stored metrics from S3.

--- a/packages/spacecat-shared-utils/src/index.js
+++ b/packages/spacecat-shared-utils/src/index.js
@@ -34,7 +34,6 @@ export {
 export {
   resolveSecretsName,
   resolveCustomerSecretsName,
-  getRUMDomainKey,
   generateCSVFile,
   replacePlaceholders,
   getPrompt,

--- a/packages/spacecat-shared-utils/src/index.js
+++ b/packages/spacecat-shared-utils/src/index.js
@@ -38,6 +38,7 @@ export {
   generateCSVFile,
   replacePlaceholders,
   getPrompt,
+  getQuery,
 } from './helpers.js';
 
 export { sqsWrapper } from './sqs.js';

--- a/packages/spacecat-shared-utils/test/helpers.test.js
+++ b/packages/spacecat-shared-utils/test/helpers.test.js
@@ -20,7 +20,8 @@ import {
   generateCSVFile,
   resolveSecretsName,
   resolveCustomerSecretsName,
-  replacePlaceholders, getPrompt, getQuery,
+  replacePlaceholders, getPrompt,
+  getQuery,
 } from '../src/helpers.js';
 
 describe('resolveSecretsName', () => {

--- a/packages/spacecat-shared-utils/test/helpers.test.js
+++ b/packages/spacecat-shared-utils/test/helpers.test.js
@@ -14,17 +14,13 @@
 
 import { expect } from 'chai';
 
-import nock from 'nock';
 import { promises as fs } from 'fs';
 import sinon from 'sinon';
 import {
   generateCSVFile,
   resolveSecretsName,
   resolveCustomerSecretsName,
-  getRUMDomainKey,
-  replacePlaceholders,
-  getPrompt,
-  getQuery,
+  replacePlaceholders, getPrompt, getQuery,
 } from '../src/helpers.js';
 
 describe('resolveSecretsName', () => {
@@ -94,56 +90,6 @@ describe('resolveCustomerSecretsName', () => {
   it('throws error when baseURL is not a valid url', () => {
     const ctx = { func: { version: '1.0.0' } };
     expect(() => resolveCustomerSecretsName('not a valid url', ctx)).to.throw('Invalid baseURL: must be a valid URL');
-  });
-});
-
-describe('rum utils', () => {
-  let context;
-  let processEnvCopy;
-  beforeEach('setup', () => {
-    context = {
-      env: {
-        AWS_REGION: 'us-east-1',
-        AWS_ACCESS_KEY_ID: 'some-key-id',
-        AWS_SECRET_ACCESS_KEY: 'some-secret-key',
-        AWS_SESSION_TOKEN: 'some-secret-token',
-      },
-      runtime: { name: 'aws-lambda', region: 'us-east-1' },
-      func: { package: 'spacecat-services', version: 'ci', name: 'test' },
-    };
-    processEnvCopy = { ...process.env };
-    process.env = {
-      ...process.env,
-      ...context.env,
-    };
-  });
-
-  afterEach('clean up', () => {
-    process.env = processEnvCopy;
-    nock.cleanAll();
-  });
-
-  it('throws error when domain key does not exist', async () => {
-    const scope = nock('https://secretsmanager.us-east-1.amazonaws.com/')
-      .post('/', (body) => body.SecretId === '/helix-deploy/spacecat-services/customer-secrets/some_domain_com/ci')
-      .replyWithError('Some error');
-
-    await expect(getRUMDomainKey('https://some-domain.com', context)).to.be.rejectedWith('Error retrieving the domain key for https://some-domain.com. Error: Some error');
-    scope.done();
-  });
-
-  it('retrieves the domain key', async () => {
-    const scope = nock('https://secretsmanager.us-east-1.amazonaws.com/')
-      .post('/', (body) => body.SecretId === '/helix-deploy/spacecat-services/customer-secrets/some_domain_com/ci')
-      .reply(200, {
-        SecretString: JSON.stringify({
-          RUM_DOMAIN_KEY: '42',
-        }),
-      });
-
-    const rumDomainkey = await getRUMDomainKey('https://some-domain.com', context);
-    expect(rumDomainkey).to.equal('42');
-    scope.done();
   });
 });
 

--- a/packages/spacecat-shared-utils/test/index.test.js
+++ b/packages/spacecat-shared-utils/test/index.test.js
@@ -24,7 +24,6 @@ describe('Index Exports', () => {
     'deepEqual',
     'fetch',
     'generateCSVFile',
-    'getRUMDomainKey',
     'getStoredMetrics',
     'replacePlaceholders',
     'getPrompt',

--- a/packages/spacecat-shared-utils/test/index.test.js
+++ b/packages/spacecat-shared-utils/test/index.test.js
@@ -28,6 +28,7 @@ describe('Index Exports', () => {
     'getStoredMetrics',
     'replacePlaceholders',
     'getPrompt',
+    'getQuery',
     'hasText',
     'isArray',
     'isBoolean',


### PR DESCRIPTION
In #579 comments, @solaris007 suggested handling queries as static files, external to the javascript source.  The getPrompt helper function was mentioned as a model.  This PR will create an updated release of the spacecat-shared-utils package which can be referenced by #579.
