### PR TITLE
fix: return provided data when config error

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -258,22 +258,22 @@ export function validateConfiguration(config) {
 }
 
 export const Config = (data = {}) => {
-  let validConfig;
+  let configData;
 
   try {
-    validConfig = validateConfiguration(data);
+    configData = validateConfiguration(data);
   } catch (error) {
     const logger = getLogger();
     if (logger && logger !== console) {
-      logger.error('Site configuration validation failed, using default config', {
+      logger.error('Site configuration validation failed, using provided data', {
         error: error.message,
         invalidConfig: data,
       });
     }
-    validConfig = { ...DEFAULT_CONFIG };
+    configData = { ...data };
   }
 
-  const state = { ...validConfig };
+  const state = { ...configData };
   const self = { state };
   self.getSlackConfig = () => state.slack;
   self.isInternalCustomer = () => state?.slack?.workspace === 'internal';


### PR DESCRIPTION
Return provided data when config error instead of default config