### PR TITLE
feat: add 405 response util

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19203,7 +19203,7 @@
     },
     "packages/spacecat-shared-ahrefs-client": {
       "name": "@adobe/spacecat-shared-ahrefs-client",
-      "version": "1.6.20",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.2",
@@ -20018,7 +20018,7 @@
     },
     "packages/spacecat-shared-brand-client": {
       "name": "@adobe/spacecat-shared-brand-client",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.2.2",
@@ -22238,7 +22238,7 @@
     },
     "packages/spacecat-shared-content-client": {
       "name": "@adobe/spacecat-shared-content-client",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.2.2",
@@ -30156,7 +30156,7 @@
       "version": "2.21.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/spacecat-shared-utils": "1.38.0",
+        "@adobe/spacecat-shared-utils": "1.38.4",
         "@aws-sdk/client-dynamodb": "3.817.0",
         "@aws-sdk/lib-dynamodb": "3.817.0",
         "@types/joi": "17.2.3",
@@ -30179,702 +30179,9 @@
         "npm": ">=10.9.0 <12.0.0"
       }
     },
-    "packages/spacecat-shared-data-access/node_modules/@adobe/fetch": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.1.tgz",
-      "integrity": "sha512-fPuADAIdbF3o3wpyF5yKMNYXMWG4ws+Sxp0mQWy6CfSTSkLvgP8OYCfbTFm3Dyh18sLN8hYrNrJfowT8lNqj6g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "4.4.0",
-        "http-cache-semantics": "4.2.0",
-        "lru-cache": "7.18.3"
-      },
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@adobe/spacecat-shared-utils": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.38.0.tgz",
-      "integrity": "sha512-UdEtL0Y0ah1gXDbtasmUu6huqmgY0B2uYAKnTKrp7XZQcS56hXeatgKcGGuc7cyCU9O4eWLwjEVG7+9/HOp//g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@adobe/fetch": "4.2.1",
-        "@aws-sdk/client-s3": "3.806.0",
-        "@aws-sdk/client-secrets-manager": "3.806.0",
-        "@aws-sdk/client-sqs": "3.806.0",
-        "@json2csv/plainjs": "7.0.6",
-        "aws-xray-sdk": "3.10.3",
-        "uuid": "11.1.0"
-      },
-      "engines": {
-        "node": ">=22.0.0 <23.0.0",
-        "npm": ">=10.9.0 <12.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/client-s3": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.806.0.tgz",
-      "integrity": "sha512-kQaBBBxEBU/IJ2wKG+LL2BK+uvBwpdvOA9jy1WhW+U2/DIMwMrjVs7M/ZvTlmVOJwhZaONcJbgQqsN4Yirjj4g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha1-browser": "5.2.0",
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/credential-provider-node": "3.806.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.806.0",
-        "@aws-sdk/middleware-expect-continue": "3.804.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.806.0",
-        "@aws-sdk/middleware-host-header": "3.804.0",
-        "@aws-sdk/middleware-location-constraint": "3.804.0",
-        "@aws-sdk/middleware-logger": "3.804.0",
-        "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-sdk-s3": "3.806.0",
-        "@aws-sdk/middleware-ssec": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.806.0",
-        "@aws-sdk/region-config-resolver": "3.806.0",
-        "@aws-sdk/signature-v4-multi-region": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.806.0",
-        "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.806.0",
-        "@aws-sdk/xml-builder": "3.804.0",
-        "@smithy/config-resolver": "^4.1.1",
-        "@smithy/core": "^3.3.1",
-        "@smithy/eventstream-serde-browser": "^4.0.2",
-        "@smithy/eventstream-serde-config-resolver": "^4.1.0",
-        "@smithy/eventstream-serde-node": "^4.0.2",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-blob-browser": "^4.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/hash-stream-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/md5-js": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.3",
-        "@smithy/middleware-retry": "^4.1.4",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.1.0",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.3",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.11",
-        "@smithy/util-defaults-mode-node": "^4.0.11",
-        "@smithy/util-endpoints": "^3.0.3",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.3",
-        "@smithy/util-stream": "^4.2.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "@smithy/util-waiter": "^4.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.806.0.tgz",
-      "integrity": "sha512-AYjs1hCI49JtaIX+8wvqT3odWy9shsbAxxbxQXmQtc3lbaZlsJzeKpbvjNapdjQAqUORW/iAz56MtuS03uCzFg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/credential-provider-node": "3.806.0",
-        "@aws-sdk/middleware-host-header": "3.804.0",
-        "@aws-sdk/middleware-logger": "3.804.0",
-        "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.806.0",
-        "@aws-sdk/region-config-resolver": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.806.0",
-        "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.806.0",
-        "@smithy/config-resolver": "^4.1.1",
-        "@smithy/core": "^3.3.1",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.3",
-        "@smithy/middleware-retry": "^4.1.4",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.1.0",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.3",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.11",
-        "@smithy/util-defaults-mode-node": "^4.0.11",
-        "@smithy/util-endpoints": "^3.0.3",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.3",
-        "@smithy/util-utf8": "^4.0.0",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/client-secrets-manager/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/client-sqs": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.806.0.tgz",
-      "integrity": "sha512-JvoLtAa+mS8N90smkAg7lYVi/tdV1JbGrPoRJYLOGpA6N2mn7Atv580dWTJQ3m4lhmTgBJjVnMlo3AN/UJ+VIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/credential-provider-node": "3.806.0",
-        "@aws-sdk/middleware-host-header": "3.804.0",
-        "@aws-sdk/middleware-logger": "3.804.0",
-        "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-sdk-sqs": "3.806.0",
-        "@aws-sdk/middleware-user-agent": "3.806.0",
-        "@aws-sdk/region-config-resolver": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.806.0",
-        "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.806.0",
-        "@smithy/config-resolver": "^4.1.1",
-        "@smithy/core": "^3.3.1",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/md5-js": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.3",
-        "@smithy/middleware-retry": "^4.1.4",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.1.0",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.3",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.11",
-        "@smithy/util-defaults-mode-node": "^4.0.11",
-        "@smithy/util-endpoints": "^3.0.3",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.3",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/client-sso": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.806.0.tgz",
-      "integrity": "sha512-X0p/9/u9e6b22rlQqKucdtjdqmjSNB4c/8zDEoD5MvgYAAbMF9HNE0ST2xaA/WsJ7uE0jFfhPY2/00pslL1DqQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/middleware-host-header": "3.804.0",
-        "@aws-sdk/middleware-logger": "3.804.0",
-        "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.806.0",
-        "@aws-sdk/region-config-resolver": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.806.0",
-        "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.806.0",
-        "@smithy/config-resolver": "^4.1.1",
-        "@smithy/core": "^3.3.1",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.3",
-        "@smithy/middleware-retry": "^4.1.4",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.1.0",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.3",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.11",
-        "@smithy/util-defaults-mode-node": "^4.0.11",
-        "@smithy/util-endpoints": "^3.0.3",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.3",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/core": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.806.0.tgz",
-      "integrity": "sha512-HJRINPncdjPK0iL3f6cBpqCMaxVwq2oDbRCzOx04tsLZ0tNgRACBfT3d/zNVRvMt6fnOVKXoN1LAtQaw50pjEA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/core": "^3.3.1",
-        "@smithy/node-config-provider": "^4.1.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/signature-v4": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.3",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.806.0.tgz",
-      "integrity": "sha512-nbPwmZn0kt6Q1XI2FaJWP6AhF9tro4cO5HlmZQx8NU+B0H1y9WMo659Q5zLLY46BXgoQVIJEsPSZpcZk27O4aw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.806.0.tgz",
-      "integrity": "sha512-e/gB2iJQQ4ZpecOVpEFhEvjGwuTqNCzhVaVsFYVc49FPfR1seuN7qBGYe1MO7mouGDQFInzJgcNup0DnYUrLiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.3",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-stream": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.806.0.tgz",
-      "integrity": "sha512-FogfbuYSEZgFxbNy0QcsBZHHe5mSv5HV3+JyB5n0kCyjOISCVCZD7gwxKdXjt8O1hXq5k5SOdQvydGULlB6rew==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/credential-provider-env": "3.806.0",
-        "@aws-sdk/credential-provider-http": "3.806.0",
-        "@aws-sdk/credential-provider-process": "3.806.0",
-        "@aws-sdk/credential-provider-sso": "3.806.0",
-        "@aws-sdk/credential-provider-web-identity": "3.806.0",
-        "@aws-sdk/nested-clients": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.806.0.tgz",
-      "integrity": "sha512-fZX8xP2Kf0k70kDTog/87fh/M+CV0E2yujSw1cUBJhDSwDX3RlUahiJk7TpB/KGw6hEFESMd6+7kq3UzYuw3rg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.806.0",
-        "@aws-sdk/credential-provider-http": "3.806.0",
-        "@aws-sdk/credential-provider-ini": "3.806.0",
-        "@aws-sdk/credential-provider-process": "3.806.0",
-        "@aws-sdk/credential-provider-sso": "3.806.0",
-        "@aws-sdk/credential-provider-web-identity": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.806.0.tgz",
-      "integrity": "sha512-8Y8GYEw/1e5IZRDQL02H6nsTDcRWid/afRMeWg+93oLQmbHcTtdm48tjis+7Xwqy+XazhMDmkbUht11QPTDJcQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.806.0.tgz",
-      "integrity": "sha512-hT9OBwCxWMPBydNhXm2gdNNzx5AJNheS9RglwDDvXWzQ9qDuRztjuMBilMSUMb0HF9K4IqQjYzGqczMuktz4qQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.806.0",
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/token-providers": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.806.0.tgz",
-      "integrity": "sha512-XxaSY9Zd3D4ClUGENYMvi52ac5FuJPPAsvRtEfyrSdEpf6QufbMpnexWBZMYRF31h/VutgqtJwosGgNytpxMEg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/nested-clients": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.806.0.tgz",
-      "integrity": "sha512-ACjuyKJw9OZl8z8HzPEaqn1o7ElVW94mowyoZvyUIDouwAPGqPGJbJ5V35qx1oDTFSAJX+N3O3AO6RyFc8nUhw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-arn-parser": "3.804.0",
-        "@smithy/node-config-provider": "^4.1.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.806.0.tgz",
-      "integrity": "sha512-YEmuU2Nr/+blhi70gS38fnCe2IoL6OVVZXMp4MbzqZRUqeBbnxZhHQrd5YOiboJz7iq+g98xwFebHY167iejcg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@aws-crypto/crc32c": "5.2.0",
-        "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/node-config-provider": "^4.1.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-stream": "^4.2.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.806.0.tgz",
-      "integrity": "sha512-K1ssdovHH/kPN9EUS1LznwzoL+r89Cx8qAkp0K8MqdCQuBjZ0KRnjvo9nx69Vg5d/rg01VYTxomFUPXfcPtVXw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-arn-parser": "3.804.0",
-        "@smithy/core": "^3.3.1",
-        "@smithy/node-config-provider": "^4.1.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/signature-v4": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.3",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-stream": "^4.2.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.806.0.tgz",
-      "integrity": "sha512-UHZKudmpl0nquq4iSSMKtypM3RFsybXiagd0mYmBpjG1Jw2oS/7NC4VFmxSnUC3jg8yXY4N9qu658Z4u9OMBDg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/smithy-client": "^4.2.3",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.806.0.tgz",
-      "integrity": "sha512-XoIromVffgXnc+/mjlR2EVzQVIei3bPVtafIZNsHuEmUvIWJXiWsa2eJpt3BUqa0HF9YPknK7ommNEhqRb8ucg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.806.0",
-        "@smithy/core": "^3.3.1",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.806.0.tgz",
-      "integrity": "sha512-ua2gzpfQ9MF8Rny+tOAivowOWWvqEusez2rdcQK8jdBjA1ANd/0xzToSZjZh0ziN8Kl8jOhNnHbQJ0v6dT6+hg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.806.0",
-        "@aws-sdk/middleware-host-header": "3.804.0",
-        "@aws-sdk/middleware-logger": "3.804.0",
-        "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.806.0",
-        "@aws-sdk/region-config-resolver": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.806.0",
-        "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.806.0",
-        "@smithy/config-resolver": "^4.1.1",
-        "@smithy/core": "^3.3.1",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.3",
-        "@smithy/middleware-retry": "^4.1.4",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.1.0",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.3",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.11",
-        "@smithy/util-defaults-mode-node": "^4.0.11",
-        "@smithy/util-endpoints": "^3.0.3",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.3",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.806.0.tgz",
-      "integrity": "sha512-cuv5pX55JOlzKC/iLsB5nZ9eUyVgncim3VhhWHZA/KYPh7rLMjOEfZ+xyaE9uLJXGmzOJboFH7+YdTRdIcOgrg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/node-config-provider": "^4.1.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.806.0.tgz",
-      "integrity": "sha512-IrbEnpKvG8d9rUWAvsF28g8qBlQ02FaOxn4cGXtTs0b0BGMK1M+cGQrYjJ7Ak08kIXDxBqsdIlZGsKYr+Ds9+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/signature-v4": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/token-providers": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.806.0.tgz",
-      "integrity": "sha512-I6SxcsvV7yinJZmPgGullFHS0tsTKa7K3jEc5dmyCz8X+kZPfsWNffZmtmnCvWXPqMXWBvK6hVaxwomx79yeHA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/nested-clients": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.804.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.804.0.tgz",
-      "integrity": "sha512-wmBJqn1DRXnZu3b4EkE6CWnoWMo1ZMvlfkqU5zPz67xx1GMaXlDCchFvKAXMjk4jn/L1O3tKnoFDNsoLV1kgNQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.806.0.tgz",
-      "integrity": "sha512-3YRRgZ+qFuWDdm5uAbxKsr65UAil4KkrFKua9f4m7Be3v24ETiFOOqhanFUIk9/WOtvzF7oFEiDjYKDGlwV2xg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-endpoints": "^3.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.806.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.806.0.tgz",
-      "integrity": "sha512-Az2e4/gmPZ4BpB7QRj7U76I+fctXhNcxlcgsaHnMhvt+R30nvzM2EhsyBUvsWl8+r9bnLeYt9BpvEZeq2ANDzA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.806.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/node-config-provider": "^4.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "packages/spacecat-shared-data-access/node_modules/http-cache-semantics": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "license": "BSD-2-Clause"
-    },
-    "packages/spacecat-shared-data-access/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "packages/spacecat-shared-example": {
       "name": "@adobe/spacecat-shared-example",
-      "version": "1.2.27",
+      "version": "1.2.28",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.2",
@@ -30890,7 +30197,7 @@
     },
     "packages/spacecat-shared-google-client": {
       "name": "@adobe/spacecat-shared-google-client",
-      "version": "1.4.29",
+      "version": "1.4.30",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.2",
@@ -37664,7 +36971,7 @@
     },
     "packages/spacecat-shared-gpt-client": {
       "name": "@adobe/spacecat-shared-gpt-client",
-      "version": "1.5.12",
+      "version": "1.5.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.2",
@@ -48834,7 +48141,7 @@
     },
     "packages/spacecat-shared-ims-client": {
       "name": "@adobe/spacecat-shared-ims-client",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.2",
@@ -49649,7 +48956,7 @@
     },
     "packages/spacecat-shared-rum-api-client": {
       "name": "@adobe/spacecat-shared-rum-api-client",
-      "version": "2.27.0",
+      "version": "2.27.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.2",
@@ -50468,7 +49775,7 @@
     },
     "packages/spacecat-shared-slack-client": {
       "name": "@adobe/spacecat-shared-slack-client",
-      "version": "1.5.15",
+      "version": "1.5.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.2.2",
@@ -51284,7 +50591,7 @@
     },
     "packages/spacecat-shared-splunk-client": {
       "name": "@adobe/spacecat-shared-splunk-client",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.2",

--- a/packages/spacecat-shared-data-access/package.json
+++ b/packages/spacecat-shared-data-access/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/spacecat-shared-utils": "1.38.0",
+    "@adobe/spacecat-shared-utils": "1.38.4",
     "@aws-sdk/client-dynamodb": "3.817.0",
     "@aws-sdk/lib-dynamodb": "3.817.0",
     "@types/joi": "17.2.3",

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -743,7 +743,7 @@ describe('Config Tests', () => {
         .to.throw().and.satisfy((error) => {
           expect(error.message).to.include('Configuration validation error');
           expect(error.cause.details[0].context.message)
-            .to.equal('"imports[0].destinations[0]" must be [default]. "imports[0].type" must be [organic-traffic]. "imports[0].type" must be [all-traffic]. "imports[0].type" must be [top-pages]. "imports[0].type" must be [cwv-daily]. "imports[0].type" must be [cwv-weekly]');
+            .to.equal('"imports[0].destinations[0]" must be [default]. "imports[0].type" must be [organic-keywords-nonbranded]. "imports[0].type" must be [organic-traffic]. "imports[0].type" must be [all-traffic]. "imports[0].type" must be [top-pages]. "imports[0].type" must be [cwv-daily]. "imports[0].type" must be [cwv-weekly]');
           expect(error.cause.details[0].context.details)
             .to.eql([
               {
@@ -763,6 +763,23 @@ describe('Config Tests', () => {
                   value: 'invalid',
                   key: 0,
                 },
+              },
+              {
+                context: {
+                  key: 'type',
+                  label: 'imports[0].type',
+                  valids: [
+                    'organic-keywords-nonbranded',
+                  ],
+                  value: 'organic-keywords',
+                },
+                message: '"imports[0].type" must be [organic-keywords-nonbranded]',
+                path: [
+                  'imports',
+                  0,
+                  'type',
+                ],
+                type: 'any.only',
               },
               {
                 message: '"imports[0].type" must be [organic-traffic]',

--- a/packages/spacecat-shared-http-utils/src/index.d.ts
+++ b/packages/spacecat-shared-http-utils/src/index.d.ts
@@ -23,6 +23,8 @@ export declare function badRequest(message?: string, headers?: object): Response
 
 export declare function notFound(message?: string, headers?: object): Response;
 
+export declare function methodNotAllowed(message?: string, headers?: object): Response;
+
 export declare function internalServerError(message?: string, headers?: object): Response;
 
 export declare function found(location: string): Response;

--- a/packages/spacecat-shared-http-utils/src/index.d.ts
+++ b/packages/spacecat-shared-http-utils/src/index.d.ts
@@ -11,6 +11,8 @@
  */
 import { Response } from '@adobe/fetch';
 
+export declare function createResponse(body: object, status?: number, headers?: object): Response;
+
 export declare function ok(body?: string, headers?: object): Response;
 
 export declare function created(body: object, headers?: object): Response;

--- a/packages/spacecat-shared-http-utils/src/index.js
+++ b/packages/spacecat-shared-http-utils/src/index.js
@@ -100,6 +100,13 @@ export function notFound(message = 'not found', headers = {}) {
   });
 }
 
+export function methodNotAllowed(message = 'method not allowed', headers = {}) {
+  return createResponse({ message }, 405, {
+    [HEADER_ERROR]: message,
+    ...headers,
+  });
+}
+
 export function internalServerError(message = 'internal server error', headers = {}) {
   return createResponse({ message }, 500, {
     [HEADER_ERROR]: message,

--- a/packages/spacecat-shared-http-utils/test/index.test.js
+++ b/packages/spacecat-shared-http-utils/test/index.test.js
@@ -12,9 +12,18 @@
 /* eslint-env mocha */
 import { expect } from 'chai';
 import {
-  ok, badRequest, notFound, internalServerError,
-  noContent, found, created, createResponse, unauthorized, forbidden,
   accepted,
+  badRequest,
+  createResponse,
+  created,
+  forbidden,
+  found,
+  internalServerError,
+  methodNotAllowed,
+  noContent,
+  notFound,
+  ok,
+  unauthorized,
 } from '../src/index.js';
 
 async function testMethod(response, expectedCode, expectedBody) {
@@ -163,6 +172,23 @@ describe('HTTP Response Functions', () => {
     expect(response.headers.get('custom-header')).to.equal('value');
     const responseBody = await response.json();
     expect(responseBody).to.deep.equal({ message: 'Resource not found' });
+  });
+
+  it('methodNotAllowed should return a 405 Method Not Allowed response with default message and headers', async () => {
+    const response = await methodNotAllowed();
+    expect(response.status).to.equal(405);
+    expect(response.headers.get('x-error')).to.equal('method not allowed');
+    const responseBody = await response.json();
+    expect(responseBody).to.deep.equal({ message: 'method not allowed' });
+  });
+
+  it('methodNotAllowed should return a 405 Method Not Allowed response with custom message and headers', async () => {
+    const response = await methodNotAllowed('This method is not allowed', { 'custom-header': 'value' });
+    expect(response.status).to.equal(405);
+    expect(response.headers.get('x-error')).to.equal('This method is not allowed');
+    expect(response.headers.get('custom-header')).to.equal('value');
+    const responseBody = await response.json();
+    expect(responseBody).to.deep.equal({ message: 'This method is not allowed' });
   });
 
   it('internalServerError should return a 500 Internal Server Error response with default message and headers', async () => {


### PR DESCRIPTION
- Adding `methodNotAllowed` http response util.
- Adding `createResponse` type def that was missing
- Update to latest `spacecate-shared-utils`
- Fix package lock
- Fix unrelated failing test