### PR TITLE
fix: collection._saveMany deals with empty `.unprocessed` array in response

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/base/base.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/base/base.collection.js
@@ -508,7 +508,7 @@ class BaseCollection {
       const updates = items.map((item) => item.record);
       const response = await this.entity.put(updates).go();
 
-      if (response.unprocessed) {
+      if (isNonEmptyArray(response.unprocessed)) {
         this.log.error(`Failed to process all items in batch write for [${this.entityName}]: ${JSON.stringify(response.unprocessed)}`);
       }
 

--- a/packages/spacecat-shared-data-access/test/unit/models/base/base.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/base/base.collection.test.js
@@ -601,6 +601,19 @@ describe('BaseCollection', () => {
       const result = await baseCollectionInstance._saveMany(mockRecords);
       expect(result).to.be.undefined;
       expect(mockElectroService.entities.mockEntityModel.put.calledOnce).to.be.true;
+      expect(mockLogger.error).not.called;
+    });
+
+    it('saves multiple entities successfully if `res.unprocessed` is an empty array', async () => {
+      const mockRecords = [mockRecord, mockRecord];
+      mockElectroService.entities.mockEntityModel.put.returns({
+        go: async () => ({ unprocessed: [] }),
+      });
+
+      const result = await baseCollectionInstance._saveMany(mockRecords);
+      expect(result).to.be.undefined;
+      expect(mockElectroService.entities.mockEntityModel.put.calledOnce).to.be.true;
+      expect(mockLogger.error).not.called;
     });
 
     it('saves some entities successfully with unprocessed items', async () => {


### PR DESCRIPTION

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
https://jira.corp.adobe.com/browse/SITES-30735
