### PR TITLE
feat: Add contentAiConfig validation to Config class

### DIFF
--- a/packages/spacecat-shared-data-access/README.md
+++ b/packages/spacecat-shared-data-access/README.md
@@ -184,6 +184,28 @@ export const main = wrap(run)
 
 Contributions to `spacecat-shared-data-access` are welcome. Please adhere to the standard Git workflow and submit pull requests for proposed changes.
 
+## Local Development and Testing
+
+### Testing with Dependent Projects Before Merging
+
+When making changes to this package, you can test them in dependent projects (like `spacecat-api-service`) before merging using the following approach:
+
+1. Commit and push your changes to a branch in this repository
+2. Get the commit ID of your push
+3. In your dependent project, temporarily modify the package.json dependency:
+
+   ```json
+   // From:
+   "@adobe/spacecat-shared-data-access": "2.13.1",
+   
+   // To:
+   "@adobe/spacecat-shared-data-access": "https://gitpkg.now.sh/adobe/spacecat-shared/packages/spacecat-shared-data-access?YOUR_COMMIT_ID",
+   ```
+
+4. Run `npm install` in your dependent project
+5. Test your changes
+6. Once testing is complete and your PR is merged, update the dependent project to use the released version
+
 ## License
 
 Licensed under the Apache-2.0 License.

--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -107,6 +107,10 @@ export const configSchema = Joi.object({
     headers: Joi.object().pattern(Joi.string(), Joi.string()),
     overrideBaseURL: Joi.string().uri().optional(),
   }).optional(),
+  contentAiConfig: Joi.object({
+    key: Joi.string().required(),
+    index: Joi.string().required(),
+  }).optional(),
   handlers: Joi.object().pattern(Joi.string(), Joi.object({
     mentions: Joi.object().pattern(Joi.string(), Joi.array().items(Joi.string())),
     excludedURLs: Joi.array().items(Joi.string()),
@@ -136,6 +140,7 @@ export const configSchema = Joi.object({
 export const DEFAULT_CONFIG = {
   slack: {},
   handlers: {},
+  contentAiConfig: {},
 };
 
 // Function to validate incoming configuration
@@ -158,6 +163,7 @@ export const Config = (data = {}) => {
   self.isInternalCustomer = () => state?.slack?.workspace === 'internal';
   self.getSlackMentions = (type) => state?.handlers?.[type]?.mentions?.slack;
   self.getHandlerConfig = (type) => state?.handlers?.[type];
+  self.getContentAiConfig = () => state?.contentAiConfig;
   self.getHandlers = () => state.handlers;
   self.getImports = () => state.imports;
   self.getExcludedURLs = (type) => state?.handlers?.[type]?.excludedURLs;
@@ -277,6 +283,7 @@ Config.fromDynamoItem = (dynamoItem) => Config(dynamoItem);
 Config.toDynamoItem = (config) => ({
   slack: config.getSlackConfig(),
   handlers: config.getHandlers(),
+  contentAiConfig: config.getContentAiConfig(),
   imports: config.getImports(),
   fetchConfig: config.getFetchConfig(),
   brandConfig: config.getBrandConfig(),

--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -108,7 +108,6 @@ export const configSchema = Joi.object({
     overrideBaseURL: Joi.string().uri().optional(),
   }).optional(),
   contentAiConfig: Joi.object({
-    key: Joi.string().required(),
     index: Joi.string().required(),
   }).optional(),
   handlers: Joi.object().pattern(Joi.string(), Joi.object({

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -168,7 +168,6 @@ describe('Config Tests', () => {
     it('creates a Config with contentAiConfig property', () => {
       const data = {
         contentAiConfig: {
-          key: 'test-key',
           index: 'test-index',
         },
       };
@@ -179,7 +178,6 @@ describe('Config Tests', () => {
     it('throws an error for invalid contentAi configuration', () => {
       const data = {
         contentAiConfig: {
-          key: 'test-key',
           // missing required index
         },
       };
@@ -372,7 +370,6 @@ describe('Config Tests', () => {
     it('includes contentAiConfig in toDynamoItem conversion', () => {
       const data = Config({
         contentAiConfig: {
-          key: 'test-key',
           index: 'test-index',
         },
       });

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -164,6 +164,37 @@ describe('Config Tests', () => {
       expect(config.getIncludedURLs('404')).to.be.undefined;
       expect(config.getGroupedURLs('404')).to.be.undefined;
     });
+
+    it('creates a Config with contentAiConfig property', () => {
+      const data = {
+        contentAiConfig: {
+          key: 'test-key',
+          index: 'test-index',
+        },
+      };
+      const config = Config(data);
+      expect(config.getContentAiConfig()).to.deep.equal(data.contentAiConfig);
+    });
+
+    it('throws an error for invalid contentAi configuration', () => {
+      const data = {
+        contentAiConfig: {
+          key: 'test-key',
+          // missing required index
+        },
+      };
+      expect(() => Config(data)).to.throw('Configuration validation error: "contentAiConfig.index" is required');
+    });
+
+    it('has empty contentAiConfig in default config', () => {
+      const config = Config();
+      expect(config.getContentAiConfig()).to.deep.equal(undefined);
+    });
+
+    it('should return undefined for contentAiConfig if not provided', () => {
+      const config = Config({});
+      expect(config.getContentAiConfig()).to.be.undefined;
+    });
   });
 
   describe('Grouped URLs option', () => {
@@ -336,6 +367,17 @@ describe('Config Tests', () => {
       expect(slackConfig.workspace).to.equal('external');
       expect(data.isInternalCustomer()).to.equal(false);
       expect(slackMentions[0]).to.equal('id1');
+    });
+
+    it('includes contentAiConfig in toDynamoItem conversion', () => {
+      const data = Config({
+        contentAiConfig: {
+          key: 'test-key',
+          index: 'test-index',
+        },
+      });
+      const dynamoItem = Config.toDynamoItem(data);
+      expect(dynamoItem.contentAiConfig).to.deep.equal(data.getContentAiConfig());
     });
   });
 


### PR DESCRIPTION
Adds proper validation for the `contentAiConfig` property in the `Config` class within the `spacecat-shared-data-access` package by:
- Adding schema validation for `contentAiConfig` with required key and index fields
- Adding a getter method `getContentAiConfig()` to access the configuration
- Adding a default empty object for `contentAiConfig` in `DEFAULT_CONFIG`
- Updating the `toDynamoItem` method

Testing
- Added unit tests for contentAiConfig validation

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
[Spacecat ContentAI Config](https://git.corp.adobe.com/orgs/experience-platform/projects/16?pane=issue&itemId=12200)

Thanks for contributing!
