### PR TITLE
feat: LLMO-3959 changing schema to add detectCdn flag

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -352,6 +352,7 @@ export const configSchema = Joi.object({
       cdnProvider: Joi.string().optional(),
       region: Joi.string().pattern(AWS_REGION_PATTERN).optional(),
     }).optional(),
+    detectedCdn: Joi.string().valid('aem-cs-fastly', 'other').optional(),
   }).optional(),
   cdnLogsConfig: Joi.object({
     bucketName: Joi.string().required(),
@@ -513,6 +514,7 @@ export const Config = (data = {}) => {
   self.getLlmoCdnlogsFilter = () => state?.llmo?.cdnlogsFilter;
   self.getLlmoCountryCodeIgnoreList = () => state?.llmo?.countryCodeIgnoreList;
   self.getLlmoCdnBucketConfig = () => state?.llmo?.cdnBucketConfig;
+  self.getLlmoDetectedCdn = () => state?.llmo?.detectedCdn ?? null;
   self.getTokowakaConfig = () => state?.tokowakaConfig;
   self.getEdgeOptimizeConfig = () => state?.edgeOptimizeConfig;
   self.getOnboardConfig = () => state?.onboardConfig;
@@ -670,6 +672,11 @@ export const Config = (data = {}) => {
   self.updateLlmoCdnBucketConfig = (cdnBucketConfig) => {
     state.llmo = state.llmo || {};
     state.llmo.cdnBucketConfig = cdnBucketConfig;
+  };
+
+  self.updateLlmoDetectedCdn = (detectedCdn) => {
+    state.llmo = state.llmo || {};
+    state.llmo.detectedCdn = detectedCdn;
   };
 
   self.addLlmoTag = (tag) => {

--- a/packages/spacecat-shared-data-access/src/models/site/site.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/site/site.schema.js
@@ -106,10 +106,6 @@ const schema = new SchemaBuilder(Site, SiteCollection)
     type: Object.values(Site.AUTHORING_TYPES),
     required: false,
   })
-  .addAttribute('detectedCdn', {
-    type: 'string',
-    required: false,
-  })
   .addAttribute('gitHubURL', {
     type: 'string',
     postgrestField: 'github_url',

--- a/packages/spacecat-shared-data-access/src/models/site/site.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/site/site.schema.js
@@ -106,6 +106,10 @@ const schema = new SchemaBuilder(Site, SiteCollection)
     type: Object.values(Site.AUTHORING_TYPES),
     required: false,
   })
+  .addAttribute('detectedCdn', {
+    type: 'string',
+    required: false,
+  })
   .addAttribute('gitHubURL', {
     type: 'string',
     postgrestField: 'github_url',

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -2560,6 +2560,41 @@ describe('Config Tests', () => {
     });
   });
 
+  describe('LLMO Detected CDN', () => {
+    it('creates a Config with llmo detectedCdn property', () => {
+      const data = {
+        llmo: {
+          dataFolder: '/test',
+          brand: 'testBrand',
+          detectedCdn: 'aem-cs-fastly',
+        },
+      };
+      const config = Config(data);
+      expect(config.getLlmoDetectedCdn()).to.equal('aem-cs-fastly');
+    });
+
+    it('returns null for detectedCdn in default config', () => {
+      const config = Config();
+      expect(config.getLlmoDetectedCdn()).to.be.null;
+    });
+
+    it('returns null for detectedCdn if not provided', () => {
+      const config = Config({
+        llmo: {
+          dataFolder: '/test',
+          brand: 'testBrand',
+        },
+      });
+      expect(config.getLlmoDetectedCdn()).to.be.null;
+    });
+
+    it('should be able to update detectedCdn', () => {
+      const config = Config();
+      config.updateLlmoDetectedCdn('other');
+      expect(config.getLlmoDetectedCdn()).to.equal('other');
+    });
+  });
+
   describe('Tokowaka Config', () => {
     it('creates a Config with tokowakaConfig property', () => {
       const data = {


### PR DESCRIPTION
## Summary

Add support for persisting the auto-detected CDN provider inside `config.llmo.detectedCdn` on the Site model, as part of the LLMO onboarding CDN auto-detection feature (LLMO-3959).

### Changes

- **Joi schema**: Add `detectedCdn: Joi.string().valid('aem-cs-fastly', 'other').optional()` to the `llmo` config object
- **Config model**: Add `getLlmoDetectedCdn()` getter (returns `null` when absent) and `updateLlmoDetectedCdn()` setter
- **Site schema**: Remove the previously added top-level `detectedCdn` attribute — the value is now nested inside the existing `config` JSONB column, avoiding a database migration
- **Tests**: Add 4 unit tests for the new getter/setter following the existing pattern (CdnBucketConfig, CountryCodeIgnoreList)

### Three-state values

| Value | Meaning |
|-------|---------|
| `'aem-cs-fastly'` | DNS confirmed the site uses AEM CS Fastly |
| `'other'` | DNS resolved successfully but did not match AEM CS Fastly |
| `null` / absent | DNS lookup failed — inconclusive |
