### PR TITLE
fix: async job schema

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/async-job/async-job.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/async-job/async-job.schema.js
@@ -10,7 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import { isObject, isValidUrl, isIsoDate } from '@adobe/spacecat-shared-utils';
+import {
+  isObject, isValidUrl, isIsoDate, isArray,
+} from '@adobe/spacecat-shared-utils';
 import SchemaBuilder from '../base/schema.builder.js';
 import AsyncJob from './async-job.model.js';
 import AsyncJobCollection from './async-job.collection.js';
@@ -31,7 +33,7 @@ const schema = new SchemaBuilder(AsyncJob, AsyncJobCollection)
   })
   .addAttribute('result', {
     type: 'any',
-    validate: (value) => !value || isObject(value),
+    validate: (value) => !value || isObject(value) || isArray(value),
   })
   .addAttribute('error', {
     type: 'map',

--- a/packages/spacecat-shared-data-access/src/models/async-job/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/async-job/index.d.ts
@@ -16,14 +16,14 @@ export interface AsyncJob extends BaseModel {
     getStatus(): string;
     getResultLocation(): string;
     getResultType(): string;
-    getResult(): object;
+    getResult(): object | [];
     getError(): { code: string; message: string; details?: object } | null;
     getMetadata(): object | null;
     getRecordExpiressAt(): number;
     setStatus(status: string): void;
     setResultLocation(location: string): void;
     setResultType(type: string): void;
-    setResult(result: object): void;
+    setResult(result: object | []): void;
     setError(error: { code: string; message: string; details?: object }): void;
     setMetadata(metadata: object): void;
     setExpiresAt(expiresAt: number): void;

--- a/packages/spacecat-shared-data-access/test/unit/models/async-job/async-job.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/async-job/async-job.model.test.js
@@ -99,6 +99,10 @@ describe('AsyncJobModel', () => {
       instance.setResult({ value: 42 });
       expect(instance.getResult()).to.deep.equal({ value: 42 });
     });
+    it('sets result as array', () => {
+      instance.setResult([{ value: 42 }]);
+      expect(instance.getResult()).to.deep.equal([{ value: 42 }]);
+    });
   });
 
   describe('error', () => {


### PR DESCRIPTION
extend async job result to accept an array