### PR TITLE
feat: add alt-text audit type constant

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
+++ b/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
@@ -45,6 +45,7 @@ class Audit extends BaseModel {
     STRUCTURED_DATA: 'structured-data',
     FORMS_OPPORTUNITIES: 'forms-opportunities',
     SITE_DETECTION: 'site-detection',
+    ALT_TEXT: 'alt-text',
   };
 
   static AUDIT_TYPE_PROPERTIES = {

--- a/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
@@ -172,11 +172,12 @@ describe('AuditModel', () => {
       STRUCTURED_DATA: 'structured-data',
       FORMS_OPPORTUNITIES: 'forms-opportunities',
       SITE_DETECTION: 'site-detection',
+      ALT_TEXT: 'alt-text',
     };
 
     it('should have all audit types present in AUDIT_TYPES', () => {
       expect(auditTypes).to.eql(expectedAuditTypes);
-      expect(Object.keys(auditTypes)).to.have.lengthOf(21);
+      expect(Object.keys(auditTypes)).to.have.lengthOf(22);
     });
 
     it('should not have unexpected audit types in AUDIT_TYPES', () => {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues

- [ASSETS-47752 | [Backend] Extract alt-text audit type constant to spacecat-shared](https://jira.corp.adobe.com/browse/ASSETS-47752)
- [ASSETS-47238 | [Epic] Alt text audit for Project Success Studio](https://jira.corp.adobe.com/browse/ASSETS-47238)
