### PR TITLE
Fixes the apiBaseUrl example in the Splunk client README

### DIFF
--- a/packages/spacecat-shared-splunk-client/README.md
+++ b/packages/spacecat-shared-splunk-client/README.md
@@ -22,7 +22,7 @@ npm install @adobe/spacecat-shared-splunk-client
 import SplunkAPIClient, { fetch } from '@adobe/spacecat-shared-splunk-client';
 
 const config = {
-  apiBaseUrl: 'SPLUNK_API_BASE_URL>',
+  apiBaseUrl: 'SPLUNK_API_BASE_URL',
   apiUser: 'SPLUNK_API_USER',
   apiPass: 'SPLUNK_API_PASS',
 };


### PR DESCRIPTION
Fixes a typo in the shared Splunk client README.