### PR TITLE
fix: improves logs for FF client failures

### DIFF
--- a/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
+++ b/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
@@ -137,7 +137,7 @@ export default class FirefallClient {
       let message = '';
       try {
         const errorBody = await response.json();
-        message = `Job submission failed with status code ${response.status} and message: ${errorBody.message}`;
+        message = `Job submission failed with status code ${response.status} and body: ${JSON.stringify(errorBody)}`;
       } catch {
         message = `Job submission failed with status code ${response.status}`;
       }

--- a/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
+++ b/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
@@ -134,14 +134,8 @@ export default class FirefallClient {
     });
 
     if (!response.ok) {
-      let message = '';
-      try {
-        const errorBody = await response.json();
-        message = `Job submission failed with status code ${response.status} and body: ${JSON.stringify(errorBody)}`;
-      } catch {
-        message = `Job submission failed with status code ${response.status}`;
-      }
-      throw new Error(message);
+      const errorBody = await response.text();
+      throw new Error(`Job submission failed with status code ${response.status} and body: ${errorBody}`);
     }
 
     return response.json();

--- a/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
+++ b/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
@@ -134,7 +134,14 @@ export default class FirefallClient {
     });
 
     if (!response.ok) {
-      throw new Error(`Job submission failed with status code ${response.status}`);
+      let message = '';
+      try {
+        const errorBody = await response.json();
+        message = `Job submission failed with status code ${response.status} and message: ${errorBody.message}`;
+      } catch {
+        message = `Job submission failed with status code ${response.status}`;
+      }
+      throw new Error(message);
     }
 
     return response.json();

--- a/packages/spacecat-shared-gpt-client/test/clients/firefall-client.test.js
+++ b/packages/spacecat-shared-gpt-client/test/clients/firefall-client.test.js
@@ -229,6 +229,15 @@ describe('FirefallClient', () => {
       expect(result.model).to.equal('hello');
     });
 
+    it.only('should handle a bad json response', async () => {
+      nock(mockContext.env.FIREFALL_API_ENDPOINT)
+        .post(chatPath)
+        .reply(400, { message: 'Bad request was provided' });
+
+      await expect(client.fetchChatCompletion('Test prompt'))
+        .to.be.rejectedWith('Job submission failed with status code 400 and message: Bad request was provided');
+    });
+
     it('should handle a bad response code', async () => {
       nock(mockContext.env.FIREFALL_API_ENDPOINT)
         .post(chatPath)

--- a/packages/spacecat-shared-gpt-client/test/clients/firefall-client.test.js
+++ b/packages/spacecat-shared-gpt-client/test/clients/firefall-client.test.js
@@ -229,13 +229,14 @@ describe('FirefallClient', () => {
       expect(result.model).to.equal('hello');
     });
 
-    it('should handle a bad json response', async () => {
+    it.only('should handle a bad json response', async () => {
+      const response = { message: 'Bad request was provided', status: 400 };
       nock(mockContext.env.FIREFALL_API_ENDPOINT)
         .post(chatPath)
-        .reply(400, { message: 'Bad request was provided' });
+        .reply(response.status, response);
 
       await expect(client.fetchChatCompletion('Test prompt'))
-        .to.be.rejectedWith('Job submission failed with status code 400 and message: Bad request was provided');
+        .to.be.rejectedWith(`Job submission failed with status code 400 and body: ${JSON.stringify(response)}`);
     });
 
     it('should handle a bad response code', async () => {

--- a/packages/spacecat-shared-gpt-client/test/clients/firefall-client.test.js
+++ b/packages/spacecat-shared-gpt-client/test/clients/firefall-client.test.js
@@ -229,7 +229,7 @@ describe('FirefallClient', () => {
       expect(result.model).to.equal('hello');
     });
 
-    it.only('should handle a bad json response', async () => {
+    it('should handle a bad json response', async () => {
       const response = { message: 'Bad request was provided', status: 400 };
       nock(mockContext.env.FIREFALL_API_ENDPOINT)
         .post(chatPath)

--- a/packages/spacecat-shared-gpt-client/test/clients/firefall-client.test.js
+++ b/packages/spacecat-shared-gpt-client/test/clients/firefall-client.test.js
@@ -229,7 +229,7 @@ describe('FirefallClient', () => {
       expect(result.model).to.equal('hello');
     });
 
-    it.only('should handle a bad json response', async () => {
+    it('should handle a bad json response', async () => {
       nock(mockContext.env.FIREFALL_API_ENDPOINT)
         .post(chatPath)
         .reply(400, { message: 'Bad request was provided' });


### PR DESCRIPTION
We need a way to see why Firefall is refusing some requests. Current error message is swallowed and not delivered to consumer.
This passes message across when available.

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
https://jira.corp.adobe.com/browse/ASSETS-47371

Thanks for contributing!
