### PR TITLE
(scrape-job-supervisor): add offset for URL numbering in batches

### DIFF
--- a/packages/spacecat-shared-scrape-client/src/clients/scrape-job-supervisor.js
+++ b/packages/spacecat-shared-scrape-client/src/clients/scrape-job-supervisor.js
@@ -173,11 +173,14 @@ function ScrapeJobSupervisor(services, config) {
       urlBatches = [urls]; // Wrap in an array to maintain consistent structure
     }
 
-    for (const batch of urlBatches) {
+    for (const [index, batch] of urlBatches.entries()) {
+      // Calculate the offset for numbering the URLs in the batch
+      const offset = index * maxUrlsPerMessage;
       const message = {
         processingType,
         jobId: scrapeJob.getId(),
         batch,
+        batchOffset: offset,
         customHeaders,
         options,
       };


### PR DESCRIPTION
- added calculation for the offset of url numbers and added it to the message
- single messages will also have an offset of 0 for better compatibility
