### PR TITLE
fix(tier-client): retrieve org ID via site object

### DIFF
--- a/packages/spacecat-shared-tier-client/src/tier-client.js
+++ b/packages/spacecat-shared-tier-client/src/tier-client.js
@@ -102,7 +102,7 @@ class TierClient {
    */
   async checkValidEntitlement() {
     try {
-      const orgId = this.organization.getId();
+      const orgId = this.site ? this.site.getOrganizationId() : this.organization.getId();
       this.log.info(`Checking for valid entitlement for org ${orgId} and product ${this.productCode}`);
 
       const entitlement = await this.Entitlement
@@ -162,7 +162,7 @@ class TierClient {
         throw new Error('Site required for creating entitlements');
       }
 
-      const orgId = this.organization.getId();
+      const orgId = this.site.getOrganizationId();
       const siteId = this.site.getId();
       this.log.info(`Creating entitlement for org ${orgId}, site ${siteId}, product ${this.productCode}, tier ${tier}`);
 

--- a/packages/spacecat-shared-tier-client/test/tier-client.test.js
+++ b/packages/spacecat-shared-tier-client/test/tier-client.test.js
@@ -56,6 +56,7 @@ describe('TierClient', () => {
     getId: () => siteId,
     getName: () => 'Test Site',
     getOrganization: () => organizationInstance,
+    getOrganizationId: () => orgId,
   };
 
   // Create actual Site instance for instanceof checks
@@ -260,7 +261,7 @@ describe('TierClient', () => {
     });
 
     it('should return only entitlement when no site is provided', async () => {
-      // Create a TierClient without site
+      // Create TierClient with null site to test the else branch
       const tierClientWithoutSite = new TierClient(
         mockContext,
         organizationInstance,


### PR DESCRIPTION
Workaround fix to make sure the up-to-date org ID is fetched.