### PR TITLE
Add delivery configuration object to site object

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/site.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/site/site.schema.js
@@ -64,6 +64,11 @@ const schema = new SchemaBuilder(Site, SiteCollection)
     type: 'string',
     validate: (value) => !value || isValidUrl(value),
   })
+  .addAttribute('deliveryConfig', {
+    type: 'any',
+    default: {},
+    validate: (value) => isObject(value),
+  })
   .addAttribute('hlxConfig', {
     type: 'any',
     default: {},


### PR DESCRIPTION
For AEM CS we need additional configuration similar to hlxConfig.
For now we need programId, environmentId, authorURL, and siteId (which is an AEM CS id for the site).
I assume the easiest is to just add a container object to the site object - the contents is then delivery type specific
