### PR TITLE
feat: high organic low ctr detection using traffic instead of thresholds

### DIFF
--- a/packages/spacecat-shared-rum-api-client/src/functions/opportunities/high-organic-low-ctr.js
+++ b/packages/spacecat-shared-rum-api-client/src/functions/opportunities/high-organic-low-ctr.js
@@ -14,7 +14,7 @@ import trafficAcquisition from '../traffic-acquisition.js';
 import { getCTRByUrlAndVendor, getSiteAvgCTR } from '../../common/aggregateFns.js';
 
 const VENDORS_TO_CONSIDER = 5;
-const MAX_OPPORTUNITIES = 100;
+const MAX_OPPORTUNITIES = 10;
 
 const MAIN_TYPES = ['paid', 'earned', 'owned'];
 

--- a/packages/spacecat-shared-rum-api-client/src/functions/traffic-acquisition.js
+++ b/packages/spacecat-shared-rum-api-client/src/functions/traffic-acquisition.js
@@ -47,7 +47,7 @@ function formatTraffic(row) {
     url, weight, type, category, vendor, events = [],
   } = row;
 
-  const maxTimeDelta = events.reduce((max, e) => Math.max(max, e.timeDelta), 0);
+  const maxTimeDelta = events.reduce((max, e) => Math.max(max, e.timeDelta || 0), 0);
 
   return {
     url,

--- a/packages/spacecat-shared-rum-api-client/test/fixtures/high-organic-low-ctr.json
+++ b/packages/spacecat-shared-rum-api-client/test/fixtures/high-organic-low-ctr.json
@@ -8,6 +8,7 @@
     "trackedKPISiteAverage": 0.3701385784532856,
     "pageViews": 67000,
     "samples": 67000,
+    "percentileScore": 1,
     "metrics": [
       {
         "type": "traffic",
@@ -28,10 +29,10 @@
       },
       {
         "type": "pageOnTime",
+        "vendor": "*",
         "value": {
           "time": 0
-        },
-        "vendor": "*"
+        }
       },
       {
         "type": "traffic",
@@ -52,10 +53,10 @@
       },
       {
         "type": "pageOnTime",
+        "vendor": "google",
         "value": {
           "time": 0
-        },
-        "vendor": "google"
+        }
       },
       {
         "type": "traffic",
@@ -76,10 +77,219 @@
       },
       {
         "type": "pageOnTime",
+        "vendor": "tiktok",
         "value": {
           "time": 0
-        },
-        "vendor": "tiktok"
+        }
+      }
+    ]
+  },
+  {
+    "type": "high-organic-low-ctr",
+    "page": "https://www.spacecat.com/",
+    "screenshot": "",
+    "trackedPageKPIName": "Click Through Rate",
+    "trackedPageKPIValue": 0.3492407809110629,
+    "trackedKPISiteAverage": 0.3701385784532856,
+    "pageViews": 46100,
+    "samples": 46100,
+    "percentileScore": 0.6400000000000001,
+    "metrics": [
+      {
+        "type": "traffic",
+        "vendor": "*",
+        "value": {
+          "total": 46100,
+          "paid": 40700,
+          "owned": 5400,
+          "earned": 0
+        }
+      },
+      {
+        "type": "ctr",
+        "vendor": "*",
+        "value": {
+          "page": 0.3492407809110629
+        }
+      },
+      {
+        "type": "pageOnTime",
+        "vendor": "*",
+        "value": {
+          "time": 0
+        }
+      },
+      {
+        "type": "traffic",
+        "vendor": "google",
+        "value": {
+          "total": 100,
+          "owned": 0,
+          "earned": 0,
+          "paid": 100
+        }
+      },
+      {
+        "type": "ctr",
+        "vendor": "google",
+        "value": {
+          "page": 0
+        }
+      },
+      {
+        "type": "pageOnTime",
+        "vendor": "google",
+        "value": {
+          "time": 0
+        }
+      }
+    ]
+  },
+  {
+    "type": "high-organic-low-ctr",
+    "page": "https://www.spacecat.com/pricing",
+    "screenshot": "",
+    "trackedPageKPIName": "Click Through Rate",
+    "trackedPageKPIValue": 0.12761020881670534,
+    "trackedKPISiteAverage": 0.3701385784532856,
+    "pageViews": 43100,
+    "samples": 43100,
+    "percentileScore": 0.36,
+    "metrics": [
+      {
+        "type": "traffic",
+        "vendor": "*",
+        "value": {
+          "total": 43100,
+          "paid": 24100,
+          "owned": 19000,
+          "earned": 0
+        }
+      },
+      {
+        "type": "ctr",
+        "vendor": "*",
+        "value": {
+          "page": 0.12761020881670534
+        }
+      },
+      {
+        "type": "pageOnTime",
+        "vendor": "*",
+        "value": {
+          "time": 0
+        }
+      }
+    ]
+  },
+  {
+    "type": "high-organic-low-ctr",
+    "page": "https://www.spacecat.com/landing-page",
+    "screenshot": "",
+    "trackedPageKPIName": "Click Through Rate",
+    "trackedPageKPIValue": 0.927461139896373,
+    "trackedKPISiteAverage": 0.3701385784532856,
+    "pageViews": 38600,
+    "samples": 38600,
+    "percentileScore": 0.16000000000000003,
+    "metrics": [
+      {
+        "type": "traffic",
+        "vendor": "*",
+        "value": {
+          "total": 38600,
+          "paid": 4500,
+          "owned": 34100,
+          "earned": 0
+        }
+      },
+      {
+        "type": "ctr",
+        "vendor": "*",
+        "value": {
+          "page": 0.927461139896373
+        }
+      },
+      {
+        "type": "pageOnTime",
+        "vendor": "*",
+        "value": {
+          "time": 0
+        }
+      }
+    ]
+  },
+  {
+    "type": "high-organic-low-ctr",
+    "page": "https://www.spacecat.com/products",
+    "screenshot": "",
+    "trackedPageKPIName": "Click Through Rate",
+    "trackedPageKPIValue": 0.93717277486911,
+    "trackedKPISiteAverage": 0.3701385784532856,
+    "pageViews": 19100,
+    "samples": 19100,
+    "percentileScore": 0.04000000000000001,
+    "metrics": [
+      {
+        "type": "traffic",
+        "vendor": "*",
+        "value": {
+          "total": 19100,
+          "paid": 18400,
+          "owned": 700,
+          "earned": 0
+        }
+      },
+      {
+        "type": "ctr",
+        "vendor": "*",
+        "value": {
+          "page": 0.93717277486911
+        }
+      },
+      {
+        "type": "pageOnTime",
+        "vendor": "*",
+        "value": {
+          "time": 0
+        }
+      }
+    ]
+  },
+  {
+    "type": "high-organic-low-ctr",
+    "page": "https://www.spacecat.com/contact",
+    "screenshot": "",
+    "trackedPageKPIName": "Click Through Rate",
+    "trackedPageKPIValue": 0.09183673469387756,
+    "trackedKPISiteAverage": 0.3701385784532856,
+    "pageViews": 9800,
+    "samples": 9800,
+    "percentileScore": 0,
+    "metrics": [
+      {
+        "type": "traffic",
+        "vendor": "*",
+        "value": {
+          "total": 9800,
+          "paid": 100,
+          "owned": 9700,
+          "earned": 0
+        }
+      },
+      {
+        "type": "ctr",
+        "vendor": "*",
+        "value": {
+          "page": 0.09183673469387756
+        }
+      },
+      {
+        "type": "pageOnTime",
+        "vendor": "*",
+        "value": {
+          "time": 0
+        }
       }
     ]
   }

--- a/packages/spacecat-shared-rum-api-client/test/functions.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/functions.test.js
@@ -75,11 +75,13 @@ describe('Query functions', () => {
   });
 
   it('crunches oppty/high-organic-low-ctr', async () => {
-    const highInorganicHighBounceResult = highOrganicLowCTR.handler(
+    let highOrganicHighBounceResult = highOrganicLowCTR.handler(
       bundlesWithTraffic.rumBundles,
       { interval: 7 },
     );
-    expect(highInorganicHighBounceResult).to.eql(expectedHighOrganicLowCTRResult);
+    expect(highOrganicHighBounceResult).to.eql(expectedHighOrganicLowCTRResult);
+    highOrganicHighBounceResult = highOrganicLowCTR.handler([], { interval: 7 });
+    expect(highOrganicHighBounceResult).to.eql([]);
   });
 
   it('crunches pageviews', async () => {


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/SITES-31498

Since we're not having enough high-organic-low-ctr opportunities due to our thresholds, the recommendation from leadership is to remove the thresholds ([slack thread](https://cq-dev.slack.com/archives/C05A45JBP9N/p1750161326304269)), this PR 
- removes the existing thresholds
- sorts the pages by overall traffic and earned traffic, creates a percentileScore to sort the high overall and earned traffic pages to the top
- Returns top 10 pages as high-organic-low-ctr opportunity
- This will guarantee that we'll always have 10 high impact pages based on the traffic to generate the content




