### PR TITLE
feat: set default fetch user-agent

### DIFF
--- a/packages/spacecat-shared-utils/src/index.d.ts
+++ b/packages/spacecat-shared-utils/src/index.d.ts
@@ -242,3 +242,5 @@ export function s3Wrapper(fn: (request: object, context: object) => Promise<Resp
 export function fetch(url: string | Request, options?: RequestOptions): Promise<Response>;
 
 export function tracingFetch(url: string | Request, options?: RequestOptions): Promise<Response>;
+
+export const SPACECAT_USER_AGENT: string;

--- a/packages/spacecat-shared-utils/src/index.js
+++ b/packages/spacecat-shared-utils/src/index.js
@@ -60,5 +60,5 @@ export { getStoredMetrics, storeMetrics } from './metrics-store.js';
 export { s3Wrapper } from './s3.js';
 
 export { fetch } from './adobe-fetch.js';
-export { tracingFetch } from './tracing-fetch.js';
+export { tracingFetch, SPACECAT_USER_AGENT } from './tracing-fetch.js';
 export { getHighFormViewsLowConversionMetrics, getHighPageViewsLowFormViewsMetrics, getHighPageViewsLowFormCtrMetrics } from './formcalc.js';

--- a/packages/spacecat-shared-utils/src/tracing-fetch.js
+++ b/packages/spacecat-shared-utils/src/tracing-fetch.js
@@ -15,7 +15,7 @@ import AWSXRay from 'aws-xray-sdk';
 import { fetch as adobeFetch } from './adobe-fetch.js';
 import { isNumber, isObject } from './functions.js';
 
-export const SPACECAT_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Spacecat/1.0';
+export const SPACECAT_USER_AGENT = 'Mozilla/5.0 (Linux; Android 11; moto g power (2022)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Mobile Safari/537.36 Spacecat/1.0';
 
 /**
  * Creates a subsegment for a given hostname based on whether the parent segment is traced or not.

--- a/packages/spacecat-shared-utils/test/index.test.js
+++ b/packages/spacecat-shared-utils/test/index.test.js
@@ -59,6 +59,7 @@ describe('Index Exports', () => {
     'getHighFormViewsLowConversionMetrics',
     'getHighPageViewsLowFormViewsMetrics',
     'getHighPageViewsLowFormCtrMetrics',
+    'SPACECAT_USER_AGENT',
   ];
 
   it('exports all expected functions', () => {


### PR DESCRIPTION
Sets the default user agent for `tracingFetch`. Also exports a constant with the user agent for use by consuming code.