### PR TITLE
fix: add all-traffic to import schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19491,7 +19491,7 @@
     },
     "packages/spacecat-shared-ahrefs-client": {
       "name": "@adobe/spacecat-shared-ahrefs-client",
-      "version": "1.6.9",
+      "version": "1.6.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.0",
@@ -20391,7 +20391,7 @@
     },
     "packages/spacecat-shared-content-client": {
       "name": "@adobe/spacecat-shared-content-client",
-      "version": "1.3.40",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.0.8",
@@ -27535,7 +27535,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "2.9.6",
+      "version": "2.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.33.1",
@@ -28135,7 +28135,7 @@
     },
     "packages/spacecat-shared-example": {
       "name": "@adobe/spacecat-shared-example",
-      "version": "1.2.20",
+      "version": "1.2.21",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.0",
@@ -28151,7 +28151,7 @@
     },
     "packages/spacecat-shared-google-client": {
       "name": "@adobe/spacecat-shared-google-client",
-      "version": "1.4.13",
+      "version": "1.4.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.0",
@@ -34754,7 +34754,7 @@
     },
     "packages/spacecat-shared-gpt-client": {
       "name": "@adobe/spacecat-shared-gpt-client",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.0",
@@ -40228,7 +40228,7 @@
     },
     "packages/spacecat-shared-http-utils": {
       "name": "@adobe/spacecat-shared-http-utils",
-      "version": "1.9.11",
+      "version": "1.9.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.0",
@@ -47368,7 +47368,7 @@
     },
     "packages/spacecat-shared-ims-client": {
       "name": "@adobe/spacecat-shared-ims-client",
-      "version": "1.5.7",
+      "version": "1.5.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.0",
@@ -48268,7 +48268,7 @@
     },
     "packages/spacecat-shared-rum-api-client": {
       "name": "@adobe/spacecat-shared-rum-api-client",
-      "version": "2.21.2",
+      "version": "2.21.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.0",
@@ -50073,7 +50073,7 @@
     },
     "packages/spacecat-shared-splunk-client": {
       "name": "@adobe/spacecat-shared-splunk-client",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.0",
@@ -50710,7 +50710,7 @@
     },
     "packages/spacecat-shared-utils": {
       "name": "@adobe/spacecat-shared-utils",
-      "version": "1.33.2",
+      "version": "1.33.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.0",

--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -16,6 +16,7 @@ export const IMPORT_TYPES = {
   ORGANIC_KEYWORDS: 'organic-keywords',
   ORGANIC_TRAFFIC: 'organic-traffic',
   TOP_PAGES: 'top-pages',
+  ALL_TRAFFIC: 'all-traffic',
 };
 
 export const IMPORT_DESTINATIONS = {
@@ -25,6 +26,7 @@ export const IMPORT_DESTINATIONS = {
 export const IMPORT_SOURCES = {
   AHREFS: 'ahrefs',
   GSC: 'google',
+  RUM: 'rum',
 };
 
 const IMPORT_BASE_KEYS = {
@@ -48,6 +50,10 @@ export const IMPORT_TYPE_SCHEMAS = {
     type: Joi.string().valid(IMPORT_TYPES.ORGANIC_TRAFFIC).required(),
     ...IMPORT_BASE_KEYS,
   }),
+  [IMPORT_TYPES.ALL_TRAFFIC]: Joi.object({
+    type: Joi.string().valid(IMPORT_TYPES.ALL_TRAFFIC).required(),
+    ...IMPORT_BASE_KEYS,
+  }),
   [IMPORT_TYPES.TOP_PAGES]: Joi.object({
     type: Joi.string().valid(IMPORT_TYPES.TOP_PAGES).required(),
     ...IMPORT_BASE_KEYS,
@@ -68,6 +74,12 @@ export const DEFAULT_IMPORT_CONFIGS = {
     type: 'organic-traffic',
     destinations: ['default'],
     sources: ['ahrefs'],
+    enabled: true,
+  },
+  'all-traffic': {
+    type: 'all-traffic',
+    destinations: ['default'],
+    sources: ['rum'],
     enabled: true,
   },
   'top-pages': {

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -591,6 +591,12 @@ describe('Config Tests', () => {
             enabled: true,
           },
           {
+            type: 'all-traffic',
+            destinations: ['default'],
+            sources: ['rum'],
+            enabled: true,
+          },
+          {
             type: 'top-pages',
             destinations: ['default'],
             sources: ['ahrefs'],
@@ -647,7 +653,7 @@ describe('Config Tests', () => {
         .to.throw().and.satisfy((error) => {
           expect(error.message).to.include('Configuration validation error');
           expect(error.cause.details[0].context.message)
-            .to.equal('"imports[0].destinations[0]" must be [default]. "imports[0].type" must be [organic-traffic]. "imports[0].type" must be [top-pages]');
+            .to.equal('"imports[0].destinations[0]" must be [default]. "imports[0].type" must be [organic-traffic]. "imports[0].type" must be [all-traffic]. "imports[0].type" must be [top-pages]');
           expect(error.cause.details[0].context.details)
             .to.eql([
               {
@@ -679,6 +685,23 @@ describe('Config Tests', () => {
                 context: {
                   valids: [
                     'organic-traffic',
+                  ],
+                  label: 'imports[0].type',
+                  value: 'organic-keywords',
+                  key: 'type',
+                },
+              },
+              {
+                message: '"imports[0].type" must be [all-traffic]',
+                path: [
+                  'imports',
+                  0,
+                  'type',
+                ],
+                type: 'any.only',
+                context: {
+                  valids: [
+                    'all-traffic',
                   ],
                   label: 'imports[0].type',
                   value: 'organic-keywords',


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
`all-traffic` is implemented in https://github.com/adobe/spacecat-import-worker/pull/240

Thanks for contributing!
