### PR TITLE
feat: adds site name

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/site/index.d.ts
@@ -28,6 +28,7 @@ export interface Site extends BaseModel {
   getAuditsByAuditType(auditType: string): Promise<Audit>;
   getAuditsByAuditTypeAndAuditedAt(auditType: string, auditedAt: string): Promise<Audit>;
   getBaseURL(): string;
+  getName(): string;
   getConfig(): object;
   getDeliveryType(): string;
   getExperiments(): Promise<Experiment[]>;
@@ -58,6 +59,7 @@ export interface Site extends BaseModel {
     source: string, geo: string, traffic: string
   ): Promise<SiteTopPage[]>;
   setBaseURL(baseURL: string): Site;
+  setName(name: string): Site;
   setConfig(config: object): Site;
   setDeliveryType(deliveryType: string): Site;
   setGitHubURL(gitHubURL: string): Site;

--- a/packages/spacecat-shared-data-access/src/models/site/site.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/site/site.schema.js
@@ -48,6 +48,9 @@ const schema = new SchemaBuilder(Site, SiteCollection)
     required: true,
     validate: (value) => isValidUrl(value),
   })
+  .addAttribute('name', {
+    type: 'string',
+  })
   .addAttribute('config', {
     type: 'any',
     required: true,

--- a/packages/spacecat-shared-data-access/test/fixtures/sites.fixture.js
+++ b/packages/spacecat-shared-data-access/test/fixtures/sites.fixture.js
@@ -14,6 +14,7 @@ const sites = [
   {
     siteId: '5d6d4439-6659-46c2-b646-92d110fa5a52',
     baseURL: 'https://example0.com',
+    name: 'test-site',
     deliveryType: 'aem_edge',
     gitHubURL: 'https://github.com/org-0/test-repo',
     organizationId: '4854e75e-894b-4a74-92bf-d674abad1423',

--- a/packages/spacecat-shared-data-access/test/it/site/site.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site/site.test.js
@@ -268,6 +268,7 @@ describe('Site IT', async () => {
     const newSiteData = {
       baseURL: 'https://newexample.com',
       gitHubURL: 'https://github.com/some-org/test-repo',
+      name: 'new-site',
       hlxConfig: {
         cdnProdHost: 'www.another-example.com',
         code: {
@@ -304,6 +305,7 @@ describe('Site IT', async () => {
     await checkSite(newSite);
 
     expect(newSite.getBaseURL()).to.equal(newSiteData.baseURL);
+    expect(newSite.getName()).to.equal(newSiteData.name);
   });
 
   it('updates a site', async () => {
@@ -314,6 +316,7 @@ describe('Site IT', async () => {
       gitHubURL: 'https://updated-github.com',
       isLive: false,
       organizationId: sampleData.organizations[1].getId(),
+      name: 'updated-site',
       hlxConfig: {
         cdnProdHost: 'www.another-example.com',
         code: {
@@ -336,6 +339,7 @@ describe('Site IT', async () => {
     };
 
     site.setBaseURL(updates.baseURL);
+    site.setName(updates.name);
     site.setDeliveryType(updates.deliveryType);
     site.setGitHubURL(updates.gitHubURL);
     site.setHlxConfig(updates.hlxConfig);
@@ -353,6 +357,7 @@ describe('Site IT', async () => {
     expect(updatedSite.getGitHubURL()).to.equal(updates.gitHubURL);
     expect(updatedSite.getIsLive()).to.equal(updates.isLive);
     expect(updatedSite.getOrganizationId()).to.equal(updates.organizationId);
+    expect(updatedSite.getName()).to.equal(updates.name);
   });
 
   it('reads config of a site', async () => {

--- a/packages/spacecat-shared-data-access/test/unit/models/site/site.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/site.model.test.js
@@ -97,6 +97,17 @@ describe('SiteModel', () => {
     });
   });
 
+  describe('name', () => {
+    it('gets name', () => {
+      expect(instance.getName()).to.equal('test-site');
+    });
+
+    it('sets name', () => {
+      instance.setName('new-site');
+      expect(instance.getName()).to.equal('new-site');
+    });
+  });
+
   describe('deliveryType', () => {
     it('gets deliveryType', () => {
       expect(instance.getDeliveryType()).to.equal('aem_edge');


### PR DESCRIPTION
Problem: 
PSS UI is rendering baseURL in several places. We need human friendly name for each site to render on all the pages in PSS UI. This PR adds a name attribute in Site schema and changes to update from PATCH call. 

spacecat-api-service changes - https://github.com/adobe/spacecat-api-service/pull/752

Request: 

`curl --request PATCH \
  --url https://spacecat.experiencecloud.live/api/ci/sites/{siteId} \
  --header 'Content-Type: application/json' \
  --header 'authorization: Bearer <token>' \
  --data '{
	"name": "SITE NAME"
}'`

Response: 
`{
	"id": "123",
	"baseURL": "https://example.com",
	"name": "SITE NAME",
	"hlxConfig": {},
	"deliveryType": "aem_cs",
	"organizationId": "org-id",
	"isLive": false,
	"isLiveToggledAt": "2025-01-07T10:54:22.455Z",
	"createdAt": "2025-01-07T10:54:22.453Z",
	"updatedAt": "2025-02-17T13:16:51.873Z",
	"config": {
		"slack": {},
		"handlers": {
		}
	}
}`

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
