### PR TITLE
fix: organic keyword import missing the url

### DIFF
--- a/packages/spacecat-shared-ahrefs-client/src/index.js
+++ b/packages/spacecat-shared-ahrefs-client/src/index.js
@@ -25,6 +25,7 @@ export const ORGANIC_KEYWORDS_FIELDS = /** @type {const} */ ([
   'sum_traffic',
   'volume',
   'best_position',
+  'best_position_url',
   'cpc',
   'last_update',
   'is_branded',


### PR DESCRIPTION
In the imported data, best_position_url is missing, so url is missing in the ingested data. Data excerpt from keyword imported in dev for adobe.com
```
{
    "siteId": "c2473d89-e997-458d-a86d-b4096649c12b",
    "source": "ahrefs",
    "importTime": "2025-06-02T21:28:32.522Z",
    "lastUpdateTime": "2025-06-02T19:30:23Z",
    "name": "organic-keywords",
    "keyword": "premiere pro",
    "traffic": 24382,
    "volume": 41000,
    "bestPosition": 1,
    "cpc": 206,
    "isBranded": true,
    "isNavigational": false,
    "isInformational": true,
    "isCommercial": true,
    "isTransactional": false,
    "serpFeatures": [
      "sitelink",
      "question",
      "knowledge_panel",
      "news",
      "image_th",
      "video_th"
    ]
  }
```

Added `best_position_url` to select query in the ahrefs client