### PR TITLE
fix: completionUrl not sent to content scraper and introduce skip property

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
+++ b/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
@@ -117,6 +117,7 @@ class Audit extends BaseModel {
        * @param {string} stepResult.siteId - The site ID. Will be used as the job ID.
        * @param {string} stepResult.processingType - The scraping processing type to trigger.
        * @param {object} auditContext - The audit context.
+       * @param {object} context - The context object.
        * @param {object} auditContext.next - The next audit step to run.
        * @param {string} auditContext.auditId - The audit ID.
        * @param {string} auditContext.auditType - The audit type.
@@ -124,10 +125,12 @@ class Audit extends BaseModel {
        *
        * @returns {object} - The formatted payload.
        */
-      formatPayload: (stepResult, auditContext) => ({
+      formatPayload: (stepResult, auditContext, context) => ({
         urls: stepResult.urls,
         jobId: stepResult.siteId,
         processingType: stepResult.processingType || 'default',
+        skipMessage: false,
+        completionQueueUrl: stepResult.completionQueueUrl || context.env?.AUDIT_RESULTS_QUEUE_URL,
         auditContext,
       }),
     },

--- a/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
+++ b/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
@@ -104,6 +104,7 @@ class Audit extends BaseModel {
       formatPayload: (stepResult, auditContext) => ({
         type: stepResult.type,
         siteId: stepResult.siteId,
+        allowCache: true,
         auditContext,
       }),
     },
@@ -130,6 +131,7 @@ class Audit extends BaseModel {
         jobId: stepResult.siteId,
         processingType: stepResult.processingType || 'default',
         skipMessage: false,
+        allowCache: true,
         completionQueueUrl: stepResult.completionQueueUrl || context.env?.AUDIT_RESULTS_QUEUE_URL,
         auditContext,
       }),

--- a/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
@@ -251,14 +251,21 @@ describe('AuditModel', () => {
         siteId: 'someSiteId',
         processingType: 'someProcessingType',
       };
+      const context = {
+        env: {
+          AUDIT_RESULTS_QUEUE_URL: 'audit-results-queue-url',
+        },
+      };
       const auditContext = { some: 'context' };
       const formattedPayload = auditStepDestinationConfigs[auditStepDestinations.CONTENT_SCRAPER]
-        .formatPayload(stepResult, auditContext);
+        .formatPayload(stepResult, auditContext, context);
 
       expect(formattedPayload).to.deep.equal({
         urls: [{ url: 'someUrl' }],
         jobId: 'someSiteId',
         processingType: 'someProcessingType',
+        completionQueueUrl: 'audit-results-queue-url',
+        skipMessage: false,
         auditContext: { some: 'context' },
       });
     });

--- a/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
@@ -241,6 +241,7 @@ describe('AuditModel', () => {
       expect(formattedPayload).to.deep.equal({
         type: 'someType',
         siteId: 'someSiteId',
+        allowCache: true,
         auditContext: { some: 'context' },
       });
     });
@@ -266,6 +267,7 @@ describe('AuditModel', () => {
         processingType: 'someProcessingType',
         completionQueueUrl: 'audit-results-queue-url',
         skipMessage: false,
+        allowCache: true,
         auditContext: { some: 'context' },
       });
     });


### PR DESCRIPTION
Adding missing `completionUrl` so the audit worker can be triggered back after the scraper executes.

Adding `allowCache` property for both the importer and scraper to return the already existing content instead of triggering an import/scrape again for every audit.