### PR TITLE
feat: introduce isSandbox flag for sandbox sites

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/site/index.d.ts
@@ -137,6 +137,7 @@ export interface Site extends BaseModel {
   getHlxConfig(): HlxConfig;
   getDeliveryConfig(): object;
   getIsLive(): boolean;
+  getIsSandbox(): boolean;
   getIsLiveToggledAt(): string;
   getKeyEvents(): Promise<KeyEvent[]>
   getKeyEventsByTimestamp(timestamp: string): Promise<KeyEvent[]>
@@ -164,6 +165,7 @@ export interface Site extends BaseModel {
   setHlxConfig(hlxConfig: HlxConfig): Site;
   setDeliveryConfig(deliveryConfig: object): Site;
   setIsLive(isLive: boolean): Site;
+  setIsSandbox(isSandbox: boolean): Site;
   setIsLiveToggledAt(isLiveToggledAt: string): Site;
   setOrganizationId(organizationId: string): Site;
   toggleLive(): Site;

--- a/packages/spacecat-shared-data-access/src/models/site/site.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/site/site.schema.js
@@ -87,6 +87,10 @@ const schema = new SchemaBuilder(Site, SiteCollection)
     default: {},
     validate: (value) => isObject(value),
   })
+  .addAttribute('isSandbox', {
+    type: 'boolean',
+    default: false,
+  })
   .addAttribute('isLive', {
     type: 'boolean',
     required: true,

--- a/packages/spacecat-shared-data-access/test/fixtures/sites.fixture.js
+++ b/packages/spacecat-shared-data-access/test/fixtures/sites.fixture.js
@@ -20,6 +20,7 @@ const sites = [
     gitHubURL: 'https://github.com/org-0/test-repo',
     organizationId: '4854e75e-894b-4a74-92bf-d674abad1423',
     isLive: true,
+    isSandbox: false,
     isLiveToggledAt: '2024-11-29T07:45:55.952Z',
     GSI1PK: 'ALL_SITES',
     config: {
@@ -74,6 +75,7 @@ const sites = [
     gitHubURL: 'https://github.com/org-1/test-repo',
     organizationId: '757ceb98-05c8-4e07-bb23-bc722115b2b0',
     isLive: true,
+    isSandbox: false,
     isLiveToggledAt: '2024-11-29T07:45:55.952Z',
     GSI1PK: 'ALL_SITES',
     createdAt: '2024-11-29T07:45:55.952Z',
@@ -156,6 +158,7 @@ const sites = [
     gitHubURL: 'https://github.com/org-3/test-repo',
     organizationId: '4854e75e-894b-4a74-92bf-d674abad1423',
     isLive: true,
+    isSandbox: true,
     isLiveToggledAt: '2024-11-29T07:45:55.952Z',
     GSI1PK: 'ALL_SITES',
     createdAt: '2024-11-29T07:45:55.952Z',

--- a/packages/spacecat-shared-data-access/test/unit/models/site/site.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/site.model.test.js
@@ -274,6 +274,22 @@ describe('SiteModel', () => {
     });
   });
 
+  describe('isSandbox', () => {
+    it('gets isSandbox with default value', () => {
+      expect(instance.getIsSandbox()).to.equal(false);
+    });
+
+    it('sets isSandbox to true', () => {
+      instance.setIsSandbox(true);
+      expect(instance.getIsSandbox()).to.equal(true);
+    });
+
+    it('sets isSandbox to false', () => {
+      instance.setIsSandbox(false);
+      expect(instance.getIsSandbox()).to.equal(false);
+    });
+  });
+
   describe('isLiveToggledAt', () => {
     it('gets isLiveToggledAt', () => {
       expect(instance.getIsLiveToggledAt()).to.equal('2024-11-29T07:45:55.952Z');


### PR DESCRIPTION
For Sandboxing efforts, we required to have a site config which can help us to know if a site is sandbox or not, which will help in updating the UI accordingly for those sites.