### PR TITLE
fix: Update shared-data schema to include 'da' type in options

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/import-job/import-job.model.js
+++ b/packages/spacecat-shared-data-access/src/models/import-job/import-job.model.js
@@ -54,6 +54,7 @@ class ImportJob extends BaseModel {
   static ImportOptionTypes = {
     DOC: 'doc',
     XWALK: 'xwalk',
+    DA: 'da',
   };
 
   // add your custom methods or overrides here

--- a/packages/spacecat-shared-data-access/test/it/import-job/import-job.test.js
+++ b/packages/spacecat-shared-data-access/test/it/import-job/import-job.test.js
@@ -101,6 +101,13 @@ describe('ImportJob IT', async () => {
     checkImportJob(importJob);
     expect(importJob.getOptions()).to.eql({ type: 'doc' });
 
+    // Add test for da type
+    data = { ...newJobData, options: { type: 'da' } };
+    importJob = await ImportJob.create(data);
+
+    checkImportJob(importJob);
+    expect(importJob.getOptions()).to.eql({ type: 'da' });
+
     // test to make sure data error is thrown if data is not an object
     data = { ...newJobData, options: { data: 'not-an-object' } };
     await ImportJob.create(data).catch((err) => {


### PR DESCRIPTION
To include support for da imports, we need to define type property in our options field. The value for type can either be 'xwalk' or 'doc' or 'da'. The schema needs to be updated to support this new property.

<img width="868" alt="Screenshot 2025-07-08 at 6 31 21 PM" src="https://github.com/user-attachments/assets/7df44017-59ab-4b00-97e8-74618fbeebd9" />

## Related Issues
* Parent issue for supporting DA import in EC : https://github.com/Adobe-AEM-Foundation/site-transfer-agent-import/issues/59
