### PR TITLE
feat: add contentSourcePath to deliveryConfig schema

### DIFF
--- a/packages/spacecat-shared-data-access/README.md
+++ b/packages/spacecat-shared-data-access/README.md
@@ -170,6 +170,7 @@ The `deliveryConfig` object on a Site stores delivery infrastructure details. It
 | `tenantId` | string | Cloud Manager tenant identifier (from `/program/{programId}` response) |
 | `ipAllowlistExists` | boolean | Whether the CM program has real IP allowlists configured (excludes default `0.0.0.0/32` entries) |
 | `preferContentApi` | boolean | Whether to prefer the Content API for content retrieval |
+| `contentSourcePath` | string | AEM content root path for a site. Used to disambiguate multiple sites that share the same Cloud Manager program and environment. Corresponds to `/content/<site-name>` in the AEM repository. |
 
 ## Architecture
 

--- a/packages/spacecat-shared-data-access/src/models/site/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/site/index.d.ts
@@ -52,6 +52,7 @@ export interface DeliveryConfig {
   tenantId?: string;
   ipAllowlistExists?: boolean;
   imsOrgId?: string;
+  contentSourcePath?: string;
   [key: string]: unknown;
 }
 

--- a/packages/spacecat-shared-data-access/src/models/site/site.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/site/site.schema.js
@@ -117,6 +117,7 @@ const schema = new SchemaBuilder(Site, SiteCollection)
       tenantId: { type: 'string' },
       ipAllowlistExists: { type: 'boolean' },
       imsOrgId: { type: 'string' },
+      contentSourcePath: { type: 'string' },
     },
   })
   .addAttribute('hlxConfig', {


### PR DESCRIPTION
JIRA: https://jira.corp.adobe.com/browse/SITES-41284

## Problem

- Multiple AEM CS sites can share the same Cloud Manager program and environment (e.g. insureshield.com, about.ups.com, parcelpro.com on p55671/e392469). 
- The existing lookup by programId+environmentId returns an arbitrary first match, causing Preflight to resolve the wrong site.

## Fix

- Add `contentSourcePath` (the AEM content root, e.g. /content/aboutus) to the `deliveryConfig` schema, TypeScript interface, and documentation so it can serve as an additional discriminator.

Thanks for contributing!