### PR TITLE
feat: tracing fetch timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19346,7 +19346,7 @@
         "nock": "14.0.1",
         "sinon": "19.0.2",
         "sinon-chai": "4.0.0",
-        "typescript": "^5.8.2"
+        "typescript": "5.8.2"
       },
       "engines": {
         "node": ">=22.0.0 <23.0.0",
@@ -20219,7 +20219,7 @@
     },
     "packages/spacecat-shared-brand-client": {
       "name": "@adobe/spacecat-shared-brand-client",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.0.8",
@@ -21647,7 +21647,7 @@
     },
     "packages/spacecat-shared-content-client": {
       "name": "@adobe/spacecat-shared-content-client",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.0.9",
@@ -21663,7 +21663,7 @@
         "nock": "14.0.1",
         "sinon": "19.0.2",
         "sinon-chai": "4.0.0",
-        "typescript": "^5.8.2"
+        "typescript": "5.8.2"
       },
       "engines": {
         "node": ">=20.0.0 <23.0.0",
@@ -29411,7 +29411,7 @@
         "nock": "14.0.1",
         "sinon": "19.0.2",
         "sinon-chai": "4.0.0",
-        "typescript": "^5.8.2"
+        "typescript": "5.8.2"
       },
       "engines": {
         "node": ">=22.0.0 <23.0.0",
@@ -35996,7 +35996,7 @@
         "nock": "14.0.1",
         "sinon": "19.0.2",
         "sinon-chai": "4.0.0",
-        "typescript": "^5.8.2"
+        "typescript": "5.8.2"
       },
       "engines": {
         "node": ">=22.0.0 <23.0.0",
@@ -48605,7 +48605,7 @@
         "nock": "14.0.1",
         "sinon": "19.0.2",
         "sinon-chai": "4.0.0",
-        "typescript": "^5.8.2"
+        "typescript": "5.8.2"
       },
       "engines": {
         "node": ">=22.0.0 <23.0.0",
@@ -49478,7 +49478,7 @@
     },
     "packages/spacecat-shared-rum-api-client": {
       "name": "@adobe/spacecat-shared-rum-api-client",
-      "version": "2.21.5",
+      "version": "2.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.0",
@@ -49495,7 +49495,7 @@
         "nock": "14.0.1",
         "sinon": "19.0.2",
         "sinon-chai": "4.0.0",
-        "typescript": "^5.8.2"
+        "typescript": "5.8.2"
       },
       "engines": {
         "node": ">=22.0.0 <23.0.0",
@@ -50382,7 +50382,7 @@
         "sinon": "19.0.2",
         "sinon-chai": "4.0.0",
         "slack-block-builder": "2.8.0",
-        "typescript": "^5.8.2"
+        "typescript": "5.8.2"
       },
       "engines": {
         "node": ">=22.0.0 <23.0.0",
@@ -51269,7 +51269,7 @@
         "nock": "13.5.6",
         "sinon": "19.0.2",
         "sinon-chai": "4.0.0",
-        "typescript": "^5.8.2"
+        "typescript": "5.8.2"
       },
       "engines": {
         "node": ">=22.0.0 <23.0.0",

--- a/packages/spacecat-shared-utils/src/tracing-fetch.js
+++ b/packages/spacecat-shared-utils/src/tracing-fetch.js
@@ -197,7 +197,7 @@ export async function tracingFetch(url, options) {
     const requestWithSignal = new Request(request, { signal });
 
     // Use the same fetchWithTimeout function but catch errors to handle subsegment
-    const response = await fetchWithTimeout(requestWithSignal, null, signal);
+    const response = await fetchWithTimeout(requestWithSignal, { }, signal);
 
     setSubSegmentFlagsByStatusCode(subSegment, response.status);
     addFetchRequestDataToSegment(subSegment, request, response);

--- a/packages/spacecat-shared-utils/test/tracing-fetch.test.js
+++ b/packages/spacecat-shared-utils/test/tracing-fetch.test.js
@@ -12,18 +12,16 @@
 /* eslint-env mocha */
 
 import { expect } from 'chai';
-import { AbortController } from '@adobe/fetch';
 import sinon from 'sinon';
 import nock from 'nock';
 import AWSXRay from 'aws-xray-sdk';
-import { tracingFetch, SPACECAT_USER_AGENT } from '../src/index.js';
+import { SPACECAT_USER_AGENT, tracingFetch } from '../src/index.js';
 
 describe('tracing fetch function', () => {
   let sandbox;
   let getSegmentStub;
   let parentSegment;
   let subSegment;
-  let log;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -48,10 +46,6 @@ describe('tracing fetch function', () => {
       noOp: false,
       notTraced: false,
     };
-
-    log = {
-      warn: sandbox.spy(),
-    };
   });
 
   afterEach(() => {
@@ -70,12 +64,13 @@ describe('tracing fetch function', () => {
     const options = { method: 'GET' };
 
     nock('https://example.com')
+      .matchHeader('User-Agent', SPACECAT_USER_AGENT)
       .get('/api/data')
       .reply(200, 'OK');
 
-    await tracingFetch(url, options);
+    const response = await tracingFetch(url, options);
 
-    expect(options.headers['User-Agent']).to.equal(SPACECAT_USER_AGENT);
+    expect(response.status).to.equal(200);
   });
 
   it('does not overwrite existing user agent', async () => {
@@ -260,46 +255,115 @@ describe('tracing fetch function', () => {
     expect(subSegment.close.calledOnce).to.be.true;
   });
 
-  it('handles timeout and returns 408 status with tracing', async () => {
-    const fetchWithTimeout = async (url, timeout, logger) => {
-      const controller = new AbortController();
-      const { signal } = controller;
-      const id = setTimeout(() => controller.abort(), timeout);
+  // New tests for timeout functionality
+  it('applies default timeout of 10 seconds when no timeout is specified', async () => {
+    getSegmentStub.returns(parentSegment);
 
-      try {
-        const response = await tracingFetch(url, { signal });
-        clearTimeout(id);
-        return response;
-      } catch (error) {
-        clearTimeout(id);
-        if (error.name === 'AbortError') {
-          logger.warn(`Request to ${url} timed out after ${timeout}ms`);
-          return { ok: false, status: 408 };
-        } else {
-          throw error;
-        }
-      }
-    };
+    const url = 'https://example.com/api/data';
+
+    nock('https://example.com')
+      .get('/api/data')
+      .reply(200, 'OK');
+
+    await tracingFetch(url);
+
+    // Check if addAnnotation was called with timeout_ms
+    const timeoutAnnotationCall = subSegment.addAnnotation.getCalls().find(
+      (call) => call.args[0] === 'timeout_ms' && call.args[1] === 10000,
+    );
+    expect(timeoutAnnotationCall).to.exist;
+  });
+
+  it('applies custom timeout when specified in options', async () => {
+    getSegmentStub.returns(parentSegment);
+
+    const url = 'https://example.com/api/data';
+    const customTimeout = 5000; // 5 seconds
+
+    nock('https://example.com')
+      .get('/api/data')
+      .reply(200, 'OK');
+
+    await tracingFetch(url, { timeout: customTimeout });
+
+    // Check if addAnnotation was called with timeout_ms
+    const timeoutAnnotationCall = subSegment.addAnnotation.getCalls().find(
+      (call) => call.args[0] === 'timeout_ms' && call.args[1] === customTimeout,
+    );
+    expect(timeoutAnnotationCall).to.exist;
+  });
+
+  // For timeout tests, we'll use a very short timeout and a delayed response
+  it('handles timeout correctly with parent segment', async function () {
+    this.timeout(5000); // Increase mocha timeout for this test
 
     getSegmentStub.returns(parentSegment);
 
     const url = 'https://example.com/api/data';
+    const shortTimeout = 50; // Very short timeout for testing
+
     nock('https://example.com')
       .get('/api/data')
-      .delay(1000) // Delay longer than timeout
+      .delay(200) // Delay longer than timeout
       .reply(200, 'OK');
 
-    const timeout = 500; // Timeout shorter than response delay
+    try {
+      await tracingFetch(url, { timeout: shortTimeout });
+      throw new Error('Expected fetch to throw a timeout error');
+    } catch (error) {
+      expect(error.message).to.include('timeout');
+      expect(error.code).to.equal('ETIMEOUT');
 
-    const response = await fetchWithTimeout(url, timeout, log);
+      // Check if the subsegment was properly handled
+      const timeoutAnnotationCall = subSegment.addAnnotation.getCalls().find(
+        (call) => call.args[0] === 'timeout_ms' && call.args[1] === shortTimeout,
+      );
+      expect(timeoutAnnotationCall).to.exist;
 
-    expect(response.ok).to.be.false;
-    expect(response.status).to.equal(408);
+      expect(subSegment.addErrorFlag.called).to.be.true;
+      expect(subSegment.close.called).to.be.true;
+    }
+  });
 
-    expect(parentSegment.addNewSubsegment.calledOnce).to.be.true;
-    expect(subSegment.addErrorFlag.calledOnce).to.be.true;
-    expect(subSegment.close.calledOnce).to.be.true;
+  it('handles timeout correctly without parent segment', async function () {
+    this.timeout(5000); // Increase mocha timeout for this test
 
-    expect(log.warn.calledOnceWithExactly(`Request to ${url} timed out after ${timeout}ms`)).to.be.true;
+    getSegmentStub.returns(null);
+
+    const url = 'https://example.com/api/data';
+    const shortTimeout = 50; // Very short timeout for testing
+
+    nock('https://example.com')
+      .get('/api/data')
+      .delay(200) // Delay longer than timeout
+      .reply(200, 'OK');
+
+    try {
+      await tracingFetch(url, { timeout: shortTimeout });
+      throw new Error('Expected fetch to throw a timeout error');
+    } catch (error) {
+      expect(error.message).to.include('timeout');
+      expect(error.code).to.equal('ETIMEOUT');
+    }
+  });
+
+  it('propagates non-timeout errors when there is no parent segment', async () => {
+    getSegmentStub.returns(null);
+
+    const url = 'https://example.com/api/data';
+    const networkError = new Error('Network Error');
+
+    nock('https://example.com')
+      .get('/api/data')
+      .replyWithError(networkError);
+
+    try {
+      await tracingFetch(url);
+      throw new Error('Expected fetch to throw an error');
+    } catch (error) {
+      // Verify that the original error is propagated
+      expect(error.message).to.equal('Network Error');
+      expect(error.code).to.not.equal('ETIMEOUT');
+    }
   });
 });


### PR DESCRIPTION
Introduce capability to set timeout for requests using `tracingFetch`. Default timeout is set to 10s.