### PR TITLE
fix: external site ID indexes for crosswalk authorType

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/site.model.js
+++ b/packages/spacecat-shared-data-access/src/models/site/site.model.js
@@ -33,7 +33,7 @@ export const computeExternalIds = (attrs, authoringTypes) => {
   }
 
   if (deliveryConfig
-    && (authoringType === authoringTypes.CS || authoringType === authoringTypes.CW)) {
+    && (authoringType === authoringTypes.CS || authoringType === authoringTypes.CS_CW)) {
     const { programId, environmentId } = deliveryConfig;
 
     return {

--- a/packages/spacecat-shared-data-access/test/unit/models/site/site.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/site.model.test.js
@@ -116,6 +116,23 @@ describe('SiteModel', () => {
       });
     });
 
+    it('computes external IDs for crosswalk authoring type with correct delivery config', () => {
+      const attrs = {
+        authoringType: Site.AUTHORING_TYPES.CS_CW,
+        deliveryConfig: {
+          programId: '12345',
+          environmentId: '67890',
+        },
+      };
+
+      const result = computeExternalIds(attrs, Site.AUTHORING_TYPES);
+
+      expect(result).to.deep.equal({
+        externalOwnerId: 'p12345',
+        externalSiteId: 'e67890',
+      });
+    });
+
     it('computes external IDs for cloud service authoring type with missing delivery config', () => {
       const attrs = {
         authoringType: Site.AUTHORING_TYPES.CS,


### PR DESCRIPTION
Fixes a bug where the indexes are not correctly computed for the authoring type crosswalk