### PR TITLE
fix: Change the log level from info to debug

### DIFF
--- a/packages/spacecat-shared-http-utils/src/auth/handlers/scoped-api-key.js
+++ b/packages/spacecat-shared-http-utils/src/auth/handlers/scoped-api-key.js
@@ -42,7 +42,7 @@ export default class ScopedApiKeyHandler extends AbstractHandler {
     const apiKeyEntity = await ApiKey.findByHashedApiKey(hashedApiKey);
 
     if (!apiKeyEntity) {
-      this.log(`No API key entity found in the data layer for the provided API key: ${apiKeyFromHeader}`, 'error');
+      this.log(`No API key entity found in the data layer for the provided API key: ${apiKeyFromHeader}`, 'debug');
       return null;
     }
     this.log(`Valid API key entity found. Id: ${apiKeyEntity.getId()}, name: ${apiKeyEntity.getName()}, scopes: ${apiKeyEntity.getScopes()}`, 'debug');


### PR DESCRIPTION
The log `No API key entity found in the data layer for the provided API key: ${apiKeyFromHeader}` gets printed repeatedly for any authentication request that fails to authenticate with the ScopedApiKeyHandler.
This causes a lot of polluted logs in coralogix.
Changing the log level to Debug.

