### PR TITLE
feat(rum-api-client): human readable error messages for the failed bundler api calls

### DIFF
--- a/packages/spacecat-shared-rum-api-client/src/common/rum-bundler-client.js
+++ b/packages/spacecat-shared-rum-api-client/src/common/rum-bundler-client.js
@@ -22,6 +22,19 @@ const ONE_DAY = ONE_HOUR * HOURS_IN_DAY;
 
 const CHUNK_SIZE = 31;
 
+function sanitizeURL(url) {
+  try {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.searchParams.has('domainkey')) {
+      parsedUrl.searchParams.set('domainkey', 'redacted');
+    }
+    return parsedUrl.toString();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (e) {
+    return url;
+  }
+}
+
 function isBotTraffic(bundle) {
   return bundle?.userAgent?.includes('bot');
 }
@@ -192,11 +205,26 @@ async function fetchBundles(opts, log) {
   for (const chunk of chunks) {
     // eslint-disable-next-line no-loop-func
     const responses = await Promise.all(chunk.map(async (url) => {
-      const response = await fetch(url);
-      totalTransferSize += parseInt(response.headers.get('content-length'), 10);
-      return response;
+      try {
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`Request to ${sanitizeURL(url)} failed with status ${response.status}`);
+        }
+        const contentLength = response.headers.get('content-length');
+        totalTransferSize += parseInt(contentLength, 10);
+        return response;
+      } catch (error) {
+        throw new Error(`Error fetching data from ${sanitizeURL(url)}: ${error.message}`);
+      }
     }));
-    const bundles = await Promise.all(responses.map((response) => response.json()));
+
+    const bundles = await Promise.all(responses.map(async (response) => {
+      try {
+        return await response.json();
+      } catch (error) {
+        throw new Error(`Error parsing JSON from ${sanitizeURL(response.url)}: ${error.message}`);
+      }
+    }));
 
     bundles.forEach((b) => {
       b.rumBundles


### PR DESCRIPTION
This PR introduces human readable error messages for the failed RUM Bundler API calls.

For example:

```
Error: Query 'cwv' failed. Opts: {"domain":"www.domain.com","interval":7,"granularity":"hourly"}. Reason: Error fetching data from https://bundles.aem.page/bundles/www.domain.com/2025/03/13/14?domainkey=redacted: Request to https://bundles.aem.page/bundles/www.domain.com/2025/03/13/14?domainkey=redacted failed with status 500
```