### PR TITLE
Add Page Authentication Token Retrieval Functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22413,7 +22413,7 @@
     },
     "packages/spacecat-shared-content-client": {
       "name": "@adobe/spacecat-shared-content-client",
-      "version": "1.6.12",
+      "version": "1.6.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49687,6 +49687,7 @@
       "dependencies": {
         "@adobe/fetch": "4.2.1",
         "@aws-sdk/client-s3": "3.806.0",
+        "@aws-sdk/client-secrets-manager": "3.806.0",
         "@aws-sdk/client-sqs": "3.806.0",
         "@json2csv/plainjs": "7.0.6",
         "aws-xray-sdk": "3.10.3",

--- a/packages/spacecat-shared-utils/package.json
+++ b/packages/spacecat-shared-utils/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@adobe/fetch": "4.2.1",
     "@aws-sdk/client-s3": "3.806.0",
+    "@aws-sdk/client-secrets-manager": "3.806.0",
     "@aws-sdk/client-sqs": "3.806.0",
     "@json2csv/plainjs": "7.0.6",
     "aws-xray-sdk": "3.10.3",

--- a/packages/spacecat-shared-utils/src/auth.js
+++ b/packages/spacecat-shared-utils/src/auth.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
+import { isString } from './functions.js';
+import { resolveCustomerSecretsName } from './helpers.js';
+
+/**
+ * Retrieves the page authentication token for a given site.
+ *
+ * @param {string} siteId - The site ID to retrieve authentication for
+ * @param {object} context - The context object containing dataAccess and services
+ * @returns {Promise<string>} - The authentication token
+ * @throws {Error} - If site not found, secret not found, or token missing
+ */
+export async function retrievePageAuthentication(siteId, context) {
+  const { dataAccess: { Site }, attributes: { services } } = context;
+  const site = await Site.findById(siteId);
+  if (!site) {
+    throw new Error(`Site with ID ${siteId} not found, cannot resolve customer secrets for authentication`);
+  }
+  const baseURL = site.getBaseURL();
+  const customerSecret = resolveCustomerSecretsName(baseURL, context);
+  const secretsClient = services.xray.captureAWSv3Client(services.secretsClient);
+  const command = new GetSecretValueCommand({ SecretId: customerSecret });
+
+  const response = await secretsClient.send(command);
+  if (!response.SecretString) {
+    throw new Error(`No secret string found for ${customerSecret}`);
+  }
+
+  const secrets = JSON.parse(response.SecretString);
+
+  if (!isString(secrets.PAGE_AUTH_TOKEN)) {
+    throw new Error(`Missing 'PAGE_AUTH_TOKEN' in secrets for ${customerSecret}`);
+  }
+
+  return secrets.PAGE_AUTH_TOKEN;
+}

--- a/packages/spacecat-shared-utils/src/auth.js
+++ b/packages/spacecat-shared-utils/src/auth.js
@@ -25,7 +25,7 @@ import { resolveCustomerSecretsName } from './helpers.js';
  * @param {Site} site - The site to retrieve authentication for
  * @param {object} context - The context object
  * @returns {Promise<string>} - The authentication token
- * @throws {Error} - If site not found, secret not found, or token missing
+ * @throws {Error} - If secret is not found or token is missing
  */
 export async function retrievePageAuthentication(site, context) {
   const baseURL = site.getBaseURL();

--- a/packages/spacecat-shared-utils/src/index.d.ts
+++ b/packages/spacecat-shared-utils/src/index.d.ts
@@ -246,4 +246,4 @@ export function tracingFetch(url: string | Request, options?: RequestOptions): P
 
 export const SPACECAT_USER_AGENT: string;
 
-export function retrievePageAuthentication(siteId: string, context: object): Promise<string>;
+export function retrievePageAuthentication(site: object, context: object): Promise<string>;

--- a/packages/spacecat-shared-utils/src/index.d.ts
+++ b/packages/spacecat-shared-utils/src/index.d.ts
@@ -245,3 +245,5 @@ export function fetch(url: string | Request, options?: RequestOptions): Promise<
 export function tracingFetch(url: string | Request, options?: RequestOptions): Promise<Response>;
 
 export const SPACECAT_USER_AGENT: string;
+
+export function retrievePageAuthentication(siteId: string, context: object): Promise<string>;

--- a/packages/spacecat-shared-utils/src/index.js
+++ b/packages/spacecat-shared-utils/src/index.js
@@ -73,3 +73,5 @@ export {
   getHighPageViewsLowFormCtrMetrics,
   FORMS_AUDIT_INTERVAL,
 } from './formcalc.js';
+
+export { retrievePageAuthentication } from './auth.js';

--- a/packages/spacecat-shared-utils/test/auth.test.js
+++ b/packages/spacecat-shared-utils/test/auth.test.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import { retrievePageAuthentication } from '../src/auth.js';
+
+use(chaiAsPromised);
+
+describe('auth', () => {
+  describe('retrievePageAuthentication', () => {
+    let mockSite;
+    let mockSecretsClient;
+    let mockXray;
+    let context;
+
+    beforeEach(() => {
+      mockSite = {
+        findById: sinon.stub(),
+        getBaseURL: sinon.stub().returns('https://example.com'),
+      };
+
+      mockSecretsClient = {
+        send: sinon.stub(),
+      };
+
+      mockXray = {
+        captureAWSv3Client: sinon.stub().returns(mockSecretsClient),
+      };
+
+      context = {
+        dataAccess: {
+          Site: mockSite,
+        },
+        attributes: {
+          services: {
+            xray: mockXray,
+            secretsClient: {},
+          },
+        },
+        func: {
+          version: 'test-version',
+        },
+      };
+    });
+
+    it('should retrieve authentication token successfully', async () => {
+      const siteId = 'test-site-id';
+      const authToken = 'test-token';
+      const secretString = JSON.stringify({ PAGE_AUTH_TOKEN: authToken });
+
+      mockSite.findById.resolves(mockSite);
+      mockSecretsClient.send.resolves({ SecretString: secretString });
+
+      const result = await retrievePageAuthentication(siteId, context);
+
+      expect(result).to.equal(authToken);
+      expect(mockSite.findById.calledWith(siteId)).to.be.true;
+      expect(mockSecretsClient.send.calledOnce).to.be.true;
+    });
+
+    it('should throw error when site is not found', async () => {
+      const siteId = 'non-existent-site';
+      mockSite.findById.resolves(null);
+
+      await expect(retrievePageAuthentication(siteId, context))
+        .to.be.rejectedWith(`Site with ID ${siteId} not found, cannot resolve customer secrets for authentication`);
+    });
+
+    it('should throw error when secret string is not found', async () => {
+      const siteId = 'test-site-id';
+      mockSite.findById.resolves(mockSite);
+      mockSecretsClient.send.resolves({});
+
+      await expect(retrievePageAuthentication(siteId, context))
+        .to.be.rejectedWith(/No secret string found for/);
+    });
+
+    it('should throw error when PAGE_AUTH_TOKEN is missing', async () => {
+      const siteId = 'test-site-id';
+      const secretString = JSON.stringify({});
+      mockSite.findById.resolves(mockSite);
+      mockSecretsClient.send.resolves({ SecretString: secretString });
+
+      await expect(retrievePageAuthentication(siteId, context))
+        .to.be.rejectedWith(/Missing 'PAGE_AUTH_TOKEN' in secrets for/);
+    });
+  });
+});

--- a/packages/spacecat-shared-utils/test/index.test.js
+++ b/packages/spacecat-shared-utils/test/index.test.js
@@ -64,6 +64,7 @@ describe('Index Exports', () => {
     'SPACECAT_USER_AGENT',
     'isAWSLambda',
     'instrumentAWSClient',
+    'retrievePageAuthentication',
   ];
 
   it('exports all expected functions', () => {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
https://jira.corp.adobe.com/browse/SITES-31664

This PR introduces a new authentication utility function that securely retrieves page authentication tokens for sites using AWS Secrets Manager.
