### PR TITLE
feat(audit-url): add moneyPages source to auditTargetURLs config

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -553,6 +553,13 @@ export const Config = (data = {}) => {
     state.auditTargetURLs[source] = urls;
   };
 
+  self.mergeAuditTargetURLs = (partial) => {
+    if (!partial || typeof partial !== 'object' || Array.isArray(partial)) return;
+    for (const [source, urls] of Object.entries(partial)) {
+      self.updateAuditTargetURLs(source, urls);
+    }
+  };
+
   self.addAuditTargetURL = (source, urlObj) => {
     validateAuditTargetSource(source);
     Joi.assert(urlObj, auditTargetEntrySchema, 'Invalid audit target URL');

--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -553,13 +553,6 @@ export const Config = (data = {}) => {
     state.auditTargetURLs[source] = urls;
   };
 
-  self.mergeAuditTargetURLs = (partial) => {
-    if (!partial || typeof partial !== 'object' || Array.isArray(partial)) return;
-    for (const [source, urls] of Object.entries(partial)) {
-      self.updateAuditTargetURLs(source, urls);
-    }
-  };
-
   self.addAuditTargetURL = (source, urlObj) => {
     validateAuditTargetSource(source);
     Joi.assert(urlObj, auditTargetEntrySchema, 'Invalid audit target URL');

--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -404,6 +404,9 @@ export const configSchema = Joi.object({
     manual: Joi.array().items(Joi.object({
       url: Joi.string().uri().required(),
     })).optional().default([]),
+    moneyPages: Joi.array().items(Joi.object({
+      url: Joi.string().uri().required(),
+    })).optional().default([]),
   }).options({ stripUnknown: true }).optional(),
   handlers: Joi.object().pattern(Joi.string(), Joi.object({
     mentions: Joi.object().pattern(Joi.string(), Joi.array().items(Joi.string())),
@@ -515,7 +518,7 @@ export const Config = (data = {}) => {
   self.getEdgeOptimizeConfig = () => state?.edgeOptimizeConfig;
   self.getOnboardConfig = () => state?.onboardConfig;
   self.getCommerceLlmoConfig = () => state?.commerceLlmoConfig;
-  const AUDIT_TARGET_SOURCES = ['manual'];
+  const AUDIT_TARGET_SOURCES = ['manual', 'moneyPages'];
   const auditTargetEntrySchema = Joi.object({
     url: Joi.string().uri().required(),
   });

--- a/packages/spacecat-shared-data-access/src/models/site/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/site/index.d.ts
@@ -235,7 +235,6 @@ export interface SiteConfig {
   getAuditTargetURLs(): AuditTargetEntryWithSource[];
   getAuditTargetURLsBySource(source: AuditTargetSource): AuditTargetEntry[];
   updateAuditTargetURLs(source: AuditTargetSource, urls: AuditTargetEntry[]): void;
-  mergeAuditTargetURLs(partial: Partial<AuditTargetURLs>): void;
   addAuditTargetURL(source: AuditTargetSource, urlObj: AuditTargetEntry): void;
   removeAuditTargetURL(source: AuditTargetSource, url: string): void;
 }

--- a/packages/spacecat-shared-data-access/src/models/site/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/site/index.d.ts
@@ -110,7 +110,7 @@ export interface LlmoCustomerIntent {
   value: string;
 }
 
-export type AuditTargetSource = 'manual';
+export type AuditTargetSource = 'manual' | 'moneyPages';
 
 export interface AuditTargetEntry {
   url: string;
@@ -122,6 +122,7 @@ export interface AuditTargetEntryWithSource extends AuditTargetEntry {
 
 export interface AuditTargetURLs {
   manual?: AuditTargetEntry[];
+  moneyPages?: AuditTargetEntry[];
 }
 
 export interface SiteConfig {

--- a/packages/spacecat-shared-data-access/src/models/site/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/site/index.d.ts
@@ -235,6 +235,7 @@ export interface SiteConfig {
   getAuditTargetURLs(): AuditTargetEntryWithSource[];
   getAuditTargetURLsBySource(source: AuditTargetSource): AuditTargetEntry[];
   updateAuditTargetURLs(source: AuditTargetSource, urls: AuditTargetEntry[]): void;
+  mergeAuditTargetURLs(partial: Partial<AuditTargetURLs>): void;
   addAuditTargetURL(source: AuditTargetSource, urlObj: AuditTargetEntry): void;
   removeAuditTargetURL(source: AuditTargetSource, url: string): void;
 }

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -3041,6 +3041,20 @@ describe('Config Tests', () => {
       expect(result[1].source).to.equal('manual');
     });
 
+    it('returns entries from both manual and moneyPages with correct source tags', () => {
+      const config = Config({
+        auditTargetURLs: {
+          manual: [{ url: 'https://example.com/manual1' }],
+          moneyPages: [{ url: 'https://example.com/money1' }, { url: 'https://example.com/money2' }],
+        },
+      });
+      const result = config.getAuditTargetURLs();
+      expect(result).to.have.lengthOf(3);
+      expect(result[0]).to.deep.equal({ url: 'https://example.com/manual1', source: 'manual' });
+      expect(result[1]).to.deep.equal({ url: 'https://example.com/money1', source: 'moneyPages' });
+      expect(result[2]).to.deep.equal({ url: 'https://example.com/money2', source: 'moneyPages' });
+    });
+
     describe('getAuditTargetURLsBySource', () => {
       it('returns URLs for a specific source', () => {
         const config = Config({
@@ -3054,9 +3068,22 @@ describe('Config Tests', () => {
         expect(manual[1].url).to.equal('https://example.com/m2');
       });
 
+      it('returns moneyPages URLs for moneyPages source', () => {
+        const config = Config({
+          auditTargetURLs: {
+            moneyPages: [{ url: 'https://example.com/mp1' }, { url: 'https://example.com/mp2' }],
+          },
+        });
+        const moneyPages = config.getAuditTargetURLsBySource('moneyPages');
+        expect(moneyPages).to.have.lengthOf(2);
+        expect(moneyPages[0].url).to.equal('https://example.com/mp1');
+        expect(moneyPages[1].url).to.equal('https://example.com/mp2');
+      });
+
       it('returns empty array for source with no entries', () => {
         const config = Config();
         expect(config.getAuditTargetURLsBySource('manual')).to.deep.equal([]);
+        expect(config.getAuditTargetURLsBySource('moneyPages')).to.deep.equal([]);
       });
 
       it('rejects invalid source', () => {
@@ -3096,6 +3123,19 @@ describe('Config Tests', () => {
         config.updateAuditTargetURLs('manual', []);
         expect(config.getAuditTargetURLsBySource('manual')).to.deep.equal([]);
       });
+
+      it('replaces URLs for moneyPages source', () => {
+        const config = Config({
+          auditTargetURLs: {
+            moneyPages: [{ url: 'https://old.com' }],
+          },
+        });
+        config.updateAuditTargetURLs('moneyPages', [
+          { url: 'https://new1.com' },
+          { url: 'https://new2.com' },
+        ]);
+        expect(config.getAuditTargetURLsBySource('moneyPages')).to.have.lengthOf(2);
+      });
     });
 
     describe('addAuditTargetURL', () => {
@@ -3129,6 +3169,25 @@ describe('Config Tests', () => {
         const config = Config();
         expect(() => config.addAuditTargetURL('invalid', { url: 'https://example.com' })).to.throw('Invalid audit target source');
       });
+
+      it('appends a new URL to moneyPages source', () => {
+        const config = Config();
+        config.addAuditTargetURL('moneyPages', { url: 'https://example.com/mp1' });
+        config.addAuditTargetURL('moneyPages', { url: 'https://example.com/mp2' });
+        expect(config.getAuditTargetURLsBySource('moneyPages')).to.have.lengthOf(2);
+        expect(config.getAuditTargetURLsBySource('moneyPages')[1].url).to.equal('https://example.com/mp2');
+      });
+
+      it('deduplicates across manual and moneyPages sources', () => {
+        const config = Config({
+          auditTargetURLs: {
+            manual: [{ url: 'https://example.com/shared' }],
+          },
+        });
+        config.addAuditTargetURL('moneyPages', { url: 'https://example.com/shared' });
+        expect(config.getAuditTargetURLsBySource('moneyPages')).to.have.lengthOf(0);
+        expect(config.getAuditTargetURLs()).to.have.lengthOf(1);
+      });
     });
 
     describe('removeAuditTargetURL', () => {
@@ -3161,6 +3220,17 @@ describe('Config Tests', () => {
         const config = Config();
         expect(() => config.removeAuditTargetURL('invalid', 'https://example.com')).to.throw('Invalid audit target source');
       });
+
+      it('removes by url string from moneyPages source', () => {
+        const config = Config({
+          auditTargetURLs: {
+            moneyPages: [{ url: 'https://example.com/mp1' }, { url: 'https://example.com/mp2' }],
+          },
+        });
+        config.removeAuditTargetURL('moneyPages', 'https://example.com/mp2');
+        expect(config.getAuditTargetURLsBySource('moneyPages')).to.have.lengthOf(1);
+        expect(config.getAuditTargetURLsBySource('moneyPages')[0].url).to.equal('https://example.com/mp1');
+      });
     });
 
     describe('serialization', () => {
@@ -3173,6 +3243,7 @@ describe('Config Tests', () => {
         const item = Config.toDynamoItem(config);
         expect(item.auditTargetURLs).to.deep.equal({
           manual: [{ url: 'https://example.com/page1' }],
+          moneyPages: [],
         });
       });
 
@@ -3183,6 +3254,31 @@ describe('Config Tests', () => {
               { url: 'https://example.com/page1' },
               { url: 'https://example.com/page2' },
             ],
+          },
+        });
+        const item = Config.toDynamoItem(config);
+        const restored = Config.fromDynamoItem(item);
+        expect(restored.getAuditTargetURLs()).to.deep.equal(config.getAuditTargetURLs());
+      });
+
+      it('includes moneyPages in toDynamoItem conversion', () => {
+        const config = Config({
+          auditTargetURLs: {
+            moneyPages: [{ url: 'https://example.com/mp1' }],
+          },
+        });
+        const item = Config.toDynamoItem(config);
+        expect(item.auditTargetURLs).to.deep.equal({
+          manual: [],
+          moneyPages: [{ url: 'https://example.com/mp1' }],
+        });
+      });
+
+      it('round-trips both manual and moneyPages through serialization', () => {
+        const config = Config({
+          auditTargetURLs: {
+            manual: [{ url: 'https://example.com/m1' }],
+            moneyPages: [{ url: 'https://example.com/mp1' }],
           },
         });
         const item = Config.toDynamoItem(config);
@@ -3200,17 +3296,20 @@ describe('Config Tests', () => {
         })).to.throw();
       });
 
-      it('strips unknown source keys from auditTargetURLs', () => {
+      it('strips unknown source keys from auditTargetURLs but keeps moneyPages', () => {
         const config = Config({
           auditTargetURLs: {
             manual: [{ url: 'https://example.com/page1' }],
+            moneyPages: [{ url: 'https://example.com/mp1' }],
             unknown: [{ url: 'https://example.com/page2' }],
           },
         });
         const result = config.getAuditTargetURLs();
-        expect(result).to.have.lengthOf(1);
+        expect(result).to.have.lengthOf(2);
         expect(result[0].url).to.equal('https://example.com/page1');
         expect(result[0].source).to.equal('manual');
+        expect(result[1].url).to.equal('https://example.com/mp1');
+        expect(result[1].source).to.equal('moneyPages');
       });
     });
   });

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -3141,45 +3141,6 @@ describe('Config Tests', () => {
       });
     });
 
-    describe('mergeAuditTargetURLs', () => {
-      it('merges a partial update without affecting other sources', () => {
-        const config = Config({
-          auditTargetURLs: {
-            manual: [{ url: 'https://example.com/m1' }],
-            moneyPages: [{ url: 'https://example.com/mp1' }],
-          },
-        });
-        config.mergeAuditTargetURLs({ manual: [{ url: 'https://example.com/m2' }] });
-        expect(config.getAuditTargetURLsBySource('manual')).to.deep.equal([{ url: 'https://example.com/m2' }]);
-        expect(config.getAuditTargetURLsBySource('moneyPages')).to.deep.equal([{ url: 'https://example.com/mp1' }]);
-      });
-
-      it('merges moneyPages without affecting manual', () => {
-        const config = Config({
-          auditTargetURLs: {
-            manual: [{ url: 'https://example.com/m1' }],
-            moneyPages: [{ url: 'https://example.com/mp1' }],
-          },
-        });
-        config.mergeAuditTargetURLs({ moneyPages: [{ url: 'https://example.com/mp2' }] });
-        expect(config.getAuditTargetURLsBySource('manual')).to.deep.equal([{ url: 'https://example.com/m1' }]);
-        expect(config.getAuditTargetURLsBySource('moneyPages')).to.deep.equal([{ url: 'https://example.com/mp2' }]);
-      });
-
-      it('ignores invalid input gracefully', () => {
-        const config = Config({ auditTargetURLs: { manual: [{ url: 'https://example.com/m1' }] } });
-        expect(() => config.mergeAuditTargetURLs(null)).to.not.throw();
-        expect(() => config.mergeAuditTargetURLs([])).to.not.throw();
-        expect(() => config.mergeAuditTargetURLs('string')).to.not.throw();
-        expect(config.getAuditTargetURLsBySource('manual')).to.deep.equal([{ url: 'https://example.com/m1' }]);
-      });
-
-      it('rejects invalid source in partial', () => {
-        const config = Config();
-        expect(() => config.mergeAuditTargetURLs({ invalid: [] })).to.throw('Invalid audit target source');
-      });
-    });
-
     describe('addAuditTargetURL', () => {
       it('appends a new URL to the specified source', () => {
         const config = Config();

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -3134,7 +3134,49 @@ describe('Config Tests', () => {
           { url: 'https://new1.com' },
           { url: 'https://new2.com' },
         ]);
-        expect(config.getAuditTargetURLsBySource('moneyPages')).to.have.lengthOf(2);
+        const result = config.getAuditTargetURLsBySource('moneyPages');
+        expect(result).to.have.lengthOf(2);
+        expect(result[0].url).to.equal('https://new1.com');
+        expect(result[1].url).to.equal('https://new2.com');
+      });
+    });
+
+    describe('mergeAuditTargetURLs', () => {
+      it('merges a partial update without affecting other sources', () => {
+        const config = Config({
+          auditTargetURLs: {
+            manual: [{ url: 'https://example.com/m1' }],
+            moneyPages: [{ url: 'https://example.com/mp1' }],
+          },
+        });
+        config.mergeAuditTargetURLs({ manual: [{ url: 'https://example.com/m2' }] });
+        expect(config.getAuditTargetURLsBySource('manual')).to.deep.equal([{ url: 'https://example.com/m2' }]);
+        expect(config.getAuditTargetURLsBySource('moneyPages')).to.deep.equal([{ url: 'https://example.com/mp1' }]);
+      });
+
+      it('merges moneyPages without affecting manual', () => {
+        const config = Config({
+          auditTargetURLs: {
+            manual: [{ url: 'https://example.com/m1' }],
+            moneyPages: [{ url: 'https://example.com/mp1' }],
+          },
+        });
+        config.mergeAuditTargetURLs({ moneyPages: [{ url: 'https://example.com/mp2' }] });
+        expect(config.getAuditTargetURLsBySource('manual')).to.deep.equal([{ url: 'https://example.com/m1' }]);
+        expect(config.getAuditTargetURLsBySource('moneyPages')).to.deep.equal([{ url: 'https://example.com/mp2' }]);
+      });
+
+      it('ignores invalid input gracefully', () => {
+        const config = Config({ auditTargetURLs: { manual: [{ url: 'https://example.com/m1' }] } });
+        expect(() => config.mergeAuditTargetURLs(null)).to.not.throw();
+        expect(() => config.mergeAuditTargetURLs([])).to.not.throw();
+        expect(() => config.mergeAuditTargetURLs('string')).to.not.throw();
+        expect(config.getAuditTargetURLsBySource('manual')).to.deep.equal([{ url: 'https://example.com/m1' }]);
+      });
+
+      it('rejects invalid source in partial', () => {
+        const config = Config();
+        expect(() => config.mergeAuditTargetURLs({ invalid: [] })).to.throw('Invalid audit target source');
       });
     });
 


### PR DESCRIPTION
Add moneyPages as a new audit target URL source alongside manual, with identical structure (array of { url } entries) and full cross-source deduplication support.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
