### PR TITLE
fix: sanitize headers before logging

### DIFF
--- a/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
+++ b/packages/spacecat-shared-gpt-client/src/clients/firefall-client.js
@@ -14,7 +14,7 @@ import { createUrl } from '@adobe/fetch';
 import { ImsClient } from '@adobe/spacecat-shared-ims-client';
 import { hasText, isObject, isValidUrl } from '@adobe/spacecat-shared-utils';
 
-import { fetch as httpFetch } from '../utils.js';
+import { fetch as httpFetch, sanitizeHeaders } from '../utils.js';
 
 const USER_ROLE_IMAGE_URL_TYPE = 'image_url';
 const USER_ROLE_TEXT_TYPE = 'text';
@@ -125,7 +125,7 @@ export default class FirefallClient {
       'x-gw-ims-org-id': this.config.imsOrg,
     };
 
-    this.log.info(`URL: ${url}, Headers: ${JSON.stringify(headers)}`);
+    this.log.info(`[Firefall API Call]]: ${url}, Headers: ${JSON.stringify(sanitizeHeaders(headers))}`);
 
     const response = await httpFetch(url, {
       method: 'POST',
@@ -158,7 +158,7 @@ export default class FirefallClient {
         'x-gw-ims-org-id': this.config.imsOrg,
       };
 
-      this.log.info(`URL: ${url}, Headers: ${JSON.stringify(headers)}`);
+      this.log.info(`URL: ${url}, Headers: ${JSON.stringify(sanitizeHeaders(headers))}`);
 
       const response = await httpFetch(
         createUrl(url),
@@ -314,7 +314,6 @@ export default class FirefallClient {
       const result = output.capability_response.generations[0][0];
 
       this.log.info(`Generation Info: ${JSON.stringify(result.generation_info)}`);
-      this.log.info(`LLM Info: ${JSON.stringify(output.capability_response.llm_output)}`);
 
       return result.text;
     } catch (error) {

--- a/packages/spacecat-shared-gpt-client/src/clients/genvar-client.js
+++ b/packages/spacecat-shared-gpt-client/src/clients/genvar-client.js
@@ -18,6 +18,8 @@ import {
   tracingFetch,
 } from '@adobe/spacecat-shared-utils';
 
+import { sanitizeHeaders } from '../utils.js';
+
 export default class GenvarClient {
   static createFrom(context) {
     const { log = console } = context;
@@ -84,7 +86,7 @@ export default class GenvarClient {
       'x-gw-ims-org-id': this.config.imsOrg,
     };
 
-    this.log.info(`[Genvar API Call] URL: ${url}, Headers: ${JSON.stringify({ ...headers, Authorization: '***' })}`);
+    this.log.info(`[Genvar API Call] URL: ${url}, Headers: ${JSON.stringify(sanitizeHeaders(headers))}`);
 
     let response;
     let responseJsonObj;
@@ -121,7 +123,7 @@ export default class GenvarClient {
         'x-gw-ims-org-id': this.config.imsOrg,
       };
 
-      this.log.info(`[Genvar API Call] URL: ${url}, Headers: ${JSON.stringify({ ...headers, Authorization: '***' })}`);
+      this.log.info(`[Genvar API Call] URL: ${url}, Headers: ${JSON.stringify(sanitizeHeaders(headers))}`);
 
       let response;
       try {

--- a/packages/spacecat-shared-gpt-client/src/utils.js
+++ b/packages/spacecat-shared-gpt-client/src/utils.js
@@ -16,3 +16,11 @@ import { context as h2, h1 } from '@adobe/fetch';
 export const { fetch } = process.env.HELIX_FETCH_FORCE_HTTP1
   ? h1()
   : h2();
+
+export function sanitizeHeaders(headers) {
+  return {
+    ...headers,
+    ...(headers.Authorization && { Authorization: '***' }),
+    ...(headers['x-api-key'] && { 'x-api-key': '****' }),
+  };
+}


### PR DESCRIPTION
Fixes hackathon remnant where unsanitized headers were logged: `Authorization` and `x-api-key`. Introduces small util function to sanitize such headers.