### PR TITLE
fix sqs submission of scrape job

### DIFF
--- a/packages/spacecat-shared-scrape-client/src/clients/scrape-job-supervisor.js
+++ b/packages/spacecat-shared-scrape-client/src/clients/scrape-job-supervisor.js
@@ -148,7 +148,7 @@ function ScrapeJobSupervisor(services, config) {
     const message = {
       processingType,
       jobId: scrapeJob.getId(),
-      urls,
+      urls: urls.map((url) => ({ url })),
       customHeaders,
       options,
     };

--- a/packages/spacecat-shared-scrape-client/test/index.test.js
+++ b/packages/spacecat-shared-scrape-client/test/index.test.js
@@ -355,6 +355,7 @@ describe('ScrapeJobController tests', () => {
         // (we only send a single message now, instead of 1 per URL)
         expect(mockSqsClient.sendMessage).to.have.been.calledOnce;
         const firstCall = mockSqsClient.sendMessage.getCall(0);
+        expect(firstCall.args[1].urls).to.deep.equal(urls.map((url) => ({ url })));
         expect(firstCall.args[1].customHeaders).to.deep.equal({ Authorization: 'Bearer aXsPb3183G' });
       } catch (err) {
         assert.fail(err);


### PR DESCRIPTION
The scraper SQS queue expects an array of objects with a property `url`, like `[{url: 'https://example.com'}]`. Currently the scrape job supervisor is simply submitting an array of strings.

The effect of this is that the [spacecat api to start a new scrape job](https://opensource.adobe.com/spacecat-api-service/#tag/scrape/operation/createScrapeJob) fails because the scraper tries to extract the url property from a string. See screenshot.

See an example message in the scraper here: https://github.com/adobe/spacecat-content-scraper/blob/main/test/run-sqs.test.js#L268

@danieljchuser since you wrote this file, could you help me validate and test? I'm not sure how I can test this eg. by making the spacecat API use the PR version of this library?



![Screenshot 2025-07-02 at 10 55 40](https://github.com/user-attachments/assets/3560f829-f8bc-42e3-a625-01a993486834)
