### PR TITLE
feat: import config schema

### DIFF
--- a/.github/actions/lint-test-coverage/action.yaml
+++ b/.github/actions/lint-test-coverage/action.yaml
@@ -18,7 +18,22 @@ runs:
       run: npm run lint
       shell: bash
 
-    - name: Test
+    - name: Check for IT Tests
+      id: check_it_tests
+      run: |
+        if grep -q "\"test:it\":" package.json; then
+          echo "has_it_tests=true" >> $GITHUB_OUTPUT
+        else
+          echo "has_it_tests=false" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+
+    - name: Run Integration Tests
+      if: steps.check_it_tests.outputs.has_it_tests == 'true'
+      run: npm run test:it
+      shell: bash
+
+    - name: Run Unit Tests
       run: npm run test
       shell: bash
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
     "typescriptreact"
   ],
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.formatOnSave": true,
   "javascript.format.enable": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20238,7 +20238,7 @@
     },
     "packages/spacecat-shared-content-client": {
       "name": "@adobe/spacecat-shared-content-client",
-      "version": "1.3.36",
+      "version": "1.3.37",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.0.8",
@@ -40190,7 +40190,7 @@
     },
     "packages/spacecat-shared-http-utils": {
       "name": "@adobe/spacecat-shared-http-utils",
-      "version": "1.9.9",
+      "version": "1.9.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.11",

--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -18,13 +18,13 @@ export const IMPORT_TYPES = {
   TOP_PAGES: 'top-pages',
 };
 
-const IMPORT_DESTINATIONS = {
+export const IMPORT_DESTINATIONS = {
   DEFAULT: 'default',
 };
 
-const IMPORT_SOURCES = {
+export const IMPORT_SOURCES = {
   AHREFS: 'ahrefs',
-  GSC: 'gsc',
+  GSC: 'google',
 };
 
 const IMPORT_BASE_KEYS = {
@@ -51,22 +51,22 @@ export const IMPORT_TYPE_SCHEMAS = {
 };
 
 export const DEFAULT_IMPORT_CONFIGS = {
-  [IMPORT_TYPES.ORGANIC_KEYWORDS]: {
-    type: IMPORT_TYPES.ORGANIC_KEYWORDS,
-    destinations: [IMPORT_DESTINATIONS.DEFAULT],
-    sources: [IMPORT_SOURCES.AHREFS],
+  'organic-keywords': {
+    type: 'organic-keywords',
+    destinations: ['default'],
+    sources: ['ahrefs'],
     enabled: true,
   },
-  [IMPORT_TYPES.ORGANIC_TRAFFIC]: {
-    type: IMPORT_TYPES.ORGANIC_TRAFFIC,
-    destinations: [IMPORT_DESTINATIONS.DEFAULT],
-    sources: [IMPORT_SOURCES.AHREFS],
+  'organic-traffic': {
+    type: 'organic-traffic',
+    destinations: ['default'],
+    sources: ['ahrefs'],
     enabled: true,
   },
-  [IMPORT_TYPES.TOP_PAGES]: {
-    type: IMPORT_TYPES.TOP_PAGES,
-    destinations: [IMPORT_DESTINATIONS.DEFAULT],
-    sources: [IMPORT_SOURCES.AHREFS],
+  'top-pages': {
+    type: 'top-pages',
+    destinations: ['default'],
+    sources: ['ahrefs'],
     enabled: true,
     geo: 'global',
   },

--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -12,13 +12,75 @@
 
 import Joi from 'joi';
 
+export const IMPORT_TYPES = {
+  ORGANIC_KEYWORDS: 'organic-keywords',
+  ORGANIC_TRAFFIC: 'organic-traffic',
+  TOP_PAGES: 'top-pages',
+};
+
+const IMPORT_DESTINATIONS = {
+  DEFAULT: 'default',
+};
+
+const IMPORT_SOURCES = {
+  AHREFS: 'ahrefs',
+  GSC: 'gsc',
+};
+
+const IMPORT_BASE_KEYS = {
+  destinations: Joi.array().items(Joi.string().valid(IMPORT_DESTINATIONS.DEFAULT)).required(),
+  sources: Joi.array().items(Joi.string().valid(...Object.values(IMPORT_SOURCES))).required(),
+  enabled: Joi.boolean().required().default(true),
+};
+
+export const IMPORT_TYPE_SCHEMAS = {
+  [IMPORT_TYPES.ORGANIC_KEYWORDS]: Joi.object({
+    type: Joi.string().valid(IMPORT_TYPES.ORGANIC_KEYWORDS).required(),
+    ...IMPORT_BASE_KEYS,
+    pageUrl: Joi.string().uri(),
+  }),
+  [IMPORT_TYPES.ORGANIC_TRAFFIC]: Joi.object({
+    type: Joi.string().valid(IMPORT_TYPES.ORGANIC_TRAFFIC).required(),
+    ...IMPORT_BASE_KEYS,
+  }),
+  [IMPORT_TYPES.TOP_PAGES]: Joi.object({
+    type: Joi.string().valid(IMPORT_TYPES.TOP_PAGES).required(),
+    ...IMPORT_BASE_KEYS,
+    geo: Joi.string(),
+  }),
+};
+
+export const DEFAULT_IMPORT_CONFIGS = {
+  [IMPORT_TYPES.ORGANIC_KEYWORDS]: {
+    type: IMPORT_TYPES.ORGANIC_KEYWORDS,
+    destinations: [IMPORT_DESTINATIONS.DEFAULT],
+    sources: [IMPORT_SOURCES.AHREFS],
+    enabled: true,
+  },
+  [IMPORT_TYPES.ORGANIC_TRAFFIC]: {
+    type: IMPORT_TYPES.ORGANIC_TRAFFIC,
+    destinations: [IMPORT_DESTINATIONS.DEFAULT],
+    sources: [IMPORT_SOURCES.AHREFS],
+    enabled: true,
+  },
+  [IMPORT_TYPES.TOP_PAGES]: {
+    type: IMPORT_TYPES.TOP_PAGES,
+    destinations: [IMPORT_DESTINATIONS.DEFAULT],
+    sources: [IMPORT_SOURCES.AHREFS],
+    enabled: true,
+    geo: 'global',
+  },
+};
+
 export const configSchema = Joi.object({
   slack: Joi.object({
     workspace: Joi.string(),
     channel: Joi.string(),
     invitedUserCount: Joi.number().integer().min(0),
   }),
-  imports: Joi.array().items(Joi.object({ type: Joi.string() }).unknown(true)),
+  imports: Joi.array().items(
+    Joi.alternatives().try(...Object.values(IMPORT_TYPE_SCHEMAS)),
+  ),
   fetchConfig: Joi.object({
     headers: Joi.object().pattern(Joi.string(), Joi.string()),
   }).optional(),
@@ -134,6 +196,47 @@ export const Config = (data = {}) => {
 
   self.updateFetchConfig = (fetchConfig) => {
     state.fetchConfig = fetchConfig;
+  };
+
+  self.enableImport = (type, config = {}) => {
+    if (!IMPORT_TYPE_SCHEMAS[type]) {
+      throw new Error(`Unknown import type: ${type}`);
+    }
+
+    const defaultConfig = DEFAULT_IMPORT_CONFIGS[type];
+    const newConfig = {
+      ...defaultConfig, ...config, type, enabled: true,
+    };
+
+    // Validate the new config against its schema
+    const { error } = IMPORT_TYPE_SCHEMAS[type].validate(newConfig);
+    if (error) {
+      throw new Error(`Invalid import config: ${error.message}`);
+    }
+
+    state.imports = state.imports || [];
+    // Remove existing import of same type if present
+    state.imports = state.imports.filter((imp) => imp.type !== type);
+    state.imports.push(newConfig);
+
+    validateConfiguration(state);
+  };
+
+  self.disableImport = (type) => {
+    if (!state.imports) return;
+
+    state.imports = state.imports.map(
+      (imp) => (imp.type === type ? { ...imp, enabled: false } : imp),
+    );
+
+    validateConfiguration(state);
+  };
+
+  self.getImportConfig = (type) => state.imports?.find((imp) => imp.type === type);
+
+  self.isImportEnabled = (type) => {
+    const config = self.getImportConfig(type);
+    return config?.enabled ?? false;
   };
 
   return Object.freeze(self);

--- a/packages/spacecat-shared-data-access/src/models/site/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/site/index.d.ts
@@ -23,13 +23,95 @@ import type {
   SiteTopPage,
 } from '../index';
 
+export type IMPORT_TYPES = {
+  readonly ORGANIC_KEYWORDS: 'organic-keywords';
+  readonly ORGANIC_TRAFFIC: 'organic-traffic';
+  readonly TOP_PAGES: 'top-pages';
+};
+
+export type IMPORT_DESTINATIONS = {
+  readonly DEFAULT: 'default';
+};
+
+export type IMPORT_SOURCES = {
+  readonly AHREFS: 'ahrefs';
+  readonly GSC: 'google';
+};
+
+export type ImportType = 'organic-keywords' | 'organic-traffic' | 'top-pages';
+export type ImportDestination = 'default';
+export type ImportSource = 'ahrefs' | 'google';
+
+export interface ImportConfig {
+  type: ImportType;
+  destinations: ImportDestination[];
+  sources: ImportSource[];
+  enabled: boolean;
+  pageUrl?: string;
+  geo?: string;
+}
+
+export interface SiteConfig {
+  state: {
+    slack?: {
+      workspace?: string;
+      channel?: string;
+      invitedUserCount?: number;
+    };
+    imports?: ImportConfig[];
+    handlers?: Record<string, {
+      mentions?: Record<string, string[]>;
+      excludedURLs?: string[];
+      manualOverwrites?: Array<{
+        brokenTargetURL?: string;
+        targetURL?: string;
+      }>;
+      fixedURLs?: Array<{
+        brokenTargetURL?: string;
+        targetURL?: string;
+      }>;
+      includedURLs?: string[];
+      groupedURLs?: Array<{
+        name: string;
+        pattern: string;
+      }>;
+      latestMetrics?: {
+        pageViewsChange: number;
+        ctrChange: number;
+        projectedTrafficValue: number;
+      };
+    }>;
+    fetchConfig?: {
+      headers?: Record<string, string>;
+    };
+  };
+  getSlackConfig(): { workspace?: string; channel?: string; invitedUserCount?: number };
+  getImports(): ImportConfig[];
+  getImportConfig(type: ImportType): ImportConfig | undefined;
+  isImportEnabled(type: ImportType): boolean;
+  enableImport(type: ImportType, config?: Partial<ImportConfig>): void;
+  disableImport(type: ImportType): void;
+  getHandlers(): Record<string, object>;
+  getHandlerConfig(type: string): object;
+  getSlackMentions(type: string): string[] | undefined;
+  getExcludedURLs(type: string): string[] | undefined;
+  getManualOverwrites(type: string):
+    Array<{ brokenTargetURL?: string; targetURL?: string }> | undefined;
+  getFixedURLs(type: string): Array<{ brokenTargetURL?: string; targetURL?: string }> | undefined;
+  getIncludedURLs(type: string): string[] | undefined;
+  getGroupedURLs(type: string): Array<{ name: string; pattern: string }> | undefined;
+  getLatestMetrics(type: string):
+    { pageViewsChange: number; ctrChange: number; projectedTrafficValue: number } | undefined;
+  getFetchConfig(): { headers?: Record<string, string> } | undefined;
+}
+
 export interface Site extends BaseModel {
   getAudits(): Promise<Audit>;
   getAuditsByAuditType(auditType: string): Promise<Audit>;
   getAuditsByAuditTypeAndAuditedAt(auditType: string, auditedAt: string): Promise<Audit>;
   getBaseURL(): string;
   getName(): string;
-  getConfig(): object;
+  getConfig(): SiteConfig;
   getDeliveryType(): string;
   getExperiments(): Promise<Experiment[]>;
   getExperimentsByExpId(expId: string): Promise<Experiment[]>;

--- a/packages/spacecat-shared-data-access/test/fixtures/sites.fixture.js
+++ b/packages/spacecat-shared-data-access/test/fixtures/sites.fixture.js
@@ -55,37 +55,10 @@ const sites = [
       },
       imports: [
         {
-          type: 'rum-to-aa',
-          mapper: {
-            mapping: {
-              pageURL: {
-                rumField: 'url',
-              },
-              userAgent: {
-                default: 'rum/1.0.0',
-              },
-              eVars: {
-                eVar4: {
-                  default: 'RUM',
-                },
-                eVar3: {
-                  rumField: 'url',
-                },
-              },
-              events: {
-                event4: {
-                  rumField: 'pageviews',
-                },
-              },
-              reportSuiteID: {
-                default: 'ageo1xxpnwdemoexpleugue',
-              },
-              visitorID: {
-                default: '000',
-              },
-            },
-            timezone: 'UTC-07:00',
-          },
+          type: 'organic-traffic',
+          destinations: ['default'],
+          sources: ['gsc'],
+          enabled: true,
         },
       ],
     },

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -382,14 +382,14 @@ describe('Config Tests', () => {
         const config = Config();
         config.enableImport('organic-keywords', {
           pageUrl: 'https://example.com',
-          sources: ['gsc'],
+          sources: ['google'],
         });
 
         const importConfig = config.getImportConfig('organic-keywords');
         expect(importConfig).to.deep.equal({
           type: 'organic-keywords',
           destinations: ['default'],
-          sources: ['gsc'],
+          sources: ['google'],
           enabled: true,
           pageUrl: 'https://example.com',
         });
@@ -419,12 +419,12 @@ describe('Config Tests', () => {
         });
 
         config.enableImport('organic-keywords', {
-          sources: ['gsc'],
+          sources: ['google'],
         });
 
         const imports = config.getImports();
         expect(imports).to.have.length(1);
-        expect(imports[0].sources).to.deep.equal(['gsc']);
+        expect(imports[0].sources).to.deep.equal(['google']);
       });
     });
 


### PR DESCRIPTION
Add schema to site/org config detailing the supported import types and their configuration. Adds utility methods to enable/disable imports.