### PR TITLE
Add new sec audit types

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
+++ b/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
@@ -53,6 +53,7 @@ class Audit extends BaseModel {
     SECURITY_CSP: 'security-csp',
     SECURITY_VULNERABILITIES: 'security-vulnerabilities',
     SECURITY_PERMISSIONS: 'security-permissions',
+    SECURITY_REDUNDANT: 'security-permissions-redundant',
     PAID: 'paid',
     HREFLANG: 'hreflang',
     HEADINGS: 'headings',

--- a/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
@@ -180,6 +180,7 @@ describe('AuditModel', () => {
       SECURITY_CSP: 'security-csp',
       SECURITY_VULNERABILITIES: 'security-vulnerabilities',
       SECURITY_PERMISSIONS: 'security-permissions',
+      SECURITY_REDUNDANT: 'security-permissions-redundant',
       PAID: 'paid',
       HREFLANG: 'hreflang',
       HEADINGS: 'headings',
@@ -192,7 +193,7 @@ describe('AuditModel', () => {
 
     it('should have all audit types present in AUDIT_TYPES', () => {
       expect(auditTypes).to.eql(expectedAuditTypes);
-      expect(Object.keys(auditTypes)).to.have.lengthOf(37);
+      expect(Object.keys(auditTypes)).to.have.lengthOf(38);
     });
 
     it('should not have unexpected audit types in AUDIT_TYPES', () => {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
Created a new audit security type to diferentiate between the security permission scan and the administrator redundant permissions. 

Thanks for contributing!
