### PR TITLE
fix: make max opportunities configurable

### DIFF
--- a/packages/spacecat-shared-rum-api-client/README.md
+++ b/packages/spacecat-shared-rum-api-client/README.md
@@ -335,7 +335,13 @@ Calculates the amount of inorganic traffic and the bounce rate for each page. Id
 
 ### high-organic-low-ctr (Experimentation Opportunity)
 
-Calculates the amount of non-inorganic (earned and owned) traffic and the click-through rate for each page and vendor. Identifies pages with high non-inorganic traffic and low click-through rates, which can be targeted for future experimentation opportunities. An example payload is provided below:
+Calculates the amount of non-inorganic (earned and owned) traffic and the click-through rate for each page and vendor. Identifies pages with high non-inorganic traffic and low click-through rates, which can be targeted for future experimentation opportunities. 
+
+#### options supported
+- **maxOpportunities** - No. of maximum opportunities to return, defaults to 10
+
+
+An example payload is provided below:
 
 ```json
 [

--- a/packages/spacecat-shared-rum-api-client/src/functions/opportunities/high-organic-low-ctr.js
+++ b/packages/spacecat-shared-rum-api-client/src/functions/opportunities/high-organic-low-ctr.js
@@ -14,7 +14,7 @@ import trafficAcquisition from '../traffic-acquisition.js';
 import { getCTRByUrlAndVendor, getSiteAvgCTR } from '../../common/aggregateFns.js';
 
 const VENDORS_TO_CONSIDER = 5;
-const MAX_OPPORTUNITIES = 10;
+const DEFAULT_MAX_OPPORTUNITIES = 10;
 
 const MAIN_TYPES = ['paid', 'earned', 'owned'];
 
@@ -133,13 +133,13 @@ function sortPagesByEarnedAndOverallTraffic(pages) {
   return percentiles.sort((a, b) => b.percentileScore - a.percentileScore);
 }
 
-function handler(bundles) {
+function handler(bundles, opts) {
   const trafficByUrl = trafficAcquisition.handler(bundles);
   const ctrByUrlAndVendor = getCTRByUrlAndVendor(bundles);
   const siteAvgCTR = getSiteAvgCTR(bundles);
   const pagesSortedByEarnedAndOverallTraffic = sortPagesByEarnedAndOverallTraffic(
     trafficByUrl,
-  ).slice(0, MAX_OPPORTUNITIES);
+  ).slice(0, opts.maxOpportunities || DEFAULT_MAX_OPPORTUNITIES);
 
   return pagesSortedByEarnedAndOverallTraffic.map((traffic) => ({
     ...traffic,

--- a/packages/spacecat-shared-rum-api-client/src/functions/opportunities/high-organic-low-ctr.js
+++ b/packages/spacecat-shared-rum-api-client/src/functions/opportunities/high-organic-low-ctr.js
@@ -139,7 +139,7 @@ function handler(bundles, opts) {
   const siteAvgCTR = getSiteAvgCTR(bundles);
   const pagesSortedByEarnedAndOverallTraffic = sortPagesByEarnedAndOverallTraffic(
     trafficByUrl,
-  ).slice(0, opts.maxOpportunities || DEFAULT_MAX_OPPORTUNITIES);
+  ).slice(0, opts?.maxOpportunities || DEFAULT_MAX_OPPORTUNITIES);
 
   return pagesSortedByEarnedAndOverallTraffic.map((traffic) => ({
     ...traffic,

--- a/packages/spacecat-shared-rum-api-client/test/functions.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/functions.test.js
@@ -78,13 +78,21 @@ describe('Query functions', () => {
   });
 
   it('crunches oppty/high-organic-low-ctr', async () => {
-    let highOrganicHighBounceResult = highOrganicLowCTR.handler(
+    let highOrganicLowCtrResult = highOrganicLowCTR.handler(
       bundlesWithTraffic.rumBundles,
       { interval: 7 },
     );
-    expect(highOrganicHighBounceResult).to.eql(expectedHighOrganicLowCTRResult);
-    highOrganicHighBounceResult = highOrganicLowCTR.handler([], { interval: 7 });
-    expect(highOrganicHighBounceResult).to.eql([]);
+    expect(highOrganicLowCtrResult).to.eql(expectedHighOrganicLowCTRResult);
+    highOrganicLowCtrResult = highOrganicLowCTR.handler([], { interval: 7 });
+    expect(highOrganicLowCtrResult).to.eql([]);
+  });
+
+  it('high-organic-low-ctr returns max opportunities if configured', async () => {
+    const highOrganicLowCtrResult = highOrganicLowCTR.handler(
+      bundlesWithTraffic.rumBundles,
+      { interval: 7, maxOpportunities: 1 },
+    );
+    expect(highOrganicLowCtrResult).to.eql(expectedHighOrganicLowCTRResult.slice(0, 1));
   });
 
   it('crunches pageviews', async () => {


### PR DESCRIPTION
Making maximum opportunities returned configurable using handler `options`

Required for https://github.com/adobe/spacecat-audit-worker/pull/1086