### PR TITLE
Add `'never'` to job intervals

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/configuration/configuration.model.js
+++ b/packages/spacecat-shared-data-access/src/models/configuration/configuration.model.js
@@ -31,6 +31,7 @@ class Configuration extends BaseModel {
   };
 
   static JOB_INTERVALS = {
+    NEVER: 'never', // allows to enable imports without scheduling them
     EVERY_HOUR: 'every-hour',
     DAILY: 'daily',
     WEEKLY: 'weekly',


### PR DESCRIPTION
Add `'never'` as a valid value for job intervals.

This enables activating imports for sites without ever having them scheduled by `spacecat-job-dispatcher`.

That's useful for imports that are invoked manually via the `@spacecat` bot or triggered by audits.

For ahrefs-based imports specifically, this is meant to drive down the consumption of Ahrefs API Units.

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues

https://jira.corp.adobe.com/browse/LLMO-186
