### PR TITLE
feat: Add `'never'` to job intervals (#885)

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
+++ b/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
@@ -97,6 +97,7 @@ class Audit extends BaseModel {
        * @param {string} stepResult.pageUrl - The page URL for which the import is triggered.
        * @param {object[]} stepResult.urlConfigs - The list of URL configs for which the import is
        * triggered.
+       * @param {bool} stepResult.skipEnabledCheck - Skip the enabled check when running the import.
        * @param {object} auditContext - The audit context.
        * @param {object} auditContext.next - The next audit step to run.
        * @param {string} auditContext.auditId - The audit ID.
@@ -112,6 +113,7 @@ class Audit extends BaseModel {
         siteId: stepResult.siteId,
         pageUrl: stepResult.pageUrl,
         urlConfigs: stepResult.urlConfigs,
+        skipEnabledCheck: !!stepResult.skipEnabledCheck,
         allowCache: true,
         auditContext,
       }),

--- a/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
+++ b/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
@@ -97,7 +97,6 @@ class Audit extends BaseModel {
        * @param {string} stepResult.pageUrl - The page URL for which the import is triggered.
        * @param {object[]} stepResult.urlConfigs - The list of URL configs for which the import is
        * triggered.
-       * @param {bool} stepResult.skipEnabledCheck - Skip the enabled check when running the import.
        * @param {object} auditContext - The audit context.
        * @param {object} auditContext.next - The next audit step to run.
        * @param {string} auditContext.auditId - The audit ID.
@@ -113,7 +112,6 @@ class Audit extends BaseModel {
         siteId: stepResult.siteId,
         pageUrl: stepResult.pageUrl,
         urlConfigs: stepResult.urlConfigs,
-        skipEnabledCheck: !!stepResult.skipEnabledCheck,
         allowCache: true,
         auditContext,
       }),

--- a/packages/spacecat-shared-data-access/src/models/configuration/configuration.model.js
+++ b/packages/spacecat-shared-data-access/src/models/configuration/configuration.model.js
@@ -31,7 +31,7 @@ class Configuration extends BaseModel {
   };
 
   static JOB_INTERVALS = {
-    NEVER: 'never', // allows to enable imports without scheduling them
+    NEVER: 'never', // allows to enable imports without scheduling them.
     EVERY_HOUR: 'every-hour',
     DAILY: 'daily',
     WEEKLY: 'weekly',


### PR DESCRIPTION
Add `'never'` as a valid value for job intervals.

This enables activating imports for sites without ever having them scheduled by `spacecat-job-dispatcher`.

That's useful for imports that are invoked manually via the `@spacecat` bot or triggered by audits.

For ahrefs-based imports specifically, this is meant to drive down the consumption of Ahrefs API Units.

## Related Issues

https://jira.corp.adobe.com/browse/LLMO-186

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
