### PR TITLE
fix: url override in import-schema

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -32,6 +32,7 @@ const IMPORT_BASE_KEYS = {
   sources: Joi.array().items(Joi.string().valid(...Object.values(IMPORT_SOURCES))).required(),
   // not required for now due backward compatibility
   enabled: Joi.boolean().default(true),
+  url: Joi.string().uri().optional(), // optional url to override
 };
 
 export const IMPORT_TYPE_SCHEMAS = {

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -736,6 +736,22 @@ describe('Config Tests', () => {
       expect(validated).to.deep.equal(config);
     });
 
+    it('validates optional url in the import configuration', () => {
+      const config = {
+        imports: [
+          {
+            type: 'organic-keywords',
+            destinations: ['default'],
+            sources: ['ahrefs'],
+            enabled: true,
+            url: 'https://example.com',
+          },
+        ],
+      };
+      const validated = validateConfiguration(config);
+      expect(validated).to.deep.equal(config);
+    });
+
     it('throws error for missing required import fields', () => {
       const config = {
         imports: [


### PR DESCRIPTION
When updating the site config with `url`, failing with 
```
Handler exception after 122 ms. Path: /sites/cd6528f6-fd7d-4003-a08e-d4d0c34632c5 Error: Configuration validation error: "imports[0]" does not match any of the allowed types
at validateConfiguration (/var/task/index.js:20949:11)
at Config (/var/task/index.js:20956:23)
at get (/var/task/index.js:21320:71)
at Attribute.get (/var/task/index.js:157778:14)
at #set (/var/task/index.js:22220:39)
at Patcher.patchValue (/var/task/index.js:22300:14)
at <computed> [as setConfig] (/var/task/index.js:16907:26)
at updateSite (/var/task/index.js:398214:12)
at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
at async run (/var/task/index.js:400365:14) {
[cause]: [Error [ValidationError]: "imports[0]" does not match any of the allowed types] {
_original: { imports: [Array] },
details: [ [Object] ]
}
}
```
The `url` override support is added as part of [SITES-29345](https://jira.corp.adobe.com/browse/SITES-29345)

Related to https://github.com/adobe/spacecat-shared/pull/630



