### PR TITLE
fix: import-schema backwards compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20285,7 +20285,7 @@
     },
     "packages/spacecat-shared-content-client": {
       "name": "@adobe/spacecat-shared-content-client",
-      "version": "1.3.37",
+      "version": "1.3.38",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.0.8",

--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -30,7 +30,8 @@ export const IMPORT_SOURCES = {
 const IMPORT_BASE_KEYS = {
   destinations: Joi.array().items(Joi.string().valid(IMPORT_DESTINATIONS.DEFAULT)).required(),
   sources: Joi.array().items(Joi.string().valid(...Object.values(IMPORT_SOURCES))).required(),
-  enabled: Joi.boolean().required().default(true),
+  // not required for now due backward compatibility
+  enabled: Joi.boolean().default(true),
 };
 
 export const IMPORT_TYPE_SCHEMAS = {
@@ -118,7 +119,7 @@ export function validateConfiguration(config) {
   const { error, value } = configSchema.validate(config);
 
   if (error) {
-    throw new Error(`Configuration validation error: ${error.message}`);
+    throw new Error(`Configuration validation error: ${error.message}`, { cause: error });
   }
 
   return value; // Validated and sanitized configuration

--- a/packages/spacecat-shared-data-access/test/fixtures/sites.fixture.js
+++ b/packages/spacecat-shared-data-access/test/fixtures/sites.fixture.js
@@ -22,6 +22,17 @@ const sites = [
     isLiveToggledAt: '2024-11-29T07:45:55.952Z',
     GSI1PK: 'ALL_SITES',
     config: {
+      imports: [
+        {
+          sources: [
+            'ahrefs',
+          ],
+          type: 'top-pages',
+          destinations: [
+            'default',
+          ],
+        },
+      ],
       handlers: {
         404: {
           mentions: {
@@ -53,14 +64,6 @@ const sites = [
       slack: {
         channel: 'some-channel',
       },
-      imports: [
-        {
-          type: 'organic-traffic',
-          destinations: ['default'],
-          sources: ['gsc'],
-          enabled: true,
-        },
-      ],
     },
   },
   {

--- a/packages/spacecat-shared-data-access/test/it/site/site.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site/site.test.js
@@ -363,6 +363,7 @@ describe('Site IT', async () => {
 
   it('reads config of a site', async () => {
     const { config: configFixture } = siteFixtures[0];
+    configFixture.imports[0].enabled = true; // set by joi schema default
     const site = await Site.findById('5d6d4439-6659-46c2-b646-92d110fa5a52');
     const config = site.getConfig();
     expect(config).to.be.an('object');
@@ -457,7 +458,7 @@ describe('Site IT', async () => {
       // Update import configuration
       const config = site.getConfig();
       config.enableImport('organic-traffic', {
-        sources: ['gsc'],
+        sources: ['google'],
       });
       config.disableImport('organic-keywords');
 
@@ -476,7 +477,7 @@ describe('Site IT', async () => {
       expect(updatedConfig.getImportConfig('organic-traffic')).to.deep.equal({
         type: 'organic-traffic',
         destinations: ['default'],
-        sources: ['gsc'],
+        sources: ['google'],
         enabled: true,
       });
     });
@@ -498,7 +499,7 @@ describe('Site IT', async () => {
         pageUrl: 'https://multi-import-example.com/blog',
       });
       config.enableImport('organic-traffic', {
-        sources: ['gsc'],
+        sources: ['google'],
       });
       config.enableImport('top-pages', {
         geo: 'us',
@@ -517,7 +518,7 @@ describe('Site IT', async () => {
       expect(updatedConfig.getImportConfig('organic-keywords').pageUrl)
         .to.equal('https://multi-import-example.com/blog');
       expect(updatedConfig.getImportConfig('organic-traffic').sources)
-        .to.deep.equal(['gsc']);
+        .to.deep.equal(['google']);
       expect(updatedConfig.getImportConfig('top-pages').geo)
         .to.equal('us');
     });

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -14,7 +14,7 @@
 
 import { expect } from 'chai';
 
-import { Config } from '../../../../src/models/site/config.js';
+import { Config, validateConfiguration } from '../../../../src/models/site/config.js';
 
 describe('Config Tests', () => {
   describe('Config Creation', () => {
@@ -538,6 +538,215 @@ describe('Config Tests', () => {
         const config = Config();
         expect(config.isImportEnabled('organic-keywords')).to.be.false;
       });
+    });
+  });
+
+  describe('validateConfiguration Function', () => {
+    it('validates a minimal configuration', () => {
+      const config = {
+        slack: {},
+        handlers: {},
+      };
+      const validated = validateConfiguration(config);
+      expect(validated).to.deep.equal(config);
+    });
+
+    it('validates a complete configuration with all options', () => {
+      const config = {
+        slack: {
+          channel: 'test-channel',
+          workspace: 'test-workspace',
+          invitedUserCount: 5,
+        },
+        handlers: {
+          404: {
+            mentions: { slack: ['user1', 'user2'] },
+            excludedURLs: ['https://example.com/excluded'],
+            manualOverwrites: [{ brokenTargetURL: 'old', targetURL: 'new' }],
+            fixedURLs: [{ brokenTargetURL: 'broken', targetURL: 'fixed' }],
+            includedURLs: ['https://example.com/included'],
+            groupedURLs: [{ name: 'group1', pattern: '/pattern/' }],
+            latestMetrics: {
+              pageViewsChange: 10,
+              ctrChange: 5,
+              projectedTrafficValue: 1000,
+            },
+          },
+        },
+        imports: [
+          {
+            type: 'organic-keywords',
+            destinations: ['default'],
+            sources: ['ahrefs'],
+            pageUrl: 'https://example.com',
+            enabled: false,
+          },
+          {
+            type: 'organic-traffic',
+            destinations: ['default'],
+            sources: ['ahrefs', 'google'],
+            enabled: true,
+          },
+          {
+            type: 'top-pages',
+            destinations: ['default'],
+            sources: ['ahrefs'],
+            enabled: true,
+            geo: 'us',
+          },
+        ],
+        fetchConfig: {
+          headers: {
+            'User-Agent': 'test-agent',
+          },
+        },
+      };
+      const validated = validateConfiguration(config);
+      expect(validated).to.deep.equal(config);
+    });
+
+    it('throws error for invalid slack configuration', () => {
+      const config = {
+        slack: {
+          invitedUserCount: 'not-a-number',
+        },
+      };
+      expect(() => validateConfiguration(config))
+        .to.throw('Configuration validation error: "slack.invitedUserCount" must be a number');
+    });
+
+    it('throws error for invalid handler configuration', () => {
+      const config = {
+        handlers: {
+          404: {
+            mentions: 'not-an-object',
+          },
+        },
+      };
+      expect(() => validateConfiguration(config))
+        .to.throw('Configuration validation error: "handlers.404.mentions" must be of type object');
+    });
+
+    it('throws error for invalid import configuration', () => {
+      const config = {
+        imports: [
+          {
+            type: 'organic-keywords',
+            destinations: ['invalid'],
+            sources: ['invalid-source'],
+            enabled: true,
+          },
+        ],
+      };
+      expect(() => validateConfiguration(config))
+        .to.throw().and.satisfy((error) => {
+          expect(error.message).to.include('Configuration validation error');
+          expect(error.cause.details[0].context.message)
+            .to.equal('"imports[0].destinations[0]" must be [default]. "imports[0].type" must be [organic-traffic]. "imports[0].type" must be [top-pages]');
+          expect(error.cause.details[0].context.details)
+            .to.eql([
+              {
+                message: '"imports[0].destinations[0]" must be [default]',
+                path: [
+                  'imports',
+                  0,
+                  'destinations',
+                  0,
+                ],
+                type: 'any.only',
+                context: {
+                  valids: [
+                    'default',
+                  ],
+                  label: 'imports[0].destinations[0]',
+                  value: 'invalid',
+                  key: 0,
+                },
+              },
+              {
+                message: '"imports[0].type" must be [organic-traffic]',
+                path: [
+                  'imports',
+                  0,
+                  'type',
+                ],
+                type: 'any.only',
+                context: {
+                  valids: [
+                    'organic-traffic',
+                  ],
+                  label: 'imports[0].type',
+                  value: 'organic-keywords',
+                  key: 'type',
+                },
+              },
+              {
+                message: '"imports[0].type" must be [top-pages]',
+                path: [
+                  'imports',
+                  0,
+                  'type',
+                ],
+                type: 'any.only',
+                context: {
+                  valids: [
+                    'top-pages',
+                  ],
+                  label: 'imports[0].type',
+                  value: 'organic-keywords',
+                  key: 'type',
+                },
+              },
+            ]);
+          return true;
+        });
+    });
+
+    it('throws error for invalid fetchConfig', () => {
+      const config = {
+        fetchConfig: {
+          headers: 'not-an-object',
+        },
+      };
+      expect(() => validateConfiguration(config))
+        .to.throw('Configuration validation error: "fetchConfig.headers" must be of type object');
+    });
+
+    it('validates multiple import types with different configurations', () => {
+      const config = {
+        imports: [
+          {
+            type: 'organic-keywords',
+            destinations: ['default'],
+            sources: ['ahrefs'],
+            enabled: true,
+            pageUrl: 'https://example.com',
+          },
+          {
+            type: 'top-pages',
+            destinations: ['default'],
+            sources: ['ahrefs'],
+            enabled: false,
+            geo: 'global',
+          },
+        ],
+      };
+      const validated = validateConfiguration(config);
+      expect(validated).to.deep.equal(config);
+    });
+
+    it('throws error for missing required import fields', () => {
+      const config = {
+        imports: [
+          {
+            type: 'organic-keywords',
+            // missing required destinations and sources
+            enabled: true,
+          },
+        ],
+      };
+      expect(() => validateConfiguration(config))
+        .to.throw('Configuration validation error: "imports[0]" does not match any of the allowed types');
     });
   });
 });


### PR DESCRIPTION
The import schema update introduced via #626 accidentally set the newly introduce `enabled` property as required. this caused already existing import configurations in the database to be invalid, causing outages. The `enabled` flag is now optional. Relevant unit and IT tests have been enhanced.