### PR TITLE
feat(http-utils): add HTTP 202 Accepted response helper

### DIFF
--- a/packages/spacecat-shared-http-utils/src/index.d.ts
+++ b/packages/spacecat-shared-http-utils/src/index.d.ts
@@ -15,6 +15,8 @@ export declare function ok(body?: string): Response;
 
 export declare function created(body: object): Response;
 
+export declare function accepted(body: object): Response;
+
 export declare function noContent(headers?: object): Response;
 
 export declare function badRequest(message?: string, headers?: object): Response;

--- a/packages/spacecat-shared-http-utils/src/index.js
+++ b/packages/spacecat-shared-http-utils/src/index.js
@@ -58,6 +58,10 @@ export function created(body) {
   return createResponse(body, 201);
 }
 
+export function accepted(body) {
+  return createResponse(body, 202);
+}
+
 export function noContent(headers = {}) {
   return createResponse('', 204, headers);
 }

--- a/packages/spacecat-shared-http-utils/test/index.test.js
+++ b/packages/spacecat-shared-http-utils/test/index.test.js
@@ -61,8 +61,8 @@ describe('HTTP Response Functions', () => {
   });
 
   it('accepted should return a 202 ACCEPTED response with custom body', async () => {
-    const body = { success: true };
-    const response = accepted(body);
+    const body = { status: 'ACCEPTED' };
+    const response = await accepted(body);
     await testMethod(response, 202, body);
   });
 

--- a/packages/spacecat-shared-http-utils/test/index.test.js
+++ b/packages/spacecat-shared-http-utils/test/index.test.js
@@ -14,6 +14,7 @@ import { expect } from 'chai';
 import {
   ok, badRequest, notFound, internalServerError,
   noContent, found, created, createResponse, unauthorized, forbidden,
+  accepted,
 } from '../src/index.js';
 
 async function testMethod(response, expectedCode, expectedBody) {
@@ -57,6 +58,12 @@ describe('HTTP Response Functions', () => {
     const body = { success: true };
     const response = await created(body);
     await testMethod(response, 201, body);
+  });
+
+  it('accepted should return a 202 ACCEPTED response with custom body', async () => {
+    const body = { success: true };
+    const response = accepted(body);
+    await testMethod(response, 202, body);
   });
 
   it('noContent should return a 204 No Content response with default headers', async () => {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
https://jira.corp.adobe.com/browse/SITES-31201

Adds a new `accepted()` function to the HTTP utilities to support HTTP 202 Accepted responses. This status code is commonly used for asynchronous operations where the request has been accepted for processing but the processing has not been completed.

Changes:
- Added `accepted()` function to create 202 responses
- Added TypeScript type declaration for the new function
- Added unit tests to verify the function behavior

The function follows the same pattern as other response helpers like `created()` and `ok()`, providing a consistent API for creating HTTP responses.
