### PR TITLE
[WIP]feat: make fetchAllPages=true default to prevent data truncation

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/base/base.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/base/base.collection.js
@@ -252,9 +252,11 @@ class BaseCollection {
       let result = await query.go(queryOptions);
       let allData = result.data;
 
-      // if the caller requests ALL pages and we're not using limit: 1,
-      // continue to fetch until there is no cursor.
-      if (options.fetchAllPages && options.limit !== 1) {
+      // By default, fetch ALL pages unless explicitly disabled or using limit: 1
+      // This ensures complete data retrieval to prevent truncation issues
+      const shouldFetchAllPages = options.fetchAllPages !== false && options.limit !== 1;
+
+      if (shouldFetchAllPages) {
         while (result.cursor) {
           queryOptions.cursor = result.cursor;
           // eslint-disable-next-line no-await-in-loop

--- a/packages/spacecat-shared-data-access/src/models/base/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/base/index.d.ts
@@ -34,6 +34,11 @@ export interface QueryOptions {
   limit?: number;
   order?: string;
   attributes?: string[];
+  /** 
+   * Whether to automatically fetch all pages of results. Defaults to true.
+   * Set to false to only fetch the first page (for performance optimization).
+   */
+  fetchAllPages?: boolean;
 }
 
 export interface BaseCollection<T extends BaseModel> {


### PR DESCRIPTION
- Changed BaseCollection to fetch all DynamoDB pages by default
- Prevents truncation issues when data exceeds 1MB query limit
- Added fetchAllPages option to QueryOptions interface with default true
- Added comprehensive tests for default and opt-out behavior
- Implements system-wide fix as per wiki recommendation (Option 1)

This addresses the Suggestion API pagination bug and applies the fix globally to prevent similar issues across all endpoints.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
