### PR TITLE
fix: validate IMS Org ID

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/organization/organization.model.js
+++ b/packages/spacecat-shared-data-access/src/models/organization/organization.model.js
@@ -20,8 +20,9 @@ import BaseModel from '../base/base.model.js';
  * @extends BaseModel
  */
 class Organization extends BaseModel {
-  // add your custom methods or overrides here
+  static IMS_ORG_ID_REGEX = /[a-z0-9]{24}@AdobeOrg/i;
 
+  // add your custom methods or overrides here
 }
 
 export default Organization;

--- a/packages/spacecat-shared-data-access/src/models/organization/organization.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/organization/organization.schema.js
@@ -41,7 +41,7 @@ const schema = new SchemaBuilder(Organization, OrganizationCollection)
   })
   .addAttribute('imsOrgId', {
     type: 'string',
-    default: 'default',
+    validate: (value) => !value || Organization.IMS_ORG_ID_REGEX.test(value),
   })
   .addAttribute('fulfillableItems', {
     type: 'any',

--- a/packages/spacecat-shared-data-access/test/fixtures/organizations.fixture.js
+++ b/packages/spacecat-shared-data-access/test/fixtures/organizations.fixture.js
@@ -13,7 +13,7 @@
 const organizations = [
   {
     organizationId: '4854e75e-894b-4a74-92bf-d674abad1423',
-    imsOrgId: '0-1234@AdobeOrg',
+    imsOrgId: '1234567890ABCDEF12345678@AdobeOrg',
     name: '0-1234Name',
     config:
       {
@@ -43,7 +43,7 @@ const organizations = [
   },
   {
     organizationId: '757ceb98-05c8-4e07-bb23-bc722115b2b0',
-    imsOrgId: '1-1234@AdobeOrg',
+    imsOrgId: '1234567891ABCDEF12345678@AdobeOrg',
     name: '1-1234Name',
     config:
       {
@@ -73,7 +73,7 @@ const organizations = [
   },
   {
     organizationId: '5d42bdf8-b65d-4de8-b849-a4f28ebc93cd',
-    imsOrgId: '2-1234@AdobeOrg',
+    imsOrgId: '1234567892ABCDEF12345678@AdobeOrg',
     name: '2-1234Name',
     config:
       {

--- a/packages/spacecat-shared-data-access/test/it/organization/organization.test.js
+++ b/packages/spacecat-shared-data-access/test/it/organization/organization.test.js
@@ -88,7 +88,7 @@ describe('Organization IT', async () => {
   it('adds a new organization', async () => {
     const data = {
       name: 'New Organization',
-      imsOrgId: 'newOrgId',
+      imsOrgId: '1234567893ABCDEF12345678@AdobeOrg',
       config: {
         some: 'config',
       },
@@ -114,7 +114,7 @@ describe('Organization IT', async () => {
 
     const data = {
       name: 'Updated Organization',
-      imsOrgId: 'updatedOrgId',
+      imsOrgId: '1234567894ABCDEF12345678@AdobeOrg',
       config: {
         some: 'updated',
       },

--- a/packages/spacecat-shared-data-access/test/unit/models/organization/organization.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/organization/organization.model.test.js
@@ -77,7 +77,7 @@ describe('OrganizationModel', () => {
 
   describe('imsOrgId', () => {
     it('gets imsOrgId', () => {
-      expect(instance.getImsOrgId()).to.equal('0-1234@AdobeOrg');
+      expect(instance.getImsOrgId()).to.equal('1234567890ABCDEF12345678@AdobeOrg');
     });
 
     it('sets imsOrgId', () => {


### PR DESCRIPTION
Validates the IMS Org ID for the Organization model. Also adds a constant to the Organization model with the IMS Org ID regex for consumers to leverage for similar checks.