### PR TITLE
feat: introduce getEnabledAuditsForSite in the configuration model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19422,7 +19422,7 @@
     },
     "packages/spacecat-shared-ahrefs-client": {
       "name": "@adobe/spacecat-shared-ahrefs-client",
-      "version": "1.6.8",
+      "version": "1.6.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.11",

--- a/packages/spacecat-shared-data-access/src/models/configuration/configuration.model.js
+++ b/packages/spacecat-shared-data-access/src/models/configuration/configuration.model.js
@@ -62,6 +62,17 @@ class Configuration extends BaseModel {
     return this.getHandler(type)?.enabled?.sites || [];
   }
 
+  getEnabledAuditsForSite(site) {
+    const enabledHandlers = new Set(
+      Object.keys(this.getHandlers() || {})
+        .filter((handler) => this.isHandlerEnabledForSite(handler, site)),
+    );
+
+    return (this.getJobs() || [])
+      .filter((job) => job.group === 'audits' && enabledHandlers.has(job.type))
+      .map((job) => job.type);
+  }
+
   isHandlerEnabledForSite(type, site) {
     const handler = this.getHandlers()?.[type];
     if (!handler) return false;

--- a/packages/spacecat-shared-data-access/test/fixtures/configurations.fixture.js
+++ b/packages/spacecat-shared-data-access/test/fixtures/configurations.fixture.js
@@ -44,6 +44,12 @@ const configurations = [
       404: {
         enabledByDefault: true,
       },
+      'rum-ingest': {
+        enabledByDefault: false,
+        enabled: {
+          sites: ['c6f41da6-3a7e-4a59-8b8d-2da742ac2dbe'],
+        },
+      },
       'organic-keywords': {
         enabledByDefault: false,
       },

--- a/packages/spacecat-shared-data-access/test/unit/models/configuration/configuration.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/configuration/configuration.model.test.js
@@ -145,6 +145,12 @@ describe('ConfigurationModel', () => {
       delete instance.record.handlers;
       expect(instance.getEnabledSiteIdsForHandler('lhs-mobile')).to.deep.equal([]);
     });
+
+    it('gets all enabled audits for a site', () => {
+      expect(Object.keys(instance.getHandlers() || {})
+        .filter((handler) => instance.isHandlerEnabledForSite(handler, site))).to.deep.equal(['404', 'rum-ingest', 'lhs-mobile']);
+      expect(instance.getEnabledAuditsForSite(site)).to.deep.equal(['lhs-mobile', '404']);
+    });
   });
 
   describe('manage handlers', () => {


### PR DESCRIPTION
Introduce `getEnabledAuditsForSite` for the bulk audit run command.