### PR TITLE
feat: amend llmo config with URL patterns

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -37,19 +37,31 @@ export const IMPORT_SOURCES = {
   RUM: 'rum',
 };
 
+const LLMO_TAG_PATTERN = /^(market|product|topic):\s?.+/;
+const LLMO_TAG = Joi.alternatives()
+  .try(
+    // Tag market, product, topic like this: "market: ch", "product: firefly", "topic: copyright"
+    Joi.string().pattern(LLMO_TAG_PATTERN),
+    Joi.string(),
+  );
+
 // LLMO question schema for both Human and AI questions
 const QUESTION_SCHEMA = Joi.object({
   key: Joi.string().required(),
   question: Joi.string().required(),
   source: Joi.string().optional(),
-  country: Joi.string().optional(),
-  product: Joi.string().optional(),
   volume: Joi.string().optional(),
   keyword: Joi.string().optional(),
   url: Joi.string().uri().optional(),
-  tags: Joi.array().items(Joi.string()).optional(),
+  tags: Joi.array().items(LLMO_TAG).optional(),
   importTime: Joi.string().isoDate().optional(),
 });
+
+const LLMO_URL_PATTERN_SCHEMA = {
+  urlPattern: Joi.string().uri().required(),
+  tags: Joi.array().items(LLMO_TAG).optional(),
+};
+const LLMO_URL_PATTERNS_SCHEMA = Joi.array().items(LLMO_URL_PATTERN_SCHEMA);
 
 const IMPORT_BASE_KEYS = {
   destinations: Joi.array().items(Joi.string().valid(IMPORT_DESTINATIONS.DEFAULT)).required(),
@@ -222,6 +234,7 @@ export const configSchema = Joi.object({
       Human: Joi.array().items(QUESTION_SCHEMA).optional(),
       AI: Joi.array().items(QUESTION_SCHEMA).optional(),
     }).optional(),
+    urlPatterns: LLMO_URL_PATTERNS_SCHEMA.optional(),
   }).optional(),
   cdnLogsConfig: Joi.object({
     bucketName: Joi.string().required(),
@@ -279,6 +292,20 @@ export function validateConfiguration(config) {
   return value; // Validated and sanitized configuration
 }
 
+export function extractWellKnownTags(tags) {
+  const wellKnownTags = {};
+  for (const tag of tags) {
+    if (LLMO_TAG_PATTERN.test(tag)) {
+      const colonIdx = tag.indexOf(':');
+      const value = tag.slice(colonIdx + 1).trim();
+      if (colonIdx !== -1 && value) {
+        wellKnownTags[tag.slice(0, colonIdx).trim()] = value;
+      }
+    }
+  }
+  return wellKnownTags;
+}
+
 export const Config = (data = {}) => {
   let configData;
 
@@ -296,7 +323,7 @@ export const Config = (data = {}) => {
   }
 
   const state = { ...configData };
-  const self = { state };
+  const self = { state, extractWellKnownTags };
   self.getSlackConfig = () => state.slack;
   self.isInternalCustomer = () => state?.slack?.workspace === 'internal';
   self.getSlackMentions = (type) => state?.handlers?.[type]?.mentions?.slack;
@@ -318,6 +345,7 @@ export const Config = (data = {}) => {
   self.getLlmoBrand = () => state?.llmo?.brand;
   self.getLlmoHumanQuestions = () => state?.llmo?.questions?.Human;
   self.getLlmoAIQuestions = () => state?.llmo?.questions?.AI;
+  self.getLlmoUrlPatterns = () => state?.llmo?.urlPatterns;
 
   self.updateSlackConfig = (channel, workspace, invitedUserCount) => {
     state.slack = {
@@ -327,11 +355,12 @@ export const Config = (data = {}) => {
     };
   };
 
-  self.updateLlmoConfig = (dataFolder, brand, questions) => {
+  self.updateLlmoConfig = (dataFolder, brand, questions = {}, urlPatterns = undefined) => {
     state.llmo = {
       dataFolder,
       brand,
-      ...(questions !== undefined ? { questions } : {}),
+      questions,
+      urlPatterns,
     };
   };
 
@@ -382,6 +411,36 @@ export const Config = (data = {}) => {
     state.llmo.questions.AI = state.llmo.questions.AI || [];
     state.llmo.questions.AI = state.llmo.questions.AI.map(
       (question) => (question.key === key ? { ...question, ...questionUpdate, key } : question),
+    );
+  };
+
+  self.addLlmoUrlPatterns = (urlPatterns) => {
+    Joi.assert(urlPatterns, LLMO_URL_PATTERNS_SCHEMA, 'Invalid URL patterns');
+
+    state.llmo ??= {};
+    state.llmo.urlPatterns ??= [];
+    const byPattern = new Map(
+      state.llmo.urlPatterns.map((p) => [p.urlPattern, p]),
+    );
+    for (const p of urlPatterns) {
+      byPattern.set(p.urlPattern, p);
+    }
+
+    state.llmo.urlPatterns = [...byPattern.values()];
+  };
+
+  self.replaceLlmoUrlPatterns = (urlPatterns) => {
+    Joi.assert(urlPatterns, LLMO_URL_PATTERNS_SCHEMA, 'Invalid URL patterns');
+    state.llmo ??= {};
+    state.llmo.urlPatterns = urlPatterns;
+  };
+
+  self.removeLlmoUrlPattern = (urlPattern) => {
+    const urlPatterns = state.llmo?.urlPatterns;
+    if (!urlPatterns) return;
+
+    state.llmo.urlPatterns = urlPatterns.filter(
+      (pattern) => pattern.urlPattern !== urlPattern,
     );
   };
 

--- a/packages/spacecat-shared-data-access/src/models/site/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/site/index.d.ts
@@ -21,7 +21,7 @@ import type {
   Organization,
   SiteCandidate,
   SiteTopPage,
-} from '../index';
+} from '../index.js';
 
 export interface HlxConfig {
   hlxVersion: number; // helix (AEM Edge Delivery) major version
@@ -61,17 +61,23 @@ export interface ImportConfig {
   limit?: number;
 }
 
+export type WellKnownLmmoTag = 'market' | 'product' | 'topic';
+export type LmmoTag = `${WellKnownLmmoTag}:${string}` | string;
+
 export interface LlmoQuestion {
   key: string;
   question: string;
   source?: string;
-  country?: string;
-  product?: string;
   volume?: string;
   importTime?: string;
   keyword?: string;
   url?: string;
-  tags?: string[];
+  tags?: LmmoTag[];
+}
+
+export interface LlmoUrlPattern {
+  urlPattern: string;
+  tags?: LmmoTag[];
 }
 
 export interface SiteConfig {
@@ -117,8 +123,10 @@ export interface SiteConfig {
         Human?: Array<LlmoQuestion>;
         AI?: Array<LlmoQuestion>;
       };
+      urlPatterns?: Array<LlmoUrlPattern>
     };
   };
+  extractWellKnownTags(tags: Array<string>): Partial<Record<WellKnownLmmoTag, string>>;
   getSlackConfig(): { workspace?: string; channel?: string; invitedUserCount?: number };
   getImports(): ImportConfig[];
   getImportConfig(type: ImportType): ImportConfig | undefined;
@@ -145,17 +153,20 @@ export interface SiteConfig {
   updateLlmoConfig(dataFolder: string, brand: string, questions?: {
     Human?: Array<LlmoQuestion>;
     AI?: Array<LlmoQuestion>;
-  }): void;
+  }, urlPatterns?: Array<LlmoUrlPattern>): void;
   updateLlmoDataFolder(dataFolder: string): void;
   updateLlmoBrand(brand: string): void;
   getLlmoDataFolder(): string | undefined;
   getLlmoBrand(): string | undefined;
   getLlmoHumanQuestions(): LlmoQuestion[] | undefined;
   getLlmoAIQuestions(): LlmoQuestion[] | undefined;
+  getLlmoUrlPatterns(): Array<LlmoUrlPattern> | undefined;
   addLlmoHumanQuestions(questions: LlmoQuestion[]): void;
   addLlmoAIQuestions(questions: LlmoQuestion[]): void;
   removeLlmoQuestion(key: string): void;
   updateLlmoQuestion(key: string, questionUpdate: Partial<LlmoQuestion>): void;
+  addLlmoUrlPatterns(urlPatterns: Array<LlmoUrlPattern>): void;
+  removeLlmoUrlPattern(urlPattern: string): void;
 }
 
 export interface Site extends BaseModel {


### PR DESCRIPTION
Summary:
- introduces LLMO URL patterns
- removes `country` and `product` fields from LLMO questions
- replaces these with "well known tags" and adds extraction logic

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
- https://jira.corp.adobe.com/browse/LLMO-19
- https://jira.corp.adobe.com/browse/LLMO-94


Thanks for contributing!
