### PR TITLE
feat (SITES-39993): Add read-only Google Search Console API methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20239,7 +20239,7 @@
     },
     "packages/spacecat-shared-ahrefs-client": {
       "name": "@adobe/spacecat-shared-ahrefs-client",
-      "version": "1.10.4",
+      "version": "1.10.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.3",
@@ -20330,7 +20330,7 @@
     },
     "packages/spacecat-shared-brand-client": {
       "name": "@adobe/spacecat-shared-brand-client",
-      "version": "1.1.34",
+      "version": "1.1.35",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.0",
@@ -20427,7 +20427,7 @@
     },
     "packages/spacecat-shared-content-client": {
       "name": "@adobe/spacecat-shared-content-client",
-      "version": "1.8.13",
+      "version": "1.8.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.0",
@@ -20498,7 +20498,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "2.97.2",
+      "version": "2.100.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.81.1",
@@ -20550,7 +20550,7 @@
     },
     "packages/spacecat-shared-example": {
       "name": "@adobe/spacecat-shared-example",
-      "version": "1.2.32",
+      "version": "1.2.33",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.3",
@@ -20566,7 +20566,7 @@
     },
     "packages/spacecat-shared-google-client": {
       "name": "@adobe/spacecat-shared-google-client",
-      "version": "1.4.62",
+      "version": "1.4.63",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.3",
@@ -20653,7 +20653,7 @@
     },
     "packages/spacecat-shared-gpt-client": {
       "name": "@adobe/spacecat-shared-gpt-client",
-      "version": "1.6.15",
+      "version": "1.6.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.3",
@@ -20848,7 +20848,7 @@
     },
     "packages/spacecat-shared-ims-client": {
       "name": "@adobe/spacecat-shared-ims-client",
-      "version": "1.11.8",
+      "version": "1.11.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.3",
@@ -20917,7 +20917,7 @@
     },
     "packages/spacecat-shared-rum-api-client": {
       "name": "@adobe/spacecat-shared-rum-api-client",
-      "version": "2.40.5",
+      "version": "2.40.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.3",
@@ -20967,7 +20967,7 @@
     },
     "packages/spacecat-shared-scrape-client": {
       "name": "@adobe/spacecat-shared-scrape-client",
-      "version": "2.3.6",
+      "version": "2.3.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.0",
@@ -21033,7 +21033,7 @@
     },
     "packages/spacecat-shared-slack-client": {
       "name": "@adobe/spacecat-shared-slack-client",
-      "version": "1.5.32",
+      "version": "1.5.33",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.0",
@@ -21080,7 +21080,7 @@
     },
     "packages/spacecat-shared-splunk-client": {
       "name": "@adobe/spacecat-shared-splunk-client",
-      "version": "1.0.29",
+      "version": "1.0.30",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.3",
@@ -21194,7 +21194,7 @@
     },
     "packages/spacecat-shared-tokowaka-client": {
       "name": "@adobe/spacecat-shared-tokowaka-client",
-      "version": "1.5.8",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.81.1",

--- a/packages/spacecat-shared-google-client/src/index.d.ts
+++ b/packages/spacecat-shared-google-client/src/index.d.ts
@@ -87,4 +87,65 @@ export default class GoogleClient {
    *}
    * */
   listSites(): Promise<JSON>;
+
+  /**
+   * Retrieves information about a specific site in Google Search Console.
+   *
+   * @param {string} siteUrl - The URL of the site to retrieve information for.
+   * @returns {Promise<JSON>} A promise that resolves to the site information.
+   * @throws {Error} If an error occurs while retrieving the site information.
+   * Format: {
+   *  "data": {
+   *    "siteUrl": string,
+   *    "permissionLevel": string
+   *  }
+   *}
+   * */
+  getSite(siteUrl: string): Promise<JSON>;
+
+  /**
+   * Lists all sitemaps submitted for a site in Google Search Console.
+   *
+   * @param {string} [sitemapIndex] - Optional sitemap index URL to filter results.
+   * @returns {Promise<JSON>} A promise that resolves to the list of sitemaps.
+   * @throws {Error} If an error occurs while listing the sitemaps.
+   * Format: {
+   *  "data": {
+   *    "sitemap": [
+   *      {
+   *       "path": string,
+   *       "lastSubmitted": string,
+   *       "isPending": boolean,
+   *       "isSitemapsIndex": boolean,
+   *       "type": string,
+   *       "lastDownloaded": string,
+   *       "warnings": string,
+   *       "errors": string
+   *      }
+   *    ]
+   *  }
+   *}
+   * */
+  listSitemaps(sitemapIndex?: string): Promise<JSON>;
+
+  /**
+   * Retrieves information about a specific sitemap in Google Search Console.
+   *
+   * @param {string} sitemapUrl - The URL of the sitemap to retrieve information for.
+   * @returns {Promise<JSON>} A promise that resolves to the sitemap information.
+   * @throws {Error} If an error occurs while retrieving the sitemap information.
+   * Format: {
+   *  "data": {
+   *    "path": string,
+   *    "lastSubmitted": string,
+   *    "isPending": boolean,
+   *    "isSitemapsIndex": boolean,
+   *    "type": string,
+   *    "lastDownloaded": string,
+   *    "warnings": string,
+   *    "errors": string
+   *  }
+   *}
+   * */
+  getSitemap(sitemapUrl: string): Promise<JSON>;
 }


### PR DESCRIPTION
## Summary

Extends the Google Client with additional read-only API methods from the Google Search Console API v1, completing coverage of all available read-only endpoints.

## Changes

### New Methods
- **getSite(siteUrl)** - Retrieves information about a specific site including URL and permission level
- **getSitemap(sitemapUrl)** - Retrieves detailed information about a specific sitemap including submission date, errors, and warnings
- **listSitemaps(sitemapIndex?)** - Lists all sitemaps for a site with optional sitemap index filtering

### Improvements
- Updated row limit validation for search analytics from 1,000 to 25,000 rows to match API specifications
- Added TypeScript definitions for all new methods with comprehensive JSDoc comments
- Full input validation for all parameters including URL format and domain property support

### Testing
- Added comprehensive test coverage for all new methods (36 tests total)
- Achieved 100% code coverage across statements, branches, functions, and lines
- Added edge case tests for error handling and validation

## API Coverage

All read-only methods from Google Search Console API v1 are now implemented:
- Search Analytics: query
- Sites: get, list
- Sitemaps: get, list
- URL Inspection: index.inspect