### PR TITLE
docs: add Vault migration plans, runbook, and sync scripts

### DIFF
--- a/docs/plans/2026-02-19-spacecat-infrastructure-plan.md
+++ b/docs/plans/2026-02-19-spacecat-infrastructure-plan.md
@@ -1,0 +1,390 @@
+# spacecat-infrastructure Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add per-service Vault bootstrap secret containers and IAM policy updates to support per-service AppRole credential isolation (Phase 1b of the Vault AppRole migration).
+
+**Architecture:** Create 14 empty `aws_secretsmanager_secret` resources at `/mysticat/bootstrap/{service-name}` for each core service. Expose their ARNs as module outputs. Add the `/mysticat/bootstrap/*` wildcard to three existing IAM policies so Lambda execution roles and CI/CD can read/write the new secrets. The existing `/mysticat/vault-bootstrap` secret and data-service `vault_bootstrap_secret_arn` remain unchanged.
+
+**Tech Stack:** Terraform (AWS provider), Secrets Manager, IAM
+
+---
+
+## Task 1: Create feature branch
+
+**File:** N/A (git operations)
+
+```bash
+cd /Users/dj/adobe/github/adobe/spacecat-infrastructure
+git fetch origin
+git checkout -b feat/vault-bootstrap-per-service origin/main
+```
+
+**Expected:** Clean branch from latest main.
+
+---
+
+## Task 2: Add per-service bootstrap secret resources
+
+**File:** `/Users/dj/adobe/github/adobe/spacecat-infrastructure/modules/secrets_manager/secrets.tf`
+
+Append the following after the existing `mysticat_vault_bootstrap` resource (line 82):
+
+```hcl
+# Per-service Vault AppRole bootstrap secrets
+# Empty containers - values populated manually in Phase 2 after AppRoles are provisioned
+
+resource "aws_secretsmanager_secret" "mysticat_bootstrap_api_service" {
+  name        = "/mysticat/bootstrap/api-service"
+  description = "Vault AppRole bootstrap credentials for api-service"
+}
+
+resource "aws_secretsmanager_secret" "mysticat_bootstrap_audit_worker" {
+  name        = "/mysticat/bootstrap/audit-worker"
+  description = "Vault AppRole bootstrap credentials for audit-worker"
+}
+
+resource "aws_secretsmanager_secret" "mysticat_bootstrap_reporting_worker" {
+  name        = "/mysticat/bootstrap/reporting-worker"
+  description = "Vault AppRole bootstrap credentials for reporting-worker"
+}
+
+resource "aws_secretsmanager_secret" "mysticat_bootstrap_autofix_worker" {
+  name        = "/mysticat/bootstrap/autofix-worker"
+  description = "Vault AppRole bootstrap credentials for autofix-worker"
+}
+
+resource "aws_secretsmanager_secret" "mysticat_bootstrap_jobs_dispatcher" {
+  name        = "/mysticat/bootstrap/jobs-dispatcher"
+  description = "Vault AppRole bootstrap credentials for jobs-dispatcher"
+}
+
+resource "aws_secretsmanager_secret" "mysticat_bootstrap_auth_service" {
+  name        = "/mysticat/bootstrap/auth-service"
+  description = "Vault AppRole bootstrap credentials for auth-service"
+}
+
+resource "aws_secretsmanager_secret" "mysticat_bootstrap_fulfillment_worker" {
+  name        = "/mysticat/bootstrap/fulfillment-worker"
+  description = "Vault AppRole bootstrap credentials for fulfillment-worker"
+}
+
+resource "aws_secretsmanager_secret" "mysticat_bootstrap_content_processor" {
+  name        = "/mysticat/bootstrap/content-processor"
+  description = "Vault AppRole bootstrap credentials for content-processor"
+}
+
+resource "aws_secretsmanager_secret" "mysticat_bootstrap_content_scraper" {
+  name        = "/mysticat/bootstrap/content-scraper"
+  description = "Vault AppRole bootstrap credentials for content-scraper"
+}
+
+resource "aws_secretsmanager_secret" "mysticat_bootstrap_import_worker" {
+  name        = "/mysticat/bootstrap/import-worker"
+  description = "Vault AppRole bootstrap credentials for import-worker"
+}
+
+resource "aws_secretsmanager_secret" "mysticat_bootstrap_import_job_manager" {
+  name        = "/mysticat/bootstrap/import-job-manager"
+  description = "Vault AppRole bootstrap credentials for import-job-manager"
+}
+
+resource "aws_secretsmanager_secret" "mysticat_bootstrap_coralogix_feeder" {
+  name        = "/mysticat/bootstrap/coralogix-feeder"
+  description = "Vault AppRole bootstrap credentials for coralogix-feeder"
+}
+
+resource "aws_secretsmanager_secret" "mysticat_bootstrap_task_manager" {
+  name        = "/mysticat/bootstrap/task-manager"
+  description = "Vault AppRole bootstrap credentials for task-manager"
+}
+
+resource "aws_secretsmanager_secret" "mysticat_bootstrap_data_service" {
+  name        = "/mysticat/bootstrap/data-service"
+  description = "Vault AppRole bootstrap credentials for data-service"
+}
+```
+
+**Verify:** 14 new `aws_secretsmanager_secret` resources (13 Lambda services + data-service). The existing `mysticat_vault_bootstrap` resource at line 79-82 is unchanged.
+
+---
+
+## Task 3: Add outputs for new bootstrap secret ARNs
+
+**File:** `/Users/dj/adobe/github/adobe/spacecat-infrastructure/modules/secrets_manager/outputs.tf`
+
+Append after the existing `mysticat_vault_bootstrap_arn` output (line 72):
+
+```hcl
+# Per-service Vault bootstrap secret ARNs
+
+output "mysticat_bootstrap_api_service_arn" {
+  description = "ARN of the Vault bootstrap secret for api-service"
+  value       = aws_secretsmanager_secret.mysticat_bootstrap_api_service.arn
+}
+
+output "mysticat_bootstrap_audit_worker_arn" {
+  description = "ARN of the Vault bootstrap secret for audit-worker"
+  value       = aws_secretsmanager_secret.mysticat_bootstrap_audit_worker.arn
+}
+
+output "mysticat_bootstrap_reporting_worker_arn" {
+  description = "ARN of the Vault bootstrap secret for reporting-worker"
+  value       = aws_secretsmanager_secret.mysticat_bootstrap_reporting_worker.arn
+}
+
+output "mysticat_bootstrap_autofix_worker_arn" {
+  description = "ARN of the Vault bootstrap secret for autofix-worker"
+  value       = aws_secretsmanager_secret.mysticat_bootstrap_autofix_worker.arn
+}
+
+output "mysticat_bootstrap_jobs_dispatcher_arn" {
+  description = "ARN of the Vault bootstrap secret for jobs-dispatcher"
+  value       = aws_secretsmanager_secret.mysticat_bootstrap_jobs_dispatcher.arn
+}
+
+output "mysticat_bootstrap_auth_service_arn" {
+  description = "ARN of the Vault bootstrap secret for auth-service"
+  value       = aws_secretsmanager_secret.mysticat_bootstrap_auth_service.arn
+}
+
+output "mysticat_bootstrap_fulfillment_worker_arn" {
+  description = "ARN of the Vault bootstrap secret for fulfillment-worker"
+  value       = aws_secretsmanager_secret.mysticat_bootstrap_fulfillment_worker.arn
+}
+
+output "mysticat_bootstrap_content_processor_arn" {
+  description = "ARN of the Vault bootstrap secret for content-processor"
+  value       = aws_secretsmanager_secret.mysticat_bootstrap_content_processor.arn
+}
+
+output "mysticat_bootstrap_content_scraper_arn" {
+  description = "ARN of the Vault bootstrap secret for content-scraper"
+  value       = aws_secretsmanager_secret.mysticat_bootstrap_content_scraper.arn
+}
+
+output "mysticat_bootstrap_import_worker_arn" {
+  description = "ARN of the Vault bootstrap secret for import-worker"
+  value       = aws_secretsmanager_secret.mysticat_bootstrap_import_worker.arn
+}
+
+output "mysticat_bootstrap_import_job_manager_arn" {
+  description = "ARN of the Vault bootstrap secret for import-job-manager"
+  value       = aws_secretsmanager_secret.mysticat_bootstrap_import_job_manager.arn
+}
+
+output "mysticat_bootstrap_coralogix_feeder_arn" {
+  description = "ARN of the Vault bootstrap secret for coralogix-feeder"
+  value       = aws_secretsmanager_secret.mysticat_bootstrap_coralogix_feeder.arn
+}
+
+output "mysticat_bootstrap_task_manager_arn" {
+  description = "ARN of the Vault bootstrap secret for task-manager"
+  value       = aws_secretsmanager_secret.mysticat_bootstrap_task_manager.arn
+}
+
+output "mysticat_bootstrap_data_service_arn" {
+  description = "ARN of the Vault bootstrap secret for data-service"
+  value       = aws_secretsmanager_secret.mysticat_bootstrap_data_service.arn
+}
+```
+
+**Verify:** 14 new outputs, one per service. Names follow the `mysticat_bootstrap_{service_name}_arn` pattern.
+
+---
+
+## Task 4: Add `/mysticat/bootstrap/*` to IAM policies
+
+**File:** `/Users/dj/adobe/github/adobe/spacecat-infrastructure/modules/iam/policies.tf`
+
+Three policies need updating. Each currently has a `Resource` list with only `/helix-deploy/spacecat-services/*`. Add `/mysticat/bootstrap/*` to each.
+
+### 4a. Update `spacecat_policy_secrets_rw` (line 342)
+
+Change the Resource array in the `SecretsManagerAccess` statement from:
+
+```hcl
+        Resource : [
+          "arn:aws:secretsmanager:${var.region}:${var.account_id}:secret:/helix-deploy/spacecat-services/*",
+        ]
+```
+
+to:
+
+```hcl
+        Resource : [
+          "arn:aws:secretsmanager:${var.region}:${var.account_id}:secret:/helix-deploy/spacecat-services/*",
+          "arn:aws:secretsmanager:${var.region}:${var.account_id}:secret:/mysticat/bootstrap/*",
+        ]
+```
+
+### 4b. Update `spacecat_policy_secrets_ro` (line 371)
+
+Change the Resource array in the `SecretsReadOnlyAccess` statement from:
+
+```hcl
+        Resource : [
+          "arn:aws:secretsmanager:${var.region}:${var.account_id}:secret:/helix-deploy/spacecat-services/*"
+        ]
+```
+
+to:
+
+```hcl
+        Resource : [
+          "arn:aws:secretsmanager:${var.region}:${var.account_id}:secret:/helix-deploy/spacecat-services/*",
+          "arn:aws:secretsmanager:${var.region}:${var.account_id}:secret:/mysticat/bootstrap/*",
+        ]
+```
+
+### 4c. Update `spacecat_policy_service_basic` (line 395)
+
+This policy's `ServiceLogAndXRayAccess` statement has a mixed `Resource` list covering both logs and secrets. Add the bootstrap path to the existing list. Change from:
+
+```hcl
+        "Resource" : [
+          "arn:aws:logs:${var.region}:${var.account_id}:log-group:/*",
+          "arn:aws:secretsmanager:${var.region}:${var.account_id}:secret:/helix-deploy/spacecat-services/*"
+        ]
+```
+
+to:
+
+```hcl
+        "Resource" : [
+          "arn:aws:logs:${var.region}:${var.account_id}:log-group:/*",
+          "arn:aws:secretsmanager:${var.region}:${var.account_id}:secret:/helix-deploy/spacecat-services/*",
+          "arn:aws:secretsmanager:${var.region}:${var.account_id}:secret:/mysticat/bootstrap/*"
+        ]
+```
+
+**Verify:** Three policies updated. Each adds exactly one new ARN pattern. No other changes.
+
+---
+
+## Task 5: Format and validate Terraform
+
+**Commands:**
+
+```bash
+cd /Users/dj/adobe/github/adobe/spacecat-infrastructure
+
+# Format
+terraform fmt -recursive
+
+# Validate all three environments
+for env in dev stage prod; do
+  cd /Users/dj/adobe/github/adobe/spacecat-infrastructure/environments/$env
+  terraform init -backend=false
+  terraform validate
+done
+```
+
+**Expected output for each environment:**
+```
+Success! The configuration is valid.
+```
+
+If `terraform init` fails on provider download, it may need AWS credentials. Use `terraform init -backend=false` which skips remote state but still validates module references. If validation fails, fix the issue and re-run.
+
+---
+
+## Task 6: Commit and push
+
+**Commands:**
+
+```bash
+cd /Users/dj/adobe/github/adobe/spacecat-infrastructure
+
+git add modules/secrets_manager/secrets.tf modules/secrets_manager/outputs.tf modules/iam/policies.tf
+git commit -m "feat: add per-service Vault bootstrap secrets and IAM policy updates
+
+Add 14 aws_secretsmanager_secret resources at /mysticat/bootstrap/{service-name}
+for each core service (13 Lambda + data-service). These are empty containers
+that will be populated with Vault AppRole credentials in Phase 2.
+
+Add /mysticat/bootstrap/* to three IAM policies:
+- spacecat-policy-secrets-ro (Lambda read access)
+- spacecat-policy-secrets-rw (CI/CD read-write access)
+- spacecat-policy-service-basic (basic service permissions)
+
+Part of Phase 1b: per-service Vault AppRole credential isolation.
+SITES-40735"
+
+git push -u origin feat/vault-bootstrap-per-service
+```
+
+---
+
+## Task 7: Create pull request
+
+**Command:**
+
+```bash
+gh pr create \
+  --repo adobe/spacecat-infrastructure \
+  --title "feat: add per-service Vault bootstrap secrets" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Phase 1b of the per-service Vault AppRole migration ([SITES-40735](https://jira.corp.adobe.com/browse/SITES-40735)).
+
+- Add 14 `aws_secretsmanager_secret` resources at `/mysticat/bootstrap/{service-name}` (13 Lambda services + data-service)
+- Add corresponding outputs for the new secret ARNs
+- Add `/mysticat/bootstrap/*` to three IAM policies: `spacecat-policy-secrets-ro`, `spacecat-policy-secrets-rw`, `spacecat-policy-service-basic`
+
+### What this does NOT change
+
+- The existing `/mysticat/vault-bootstrap` secret is kept as-is
+- The `vault_bootstrap_secret_arn` for data-service still points to `/mysticat/vault-bootstrap` (updated in Phase 2d)
+- No service code changes - secrets are empty containers until Phase 2
+
+### Services in scope
+
+api-service, audit-worker, reporting-worker, autofix-worker, jobs-dispatcher, auth-service, fulfillment-worker, content-processor, content-scraper, import-worker, import-job-manager, coralogix-feeder, task-manager, data-service
+
+## Test plan
+
+- [ ] `terraform fmt -recursive` passes with no changes
+- [ ] `terraform validate` passes in all three environments (dev, stage, prod)
+- [ ] CI pipeline passes (LocalStack test + dev deploy)
+- [ ] After merge: verify SM secrets exist in dev via `aws secretsmanager describe-secret --secret-id /mysticat/bootstrap/api-service --profile spacecat-dev`
+- [ ] After merge: verify IAM policies include bootstrap path via AWS Console or CLI
+EOF
+)"
+```
+
+---
+
+## Task 8: Monitor CI and verify
+
+After CI runs:
+
+```bash
+# Watch the CI workflow
+gh run watch --repo adobe/spacecat-infrastructure
+
+# After merge + deploy, verify one secret exists in dev
+AWS_PROFILE=spacecat-dev aws secretsmanager describe-secret \
+  --secret-id "/mysticat/bootstrap/api-service" \
+  --query "{Name:Name,ARN:ARN}"
+
+# Verify IAM policy includes bootstrap path
+POLICY_ARN=$(AWS_PROFILE=spacecat-dev aws iam list-policies \
+  --query "Policies[?PolicyName=='spacecat-policy-secrets-ro'].Arn" --output text)
+VERSION=$(AWS_PROFILE=spacecat-dev aws iam get-policy \
+  --policy-arn "$POLICY_ARN" --query "Policy.DefaultVersionId" --output text)
+AWS_PROFILE=spacecat-dev aws iam get-policy-version \
+  --policy-arn "$POLICY_ARN" --version-id "$VERSION" \
+  --query "PolicyVersion.Document" --output text | grep -o "bootstrap"
+```
+
+**Expected:** Secret exists, IAM policy contains "bootstrap".
+
+---
+
+## Notes
+
+- **No data-service migration in this PR.** The `vault_bootstrap_secret_arn` variable in the `mysticat_data_service` module continues to reference `module.spacecat_secrets.mysticat_vault_bootstrap_arn`. Phase 2d will update it to `module.spacecat_secrets.mysticat_bootstrap_data_service_arn`.
+- **Additive-only changes.** No existing resources are modified or destroyed. IAM policy changes add a new Resource entry alongside the existing one. This makes rollback trivial - just revert the PR.
+- **No environment-specific changes.** All three environments (dev/stage/prod) use the same secrets_manager module without conditional logic, so all 14 secrets are created in all accounts.

--- a/docs/plans/2026-02-19-vault-policies-plan.md
+++ b/docs/plans/2026-02-19-vault-policies-plan.md
@@ -1,0 +1,709 @@
+# vault_policies Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Create HCL policy files and mappings.yaml entries for 13 SpaceCat services across 3 environments (39 new files + 39 new mappings entries) in the vault_policies repo.
+**Architecture:** Each service gets three HCL policy files (dev/stage/prod) granting read access to its own Vault KV path (`dx_mysticat/data/{env}/{service-name}/*`) plus AppRole self-service paths. All files live in `prod/dx_mysticat/` alongside the existing `data-service` policies. The `mappings.yaml` file gets 39 new `APPROLE_ROLE` entries.
+**Tech Stack:** HCL (HashiCorp Configuration Language), YAML
+
+---
+
+## Task 0: Setup - Create feature branch
+
+**File:** N/A (git operations)
+
+```bash
+cd /Users/dj/adobe/github/adobe/vault_policies
+git checkout main
+git pull origin main
+git checkout -b feat/per-service-approles
+```
+
+**Validate:**
+```bash
+git branch --show-current
+# Expected: feat/per-service-approles
+```
+
+---
+
+## Task 1: Create HCL files for api-service (template reference)
+
+This task serves as the template. All subsequent services follow this exact pattern with service name and underscore-name substituted.
+
+**Naming convention:**
+- Service name in paths: as-is with hyphens (e.g., `api-service`)
+- Policy/role name: hyphens replaced with underscores (e.g., `dx_mysticat_api_service_dev`)
+
+**File:** `/Users/dj/adobe/github/adobe/vault_policies/prod/dx_mysticat/dx_mysticat_api_service_dev.hcl`
+
+```hcl
+# AppRole self-service paths for dx_mysticat_api_service_dev
+path "auth/approle/role/dx_mysticat_api_service_dev/role-id" {
+    capabilities = ["read"]
+}
+
+path "auth/approle/role/dx_mysticat_api_service_dev/secret-id*" {
+    capabilities = ["update"]
+}
+
+# Read access to api-service secrets for DEV environment only
+path "dx_mysticat/data/dev/api-service/*" {
+    capabilities = ["read"]
+}
+
+# Metadata list access (for debugging/discovery)
+path "dx_mysticat/metadata/dev/api-service/*" {
+    capabilities = ["list"]
+}
+```
+
+**File:** `/Users/dj/adobe/github/adobe/vault_policies/prod/dx_mysticat/dx_mysticat_api_service_stage.hcl`
+
+```hcl
+# AppRole self-service paths for dx_mysticat_api_service_stage
+path "auth/approle/role/dx_mysticat_api_service_stage/role-id" {
+    capabilities = ["read"]
+}
+
+path "auth/approle/role/dx_mysticat_api_service_stage/secret-id*" {
+    capabilities = ["update"]
+}
+
+# Read access to api-service secrets for STAGE environment only
+path "dx_mysticat/data/stage/api-service/*" {
+    capabilities = ["read"]
+}
+
+# Metadata list access (for debugging/discovery)
+path "dx_mysticat/metadata/stage/api-service/*" {
+    capabilities = ["list"]
+}
+```
+
+**File:** `/Users/dj/adobe/github/adobe/vault_policies/prod/dx_mysticat/dx_mysticat_api_service_prod.hcl`
+
+```hcl
+# AppRole self-service paths for dx_mysticat_api_service_prod
+path "auth/approle/role/dx_mysticat_api_service_prod/role-id" {
+    capabilities = ["read"]
+}
+
+path "auth/approle/role/dx_mysticat_api_service_prod/secret-id*" {
+    capabilities = ["update"]
+}
+
+# Read access to api-service secrets for PROD environment only
+path "dx_mysticat/data/prod/api-service/*" {
+    capabilities = ["read"]
+}
+
+# Metadata list access (for debugging/discovery)
+path "dx_mysticat/metadata/prod/api-service/*" {
+    capabilities = ["list"]
+}
+```
+
+**Validate:**
+```bash
+cd /Users/dj/adobe/github/adobe/vault_policies
+# Verify files exist and have correct structure
+for env in dev stage prod; do
+  file="prod/dx_mysticat/dx_mysticat_api_service_${env}.hcl"
+  test -f "$file" && echo "OK: $file" || echo "MISSING: $file"
+  grep -q "api-service" "$file" && echo "  - Contains api-service path" || echo "  - MISSING api-service path"
+  grep -q "dx_mysticat_api_service_${env}" "$file" && echo "  - Contains correct role name" || echo "  - MISSING correct role name"
+  grep -q "${env}" "$file" && echo "  - Contains correct env" || echo "  - MISSING correct env"
+done
+```
+
+**Commit:**
+```bash
+git add prod/dx_mysticat/dx_mysticat_api_service_*.hcl
+git commit -m "Add Vault policies for api-service (dev/stage/prod)"
+```
+
+---
+
+## Task 2: Create HCL files for audit-worker, reporting-worker, autofix-worker
+
+For each service below, create three HCL files (dev/stage/prod) following the exact pattern from Task 1. Substitute the service name and underscore name:
+
+| Service | Underscore Name | Path Name |
+|---------|----------------|-----------|
+| audit-worker | audit_worker | audit-worker |
+| reporting-worker | reporting_worker | reporting-worker |
+| autofix-worker | autofix_worker | autofix-worker |
+
+**Files to create (9 total):**
+- `prod/dx_mysticat/dx_mysticat_audit_worker_{dev,stage,prod}.hcl`
+- `prod/dx_mysticat/dx_mysticat_reporting_worker_{dev,stage,prod}.hcl`
+- `prod/dx_mysticat/dx_mysticat_autofix_worker_{dev,stage,prod}.hcl`
+
+Each file follows the same 4-path structure as Task 1:
+1. `auth/approle/role/dx_mysticat_{underscore_name}_{env}/role-id` - capabilities: `["read"]`
+2. `auth/approle/role/dx_mysticat_{underscore_name}_{env}/secret-id*` - capabilities: `["update"]`
+3. `dx_mysticat/data/{env}/{service-name}/*` - capabilities: `["read"]`
+4. `dx_mysticat/metadata/{env}/{service-name}/*` - capabilities: `["list"]`
+
+**Validate:**
+```bash
+cd /Users/dj/adobe/github/adobe/vault_policies
+for svc_pair in "audit-worker:audit_worker" "reporting-worker:reporting_worker" "autofix-worker:autofix_worker"; do
+  svc=$(echo "$svc_pair" | cut -d: -f1)
+  uscore=$(echo "$svc_pair" | cut -d: -f2)
+  for env in dev stage prod; do
+    file="prod/dx_mysticat/dx_mysticat_${uscore}_${env}.hcl"
+    test -f "$file" && echo "OK: $file" || echo "MISSING: $file"
+    grep -q "${svc}" "$file" && echo "  - path OK" || echo "  - path MISSING"
+    grep -q "dx_mysticat_${uscore}_${env}" "$file" && echo "  - role OK" || echo "  - role MISSING"
+  done
+done
+```
+
+**Commit:**
+```bash
+git add prod/dx_mysticat/dx_mysticat_audit_worker_*.hcl \
+        prod/dx_mysticat/dx_mysticat_reporting_worker_*.hcl \
+        prod/dx_mysticat/dx_mysticat_autofix_worker_*.hcl
+git commit -m "Add Vault policies for audit-worker, reporting-worker, autofix-worker"
+```
+
+---
+
+## Task 3: Create HCL files for jobs-dispatcher, auth-service, fulfillment-worker
+
+| Service | Underscore Name | Path Name |
+|---------|----------------|-----------|
+| jobs-dispatcher | jobs_dispatcher | jobs-dispatcher |
+| auth-service | auth_service | auth-service |
+| fulfillment-worker | fulfillment_worker | fulfillment-worker |
+
+**Files to create (9 total):**
+- `prod/dx_mysticat/dx_mysticat_jobs_dispatcher_{dev,stage,prod}.hcl`
+- `prod/dx_mysticat/dx_mysticat_auth_service_{dev,stage,prod}.hcl`
+- `prod/dx_mysticat/dx_mysticat_fulfillment_worker_{dev,stage,prod}.hcl`
+
+Same 4-path structure as Task 1.
+
+**Validate:**
+```bash
+cd /Users/dj/adobe/github/adobe/vault_policies
+for svc_pair in "jobs-dispatcher:jobs_dispatcher" "auth-service:auth_service" "fulfillment-worker:fulfillment_worker"; do
+  svc=$(echo "$svc_pair" | cut -d: -f1)
+  uscore=$(echo "$svc_pair" | cut -d: -f2)
+  for env in dev stage prod; do
+    file="prod/dx_mysticat/dx_mysticat_${uscore}_${env}.hcl"
+    test -f "$file" && echo "OK: $file" || echo "MISSING: $file"
+    grep -q "${svc}" "$file" && echo "  - path OK" || echo "  - path MISSING"
+    grep -q "dx_mysticat_${uscore}_${env}" "$file" && echo "  - role OK" || echo "  - role MISSING"
+  done
+done
+```
+
+**Commit:**
+```bash
+git add prod/dx_mysticat/dx_mysticat_jobs_dispatcher_*.hcl \
+        prod/dx_mysticat/dx_mysticat_auth_service_*.hcl \
+        prod/dx_mysticat/dx_mysticat_fulfillment_worker_*.hcl
+git commit -m "Add Vault policies for jobs-dispatcher, auth-service, fulfillment-worker"
+```
+
+---
+
+## Task 4: Create HCL files for content-processor, content-scraper, import-worker
+
+| Service | Underscore Name | Path Name |
+|---------|----------------|-----------|
+| content-processor | content_processor | content-processor |
+| content-scraper | content_scraper | content-scraper |
+| import-worker | import_worker | import-worker |
+
+**Files to create (9 total):**
+- `prod/dx_mysticat/dx_mysticat_content_processor_{dev,stage,prod}.hcl`
+- `prod/dx_mysticat/dx_mysticat_content_scraper_{dev,stage,prod}.hcl`
+- `prod/dx_mysticat/dx_mysticat_import_worker_{dev,stage,prod}.hcl`
+
+Same 4-path structure as Task 1.
+
+**Validate:**
+```bash
+cd /Users/dj/adobe/github/adobe/vault_policies
+for svc_pair in "content-processor:content_processor" "content-scraper:content_scraper" "import-worker:import_worker"; do
+  svc=$(echo "$svc_pair" | cut -d: -f1)
+  uscore=$(echo "$svc_pair" | cut -d: -f2)
+  for env in dev stage prod; do
+    file="prod/dx_mysticat/dx_mysticat_${uscore}_${env}.hcl"
+    test -f "$file" && echo "OK: $file" || echo "MISSING: $file"
+    grep -q "${svc}" "$file" && echo "  - path OK" || echo "  - path MISSING"
+    grep -q "dx_mysticat_${uscore}_${env}" "$file" && echo "  - role OK" || echo "  - role MISSING"
+  done
+done
+```
+
+**Commit:**
+```bash
+git add prod/dx_mysticat/dx_mysticat_content_processor_*.hcl \
+        prod/dx_mysticat/dx_mysticat_content_scraper_*.hcl \
+        prod/dx_mysticat/dx_mysticat_import_worker_*.hcl
+git commit -m "Add Vault policies for content-processor, content-scraper, import-worker"
+```
+
+---
+
+## Task 5: Create HCL files for import-job-manager, coralogix-feeder, task-manager
+
+| Service | Underscore Name | Path Name |
+|---------|----------------|-----------|
+| import-job-manager | import_job_manager | import-job-manager |
+| coralogix-feeder | coralogix_feeder | coralogix-feeder |
+| task-manager | task_manager | task-manager |
+
+**Files to create (9 total):**
+- `prod/dx_mysticat/dx_mysticat_import_job_manager_{dev,stage,prod}.hcl`
+- `prod/dx_mysticat/dx_mysticat_coralogix_feeder_{dev,stage,prod}.hcl`
+- `prod/dx_mysticat/dx_mysticat_task_manager_{dev,stage,prod}.hcl`
+
+Same 4-path structure as Task 1.
+
+**Validate:**
+```bash
+cd /Users/dj/adobe/github/adobe/vault_policies
+for svc_pair in "import-job-manager:import_job_manager" "coralogix-feeder:coralogix_feeder" "task-manager:task_manager"; do
+  svc=$(echo "$svc_pair" | cut -d: -f1)
+  uscore=$(echo "$svc_pair" | cut -d: -f2)
+  for env in dev stage prod; do
+    file="prod/dx_mysticat/dx_mysticat_${uscore}_${env}.hcl"
+    test -f "$file" && echo "OK: $file" || echo "MISSING: $file"
+    grep -q "${svc}" "$file" && echo "  - path OK" || echo "  - path MISSING"
+    grep -q "dx_mysticat_${uscore}_${env}" "$file" && echo "  - role OK" || echo "  - role MISSING"
+  done
+done
+```
+
+**Commit:**
+```bash
+git add prod/dx_mysticat/dx_mysticat_import_job_manager_*.hcl \
+        prod/dx_mysticat/dx_mysticat_coralogix_feeder_*.hcl \
+        prod/dx_mysticat/dx_mysticat_task_manager_*.hcl
+git commit -m "Add Vault policies for import-job-manager, coralogix-feeder, task-manager"
+```
+
+---
+
+## Task 6: Update mappings.yaml with all 39 new APPROLE_ROLE entries
+
+**File:** `/Users/dj/adobe/github/adobe/vault_policies/prod/dx_mysticat/mappings.yaml`
+
+Add 39 new `APPROLE_ROLE` entries (13 services x 3 environments) to the existing `APPROLE_ROLE` list. The existing 3 `data-service` entries remain unchanged. Append the new entries after the existing `dx_mysticat_data_service_prod` entry, before the `OKTA` section.
+
+The complete file should be:
+
+```yaml
+- ALLOWED_PATHS:
+  - dx_mysticat
+- APPROLE_ROLE:
+  - role_name: dx_mysticat_data_service_dev
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_data_service_dev
+  - role_name: dx_mysticat_data_service_stage
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_data_service_stage
+  - role_name: dx_mysticat_data_service_prod
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_data_service_prod
+  - role_name: dx_mysticat_api_service_dev
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_api_service_dev
+  - role_name: dx_mysticat_api_service_stage
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_api_service_stage
+  - role_name: dx_mysticat_api_service_prod
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_api_service_prod
+  - role_name: dx_mysticat_audit_worker_dev
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_audit_worker_dev
+  - role_name: dx_mysticat_audit_worker_stage
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_audit_worker_stage
+  - role_name: dx_mysticat_audit_worker_prod
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_audit_worker_prod
+  - role_name: dx_mysticat_reporting_worker_dev
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_reporting_worker_dev
+  - role_name: dx_mysticat_reporting_worker_stage
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_reporting_worker_stage
+  - role_name: dx_mysticat_reporting_worker_prod
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_reporting_worker_prod
+  - role_name: dx_mysticat_autofix_worker_dev
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_autofix_worker_dev
+  - role_name: dx_mysticat_autofix_worker_stage
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_autofix_worker_stage
+  - role_name: dx_mysticat_autofix_worker_prod
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_autofix_worker_prod
+  - role_name: dx_mysticat_jobs_dispatcher_dev
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_jobs_dispatcher_dev
+  - role_name: dx_mysticat_jobs_dispatcher_stage
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_jobs_dispatcher_stage
+  - role_name: dx_mysticat_jobs_dispatcher_prod
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_jobs_dispatcher_prod
+  - role_name: dx_mysticat_auth_service_dev
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_auth_service_dev
+  - role_name: dx_mysticat_auth_service_stage
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_auth_service_stage
+  - role_name: dx_mysticat_auth_service_prod
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_auth_service_prod
+  - role_name: dx_mysticat_fulfillment_worker_dev
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_fulfillment_worker_dev
+  - role_name: dx_mysticat_fulfillment_worker_stage
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_fulfillment_worker_stage
+  - role_name: dx_mysticat_fulfillment_worker_prod
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_fulfillment_worker_prod
+  - role_name: dx_mysticat_content_processor_dev
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_content_processor_dev
+  - role_name: dx_mysticat_content_processor_stage
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_content_processor_stage
+  - role_name: dx_mysticat_content_processor_prod
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_content_processor_prod
+  - role_name: dx_mysticat_content_scraper_dev
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_content_scraper_dev
+  - role_name: dx_mysticat_content_scraper_stage
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_content_scraper_stage
+  - role_name: dx_mysticat_content_scraper_prod
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_content_scraper_prod
+  - role_name: dx_mysticat_import_worker_dev
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_import_worker_dev
+  - role_name: dx_mysticat_import_worker_stage
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_import_worker_stage
+  - role_name: dx_mysticat_import_worker_prod
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_import_worker_prod
+  - role_name: dx_mysticat_import_job_manager_dev
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_import_job_manager_dev
+  - role_name: dx_mysticat_import_job_manager_stage
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_import_job_manager_stage
+  - role_name: dx_mysticat_import_job_manager_prod
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_import_job_manager_prod
+  - role_name: dx_mysticat_coralogix_feeder_dev
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_coralogix_feeder_dev
+  - role_name: dx_mysticat_coralogix_feeder_stage
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_coralogix_feeder_stage
+  - role_name: dx_mysticat_coralogix_feeder_prod
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_coralogix_feeder_prod
+  - role_name: dx_mysticat_task_manager_dev
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_task_manager_dev
+  - role_name: dx_mysticat_task_manager_stage
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_task_manager_stage
+  - role_name: dx_mysticat_task_manager_prod
+    token_ttl: 3600
+    token_max_ttl: 3600
+    policies:
+    - dx_mysticat_task_manager_prod
+- OKTA:
+  - group_name: DX_AEM_EXP_SUCCESS_ENG
+    policies:
+    - dx_mysticat
+```
+
+**Validate:**
+```bash
+cd /Users/dj/adobe/github/adobe/vault_policies
+
+# Count APPROLE_ROLE entries (should be 42: 3 existing + 39 new)
+grep -c "role_name:" prod/dx_mysticat/mappings.yaml
+# Expected: 42
+
+# Verify all 13 services are present
+for svc in api_service audit_worker reporting_worker autofix_worker jobs_dispatcher \
+           auth_service fulfillment_worker content_processor content_scraper \
+           import_worker import_job_manager coralogix_feeder task_manager; do
+  count=$(grep -c "dx_mysticat_${svc}_" prod/dx_mysticat/mappings.yaml)
+  echo "$svc: $count entries (expected 3)"
+done
+
+# Verify data-service entries unchanged
+grep -c "dx_mysticat_data_service_" prod/dx_mysticat/mappings.yaml
+# Expected: 3
+
+# Validate YAML syntax
+python3 -c "import yaml; yaml.safe_load(open('prod/dx_mysticat/mappings.yaml')); print('YAML valid')"
+```
+
+**Commit:**
+```bash
+git add prod/dx_mysticat/mappings.yaml
+git commit -m "Add mappings.yaml entries for 13 per-service AppRoles (39 new entries)"
+```
+
+---
+
+## Task 7: Final validation - all files and cross-checks
+
+**Validate all 39 HCL files exist:**
+```bash
+cd /Users/dj/adobe/github/adobe/vault_policies
+MISSING=0
+for svc_pair in \
+  "api-service:api_service" \
+  "audit-worker:audit_worker" \
+  "reporting-worker:reporting_worker" \
+  "autofix-worker:autofix_worker" \
+  "jobs-dispatcher:jobs_dispatcher" \
+  "auth-service:auth_service" \
+  "fulfillment-worker:fulfillment_worker" \
+  "content-processor:content_processor" \
+  "content-scraper:content_scraper" \
+  "import-worker:import_worker" \
+  "import-job-manager:import_job_manager" \
+  "coralogix-feeder:coralogix_feeder" \
+  "task-manager:task_manager"; do
+  svc=$(echo "$svc_pair" | cut -d: -f1)
+  uscore=$(echo "$svc_pair" | cut -d: -f2)
+  for env in dev stage prod; do
+    file="prod/dx_mysticat/dx_mysticat_${uscore}_${env}.hcl"
+    if [ ! -f "$file" ]; then
+      echo "MISSING: $file"
+      MISSING=$((MISSING+1))
+    fi
+  done
+done
+echo "Missing files: $MISSING (expected: 0)"
+```
+
+**Validate every HCL file references the correct env and service:**
+```bash
+cd /Users/dj/adobe/github/adobe/vault_policies
+ERRORS=0
+for svc_pair in \
+  "api-service:api_service" \
+  "audit-worker:audit_worker" \
+  "reporting-worker:reporting_worker" \
+  "autofix-worker:autofix_worker" \
+  "jobs-dispatcher:jobs_dispatcher" \
+  "auth-service:auth_service" \
+  "fulfillment-worker:fulfillment_worker" \
+  "content-processor:content_processor" \
+  "content-scraper:content_scraper" \
+  "import-worker:import_worker" \
+  "import-job-manager:import_job_manager" \
+  "coralogix-feeder:coralogix_feeder" \
+  "task-manager:task_manager"; do
+  svc=$(echo "$svc_pair" | cut -d: -f1)
+  uscore=$(echo "$svc_pair" | cut -d: -f2)
+  for env in dev stage prod; do
+    file="prod/dx_mysticat/dx_mysticat_${uscore}_${env}.hcl"
+    # Check all 4 expected paths are present
+    grep -q "auth/approle/role/dx_mysticat_${uscore}_${env}/role-id" "$file" || { echo "ERROR: $file missing role-id path"; ERRORS=$((ERRORS+1)); }
+    grep -q "auth/approle/role/dx_mysticat_${uscore}_${env}/secret-id" "$file" || { echo "ERROR: $file missing secret-id path"; ERRORS=$((ERRORS+1)); }
+    grep -q "dx_mysticat/data/${env}/${svc}/\*" "$file" || { echo "ERROR: $file missing data path"; ERRORS=$((ERRORS+1)); }
+    grep -q "dx_mysticat/metadata/${env}/${svc}/\*" "$file" || { echo "ERROR: $file missing metadata path"; ERRORS=$((ERRORS+1)); }
+  done
+done
+echo "Errors: $ERRORS (expected: 0)"
+```
+
+**Validate mappings.yaml has a matching entry for every HCL file:**
+```bash
+cd /Users/dj/adobe/github/adobe/vault_policies
+MISMATCHES=0
+for svc in api_service audit_worker reporting_worker autofix_worker jobs_dispatcher \
+           auth_service fulfillment_worker content_processor content_scraper \
+           import_worker import_job_manager coralogix_feeder task_manager; do
+  for env in dev stage prod; do
+    role="dx_mysticat_${svc}_${env}"
+    # Check HCL file exists
+    test -f "prod/dx_mysticat/${role}.hcl" || { echo "MISSING HCL: ${role}.hcl"; MISMATCHES=$((MISMATCHES+1)); }
+    # Check mappings.yaml has the role
+    grep -q "role_name: ${role}" prod/dx_mysticat/mappings.yaml || { echo "MISSING MAPPING: ${role}"; MISMATCHES=$((MISMATCHES+1)); }
+    # Check mappings.yaml references the correct policy
+    grep -A3 "role_name: ${role}" prod/dx_mysticat/mappings.yaml | grep -q "- ${role}" || { echo "MISSING POLICY REF: ${role}"; MISMATCHES=$((MISMATCHES+1)); }
+  done
+done
+echo "Mismatches: $MISMATCHES (expected: 0)"
+```
+
+**Count total new files:**
+```bash
+cd /Users/dj/adobe/github/adobe/vault_policies
+ls prod/dx_mysticat/dx_mysticat_*.hcl | wc -l
+# Expected: 42 (3 existing data-service + 39 new)
+```
+
+---
+
+## Task 8: Push branch and create PR
+
+```bash
+cd /Users/dj/adobe/github/adobe/vault_policies
+git push -u origin feat/per-service-approles
+```
+
+Create a PR targeting the `main` branch of `cst-vault/vault_policies` on git.corp.adobe.com. The PR should be created from the `djaeggi` fork.
+
+**PR Title:** Add per-service Vault AppRole policies for 13 SpaceCat services
+
+**PR Body:**
+```
+## Summary
+
+Adds Vault HCL policy files and mappings.yaml AppRole entries for 13 SpaceCat services
+across all three environments (dev/stage/prod). This is Phase 1a of the per-service Vault
+AppRole migration (SITES-40735).
+
+## Changes
+
+- 39 new HCL policy files (13 services x 3 environments)
+- 39 new APPROLE_ROLE entries in mappings.yaml
+- Existing data-service policies and mappings unchanged
+
+## Services
+
+api-service, audit-worker, reporting-worker, autofix-worker, jobs-dispatcher,
+auth-service, fulfillment-worker, content-processor, content-scraper,
+import-worker, import-job-manager, coralogix-feeder, task-manager
+
+## Policy structure (per service per env)
+
+Each policy grants:
+1. AppRole self-service (read role-id, generate secret-id)
+2. Read access to `dx_mysticat/data/{env}/{service-name}/*`
+3. List access to `dx_mysticat/metadata/{env}/{service-name}/*`
+
+## JIRA
+
+SITES-40735
+```
+
+---
+
+## Reference: Complete service name mapping
+
+| Service Name | Underscore Name | Example Role (dev) |
+|-------------|----------------|-------------------|
+| api-service | api_service | dx_mysticat_api_service_dev |
+| audit-worker | audit_worker | dx_mysticat_audit_worker_dev |
+| reporting-worker | reporting_worker | dx_mysticat_reporting_worker_dev |
+| autofix-worker | autofix_worker | dx_mysticat_autofix_worker_dev |
+| jobs-dispatcher | jobs_dispatcher | dx_mysticat_jobs_dispatcher_dev |
+| auth-service | auth_service | dx_mysticat_auth_service_dev |
+| fulfillment-worker | fulfillment_worker | dx_mysticat_fulfillment_worker_dev |
+| content-processor | content_processor | dx_mysticat_content_processor_dev |
+| content-scraper | content_scraper | dx_mysticat_content_scraper_dev |
+| import-worker | import_worker | dx_mysticat_import_worker_dev |
+| import-job-manager | import_job_manager | dx_mysticat_import_job_manager_dev |
+| coralogix-feeder | coralogix_feeder | dx_mysticat_coralogix_feeder_dev |
+| task-manager | task_manager | dx_mysticat_task_manager_dev |

--- a/docs/plans/2026-02-19-vault-secrets-wrapper-plan.md
+++ b/docs/plans/2026-02-19-vault-secrets-wrapper-plan.md
@@ -1,0 +1,274 @@
+# spacecat-shared vault-secrets-wrapper Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Update `vault-secrets-wrapper.js` to auto-resolve `bootstrapPath` from `ctx.func.name` instead of using a static `DEFAULT_BOOTSTRAP_PATH` constant, while preserving the explicit `bootstrapPath` option for overrides.
+
+**Architecture:** The `ensureClient` function currently falls back to `DEFAULT_BOOTSTRAP_PATH = '/mysticat/vault-bootstrap'` when `opts.bootstrapPath` is not provided. We replace this with a `resolveBootstrapPath(ctx, opts)` function that returns `opts.bootstrapPath` if set, otherwise derives the path from the context as `/mysticat/bootstrap/${ctx.func.name}`. This makes the wrapper zero-config for Lambda services where `ctx.func.name` matches the service name. An error is thrown if neither `opts.bootstrapPath` nor `ctx.func.name` is available.
+
+**Tech Stack:** Node.js 22+, Mocha + Chai + Sinon + Nock for testing, c8 for coverage
+
+---
+
+## Task 1: Write failing tests for auto-resolution from ctx.func.name
+
+### File: `/Users/dj/adobe/github/adobe/spacecat-shared/packages/spacecat-shared-vault-secrets/test/vault-secrets-wrapper.test.js`
+
+Add a new `describe` block for bootstrap path resolution inside the existing `vaultSecrets wrapper` describe. This goes after the existing `path resolution` describe block (after line 467).
+
+### Code to add (after the closing `});` of `describe('path resolution', ...)` at line 467):
+
+```js
+  describe('bootstrap path resolution', () => {
+    it('auto-resolves bootstrapPath from ctx.func.name', async () => {
+      // Bootstrap should be fetched from /mysticat/bootstrap/api-service
+      const autoBootstrapPath = '/mysticat/bootstrap/api-service';
+      nock(AWS_ENDPOINT)
+        .post('/', (body) => {
+          const str = typeof body === 'string' ? body : JSON.stringify(body);
+          return str.includes(autoBootstrapPath);
+        })
+        .reply(200, { SecretString: JSON.stringify(bootstrapConfig) });
+
+      mockAppRoleLogin();
+      mockSecretRead();
+
+      const ctx = makeContext();
+      const result = await loadSecrets(ctx);
+
+      expect(result).to.deep.equal(testSecrets);
+    });
+
+    it('explicit bootstrapPath overrides auto-resolution', async () => {
+      const customPath = '/custom/bootstrap/path';
+      nock(AWS_ENDPOINT)
+        .post('/', (body) => {
+          const str = typeof body === 'string' ? body : JSON.stringify(body);
+          return str.includes(customPath);
+        })
+        .reply(200, { SecretString: JSON.stringify(bootstrapConfig) });
+
+      mockAppRoleLogin();
+      mockSecretRead();
+
+      const ctx = makeContext();
+      const result = await loadSecrets(ctx, { bootstrapPath: customPath });
+
+      expect(result).to.deep.equal(testSecrets);
+    });
+
+    it('throws when ctx.func.name is missing and no bootstrapPath provided', async () => {
+      const ctx = makeContext({ func: { package: 'test', version: '1.0.0' } });
+
+      await expect(loadSecrets(ctx)).to.be.rejectedWith(
+        'Cannot resolve bootstrap path: ctx.func.name is not set and no bootstrapPath option provided',
+      );
+    });
+  });
+```
+
+### Verify
+
+```bash
+cd /Users/dj/adobe/github/adobe/spacecat-shared/packages/spacecat-shared-vault-secrets && npm test
+```
+
+**Expected:** 3 new tests FAIL:
+1. `auto-resolves bootstrapPath from ctx.func.name` - FAILS because the wrapper still uses `DEFAULT_BOOTSTRAP_PATH` (`/mysticat/vault-bootstrap`), not `/mysticat/bootstrap/api-service`. The nock mock won't match, causing a connection error.
+2. `explicit bootstrapPath overrides auto-resolution` - PASSES (this already works).
+3. `throws when ctx.func.name is missing` - FAILS because the wrapper currently falls back to `DEFAULT_BOOTSTRAP_PATH` silently instead of throwing.
+
+The existing 51 tests should still pass because they all explicitly pass `bootstrapPath: BOOTSTRAP_PATH`.
+
+---
+
+## Task 2: Implement resolveBootstrapPath and update ensureClient
+
+### File: `/Users/dj/adobe/github/adobe/spacecat-shared/packages/spacecat-shared-vault-secrets/src/vault-secrets-wrapper.js`
+
+### Change 1: Remove the DEFAULT_BOOTSTRAP_PATH constant
+
+**Find (line 18):**
+```js
+const DEFAULT_BOOTSTRAP_PATH = '/mysticat/vault-bootstrap';
+```
+
+**Replace with:**
+```js
+function resolveBootstrapPath(ctx, opts) {
+  if (opts.bootstrapPath) return opts.bootstrapPath;
+  if (ctx.func && ctx.func.name) return `/mysticat/bootstrap/${ctx.func.name}`;
+  throw new Error(
+    'Cannot resolve bootstrap path: ctx.func.name is not set and no bootstrapPath option provided',
+  );
+}
+```
+
+### Change 2: Update ensureClient to accept ctx and use resolveBootstrapPath
+
+**Find (line 38-77):**
+```js
+async function ensureClient(opts, log) {
+  if (clientLock) {
+    await clientLock;
+    if (!vaultClient || !vaultClient.isAuthenticated()) {
+      throw new Error('Vault client initialization failed');
+    }
+    return;
+  }
+
+  let resolve;
+  clientLock = new Promise((r) => {
+    resolve = r;
+  });
+
+  try {
+    if (!vaultClient) {
+      const bootstrapPath = opts.bootstrapPath || DEFAULT_BOOTSTRAP_PATH;
+      bootstrapConfig = await loadBootstrapConfig({ bootstrapPath });
+
+      vaultClient = new VaultClient({
+        vaultAddr: bootstrapConfig.vault_addr,
+        mountPoint: bootstrapConfig.mount_point,
+      });
+      bootstrapEnvironment = bootstrapConfig.environment;
+
+      await vaultClient.authenticate(bootstrapConfig.role_id, bootstrapConfig.secret_id);
+    } else if (!vaultClient.isAuthenticated()) {
+      await vaultClient.authenticate(bootstrapConfig.role_id, bootstrapConfig.secret_id);
+    } else if (vaultClient.isTokenExpiringSoon()) {
+      await vaultClient.renewToken();
+    }
+
+    if (log) {
+      log.info('Vault client ready');
+    }
+  } finally {
+    clientLock = null;
+    resolve();
+  }
+}
+```
+
+**Replace with:**
+```js
+async function ensureClient(ctx, opts, log) {
+  if (clientLock) {
+    await clientLock;
+    if (!vaultClient || !vaultClient.isAuthenticated()) {
+      throw new Error('Vault client initialization failed');
+    }
+    return;
+  }
+
+  let resolve;
+  clientLock = new Promise((r) => {
+    resolve = r;
+  });
+
+  try {
+    if (!vaultClient) {
+      const bootstrapPath = resolveBootstrapPath(ctx, opts);
+      bootstrapConfig = await loadBootstrapConfig({ bootstrapPath });
+
+      vaultClient = new VaultClient({
+        vaultAddr: bootstrapConfig.vault_addr,
+        mountPoint: bootstrapConfig.mount_point,
+      });
+      bootstrapEnvironment = bootstrapConfig.environment;
+
+      await vaultClient.authenticate(bootstrapConfig.role_id, bootstrapConfig.secret_id);
+    } else if (!vaultClient.isAuthenticated()) {
+      await vaultClient.authenticate(bootstrapConfig.role_id, bootstrapConfig.secret_id);
+    } else if (vaultClient.isTokenExpiringSoon()) {
+      await vaultClient.renewToken();
+    }
+
+    if (log) {
+      log.info('Vault client ready');
+    }
+  } finally {
+    clientLock = null;
+    resolve();
+  }
+}
+```
+
+### Change 3: Update loadSecrets to pass ctx to ensureClient
+
+**Find (line 113):**
+```js
+  await ensureClient(opts, ctx.log);
+```
+
+**Replace with:**
+```js
+  await ensureClient(ctx, opts, ctx.log);
+```
+
+### Verify
+
+```bash
+cd /Users/dj/adobe/github/adobe/spacecat-shared/packages/spacecat-shared-vault-secrets && npm test
+```
+
+**Expected:** All 54 tests pass (51 existing + 3 new). The existing tests pass because they all explicitly provide `bootstrapPath: BOOTSTRAP_PATH`, which takes priority in `resolveBootstrapPath`. The 3 new tests now pass because:
+1. Auto-resolution uses `/mysticat/bootstrap/api-service` from `ctx.func.name`
+2. Explicit `bootstrapPath` overrides auto-resolution (already worked)
+3. Missing `ctx.func.name` without `bootstrapPath` throws the expected error
+
+---
+
+## Task 3: Verify lint passes
+
+### Verify
+
+```bash
+cd /Users/dj/adobe/github/adobe/spacecat-shared/packages/spacecat-shared-vault-secrets && npm run lint
+```
+
+**Expected:** No lint errors.
+
+---
+
+## Task 4: Commit the changes
+
+### Commands
+
+```bash
+cd /Users/dj/adobe/github/adobe/spacecat-shared
+git add packages/spacecat-shared-vault-secrets/src/vault-secrets-wrapper.js
+git add packages/spacecat-shared-vault-secrets/test/vault-secrets-wrapper.test.js
+git commit -m "feat(vault-secrets): auto-resolve bootstrapPath from ctx.func.name
+
+Replace static DEFAULT_BOOTSTRAP_PATH with resolveBootstrapPath() that
+derives the SM path from ctx.func.name (/mysticat/bootstrap/{service}).
+Explicit bootstrapPath option still works for overrides. Throws if
+neither ctx.func.name nor bootstrapPath is available."
+```
+
+**Expected:** Commit succeeds on `feat/vault-secrets-wrapper` branch.
+
+---
+
+## Summary of changes
+
+### Source change (`vault-secrets-wrapper.js`)
+
+| Before | After |
+|--------|-------|
+| `const DEFAULT_BOOTSTRAP_PATH = '/mysticat/vault-bootstrap';` | `function resolveBootstrapPath(ctx, opts)` that returns `opts.bootstrapPath` or `/mysticat/bootstrap/${ctx.func.name}` |
+| `ensureClient(opts, log)` with `opts.bootstrapPath \|\| DEFAULT_BOOTSTRAP_PATH` | `ensureClient(ctx, opts, log)` calling `resolveBootstrapPath(ctx, opts)` |
+| `await ensureClient(opts, ctx.log)` | `await ensureClient(ctx, opts, ctx.log)` |
+
+### Test additions (`vault-secrets-wrapper.test.js`)
+
+| Test | Asserts |
+|------|---------|
+| auto-resolves bootstrapPath from ctx.func.name | nock matches `/mysticat/bootstrap/api-service` (not the old static path) |
+| explicit bootstrapPath overrides auto-resolution | nock matches `/custom/bootstrap/path` |
+| throws when ctx.func.name is missing | rejects with descriptive error message |
+
+### Existing test impact
+
+All 51 existing tests pass unchanged because they all explicitly pass `bootstrapPath: BOOTSTRAP_PATH` in their options, which takes priority in `resolveBootstrapPath`.

--- a/docs/plans/vault-migration-runbook.md
+++ b/docs/plans/vault-migration-runbook.md
@@ -1,0 +1,139 @@
+# Vault Migration Runbook - SM to Vault Secret Sync
+
+**JIRA:** [SITES-40735](https://jira.corp.adobe.com/browse/SITES-40735)
+**Phase:** 3 (Copy secrets to Vault)
+**Impact:** None - secrets are written to Vault but no service reads from Vault until Phase 4
+
+## Overview
+
+This runbook syncs service secrets from AWS Secrets Manager to HashiCorp Vault. It is **idempotent** and should be re-run before Phase 4 (service switchover) to ensure Vault has the latest values.
+
+## Prerequisites
+
+| Requirement | Command | TTL |
+|-------------|---------|-----|
+| Vault token | `vldj` | 4h |
+| AWS sessions | `klam login && klsa` | ~1h |
+
+Both scripts live in `spacecat-shared/docs/plans/`.
+
+## Quick Reference
+
+```bash
+cd ~/adobe/github/adobe/spacecat-shared/docs/plans
+
+# Dry run (shows what would happen, no writes)
+DRY_RUN=1 ./vault-sm-to-vault-sync.sh
+
+# Sync all services, all envs
+./vault-sm-to-vault-sync.sh
+
+# Sync single env
+./vault-sm-to-vault-sync.sh dev
+
+# Sync single service + env
+./vault-sm-to-vault-sync.sh dev api-service
+
+# Validate (after sync)
+./vault-sm-to-vault-validate.sh
+./vault-sm-to-vault-validate.sh dev   # dev only
+```
+
+## What Gets Synced
+
+| Source (SM) | Destination (Vault) |
+|-------------|---------------------|
+| `/helix-deploy/spacecat-services/{service}/latest` | `dx_mysticat/{env}/{service}` |
+
+Services: api-service, audit-worker, auth-service, autofix-worker, content-processor, content-scraper, fulfillment-worker, import-job-manager, import-worker, jobs-dispatcher, reporting-worker, task-manager
+
+Environments: dev (spacecat-dev), stage (spacecat-stage), prod (spacecat-prod)
+
+**Excluded:** data-service (ECS, different bootstrap path and secret layout)
+
+## Procedure
+
+### 1. Authenticate
+
+```bash
+vldj              # Vault (needs MFA push)
+klam login && klsa  # AWS (needs MFA)
+```
+
+### 2. Dry run
+
+```bash
+DRY_RUN=1 ./vault-sm-to-vault-sync.sh
+```
+
+Verify: output shows expected key counts for each service/env. No writes performed.
+
+### 3. Sync - dev first
+
+```bash
+./vault-sm-to-vault-sync.sh dev
+```
+
+Verify: 12 passed, 0 failed.
+
+### 4. Validate dev
+
+```bash
+./vault-sm-to-vault-validate.sh dev
+```
+
+Verify: key counts match, AppRole reads succeed, isolation holds.
+
+### 5. Sync stage + prod
+
+```bash
+./vault-sm-to-vault-sync.sh stage
+./vault-sm-to-vault-sync.sh prod
+```
+
+### 6. Full validation
+
+```bash
+./vault-sm-to-vault-validate.sh
+```
+
+Expected: 36 key count checks pass + 2 AppRole read checks + 1 isolation check = 39 total.
+
+## Re-sync Before Switchover
+
+Before switching any service to Vault (Phase 4), re-run the sync to pick up any secret changes made since the last sync:
+
+```bash
+# Re-sync the specific service about to switch
+./vault-sm-to-vault-sync.sh dev api-service
+./vault-sm-to-vault-sync.sh stage api-service
+./vault-sm-to-vault-sync.sh prod api-service
+```
+
+Or re-sync everything:
+
+```bash
+./vault-sm-to-vault-sync.sh
+```
+
+## Rollback
+
+Vault secrets can be deleted without affecting any service (until Phase 4 switchover):
+
+```bash
+# Delete a single service's secrets from Vault
+vault kv metadata delete dx_mysticat/dev/api-service
+```
+
+No SM secrets are modified by this process.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `permission denied` on vault commands | Token expired | `vldj` |
+| `ExpiredTokenException` on AWS commands | Session expired | `klam login && klsa` |
+| `No value found at dx_mysticat/data/...` | Secret not yet synced | Run sync script |
+| Key count mismatch | SM secret changed after sync | Re-run sync for that service/env |
+| AppRole read fails | Bootstrap secret has stale secret_id | Re-run Phase 2 bootstrap script |
+| Isolation check fails | HCL policy too permissive | Check `dx_mysticat_{service}_{env}.hcl` |

--- a/docs/plans/vault-sm-to-vault-sync.sh
+++ b/docs/plans/vault-sm-to-vault-sync.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Phase 3: Sync secrets from AWS Secrets Manager to HashiCorp Vault
+#
+# Reads service secrets from SM (/helix-deploy/spacecat-services/{service}/latest)
+# and writes them to Vault KV (dx_mysticat/{env}/{service}).
+#
+# This script is idempotent - safe to re-run before the Phase 4 switchover.
+# Each run overwrites the Vault KV version, creating a new version in the
+# version history.
+#
+# Prerequisites:
+#   - Vault token: run `vldj` (4h TTL)
+#   - AWS sessions: run `klam login && klsa`
+#
+# Usage:
+#   ./vault-sm-to-vault-sync.sh                  # All services, all envs
+#   ./vault-sm-to-vault-sync.sh dev              # All services, dev only
+#   ./vault-sm-to-vault-sync.sh dev api-service  # Single service + env
+#   DRY_RUN=1 ./vault-sm-to-vault-sync.sh        # Show what would happen
+
+VAULT_MOUNT="dx_mysticat"
+
+SERVICES=(
+  api-service
+  audit-worker
+  auth-service
+  autofix-worker
+  content-processor
+  content-scraper
+  fulfillment-worker
+  import-job-manager
+  import-worker
+  jobs-dispatcher
+  reporting-worker
+  task-manager
+)
+# data-service excluded: uses ECS + different secret layout
+
+ALL_ENVS=(dev stage prod)
+
+declare -A AWS_PROFILES=(
+  [dev]=spacecat-dev
+  [stage]=spacecat-stage
+  [prod]=spacecat-prod
+)
+
+# Parse optional arguments
+FILTER_ENV="${1:-}"
+FILTER_SVC="${2:-}"
+DRY_RUN="${DRY_RUN:-0}"
+
+if [ -n "$FILTER_ENV" ] && [ "$FILTER_ENV" != "dev" ] && [ "$FILTER_ENV" != "stage" ] && [ "$FILTER_ENV" != "prod" ]; then
+  echo "Usage: $0 [dev|stage|prod] [service-name]"
+  exit 1
+fi
+
+ENVS=("${ALL_ENVS[@]}")
+if [ -n "$FILTER_ENV" ]; then
+  ENVS=("$FILTER_ENV")
+fi
+
+pass=0
+fail=0
+skip=0
+failures=()
+
+for service in "${SERVICES[@]}"; do
+  if [ -n "$FILTER_SVC" ] && [ "$service" != "$FILTER_SVC" ]; then
+    continue
+  fi
+
+  for env in "${ENVS[@]}"; do
+    profile="${AWS_PROFILES[$env]}"
+    sm_path="/helix-deploy/spacecat-services/${service}/latest"
+    vault_path="${VAULT_MOUNT}/${env}/${service}"
+
+    echo "--- ${service} / ${env} ---"
+
+    # Read from SM
+    echo "  Reading SM secret: ${sm_path} (${profile})"
+    if ! SM_JSON=$(AWS_PROFILE="${profile}" aws secretsmanager get-secret-value \
+      --secret-id "${sm_path}" \
+      --query SecretString --output text 2>&1); then
+      echo "  SKIP: SM secret not found or not accessible: ${SM_JSON}"
+      skip=$((skip + 1))
+      continue
+    fi
+
+    # Count keys for reporting
+    KEY_COUNT=$(echo "$SM_JSON" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))")
+    echo "  SM has ${KEY_COUNT} keys"
+
+    if [ "$DRY_RUN" = "1" ]; then
+      echo "  DRY RUN: would write ${KEY_COUNT} keys to Vault at ${vault_path}"
+      pass=$((pass + 1))
+      continue
+    fi
+
+    # Write to Vault KV
+    echo "  Writing to Vault: ${vault_path}"
+    if ! VAULT_RESULT=$(echo "$SM_JSON" | vault kv put "${vault_path}" - 2>&1); then
+      echo "  FAIL: Vault write failed: ${VAULT_RESULT}"
+      fail=$((fail + 1))
+      failures+=("${service}/${env}: vault kv put failed - ${VAULT_RESULT}")
+      continue
+    fi
+
+    # Verify round-trip: read back and compare key count
+    VAULT_KEY_COUNT=$(vault kv get -format=json "${vault_path}" 2>/dev/null \
+      | python3 -c "import sys,json; print(len(json.load(sys.stdin)['data']['data']))" 2>/dev/null || echo "0")
+
+    if [ "$KEY_COUNT" = "$VAULT_KEY_COUNT" ]; then
+      echo "  PASS: ${KEY_COUNT} keys synced and verified"
+      pass=$((pass + 1))
+    else
+      echo "  FAIL: key count mismatch - SM=${KEY_COUNT}, Vault=${VAULT_KEY_COUNT}"
+      fail=$((fail + 1))
+      failures+=("${service}/${env}: key count mismatch SM=${KEY_COUNT} Vault=${VAULT_KEY_COUNT}")
+    fi
+  done
+done
+
+echo ""
+echo "========================================="
+echo "Results: ${pass} passed, ${fail} failed, ${skip} skipped"
+echo "========================================="
+
+if [ ${#failures[@]} -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for f in "${failures[@]}"; do
+    echo "  - ${f}"
+  done
+  exit 1
+fi

--- a/docs/plans/vault-sm-to-vault-validate.sh
+++ b/docs/plans/vault-sm-to-vault-validate.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Phase 3 Validation: Verify secrets in Vault match SM and AppRole isolation works
+#
+# Prerequisites:
+#   - Vault token: run `vldj` (4h TTL)
+#   - AWS sessions: run `klam login && klsa`
+#
+# Usage:
+#   ./vault-sm-to-vault-validate.sh           # Full validation
+#   ./vault-sm-to-vault-validate.sh dev       # Dev only
+
+VAULT_MOUNT="dx_mysticat"
+
+SERVICES=(
+  api-service
+  audit-worker
+  auth-service
+  autofix-worker
+  content-processor
+  content-scraper
+  fulfillment-worker
+  import-job-manager
+  import-worker
+  jobs-dispatcher
+  reporting-worker
+  task-manager
+)
+
+ALL_ENVS=(dev stage prod)
+
+declare -A AWS_PROFILES=(
+  [dev]=spacecat-dev
+  [stage]=spacecat-stage
+  [prod]=spacecat-prod
+)
+
+FILTER_ENV="${1:-}"
+ENVS=("${ALL_ENVS[@]}")
+if [ -n "$FILTER_ENV" ]; then
+  ENVS=("$FILTER_ENV")
+fi
+
+pass=0
+fail=0
+
+echo "=== Check 1: Key count match (SM vs Vault) ==="
+echo ""
+
+for service in "${SERVICES[@]}"; do
+  for env in "${ENVS[@]}"; do
+    profile="${AWS_PROFILES[$env]}"
+
+    SM_KEYS=$(AWS_PROFILE="${profile}" aws secretsmanager get-secret-value \
+      --secret-id "/helix-deploy/spacecat-services/${service}/latest" \
+      --query SecretString --output text 2>/dev/null \
+      | python3 -c "import sys,json; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
+
+    VAULT_KEYS=$(vault kv get -format=json "${VAULT_MOUNT}/${env}/${service}" 2>/dev/null \
+      | python3 -c "import sys,json; print(len(json.load(sys.stdin)['data']['data']))" 2>/dev/null || echo "0")
+
+    if [ "$SM_KEYS" = "0" ] && [ "$VAULT_KEYS" = "0" ]; then
+      echo "  SKIP: ${env}/${service} - no secret in SM or Vault"
+    elif [ "$SM_KEYS" = "$VAULT_KEYS" ]; then
+      echo "  OK: ${env}/${service} (${SM_KEYS} keys)"
+      pass=$((pass + 1))
+    else
+      echo "  MISMATCH: ${env}/${service} - SM=${SM_KEYS}, Vault=${VAULT_KEYS}"
+      fail=$((fail + 1))
+    fi
+  done
+done
+
+echo ""
+echo "=== Check 2: AppRole-scoped reads (service can read its own secrets) ==="
+echo ""
+
+# Spot-check: first and last service in dev
+for svc in api-service task-manager; do
+  BOOTSTRAP=$(AWS_PROFILE=spacecat-dev aws secretsmanager get-secret-value \
+    --secret-id "/mysticat/bootstrap/${svc}" \
+    --query SecretString --output text 2>/dev/null)
+  ROLE_ID=$(echo "$BOOTSTRAP" | python3 -c "import sys,json; print(json.load(sys.stdin)['role_id'])")
+  SEC_ID=$(echo "$BOOTSTRAP" | python3 -c "import sys,json; print(json.load(sys.stdin)['secret_id'])")
+  TOKEN=$(vault write -field=token auth/approle/login role_id="$ROLE_ID" secret_id="$SEC_ID" 2>/dev/null)
+
+  if VAULT_TOKEN=$TOKEN vault kv get "${VAULT_MOUNT}/dev/${svc}" > /dev/null 2>&1; then
+    echo "  OK: ${svc} can read its own secrets via AppRole"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: ${svc} cannot read its own secrets via AppRole"
+    fail=$((fail + 1))
+  fi
+done
+
+echo ""
+echo "=== Check 3: Credential isolation (cross-service read must fail) ==="
+echo ""
+
+# Login as reporting-worker, try to read api-service (should be denied)
+BOOTSTRAP=$(AWS_PROFILE=spacecat-dev aws secretsmanager get-secret-value \
+  --secret-id "/mysticat/bootstrap/reporting-worker" \
+  --query SecretString --output text 2>/dev/null)
+ROLE_ID=$(echo "$BOOTSTRAP" | python3 -c "import sys,json; print(json.load(sys.stdin)['role_id'])")
+SEC_ID=$(echo "$BOOTSTRAP" | python3 -c "import sys,json; print(json.load(sys.stdin)['secret_id'])")
+TOKEN=$(vault write -field=token auth/approle/login role_id="$ROLE_ID" secret_id="$SEC_ID" 2>/dev/null)
+
+if VAULT_TOKEN=$TOKEN vault kv get "${VAULT_MOUNT}/dev/api-service" > /dev/null 2>&1; then
+  echo "  FAIL: isolation broken - reporting-worker CAN read api-service secrets"
+  fail=$((fail + 1))
+else
+  echo "  OK: isolation verified - reporting-worker CANNOT read api-service secrets"
+  pass=$((pass + 1))
+fi
+
+echo ""
+echo "========================================="
+echo "Validation: ${pass} passed, ${fail} failed"
+echo "========================================="
+
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

- Adds Phase 1a/1b/1c implementation plans for the per-service Vault AppRole migration
- Adds repeatable SM-to-Vault sync and validation scripts (Phase 3)
- Adds runbook documenting the full sync/validate procedure

These are documentation and operational scripts only - no code changes.

SITES-40735