### PR TITLE
fix: Update entitlement.schema.js for consume numbers

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/entitlement/entitlement.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/entitlement/entitlement.schema.js
@@ -39,6 +39,7 @@ const schema = new SchemaBuilder(Entitlement, EntitlementCollection)
     required: false,
     properties: {
       llmo_trial_prompts: { type: 'number' },
+      llmo_trial_prompts_consumed: { type: 'number' },
     },
   })
   .addIndex(


### PR DESCRIPTION
@herzog31 I have tried to save `llmo_trial_prompts_consumed`  it without adding it in schema , but didn't work out may because it's a `map` not `any`

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
