### PR TITLE
feat: Support fetching only unbranded keywords from ahrefs

### DIFF
--- a/packages/spacecat-shared-ahrefs-client/src/index.d.ts
+++ b/packages/spacecat-shared-ahrefs-client/src/index.d.ts
@@ -73,13 +73,15 @@ export default class AhrefsAPIClient {
 
   /**
    * Asynchronous method to get organic keywords.
-   * @param url
-   * @param country
-   * @param keywordFilter
-   * @param limit
-   * @param mode
    */
-  getOrganicKeywords(url: string, country?: string, keywordFilter?: string[],
-                     limit?: number, mode?: string):
+  getOrganicKeywords(
+    url: string,
+    options?: {
+      country?: string,
+      keywordFilter?: string[],
+      limit?: number,
+      mode?: 'exaxt' | 'prefix',
+      excludeBranded?: boolean,
+    }):
       Promise<{ result: object, fullAuditRef: string }>;
 }

--- a/packages/spacecat-shared-ahrefs-client/src/index.d.ts
+++ b/packages/spacecat-shared-ahrefs-client/src/index.d.ts
@@ -80,7 +80,7 @@ export default class AhrefsAPIClient {
       country?: string,
       keywordFilter?: string[],
       limit?: number,
-      mode?: 'exaxt' | 'prefix',
+      mode?: 'exact' | 'prefix',
       excludeBranded?: boolean,
     }):
       Promise<{ result: object, fullAuditRef: string }>;


### PR DESCRIPTION
Adds an `excludeBranded` option to `AhrefsAPIClient#getOrganicKeywords` to exclusively retreive unbranded keywords from Ahrefs.

This is required for Project Elmo