### PR TITLE
chore: enforce curly braces and remove deprecated eslint-env comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "./packages/*"
       ],
       "devDependencies": {
-        "@adobe/eslint-config-helix": "3.0.23",
+        "@adobe/eslint-config-helix": "3.0.24",
         "@babel/core": "7.29.0",
         "@babel/eslint-parser": "7.28.6",
         "@babel/plugin-syntax-import-assertions": "7.28.6",
@@ -81,9 +81,9 @@
       "license": "MIT"
     },
     "node_modules/@adobe/eslint-config-helix": {
-      "version": "3.0.23",
-      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-helix/-/eslint-config-helix-3.0.23.tgz",
-      "integrity": "sha512-CdZ9ehUwq3HvEOSzo1VPHbWTNEEilCmyZkPJ7489pR6T5cCO1A1f/HU4PEsSwT7JOB5PrPhBWGZ2hW9leFZXmA==",
+      "version": "3.0.24",
+      "resolved": "https://registry.npmjs.org/@adobe/eslint-config-helix/-/eslint-config-helix-3.0.24.tgz",
+      "integrity": "sha512-JspRdcd9JVlIcj1FTVvX1+tP9QbgENUdjVUqQcYBS0KesLWgLemSWn3LL4bsBvO33QrGo/DySk3/0zFXRAWXRw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -112,9 +112,9 @@
       }
     },
     "node_modules/@adobe/fetch": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
-      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.3.0.tgz",
+      "integrity": "sha512-CWqxnxnFl8QNuTT2MlHG3UFcglbeWiv9FUIdSOtA21McycI9s8SY+PLm+t1kodyWLAYZiMiN0Ma/jV+52tEMEQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "4.4.3",
@@ -224,6 +224,20 @@
         "remark-parse": "11.0.0",
         "unified": "11.0.5",
         "unist-util-visit": "5.0.0"
+      }
+    },
+    "node_modules/@adobe/helix-md2docx/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "node_modules/@adobe/helix-md2docx/node_modules/@adobe/helix-docx2md": {
@@ -349,6 +363,20 @@
         "aws4": "1.13.2"
       }
     },
+    "node_modules/@adobe/helix-universal/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "node_modules/@adobe/mammoth": {
       "version": "1.7.1-bleeding.2",
       "resolved": "https://registry.npmjs.org/@adobe/mammoth/-/mammoth-1.7.1-bleeding.2.tgz",
@@ -471,6 +499,20 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-helix-content-sdk/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "node_modules/@adobe/spacecat-shared-ahrefs-client": {
@@ -870,7 +912,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.940.0.tgz",
       "integrity": "sha512-u2sXsNJazJbuHeWICvsj6RvNyJh3isedEfPvB21jK/kxcriK+dE/izlKC2cyxUjERCmku0zTFNzY9FhrLbYHjQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -3008,7 +3049,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -4501,7 +4541,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -6759,7 +6798,6 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -6932,7 +6970,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -7165,7 +7202,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7580,7 +7616,6 @@
       "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.12.0.tgz",
       "integrity": "sha512-lwalRdxXRy+Sn49/vN7W507qqmBRk5Fy2o0a9U6XTjL9IV+oR5PUiiptoBrOcaYCiVuGld8OEbNqhm6wvV3m6A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -7838,7 +7873,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8050,7 +8084,6 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10002,7 +10035,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -13538,7 +13570,6 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -16730,7 +16761,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18348,7 +18378,6 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -18507,7 +18536,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -20421,7 +20449,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20530,7 +20557,6 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -21570,7 +21596,7 @@
       "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/fetch": "4.2.3",
+        "@adobe/fetch": "4.3.0",
         "@adobe/helix-universal": "5.4.0",
         "@adobe/spacecat-shared-utils": "1.81.1",
         "urijs": "1.19.11"
@@ -21610,6 +21636,20 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/mysticat-shared-seo-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "packages/mysticat-shared-seo-client/node_modules/@aws-sdk/client-s3": {
@@ -22295,7 +22335,7 @@
       "version": "1.10.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/fetch": "4.2.3",
+        "@adobe/fetch": "4.3.0",
         "@adobe/helix-universal": "5.4.0",
         "@adobe/spacecat-shared-utils": "1.81.1"
       },
@@ -22334,6 +22374,20 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-ahrefs-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "packages/spacecat-shared-ahrefs-client/node_modules/@aws-sdk/client-s3": {
@@ -23032,6 +23086,20 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-athena-client/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "packages/spacecat-shared-athena-client/node_modules/@adobe/spacecat-shared-utils": {
@@ -23760,6 +23828,20 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-brand-client/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "packages/spacecat-shared-brand-client/node_modules/@adobe/spacecat-shared-ims-client": {
@@ -24536,7 +24618,7 @@
       "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/fetch": "4.2.3",
+        "@adobe/fetch": "4.3.0",
         "@adobe/spacecat-shared-ims-client": "1.11.6",
         "@adobe/spacecat-shared-utils": "1.81.1",
         "@aws-sdk/client-s3": "3.1024.0",
@@ -24565,6 +24647,20 @@
       "dependencies": {
         "@adobe/fetch": "4.2.3",
         "aws4": "1.13.2"
+      }
+    },
+    "packages/spacecat-shared-cloud-manager-client/node_modules/@adobe/helix-universal/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "packages/spacecat-shared-cloud-manager-client/node_modules/@adobe/spacecat-shared-data-access": {
@@ -24605,6 +24701,20 @@
         "npm": ">=10.9.0 <12.0.0"
       }
     },
+    "packages/spacecat-shared-cloud-manager-client/node_modules/@adobe/spacecat-shared-ims-client/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "packages/spacecat-shared-cloud-manager-client/node_modules/@adobe/spacecat-shared-utils": {
       "version": "1.81.1",
       "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.81.1.tgz",
@@ -24627,6 +24737,20 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloud-manager-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "packages/spacecat-shared-cloud-manager-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/client-s3": {
@@ -25401,6 +25525,20 @@
         "npm": ">=10.0.0 <12.0.0"
       }
     },
+    "packages/spacecat-shared-content-client/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "packages/spacecat-shared-content-client/node_modules/@adobe/spacecat-shared-utils": {
       "version": "1.81.1",
       "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.81.1.tgz",
@@ -26105,7 +26243,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "3.46.0",
+      "version": "3.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",
@@ -26127,6 +26265,20 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-data-access/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "packages/spacecat-shared-data-access/node_modules/@adobe/spacecat-shared-utils": {
@@ -26311,6 +26463,20 @@
         "npm": ">=10.9.0 <12.0.0"
       }
     },
+    "packages/spacecat-shared-drs-client/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "packages/spacecat-shared-drs-client/node_modules/@adobe/spacecat-shared-utils": {
       "version": "1.98.1",
       "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.98.1.tgz",
@@ -26490,7 +26656,7 @@
       "version": "1.2.33",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/fetch": "4.2.3",
+        "@adobe/fetch": "4.3.0",
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-universal": "5.4.0",
         "aws4": "1.13.2"
@@ -26506,7 +26672,7 @@
       "version": "1.5.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/fetch": "4.2.3",
+        "@adobe/fetch": "4.3.0",
         "@adobe/helix-universal": "5.4.0",
         "@adobe/spacecat-shared-http-utils": "1.21.0",
         "@adobe/spacecat-shared-utils": "1.81.1",
@@ -26544,6 +26710,20 @@
         "npm": ">=10.9.0 <12.0.0"
       }
     },
+    "packages/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-http-utils/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "packages/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils": {
       "version": "1.81.1",
       "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.81.1.tgz",
@@ -26566,6 +26746,20 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "packages/spacecat-shared-google-client/node_modules/@aws-sdk/client-s3": {
@@ -27260,7 +27454,7 @@
       "version": "1.6.21",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/fetch": "4.2.3",
+        "@adobe/fetch": "4.3.0",
         "@adobe/helix-universal": "5.4.0",
         "@adobe/spacecat-shared-ims-client": "1.11.10",
         "@adobe/spacecat-shared-utils": "1.81.1"
@@ -27295,6 +27489,20 @@
         "npm": ">=10.9.0 <12.0.0"
       }
     },
+    "packages/spacecat-shared-gpt-client/node_modules/@adobe/spacecat-shared-ims-client/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "packages/spacecat-shared-gpt-client/node_modules/@adobe/spacecat-shared-utils": {
       "version": "1.81.1",
       "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.81.1.tgz",
@@ -27317,6 +27525,20 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-gpt-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "packages/spacecat-shared-gpt-client/node_modules/@aws-sdk/client-s3": {
@@ -28087,7 +28309,7 @@
       "version": "1.25.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/fetch": "4.2.3",
+        "@adobe/fetch": "4.3.0",
         "@adobe/spacecat-shared-utils": "1.81.1",
         "jose": "6.2.2"
       },
@@ -28124,6 +28346,20 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-http-utils/node_modules/@adobe/spacecat-shared-utils/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "packages/spacecat-shared-http-utils/node_modules/@aws-sdk/client-s3": {
@@ -28795,7 +29031,7 @@
       "version": "1.12.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/fetch": "4.2.3",
+        "@adobe/fetch": "4.3.0",
         "@adobe/helix-universal": "5.4.0",
         "@adobe/spacecat-shared-utils": "1.81.1",
         "@aws-sdk/client-secrets-manager": "3.1024.0",
@@ -28836,6 +29072,20 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-ims-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "packages/spacecat-shared-ims-client/node_modules/@aws-sdk/client-s3": {
@@ -29518,7 +29768,7 @@
     },
     "packages/spacecat-shared-launchdarkly-client": {
       "name": "@adobe/spacecat-shared-launchdarkly-client",
-      "version": "1.0.6",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.0",
@@ -29537,6 +29787,20 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-launchdarkly-client/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "packages/spacecat-shared-launchdarkly-client/node_modules/@adobe/spacecat-shared-utils": {
@@ -30246,7 +30510,7 @@
       "version": "2.40.11",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/fetch": "4.2.3",
+        "@adobe/fetch": "4.3.0",
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-universal": "5.4.0",
         "@adobe/rum-distiller": "1.23.0",
@@ -30289,6 +30553,20 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-rum-api-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "packages/spacecat-shared-rum-api-client/node_modules/@aws-sdk/client-s3": {
@@ -30989,6 +31267,20 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-scrape-client/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "packages/spacecat-shared-scrape-client/node_modules/@adobe/spacecat-shared-utils": {
@@ -31716,6 +32008,20 @@
         "npm": ">=10.9.0 <12.0.0"
       }
     },
+    "packages/spacecat-shared-slack-client/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "packages/spacecat-shared-slack-client/node_modules/@adobe/spacecat-shared-utils": {
       "version": "1.81.1",
       "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.81.1.tgz",
@@ -32423,7 +32729,7 @@
       "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/fetch": "4.2.3",
+        "@adobe/fetch": "4.3.0",
         "@adobe/helix-universal": "5.4.0",
         "@adobe/spacecat-shared-utils": "1.81.1",
         "xml-js": "1.6.11"
@@ -32463,6 +32769,20 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-splunk-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "packages/spacecat-shared-splunk-client/node_modules/@aws-sdk/client-s3": {
@@ -33145,7 +33465,7 @@
     },
     "packages/spacecat-shared-tier-client": {
       "name": "@adobe/spacecat-shared-tier-client",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.81.1",
@@ -33164,6 +33484,29 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-tier-client/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "packages/spacecat-shared-tier-client/node_modules/@adobe/fetch/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/spacecat-shared-tier-client/node_modules/@adobe/spacecat-shared-utils": {
@@ -33990,6 +34333,29 @@
         "npm": ">=10.9.0 <12.0.0"
       }
     },
+    "packages/spacecat-shared-tokowaka-client/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "packages/spacecat-shared-tokowaka-client/node_modules/@adobe/fetch/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "packages/spacecat-shared-tokowaka-client/node_modules/@adobe/spacecat-shared-utils": {
       "version": "1.81.1",
       "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.81.1.tgz",
@@ -34807,10 +35173,10 @@
     },
     "packages/spacecat-shared-utils": {
       "name": "@adobe/spacecat-shared-utils",
-      "version": "1.112.2",
+      "version": "1.112.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/fetch": "4.2.3",
+        "@adobe/fetch": "4.3.0",
         "@aws-sdk/client-s3": "3.1024.0",
         "@aws-sdk/client-sqs": "3.1024.0",
         "@json2csv/plainjs": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "./packages/*"
   ],
   "devDependencies": {
-    "@adobe/eslint-config-helix": "3.0.23",
+    "@adobe/eslint-config-helix": "3.0.24",
     "@babel/core": "7.29.0",
     "@babel/eslint-parser": "7.28.6",
     "@babel/plugin-syntax-import-assertions": "7.28.6",

--- a/packages/mysticat-shared-seo-client/package.json
+++ b/packages/mysticat-shared-seo-client/package.json
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/fetch": "4.2.3",
+    "@adobe/fetch": "4.3.0",
     "@adobe/helix-universal": "5.4.0",
     "@adobe/spacecat-shared-utils": "1.81.1",
     "urijs": "1.19.11"

--- a/packages/mysticat-shared-seo-client/src/utils.js
+++ b/packages/mysticat-shared-seo-client/src/utils.js
@@ -101,9 +101,13 @@ function splitCsvLine(line) {
  * @returns {object[]} Array of row objects keyed by column codes
  */
 export function parseCsvResponse(text) {
-  if (!text || typeof text !== 'string') return [];
+  if (!text || typeof text !== 'string') {
+    return [];
+  }
   const lines = text.trim().split('\n');
-  if (lines.length < 2) return [];
+  if (lines.length < 2) {
+    return [];
+  }
   const headers = splitCsvLine(lines[0]).map((h) => normalizeHeader(h.trim()));
   return lines.slice(1).map((line) => {
     const values = splitCsvLine(line);
@@ -120,7 +124,9 @@ export function parseCsvResponse(text) {
  * @returns {*} Coerced value
  */
 export function coerceValue(value, type) {
-  if (value === '' || value === undefined || value === null) return null;
+  if (value === '' || value === undefined || value === null) {
+    return null;
+  }
   switch (type) {
     case 'int': {
       const parsed = parseInt(value, 10);
@@ -169,7 +175,9 @@ export function todayISO() {
  * @returns {string|null} Date in YYYY-MM-DD format, or null if invalid
  */
 export function fromApiDate(apiDate) {
-  if (!apiDate || apiDate.length < 8 || !/^\d{8}$/.test(apiDate)) return null;
+  if (!apiDate || apiDate.length < 8 || !/^\d{8}$/.test(apiDate)) {
+    return null;
+  }
   return `${apiDate.slice(0, 4)}-${apiDate.slice(4, 6)}-${apiDate.slice(6, 8)}`;
 }
 
@@ -205,7 +213,9 @@ export function buildFilter(filters) {
  * @returns {string} Lowercase brand name
  */
 export function extractBrand(domain) {
-  if (!domain) return '';
+  if (!domain) {
+    return '';
+  }
   const normalized = domain.includes('://') ? domain : `https://${domain}`;
   const registrable = new URI(normalized).domain();
   return registrable.split('.')[0].toLowerCase();

--- a/packages/spacecat-shared-ahrefs-client/package.json
+++ b/packages/spacecat-shared-ahrefs-client/package.json
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/fetch": "4.2.3",
+    "@adobe/fetch": "4.3.0",
     "@adobe/helix-universal": "5.4.0",
     "@adobe/spacecat-shared-utils": "1.81.1"
   },

--- a/packages/spacecat-shared-ahrefs-client/test/index.test.js
+++ b/packages/spacecat-shared-ahrefs-client/test/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';

--- a/packages/spacecat-shared-athena-client/src/index.js
+++ b/packages/spacecat-shared-athena-client/src/index.js
@@ -64,7 +64,9 @@ export class AWSAthenaClient {
    * @returns {AWSAthenaClient}
    */
   static fromContext(context, tempLocation, opts = {}) {
-    if (context.athenaClient) return context.athenaClient;
+    if (context.athenaClient) {
+      return context.athenaClient;
+    }
 
     const { env = {}, log } = context;
     const region = env.AWS_REGION || 'us-east-1';

--- a/packages/spacecat-shared-athena-client/src/traffic-analysis/traffic-data-with-cwv.js
+++ b/packages/spacecat-shared-athena-client/src/traffic-analysis/traffic-data-with-cwv.js
@@ -30,8 +30,12 @@ function scoreCWV(metric, val, config) {
   const GOOD = getThreshold(`${metric}_GOOD`, config);
   const NEEDS_IMPROVEMENT = getThreshold(`${metric}_NEEDS_IMPROVEMENT`, config);
 
-  if (val <= GOOD) return 'good';
-  if (val <= NEEDS_IMPROVEMENT) return 'needs improvement';
+  if (val <= GOOD) {
+    return 'good';
+  }
+  if (val <= NEEDS_IMPROVEMENT) {
+    return 'needs improvement';
+  }
   return 'poor';
 }
 

--- a/packages/spacecat-shared-athena-client/test/index.test.js
+++ b/packages/spacecat-shared-athena-client/test/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';

--- a/packages/spacecat-shared-athena-client/test/pta2-queries.test.js
+++ b/packages/spacecat-shared-athena-client/test/pta2-queries.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import {
   getPTASummaryQuery,

--- a/packages/spacecat-shared-athena-client/test/traffic-analysis-queries.test.js
+++ b/packages/spacecat-shared-athena-client/test/traffic-analysis-queries.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import {
   getTrafficAnalysisQuery,

--- a/packages/spacecat-shared-brand-client/src/index.js
+++ b/packages/spacecat-shared-brand-client/src/index.js
@@ -27,7 +27,9 @@ export default class BrandClient {
     const { env, log = console } = context;
     const { BRAND_API_BASE_URL: apiBaseUrl, BRAND_API_KEY: apiKey } = env;
 
-    if (context.brandClient) return context.brandClient;
+    if (context.brandClient) {
+      return context.brandClient;
+    }
 
     const client = new BrandClient({ apiBaseUrl, apiKey }, log);
     context.brandClient = client;

--- a/packages/spacecat-shared-brand-client/test/index.test.js
+++ b/packages/spacecat-shared-brand-client/test/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';

--- a/packages/spacecat-shared-cloud-manager-client/package.json
+++ b/packages/spacecat-shared-cloud-manager-client/package.json
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/fetch": "4.2.3",
+    "@adobe/fetch": "4.3.0",
     "@adobe/spacecat-shared-ims-client": "1.11.6",
     "@adobe/spacecat-shared-utils": "1.81.1",
     "@aws-sdk/client-s3": "3.1024.0",

--- a/packages/spacecat-shared-cloud-manager-client/src/index.js
+++ b/packages/spacecat-shared-cloud-manager-client/src/index.js
@@ -628,7 +628,9 @@ export default class CloudManagerClient {
       rmSync(extractPath, { recursive: true, force: true });
       throw new Error(`Failed to unzip repository: ${error.message}`);
     } finally /* c8 ignore next */ {
-      if (zipDir) rmSync(zipDir, { recursive: true, force: true });
+      if (zipDir) {
+        rmSync(zipDir, { recursive: true, force: true });
+      }
     }
   }
 

--- a/packages/spacecat-shared-cloud-manager-client/test/cloud-manager-client.test.js
+++ b/packages/spacecat-shared-cloud-manager-client/test/cloud-manager-client.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import os from 'os';
 import path from 'path';
 import { expect, use } from 'chai';

--- a/packages/spacecat-shared-content-client/test/clients/content-client.test.js
+++ b/packages/spacecat-shared-content-client/test/clients/content-client.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import esmock from 'esmock';

--- a/packages/spacecat-shared-content-client/test/index.test.js
+++ b/packages/spacecat-shared-content-client/test/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 
 describe('index', async () => {

--- a/packages/spacecat-shared-data-access/src/models/audit-url/audit-url.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/audit-url/audit-url.collection.js
@@ -60,6 +60,7 @@ class AuditUrlCollection extends BaseCollection {
       }
 
       // Handle null/undefined values (push to end)
+      /* c8 ignore next 6 */
       if (aValue == null && bValue == null) {
         return 0;
       }

--- a/packages/spacecat-shared-data-access/src/models/audit-url/audit-url.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/audit-url/audit-url.collection.js
@@ -60,9 +60,15 @@ class AuditUrlCollection extends BaseCollection {
       }
 
       // Handle null/undefined values (push to end)
-      if (aValue == null && bValue == null) return 0;
-      if (aValue == null) return 1;
-      if (bValue == null) return -1;
+      if (aValue == null && bValue == null) {
+        return 0;
+      }
+      if (aValue == null) {
+        return 1;
+      }
+      if (bValue == null) {
+        return -1;
+      }
 
       // Compare values
       let comparison = 0;

--- a/packages/spacecat-shared-data-access/src/models/base/base.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/base/base.collection.js
@@ -75,6 +75,7 @@ class BaseCollection {
 
   // eslint-disable-next-line class-methods-use-this
   #resolveBulkKeyField(keys) {
+    /* c8 ignore next 3 */
     if (!isNonEmptyArray(keys)) {
       return null;
     }
@@ -126,6 +127,7 @@ class BaseCollection {
     if (cause?.details) {
       parts.push(cause.details);
     }
+    /* c8 ignore next 3 */
     if (cause?.hint) {
       parts.push(`hint: ${cause.hint}`);
     }
@@ -609,6 +611,7 @@ class BaseCollection {
    * @returns {object|null} A model instance, or null if the row is empty/invalid.
    */
   createInstanceFromRow(row) {
+    /* c8 ignore next 3 */
     if (!isNonEmptyObject(row)) {
       return null;
     }

--- a/packages/spacecat-shared-data-access/src/models/base/base.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/base/base.collection.js
@@ -75,7 +75,9 @@ class BaseCollection {
 
   // eslint-disable-next-line class-methods-use-this
   #resolveBulkKeyField(keys) {
-    if (!isNonEmptyArray(keys)) return null;
+    if (!isNonEmptyArray(keys)) {
+      return null;
+    }
 
     const [firstKey] = keys;
     const fields = Object.keys(firstKey);
@@ -93,9 +95,13 @@ class BaseCollection {
   }
 
   #normalizeEnumValue(key, value) {
-    if (typeof value !== 'string') return value;
+    if (typeof value !== 'string') {
+      return value;
+    }
     const attr = this.schema.getAttribute(key);
-    if (!Array.isArray(attr?.type)) return value;
+    if (!Array.isArray(attr?.type)) {
+      return value;
+    }
     const match = attr.type.find((v) => v.toLowerCase() === value.toLowerCase());
     return match ?? value;
   }
@@ -104,7 +110,9 @@ class BaseCollection {
   #isInvalidInputError(error) {
     let current = error;
     while (current) {
-      if (current?.code === '22P02') return true;
+      if (current?.code === '22P02') {
+        return true;
+      }
       current = current.cause;
     }
     return false;
@@ -112,9 +120,15 @@ class BaseCollection {
 
   #logAndThrowError(message, cause) {
     const parts = [message];
-    if (cause?.code) parts.push(`[${cause.code}] ${cause.message}`);
-    if (cause?.details) parts.push(cause.details);
-    if (cause?.hint) parts.push(`hint: ${cause.hint}`);
+    if (cause?.code) {
+      parts.push(`[${cause.code}] ${cause.message}`);
+    }
+    if (cause?.details) {
+      parts.push(cause.details);
+    }
+    if (cause?.hint) {
+      parts.push(`hint: ${cause.hint}`);
+    }
 
     this.log.error(`[${this.entityName}] ${parts.join(' - ')}`);
 
@@ -595,7 +609,9 @@ class BaseCollection {
    * @returns {object|null} A model instance, or null if the row is empty/invalid.
    */
   createInstanceFromRow(row) {
-    if (!isNonEmptyObject(row)) return null;
+    if (!isNonEmptyObject(row)) {
+      return null;
+    }
     return this.#createInstance(this.#toModelRecord(row));
   }
 
@@ -748,7 +764,9 @@ class BaseCollection {
       return instance;
     } catch (error) {
       /* c8 ignore next -- re-throw guard (exact match; excludes ValidationError subclass) */
-      if (error.constructor === DataAccessError) throw error;
+      if (error.constructor === DataAccessError) {
+        throw error;
+      }
       return this.#logAndThrowError('Failed to create', error);
     }
   }
@@ -862,7 +880,9 @@ class BaseCollection {
       return { createdItems, errorItems };
     } catch (error) {
       /* c8 ignore next -- re-throw guard (exact match; excludes ValidationError subclass) */
-      if (error.constructor === DataAccessError) throw error;
+      if (error.constructor === DataAccessError) {
+        throw error;
+      }
       return this.#logAndThrowError('Failed to create many', error);
     }
   }
@@ -990,7 +1010,9 @@ class BaseCollection {
       return undefined;
     } catch (error) {
       /* c8 ignore next -- re-throw guard (exact match; excludes ValidationError subclass) */
-      if (error.constructor === DataAccessError) throw error;
+      if (error.constructor === DataAccessError) {
+        throw error;
+      }
       return this.#logAndThrowError('Failed to save many', error);
     }
   }
@@ -1022,7 +1044,9 @@ class BaseCollection {
       return undefined;
     } catch (error) {
       /* c8 ignore next -- re-throw guard (exact match; excludes ValidationError subclass) */
-      if (error.constructor === DataAccessError) throw error;
+      if (error.constructor === DataAccessError) {
+        throw error;
+      }
       return this.#logAndThrowError('Failed to remove by IDs', error);
     }
   }

--- a/packages/spacecat-shared-data-access/src/models/base/schema.js
+++ b/packages/spacecat-shared-data-access/src/models/base/schema.js
@@ -143,7 +143,9 @@ class Schema {
     Object.keys(indexes).forEach((indexName) => {
       const indexKeys = this.getIndexKeys(indexName);
 
-      if (!isNonEmptyArray(indexKeys)) return;
+      if (!isNonEmptyArray(indexKeys)) {
+        return;
+      }
 
       const keySets = [];
       for (let i = 1; i <= indexKeys.length; i += 1) {

--- a/packages/spacecat-shared-data-access/src/models/configuration/configuration.model.js
+++ b/packages/spacecat-shared-data-access/src/models/configuration/configuration.model.js
@@ -176,7 +176,9 @@ class Configuration {
 
   isHandlerEnabledForSite(type, site) {
     const handler = this.getHandlers()?.[type];
-    if (!handler) return false;
+    if (!handler) {
+      return false;
+    }
 
     const siteId = site.getId();
     const orgId = site.getOrganizationId();
@@ -203,7 +205,9 @@ class Configuration {
 
   isHandlerEnabledForOrg(type, org) {
     const handler = this.getHandlers()?.[type];
-    if (!handler) return false;
+    if (!handler) {
+      return false;
+    }
 
     const orgId = org.getId();
 
@@ -226,7 +230,9 @@ class Configuration {
     const handlers = this.getHandlers();
     const handler = handlers?.[type];
 
-    if (!isNonEmptyObject(handler)) return;
+    if (!isNonEmptyObject(handler)) {
+      return;
+    }
 
     if (!isNonEmptyObject(handler.disabled)) {
       handler.disabled = { orgs: [], sites: [] };
@@ -267,7 +273,9 @@ class Configuration {
 
   enableHandlerForSite(type, site) {
     const siteId = site.getId();
-    if (this.isHandlerEnabledForSite(type, site)) return;
+    if (this.isHandlerEnabledForSite(type, site)) {
+      return;
+    }
 
     const deps = this.isHandlerDependencyMetForSite(type, site);
     if (deps !== true) {
@@ -287,7 +295,9 @@ class Configuration {
   isHandlerDependencyMetForOrg(type, org) {
     const handler = this.getHandler(type);
 
-    if (!handler || !isNonEmptyArray(handler?.dependencies)) return true;
+    if (!handler || !isNonEmptyArray(handler?.dependencies)) {
+      return true;
+    }
 
     const unmetDependencies = handler.dependencies
       .filter(({ handler: depHandler }) => !this.isHandlerEnabledForOrg(depHandler, org))
@@ -305,7 +315,9 @@ class Configuration {
    */
   isHandlerDependencyMetForSite(type, site) {
     const handler = this.getHandler(type);
-    if (!handler || !isNonEmptyArray(handler?.dependencies)) return true;
+    if (!handler || !isNonEmptyArray(handler?.dependencies)) {
+      return true;
+    }
 
     const unmetDependencies = handler.dependencies
       .filter(({ handler: depHandler }) => !this.isHandlerEnabledForSite(depHandler, site))
@@ -316,7 +328,9 @@ class Configuration {
 
   enableHandlerForOrg(type, org) {
     const orgId = org.getId();
-    if (this.isHandlerEnabledForOrg(type, org)) return;
+    if (this.isHandlerEnabledForOrg(type, org)) {
+      return;
+    }
     const deps = this.isHandlerDependencyMetForOrg(type, org);
     if (deps !== true) {
       throw new Error(`Cannot enable handler ${type} for org ${orgId} because of missing dependencies: ${deps}`);
@@ -327,14 +341,18 @@ class Configuration {
 
   disableHandlerForSite(type, site) {
     const siteId = site.getId();
-    if (!this.isHandlerEnabledForSite(type, site)) return;
+    if (!this.isHandlerEnabledForSite(type, site)) {
+      return;
+    }
 
     this.updateHandlerSites(type, siteId, false);
   }
 
   disableHandlerForOrg(type, org) {
     const orgId = org.getId();
-    if (!this.isHandlerEnabledForOrg(type, org)) return;
+    if (!this.isHandlerEnabledForOrg(type, org)) {
+      return;
+    }
 
     this.updateHandlerOrgs(type, orgId, false);
   }

--- a/packages/spacecat-shared-data-access/src/models/plg-onboarding/plg-onboarding.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/plg-onboarding/plg-onboarding.schema.js
@@ -94,7 +94,9 @@ const schema = new SchemaBuilder(PlgOnboarding, PlgOnboardingCollection)
       },
     },
     validate: (value) => {
-      if (!Array.isArray(value)) return false;
+      if (!Array.isArray(value)) {
+        return false;
+      }
       const valid = Object.values(PlgOnboarding.REVIEW_DECISIONS);
       return value.every((r) => valid.includes(r.decision) && isIsoDate(r.reviewedAt));
     },

--- a/packages/spacecat-shared-data-access/src/models/site-enrollment/site-enrollment.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/site-enrollment/site-enrollment.collection.js
@@ -53,7 +53,9 @@ class SiteEnrollmentCollection extends BaseCollection {
         siteId: item.siteId,
         entitlementId: item.entitlementId,
       });
-      if (existing) return existing;
+      if (existing) {
+        return existing;
+      }
     }
 
     return super.create(item, options);

--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -530,7 +530,9 @@ export const Config = (data = {}) => {
 
   self.getAuditTargetURLs = () => {
     const targets = state?.auditTargetURLs;
-    if (!targets) return [];
+    if (!targets) {
+      return [];
+    }
     return AUDIT_TARGET_SOURCES.flatMap(
       (source) => (targets[source] || []).map((entry) => ({ ...entry, source })),
     );
@@ -564,7 +566,9 @@ export const Config = (data = {}) => {
 
   self.removeAuditTargetURL = (source, url) => {
     validateAuditTargetSource(source);
-    if (!state.auditTargetURLs?.[source]) return;
+    if (!state.auditTargetURLs?.[source]) {
+      return;
+    }
     state.auditTargetURLs[source] = state.auditTargetURLs[source]
       .filter((t) => t.url !== url);
   };
@@ -702,7 +706,9 @@ export const Config = (data = {}) => {
 
   self.removeLlmoUrlPattern = (urlPattern) => {
     const urlPatterns = state.llmo?.urlPatterns;
-    if (!urlPatterns) return;
+    if (!urlPatterns) {
+      return;
+    }
 
     state.llmo.urlPatterns = urlPatterns.filter(
       (pattern) => pattern.urlPattern !== urlPattern,
@@ -733,7 +739,9 @@ export const Config = (data = {}) => {
   };
 
   self.removeLlmoTag = (tag) => {
-    if (!state.llmo?.tags) return;
+    if (!state.llmo?.tags) {
+      return;
+    }
     state.llmo.tags = state.llmo.tags.filter((t) => t !== tag);
   };
 
@@ -803,7 +811,9 @@ export const Config = (data = {}) => {
     const prior = state.brandProfile || {};
     // compute hash over all content except functional fields
     const stripFunctional = (p) => {
-      if (!isNonEmptyObject(p)) return {};
+      if (!isNonEmptyObject(p)) {
+        return {};
+      }
       const {
         /* eslint-disable no-unused-vars */
         version, updatedAt, contentHash, ...rest
@@ -861,7 +871,9 @@ export const Config = (data = {}) => {
   };
 
   self.disableImport = (type) => {
-    if (!state.imports) return;
+    if (!state.imports) {
+      return;
+    }
 
     state.imports = state.imports.map(
       (imp) => (imp.type === type ? { ...imp, enabled: false } : imp),

--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -706,6 +706,7 @@ export const Config = (data = {}) => {
 
   self.removeLlmoUrlPattern = (urlPattern) => {
     const urlPatterns = state.llmo?.urlPatterns;
+    /* c8 ignore next 3 */
     if (!urlPatterns) {
       return;
     }
@@ -811,6 +812,7 @@ export const Config = (data = {}) => {
     const prior = state.brandProfile || {};
     // compute hash over all content except functional fields
     const stripFunctional = (p) => {
+      /* c8 ignore next 3 */
       if (!isNonEmptyObject(p)) {
         return {};
       }

--- a/packages/spacecat-shared-data-access/src/models/suggestion-grant/suggestion-grant.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/suggestion-grant/suggestion-grant.collection.js
@@ -100,7 +100,9 @@ class SuggestionGrantCollection extends BaseCollection {
 
       return { grantedIds, notGrantedIds, grantIds };
     } catch (err) {
-      if (err instanceof DataAccessError) throw err;
+      if (err instanceof DataAccessError) {
+        throw err;
+      }
       this.log.error('splitSuggestionsByGrantStatus failed', err);
       throw new DataAccessError('Failed to split suggestions by grant status', this, err);
     }
@@ -115,7 +117,9 @@ class SuggestionGrantCollection extends BaseCollection {
    *   false otherwise or if id is empty.
    */
   async isSuggestionGranted(suggestionId) {
-    if (!hasText(suggestionId)) return false;
+    if (!hasText(suggestionId)) {
+      return false;
+    }
     const { grantedIds } = await this.splitSuggestionsByGrantStatus([suggestionId]);
     return grantedIds.length > 0;
   }

--- a/packages/spacecat-shared-data-access/src/models/suggestion/suggestion.projection-utils.js
+++ b/packages/spacecat-shared-data-access/src/models/suggestion/suggestion.projection-utils.js
@@ -37,7 +37,9 @@ export const FIELD_TRANSFORMERS = {
    * Used for accessibility-related opportunity types.
    */
   filterIssuesOccurrences: (issues) => {
-    if (!Array.isArray(issues)) return issues;
+    if (!Array.isArray(issues)) {
+      return issues;
+    }
     return issues.map((issue) => ({
       occurrences: issue.occurrences,
     }));
@@ -47,7 +49,9 @@ export const FIELD_TRANSFORMERS = {
    * Used for Core Web Vitals opportunity type.
    */
   filterCwvMetrics: (metrics) => {
-    if (!Array.isArray(metrics)) return metrics;
+    if (!Array.isArray(metrics)) {
+      return metrics;
+    }
     return metrics.map((metric) => ({
       deviceType: metric.deviceType,
       lcp: metric.lcp,
@@ -65,7 +69,9 @@ export const FIELD_TRANSFORMERS = {
    * /AltText/handlers/AltTextOpportunityAdapter.tsx
    */
   extractPageUrlFromRecommendations: (recommendations) => {
-    if (!Array.isArray(recommendations)) return recommendations;
+    if (!Array.isArray(recommendations)) {
+      return recommendations;
+    }
     return recommendations.map((rec) => ({
       pageUrl: rec.pageUrl,
       ...(rec.isDecorative !== undefined && { isDecorative: rec.isDecorative }),
@@ -77,7 +83,9 @@ export const FIELD_TRANSFORMERS = {
    * Used for security vulnerability opportunity types.
    */
   extractCveUrls: (cves) => {
-    if (!Array.isArray(cves)) return cves;
+    if (!Array.isArray(cves)) {
+      return cves;
+    }
     return cves.map((cve) => ({
       url: cve.url,
     }));

--- a/packages/spacecat-shared-data-access/src/util/guards.js
+++ b/packages/spacecat-shared-data-access/src/util/guards.js
@@ -74,14 +74,18 @@ export const guardAny = (propertyName, value, entityName, nullable = false) => {
  * @throws Will throw an error if the value is not a valid boolean.
  */
 export const guardBoolean = (propertyName, value, entityName, nullable = false) => {
-  if (checkNullable(value, nullable)) return;
+  if (checkNullable(value, nullable)) {
+    return;
+  }
   if (typeof value !== 'boolean') {
     throw new ValidationError(`Validation failed in ${entityName}: ${propertyName} must be a boolean`);
   }
 };
 
 export const guardArray = (propertyName, value, entityName, type = 'string', nullable = false) => {
-  if (checkNullable(value, nullable)) return;
+  if (checkNullable(value, nullable)) {
+    return;
+  }
   if (!Array.isArray(value)) {
     throw new ValidationError(`Validation failed in ${entityName}: ${propertyName} must be an array`);
   }
@@ -100,7 +104,9 @@ export const guardArray = (propertyName, value, entityName, type = 'string', nul
  * @throws Will throw an error if the value is not a valid set (unique array) of a given type.
  */
 export const guardSet = (propertyName, value, entityName, type = 'string', nullable = false) => {
-  if (checkNullable(value, nullable)) return;
+  if (checkNullable(value, nullable)) {
+    return;
+  }
   if (!Array.isArray(value) || new Set(value).size !== value.length) {
     throw new ValidationError(`Validation failed in ${entityName}: ${propertyName} must be a unique array (set)`);
   }
@@ -118,7 +124,9 @@ export const guardSet = (propertyName, value, entityName, type = 'string', nulla
  * @throws Will throw an error if the value is not a valid string.
  */
 export const guardString = (propertyName, value, entityName, nullable = false) => {
-  if (checkNullable(value, nullable)) return;
+  if (checkNullable(value, nullable)) {
+    return;
+  }
   if (!hasText(value)) {
     throw new ValidationError(`Validation failed in ${entityName}: ${propertyName} is required`);
   }
@@ -134,7 +142,9 @@ export const guardString = (propertyName, value, entityName, nullable = false) =
  * @throws Will throw an error if the value is not a valid enum value.
  */
 export const guardEnum = (propertyName, value, enumValues, entityName, nullable = false) => {
-  if (checkNullable(value, nullable)) return;
+  if (checkNullable(value, nullable)) {
+    return;
+  }
   if (!enumValues.includes(value)) {
     throw new ValidationError(`Validation failed in ${entityName}: ${propertyName} must be one of ${enumValues}`);
   }
@@ -149,7 +159,9 @@ export const guardEnum = (propertyName, value, enumValues, entityName, nullable 
  * @throws Will throw an error if the value is not a valid ID.
  */
 export const guardId = (propertyName, value, entityName, nullable = false) => {
-  if (checkNullable(value, nullable)) return;
+  if (checkNullable(value, nullable)) {
+    return;
+  }
   if (!isValidUUID(value)) {
     throw new ValidationError(`Validation failed in ${entityName}: ${propertyName} must be a valid UUID`);
   }
@@ -164,7 +176,9 @@ export const guardId = (propertyName, value, entityName, nullable = false) => {
  * @throws Will throw an error if the value is not a valid map (object).
  */
 export const guardMap = (propertyName, value, entityName, nullable = false) => {
-  if (checkNullable(value, nullable)) return;
+  if (checkNullable(value, nullable)) {
+    return;
+  }
   if (!isObject(value)) {
     throw new ValidationError(`Validation failed in ${entityName}: ${propertyName} must be an object`);
   }
@@ -179,7 +193,9 @@ export const guardMap = (propertyName, value, entityName, nullable = false) => {
  * @throws Will throw an error if the value is not a valid number.
  */
 export const guardNumber = (propertyName, value, entityName, nullable = false) => {
-  if (checkNullable(value, nullable)) return;
+  if (checkNullable(value, nullable)) {
+    return;
+  }
   if (!isNumber(value)) {
     throw new ValidationError(`Validation failed in ${entityName}: ${propertyName} must be a number`);
   }

--- a/packages/spacecat-shared-data-access/test/it/access-grant-log/access-grant-log.test.js
+++ b/packages/spacecat-shared-data-access/test/it/access-grant-log/access-grant-log.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/api-key/api-key.test.js
+++ b/packages/spacecat-shared-data-access/test/it/api-key/api-key.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/async-job/async-job.test.js
+++ b/packages/spacecat-shared-data-access/test/it/async-job/async-job.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import AsyncJobModel from '../../../src/models/async-job/async-job.model.js';

--- a/packages/spacecat-shared-data-access/test/it/audit-url/audit-url.test.js
+++ b/packages/spacecat-shared-data-access/test/it/audit-url/audit-url.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/audit/audit.test.js
+++ b/packages/spacecat-shared-data-access/test/it/audit/audit.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/configuration/configuration.test.js
+++ b/packages/spacecat-shared-data-access/test/it/configuration/configuration.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';

--- a/packages/spacecat-shared-data-access/test/it/consumer/consumer.test.js
+++ b/packages/spacecat-shared-data-access/test/it/consumer/consumer.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/contact-sales-lead/contact-sales-lead.test.js
+++ b/packages/spacecat-shared-data-access/test/it/contact-sales-lead/contact-sales-lead.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { isValidUUID } from '@adobe/spacecat-shared-utils';
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';

--- a/packages/spacecat-shared-data-access/test/it/entitlement/entitlement.test.js
+++ b/packages/spacecat-shared-data-access/test/it/entitlement/entitlement.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/experiment/experiment.test.js
+++ b/packages/spacecat-shared-data-access/test/it/experiment/experiment.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/fix-entity-suggestion/fix-entity-suggestion.test.js
+++ b/packages/spacecat-shared-data-access/test/it/fix-entity-suggestion/fix-entity-suggestion.test.js
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';

--- a/packages/spacecat-shared-data-access/test/it/fix-entity/fix-entity.test.js
+++ b/packages/spacecat-shared-data-access/test/it/fix-entity/fix-entity.test.js
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/import-job/import-job.test.js
+++ b/packages/spacecat-shared-data-access/test/it/import-job/import-job.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/import-url/import-url.test.js
+++ b/packages/spacecat-shared-data-access/test/it/import-url/import-url.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/key-events/key-events.test.js
+++ b/packages/spacecat-shared-data-access/test/it/key-events/key-events.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/latest-audit/latest-audit.test.js
+++ b/packages/spacecat-shared-data-access/test/it/latest-audit/latest-audit.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/opportunity/opportunity.test.js
+++ b/packages/spacecat-shared-data-access/test/it/opportunity/opportunity.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { isIsoDate, isValidUUID } from '@adobe/spacecat-shared-utils';
 
 import { expect, use } from 'chai';

--- a/packages/spacecat-shared-data-access/test/it/organization/organization.test.js
+++ b/packages/spacecat-shared-data-access/test/it/organization/organization.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/page-citability/page-citability.test.js
+++ b/packages/spacecat-shared-data-access/test/it/page-citability/page-citability.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/page-intent/page-intent.test.js
+++ b/packages/spacecat-shared-data-access/test/it/page-intent/page-intent.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/project/project.test.js
+++ b/packages/spacecat-shared-data-access/test/it/project/project.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/report/report.test.js
+++ b/packages/spacecat-shared-data-access/test/it/report/report.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { isValidUUID } from '@adobe/spacecat-shared-utils';
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';

--- a/packages/spacecat-shared-data-access/test/it/scrape-job/scrape-job.test.js
+++ b/packages/spacecat-shared-data-access/test/it/scrape-job/scrape-job.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/scrape-url/scrape-url.test.js
+++ b/packages/spacecat-shared-data-access/test/it/scrape-url/scrape-url.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/sentiment-guideline/sentiment-guideline.test.js
+++ b/packages/spacecat-shared-data-access/test/it/sentiment-guideline/sentiment-guideline.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/sentiment-topic/sentiment-topic.test.js
+++ b/packages/spacecat-shared-data-access/test/it/sentiment-topic/sentiment-topic.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/site-candidate/site-candidate.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site-candidate/site-candidate.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/site-enrollment/site-enrollment.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site-enrollment/site-enrollment.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/site-ims-org-access/site-ims-org-access.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site-ims-org-access/site-ims-org-access.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/site-top-form/site-top-form.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site-top-form/site-top-form.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/site-top-page/site-top-page.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site-top-page/site-top-page.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/site/site.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site/site.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { isIsoDate } from '@adobe/spacecat-shared-utils';
 
 import { expect, use } from 'chai';

--- a/packages/spacecat-shared-data-access/test/it/suggestion-grant/suggestion-grant.test.js
+++ b/packages/spacecat-shared-data-access/test/it/suggestion-grant/suggestion-grant.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 
 import { getDataAccess } from '../util/db.js';

--- a/packages/spacecat-shared-data-access/test/it/suggestion/suggestion.test.js
+++ b/packages/spacecat-shared-data-access/test/it/suggestion/suggestion.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { isIsoDate, isValidUUID } from '@adobe/spacecat-shared-utils';
 
 import { expect, use } from 'chai';

--- a/packages/spacecat-shared-data-access/test/it/token/token.test.js
+++ b/packages/spacecat-shared-data-access/test/it/token/token.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { getTokenGrantConfig } from '@adobe/spacecat-shared-utils';
 
 import { expect, use } from 'chai';

--- a/packages/spacecat-shared-data-access/test/it/trial-user-activity/trial-user-activities.test.js
+++ b/packages/spacecat-shared-data-access/test/it/trial-user-activity/trial-user-activities.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/it/trial-user/trial-user.test.js
+++ b/packages/spacecat-shared-data-access/test/it/trial-user/trial-user.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/unit/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 import dataAccessWrapper from '../../src/index.js';

--- a/packages/spacecat-shared-data-access/test/unit/models/access-grant-log/access-grant-log.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/access-grant-log/access-grant-log.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/access-grant-log/access-grant-log.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/access-grant-log/access-grant-log.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/access-grant-log/access-grant-log.schema.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/access-grant-log/access-grant-log.schema.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import accessGrantLogSchema from '../../../../src/models/access-grant-log/access-grant-log.schema.js';
 

--- a/packages/spacecat-shared-data-access/test/unit/models/api-key/api-key.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/api-key/api-key.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/api-key/api-key.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/api-key/api-key.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/async-job/async-job.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/async-job/async-job.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/audit-url/audit-url.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/audit-url/audit-url.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/audit-url/audit-url.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/audit-url/audit-url.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/audit/audit.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/audit/audit.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon, { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/base/base.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/base/base.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 // eslint-disable-next-line max-classes-per-file
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';

--- a/packages/spacecat-shared-data-access/test/unit/models/base/base.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/base/base.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { spy, stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/base/entity.registry.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/base/entity.registry.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 // eslint-disable-next-line max-classes-per-file
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';

--- a/packages/spacecat-shared-data-access/test/unit/models/base/reference.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/base/reference.test.js
@@ -22,8 +22,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/base/schema.builder.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/base/schema.builder.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 // eslint-disable-next-line max-classes-per-file
 import { isIsoDate, isValidUUID } from '@adobe/spacecat-shared-utils';
 import { expect, use as chaiUse } from 'chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/base/schema.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/base/schema.test.js
@@ -22,8 +22,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 // eslint-disable-next-line max-classes-per-file
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';

--- a/packages/spacecat-shared-data-access/test/unit/models/configuration/configuration.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/configuration/configuration.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/configuration/configuration.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/configuration/configuration.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/consumer/consumer.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/consumer/consumer.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/consumer/consumer.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/consumer/consumer.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/contact-sales-lead/contact-sales-lead.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/contact-sales-lead/contact-sales-lead.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/contact-sales-lead/contact-sales-lead.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/contact-sales-lead/contact-sales-lead.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/contact-sales-lead/contact-sales-lead.schema.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/contact-sales-lead/contact-sales-lead.schema.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import contactSalesLeadSchema from '../../../../src/models/contact-sales-lead/contact-sales-lead.schema.js';
 

--- a/packages/spacecat-shared-data-access/test/unit/models/entitlement/entitlement.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/entitlement/entitlement.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/entitlement/entitlement.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/entitlement/entitlement.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/experiment/experiment.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/experiment/experiment.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/experiment/experiment.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/experiment/experiment.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/fix-entity-suggestion/fix-entity-suggestion.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/fix-entity-suggestion/fix-entity-suggestion.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import { stub } from 'sinon';
 

--- a/packages/spacecat-shared-data-access/test/unit/models/fix-entity-suggestion/fix-entity-suggestion.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/fix-entity-suggestion/fix-entity-suggestion.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { restore } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/fix-entity/fix-entity.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/fix-entity/fix-entity.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub, restore } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/geo-experiment/geo-experiment.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/geo-experiment/geo-experiment.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/geo-experiment/geo-experiment.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/geo-experiment/geo-experiment.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/import-job/import-job.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/import-job/import-job.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/import-job/import-job.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/import-job/import-job.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/import-url/import-url.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/import-url/import-url.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/import-url/import-url.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/import-url/import-url.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/key-event/key-event.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/key-event/key-event.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/key-event/key-event.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/key-event/key-event.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/latest-audit/latest-audit.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/latest-audit/latest-audit.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/latest-audit/latest-audit.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/latest-audit/latest-audit.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/opportunity/opportunity.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/opportunity/opportunity.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/opportunity/opportunity.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/opportunity/opportunity.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/organization/organization.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/organization/organization.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/organization/organization.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/organization/organization.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/page-citability/page-citability.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/page-citability/page-citability.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/page-intent/page‑intent.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/page-intent/page‑intent.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/plg-onboarding/plg-onboarding.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/plg-onboarding/plg-onboarding.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/plg-onboarding/plg-onboarding.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/plg-onboarding/plg-onboarding.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/plg-onboarding/plg-onboarding.schema.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/plg-onboarding/plg-onboarding.schema.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import plgOnboardingSchema from '../../../../src/models/plg-onboarding/plg-onboarding.schema.js';
 

--- a/packages/spacecat-shared-data-access/test/unit/models/project/project.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/project/project.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/project/project.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/project/project.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/report/report.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/report/report.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/report/report.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/report/report.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/report/report.schema.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/report/report.schema.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import reportSchema from '../../../../src/models/report/report.schema.js';
 

--- a/packages/spacecat-shared-data-access/test/unit/models/scrape-job/scrape-job.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/scrape-job/scrape-job.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/scrape-job/scrape-job.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/scrape-job/scrape-job.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/scrape-url/scrape-url.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/scrape-url/scrape-url.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub, useFakeTimers } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/sentiment-guideline/sentiment-guideline.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/sentiment-guideline/sentiment-guideline.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/sentiment-guideline/sentiment-guideline.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/sentiment-guideline/sentiment-guideline.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/sentiment-topic/sentiment-topic.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/sentiment-topic/sentiment-topic.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/sentiment-topic/sentiment-topic.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/sentiment-topic/sentiment-topic.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/site-candidate/site-candidate.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site-candidate/site-candidate.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/site-enrollment/site-enrollment.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site-enrollment/site-enrollment.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/site-enrollment/site-enrollment.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site-enrollment/site-enrollment.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/site-ims-org-access/site-ims-org-access.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site-ims-org-access/site-ims-org-access.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/site-ims-org-access/site-ims-org-access.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site-ims-org-access/site-ims-org-access.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/site-ims-org-access/site-ims-org-access.schema.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site-ims-org-access/site-ims-org-access.schema.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import siteImsOrgAccessSchema from '../../../../src/models/site-ims-org-access/site-ims-org-access.schema.js';
 

--- a/packages/spacecat-shared-data-access/test/unit/models/site-top-form/site-top-form.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site-top-form/site-top-form.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/site-top-page/site-top-page.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site-top-page/site-top-page.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 
 import {

--- a/packages/spacecat-shared-data-access/test/unit/models/site/site.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/site.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/site/site.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/site.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/suggestion-grant/suggestion-grant.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/suggestion-grant/suggestion-grant.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub, restore } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/suggestion-grant/suggestion-grant.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/suggestion-grant/suggestion-grant.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/suggestion/suggestion.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/suggestion/suggestion.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/suggestion/suggestion.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/suggestion/suggestion.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/suggestion/suggestion.projection-utils.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/suggestion/suggestion.projection-utils.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 
 import { FIELD_TRANSFORMERS, FALLBACK_PROJECTION } from '../../../../src/models/suggestion/suggestion.projection-utils.js';

--- a/packages/spacecat-shared-data-access/test/unit/models/token/token.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/token/token.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/token/token.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/token/token.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/token/token.schema.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/token/token.schema.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 
 import tokenSchema from '../../../../src/models/token/token.schema.js';

--- a/packages/spacecat-shared-data-access/test/unit/models/trial-user-activity/trial-user-activity.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/trial-user-activity/trial-user-activity.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/trial-user-activity/trial-user-activity.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/trial-user-activity/trial-user-activity.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/models/trial-user/trial-user.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/trial-user/trial-user.collection.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/models/trial-user/trial-user.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/trial-user/trial-user.model.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { stub } from 'sinon';

--- a/packages/spacecat-shared-data-access/test/unit/service/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/packages/spacecat-shared-data-access/test/unit/util/accessor.utils.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/util/accessor.utils.test.js
@@ -21,8 +21,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import sinon, { stub } from 'sinon';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-data-access/test/unit/util/guards.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/util/guards.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 

--- a/packages/spacecat-shared-data-access/test/unit/util/logger-registry.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/util/logger-registry.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 
 import {

--- a/packages/spacecat-shared-data-access/test/unit/util/patcher.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/util/patcher.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 // eslint-disable-next-line max-classes-per-file
 import { isIsoDate } from '@adobe/spacecat-shared-utils';
 

--- a/packages/spacecat-shared-data-access/test/unit/util/postgrest.utils.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/util/postgrest.utils.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/packages/spacecat-shared-data-access/test/unit/util/util.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/util/util.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 // utils.test.js
 // This suite tests all utility functions from the provided utils file.
 // Requires Mocha for tests, Chai for assertions, and Sinon for spying/stubbing.

--- a/packages/spacecat-shared-drs-client/src/index.js
+++ b/packages/spacecat-shared-drs-client/src/index.js
@@ -40,7 +40,9 @@ export default class DrsClient {
     const { env, log = console } = context;
     const { DRS_API_URL: apiBaseUrl, DRS_API_KEY: apiKey } = env;
 
-    if (context.drsClient) return context.drsClient;
+    if (context.drsClient) {
+      return context.drsClient;
+    }
 
     const client = new DrsClient({ apiBaseUrl, apiKey }, log);
     context.drsClient = client;
@@ -51,7 +53,9 @@ export default class DrsClient {
     // Strip trailing slashes without regex (CodeQL flags /\/+$/ as polynomial)
     let url = apiBaseUrl;
     if (url) {
-      while (url.endsWith('/')) url = url.slice(0, -1);
+      while (url.endsWith('/')) {
+        url = url.slice(0, -1);
+      }
     }
     this.apiBaseUrl = url || undefined;
     this.apiKey = apiKey;

--- a/packages/spacecat-shared-drs-client/test/index.test.js
+++ b/packages/spacecat-shared-drs-client/test/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';

--- a/packages/spacecat-shared-example/package.json
+++ b/packages/spacecat-shared-example/package.json
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/fetch": "4.2.3",
+    "@adobe/fetch": "4.3.0",
     "@adobe/helix-shared-wrap": "2.0.2",
     "@adobe/helix-universal": "5.4.0",
     "aws4": "1.13.2"

--- a/packages/spacecat-shared-example/test/example-wrapper.test.js
+++ b/packages/spacecat-shared-example/test/example-wrapper.test.js
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
 import assert from 'assert';
 
 // eslint-disable-next-line import/no-named-default

--- a/packages/spacecat-shared-google-client/package.json
+++ b/packages/spacecat-shared-google-client/package.json
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/fetch": "4.2.3",
+    "@adobe/fetch": "4.3.0",
     "@adobe/helix-universal": "5.4.0",
     "@adobe/spacecat-shared-http-utils": "1.21.0",
     "@adobe/spacecat-shared-utils": "1.81.1",

--- a/packages/spacecat-shared-google-client/test/index.test.js
+++ b/packages/spacecat-shared-google-client/test/index.test.js
@@ -9,8 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { google } from 'googleapis';

--- a/packages/spacecat-shared-gpt-client/package.json
+++ b/packages/spacecat-shared-gpt-client/package.json
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/fetch": "4.2.3",
+    "@adobe/fetch": "4.3.0",
     "@adobe/helix-universal": "5.4.0",
     "@adobe/spacecat-shared-ims-client": "1.11.10",
     "@adobe/spacecat-shared-utils": "1.81.1"

--- a/packages/spacecat-shared-gpt-client/test/clients/azure-openai-client.test.js
+++ b/packages/spacecat-shared-gpt-client/test/clients/azure-openai-client.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';

--- a/packages/spacecat-shared-gpt-client/test/clients/firefall-client.test.js
+++ b/packages/spacecat-shared-gpt-client/test/clients/firefall-client.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';

--- a/packages/spacecat-shared-gpt-client/test/clients/genvar-client.test.js
+++ b/packages/spacecat-shared-gpt-client/test/clients/genvar-client.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';

--- a/packages/spacecat-shared-gpt-client/test/index.test.js
+++ b/packages/spacecat-shared-gpt-client/test/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 
 describe('index', async () => {

--- a/packages/spacecat-shared-html-analyzer/rollup.config.js
+++ b/packages/spacecat-shared-html-analyzer/rollup.config.js
@@ -64,7 +64,9 @@ export default {
   ],
   onwarn(warning, warn) {
     // Suppress warnings about dynamic imports that we'll handle
-    if (warning.code === 'UNRESOLVED_IMPORT') return;
+    if (warning.code === 'UNRESOLVED_IMPORT') {
+      return;
+    }
     warn(warning);
   },
 };

--- a/packages/spacecat-shared-html-analyzer/src/diff-engine.js
+++ b/packages/spacecat-shared-html-analyzer/src/diff-engine.js
@@ -31,7 +31,9 @@ export function diffTokens(aStr, bStr, mode = 'word') {
   // Map tokens to integers for faster LCS computation
   const sym = new Map();
   const mapTok = (t) => {
-    if (!sym.has(t)) sym.set(t, sym.size + 1);
+    if (!sym.has(t)) {
+      sym.set(t, sym.size + 1);
+    }
     return sym.get(t);
   };
   const a = A.map(mapTok);

--- a/packages/spacecat-shared-html-analyzer/src/html-filter.js
+++ b/packages/spacecat-shared-html-analyzer/src/html-filter.js
@@ -376,7 +376,9 @@ export function filterHtmlContent(
   returnText = true,
   includeNoscript = false,
 ) {
-  if (!htmlContent) return '';
+  if (!htmlContent) {
+    return '';
+  }
 
   // Browser environment (DOMParser) - works in Chrome extensions too - SYNCHRONOUS
   if (isBrowser()) {

--- a/packages/spacecat-shared-html-analyzer/src/markdown-diff.js
+++ b/packages/spacecat-shared-html-analyzer/src/markdown-diff.js
@@ -47,7 +47,9 @@ export function diffDOMBlocks(originalBlocks, currentBlocks) {
   // Map tokens to ints for faster LCS
   const sym = new Map();
   const mapTok = (t) => {
-    if (!sym.has(t)) sym.set(t, sym.size + 1);
+    if (!sym.has(t)) {
+      sym.set(t, sym.size + 1);
+    }
     return sym.get(t);
   };
   const a = A.map(mapTok);
@@ -187,7 +189,9 @@ function extractBlocks(children, $) {
         if (getTagName(li) === 'LI') {
           // Skip empty list items - they cause alignment issues
           const liText = getTextContent(li, $).trim();
-          if (!liText) return;
+          if (!liText) {
+            return;
+          }
 
           // Check if the list item contains nested block elements (p, div, h1-h6, etc.)
           const liChildren = getChildren(li);
@@ -204,7 +208,9 @@ function extractBlocks(children, $) {
             // but wrap them in li/ul for proper display
             nestedBlocks.forEach((child) => {
               const childText = getTextContent(child, $).trim();
-              if (!childText) return; // Skip empty nested blocks too
+              if (!childText) {
+                return; // Skip empty nested blocks too
+              }
 
               blocks.push({
                 html: `<${listType}><li>${getOuterHTML(child, $)}</li></${listType}>`,

--- a/packages/spacecat-shared-html-analyzer/src/utils.js
+++ b/packages/spacecat-shared-html-analyzer/src/utils.js
@@ -20,7 +20,9 @@
  * @returns {string} Hex hash string
  */
 export function hashDJB2(str) {
-  if (!str) return '';
+  if (!str) {
+    return '';
+  }
   let h = 5381;
   for (let i = 0; i < str.length; i += 1) {
     // eslint-disable-next-line no-bitwise
@@ -67,12 +69,20 @@ export function isBrowser() {
  */
 export function getGlobalObject() {
   // eslint-disable-next-line no-undef
-  if (typeof globalThis !== 'undefined') return globalThis;
-  // eslint-disable-next-line no-undef
-  if (typeof self !== 'undefined') return self;
-  // eslint-disable-next-line no-undef
-  if (typeof window !== 'undefined') return window;
-  // eslint-disable-next-line no-undef
-  if (typeof global !== 'undefined') return global;
+  if (typeof globalThis !== 'undefined') {
+    return globalThis;
+  }
+  if (typeof self !== 'undefined') {
+    // eslint-disable-next-line no-undef
+    return self;
+  }
+  if (typeof window !== 'undefined') {
+    // eslint-disable-next-line no-undef
+    return window;
+  }
+  if (typeof global !== 'undefined') {
+    // eslint-disable-next-line no-undef
+    return global;
+  }
   return {};
 }

--- a/packages/spacecat-shared-http-utils/package.json
+++ b/packages/spacecat-shared-http-utils/package.json
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/fetch": "4.2.3",
+    "@adobe/fetch": "4.3.0",
     "@adobe/spacecat-shared-utils": "1.81.1",
     "jose": "6.2.2"
   },

--- a/packages/spacecat-shared-http-utils/src/auth/auth-info.js
+++ b/packages/spacecat-shared-http-utils/src/auth/auth-info.js
@@ -111,7 +111,9 @@ export default class AuthInfo {
    * @returns {Object|undefined} A shallow copy of the matching delegated tenant entry, or undefined
    */
   getDelegatedTenant(imsOrgId, productCode) {
-    if (!imsOrgId) return undefined;
+    if (!imsOrgId) {
+      return undefined;
+    }
     const [id] = String(imsOrgId).split('@');
     const delegated = this.profile?.delegated_tenants || [];
     const match = delegated.find((dt) => dt.id === id

--- a/packages/spacecat-shared-http-utils/src/auth/handlers/utils/cookie.js
+++ b/packages/spacecat-shared-http-utils/src/auth/handlers/utils/cookie.js
@@ -33,7 +33,9 @@ export const getCookie = (context) => {
  */
 export const getCookieValue = (context, name) => {
   const cookieString = getCookie(context);
-  if (!cookieString) return null;
+  if (!cookieString) {
+    return null;
+  }
 
   const cookies = cookieString.split(';');
   for (const cookie of cookies) {

--- a/packages/spacecat-shared-http-utils/src/auth/s2s-wrapper.js
+++ b/packages/spacecat-shared-http-utils/src/auth/s2s-wrapper.js
@@ -22,13 +22,19 @@ import { loadPublicKey, validateToken } from './handlers/utils/token.js';
  */
 function matchRoute(method, requestSegments, routeKey) {
   const spaceIdx = routeKey.indexOf(' ');
-  if (spaceIdx === -1) return false;
+  if (spaceIdx === -1) {
+    return false;
+  }
 
   const routeMethod = routeKey.slice(0, spaceIdx);
-  if (routeMethod !== method) return false;
+  if (routeMethod !== method) {
+    return false;
+  }
 
   const routeSegments = routeKey.slice(spaceIdx + 1).split('/').filter(Boolean);
-  if (routeSegments.length !== requestSegments.length) return false;
+  if (routeSegments.length !== requestSegments.length) {
+    return false;
+  }
 
   return routeSegments.every(
     (seg, i) => seg.charCodeAt(0) === 58 /* ':' */ || seg === requestSegments[i],
@@ -42,10 +48,14 @@ function matchRoute(method, requestSegments, routeKey) {
 function resolveCapability(context, routeCapabilities) {
   const method = context.pathInfo?.method?.toUpperCase();
   const path = context.pathInfo?.suffix;
-  if (!method || !path) return null;
+  if (!method || !path) {
+    return null;
+  }
 
   const exactKey = `${method} ${path}`;
-  if (routeCapabilities[exactKey]) return routeCapabilities[exactKey];
+  if (routeCapabilities[exactKey]) {
+    return routeCapabilities[exactKey];
+  }
 
   const requestSegments = path.split('/').filter(Boolean);
   const matchedKey = Object.keys(routeCapabilities)

--- a/packages/spacecat-shared-http-utils/src/compression-wrapper.js
+++ b/packages/spacecat-shared-http-utils/src/compression-wrapper.js
@@ -62,7 +62,9 @@ export function negotiateEncoding(header, preference = DEFAULT_PREFERENCE) {
 
   // Highest quality first; preference order breaks ties
   candidates.sort((a, b) => {
-    if (b.quality !== a.quality) return b.quality - a.quality;
+    if (b.quality !== a.quality) {
+      return b.quality - a.quality;
+    }
     return preference.indexOf(a.encoding) - preference.indexOf(b.encoding);
   });
 
@@ -78,15 +80,23 @@ const COMPRESSIBLE_TYPES = [
 ];
 
 export function isCompressible(contentType) {
-  if (!contentType) return false;
+  if (!contentType) {
+    return false;
+  }
   return COMPRESSIBLE_TYPES.some((re) => re.test(contentType));
 }
 
 export function mergeVary(existing) {
-  if (!existing) return 'Accept-Encoding';
-  if (existing.trim() === '*') return existing;
+  if (!existing) {
+    return 'Accept-Encoding';
+  }
+  if (existing.trim() === '*') {
+    return existing;
+  }
   const tokens = existing.split(',').map((t) => t.trim().toLowerCase());
-  if (tokens.includes('accept-encoding')) return existing;
+  if (tokens.includes('accept-encoding')) {
+    return existing;
+  }
   return `${existing}, Accept-Encoding`;
 }
 

--- a/packages/spacecat-shared-http-utils/test/auth/auth-info.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/auth-info.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import AuthInfo from '../../src/auth/auth-info.js';
 

--- a/packages/spacecat-shared-http-utils/test/auth/auth-wrapper.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/auth-wrapper.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { Request } from '@adobe/fetch';
 import wrap from '@adobe/helix-shared-wrap';
 import { expect, use } from 'chai';

--- a/packages/spacecat-shared-http-utils/test/auth/authentication-manager.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/authentication-manager.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import chaiAsPromised from 'chai-as-promised';

--- a/packages/spacecat-shared-http-utils/test/auth/check-scopes.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/check-scopes.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { checkScopes } from '../../src/auth/check-scopes.js';

--- a/packages/spacecat-shared-http-utils/test/auth/handlers/abstract.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/handlers/abstract.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 // eslint-disable-next-line max-classes-per-file
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';

--- a/packages/spacecat-shared-http-utils/test/auth/handlers/ims.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/handlers/ims.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import chaiAsPromised from 'chai-as-promised';

--- a/packages/spacecat-shared-http-utils/test/auth/handlers/jwt.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/handlers/jwt.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import crypto from 'crypto';
 import sinon from 'sinon';

--- a/packages/spacecat-shared-http-utils/test/auth/handlers/legacy-api-keys.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/handlers/legacy-api-keys.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import chaiAsPromised from 'chai-as-promised';

--- a/packages/spacecat-shared-http-utils/test/auth/handlers/scoped-api-key.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/handlers/scoped-api-key.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import chaiAsPromised from 'chai-as-promised';

--- a/packages/spacecat-shared-http-utils/test/auth/handlers/utils/cookie.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/handlers/utils/cookie.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import { getCookie, getCookieValue } from '../../../../src/auth/handlers/utils/cookie.js';
 

--- a/packages/spacecat-shared-http-utils/test/auth/s2s-wrapper.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/s2s-wrapper.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import crypto from 'crypto';
 import sinon from 'sinon';

--- a/packages/spacecat-shared-http-utils/test/compression-wrapper.test.js
+++ b/packages/spacecat-shared-http-utils/test/compression-wrapper.test.js
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-env mocha */
 import { expect } from 'chai';
 import { gunzip, brotliDecompress, inflate } from 'zlib';
 import { promisify } from 'util';

--- a/packages/spacecat-shared-http-utils/test/enrich-path-info-wrapper.test.js
+++ b/packages/spacecat-shared-http-utils/test/enrich-path-info-wrapper.test.js
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-env mocha */
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/packages/spacecat-shared-http-utils/test/index.test.js
+++ b/packages/spacecat-shared-http-utils/test/index.test.js
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-env mocha */
 import { expect } from 'chai';
 import { brotliDecompress, gunzip } from 'zlib';
 import { promisify } from 'util';

--- a/packages/spacecat-shared-ims-client/package.json
+++ b/packages/spacecat-shared-ims-client/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/fetch": "4.2.3",
+    "@adobe/fetch": "4.3.0",
     "@adobe/helix-universal": "5.4.0",
     "@adobe/spacecat-shared-utils": "1.81.1",
     "@aws-sdk/client-secrets-manager": "3.1024.0",

--- a/packages/spacecat-shared-ims-client/test/auth.test.js
+++ b/packages/spacecat-shared-ims-client/test/auth.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';

--- a/packages/spacecat-shared-ims-client/test/clients/ims-client-wrapper.test.js
+++ b/packages/spacecat-shared-ims-client/test/clients/ims-client-wrapper.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/packages/spacecat-shared-ims-client/test/clients/ims-client.test.js
+++ b/packages/spacecat-shared-ims-client/test/clients/ims-client.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';

--- a/packages/spacecat-shared-ims-client/test/clients/ims-promise-client.test.js
+++ b/packages/spacecat-shared-ims-client/test/clients/ims-promise-client.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';

--- a/packages/spacecat-shared-ims-client/test/index.test.js
+++ b/packages/spacecat-shared-ims-client/test/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 
 describe('index', async () => {

--- a/packages/spacecat-shared-ims-client/test/utils.test.js
+++ b/packages/spacecat-shared-ims-client/test/utils.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import { encrypt, decrypt } from '../src/utils.js';
 

--- a/packages/spacecat-shared-launchdarkly-client/test/exports.test.js
+++ b/packages/spacecat-shared-launchdarkly-client/test/exports.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import DefaultExport, { LaunchDarklyClient } from '../src/index.js';
 

--- a/packages/spacecat-shared-launchdarkly-client/test/index.test.js
+++ b/packages/spacecat-shared-launchdarkly-client/test/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';

--- a/packages/spacecat-shared-rum-api-client/package.json
+++ b/packages/spacecat-shared-rum-api-client/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/fetch": "4.2.3",
+    "@adobe/fetch": "4.3.0",
     "@adobe/helix-shared-wrap": "2.0.2",
     "@adobe/helix-universal": "5.4.0",
     "@adobe/rum-distiller": "1.23.0",

--- a/packages/spacecat-shared-rum-api-client/src/common/rum-bundler-client.js
+++ b/packages/spacecat-shared-rum-api-client/src/common/rum-bundler-client.js
@@ -121,7 +121,9 @@ function generateUrlsForDateRange(startDate, endDate, domain, granularity, domai
  * then data for the `/a1/` and `/a2` are counted towards `/`'s data
  */
 async function mergeBundlesWithSameId(bundles) {
-  if (!bundles[0]?.url?.includes('bamboohr.com')) return bundles;
+  if (!bundles[0]?.url?.includes('bamboohr.com')) {
+    return bundles;
+  }
   const prodBaseUrl = 'https://www.bamboohr.com/experiments/';
   const previewBaseUrl = 'https://main--bamboohr-website--bamboohr.hlx.page/experiments/archive/';
   const manifestUrls = [
@@ -178,14 +180,18 @@ async function mergeBundlesWithSameId(bundles) {
 
   const getControlPath = (url) => {
     const path = new URL(url).pathname;
-    if (variantPaths.includes(path)) return mapping[path];
+    if (variantPaths.includes(path)) {
+      return mapping[path];
+    }
     return path;
   };
 
   const byIdAndPath = bundles.reduce((acc, cur) => {
     const controlPath = getControlPath(cur.url);
     const key = `${cur.id}-${controlPath}`;
-    if (!acc[key]) acc[key] = [];
+    if (!acc[key]) {
+      acc[key] = [];
+    }
     if (variantPaths.includes(new URL(cur.url).pathname)) {
       // eslint-disable-next-line no-param-reassign
       cur.url = new URL(controlPath, cur.url).href;

--- a/packages/spacecat-shared-rum-api-client/src/common/traffic.js
+++ b/packages/spacecat-shared-rum-api-client/src/common/traffic.js
@@ -25,8 +25,12 @@ import URI from 'urijs';
  *                    URL if it does not contain any text.
  */
 export function getSecondLevelDomain(url) {
-  if (!hasText(url)) return url;
-  if (url === '(direct)') return '';
+  if (!hasText(url)) {
+    return url;
+  }
+  if (url === '(direct)') {
+    return '';
+  }
 
   try {
     const uri = new URI(prependSchema(url));
@@ -132,8 +136,12 @@ const emailTrackingParams = ['email'];
 const any = () => true;
 
 const anyOf = (truth) => (text) => {
-  if (Array.isArray(truth)) return truth.includes(text);
-  if (truth instanceof RegExp) return truth.test(text);
+  if (Array.isArray(truth)) {
+    return truth.includes(text);
+  }
+  if (truth instanceof RegExp) {
+    return truth.test(text);
+  }
   return truth === text;
 };
 
@@ -141,9 +149,15 @@ const anyOf = (truth) => (text) => {
 const none = (input) => (Array.isArray(input) ? input.length === 0 : !hasText(input));
 
 const not = (truth) => (text) => {
-  if (!hasText(text)) return false;
-  if (Array.isArray(truth)) return !truth.includes(text);
-  if (truth instanceof RegExp) return !truth.test(text);
+  if (!hasText(text)) {
+    return false;
+  }
+  if (Array.isArray(truth)) {
+    return !truth.includes(text);
+  }
+  if (truth instanceof RegExp) {
+    return !truth.test(text);
+  }
   return truth !== text;
 };
 
@@ -199,12 +213,16 @@ const ALLOWED_VENDORS = {
  * @returns {string} The vendor if allowed, empty string otherwise
  */
 function validateVendor(type, category, vendor) {
-  if (!vendor) return '';
+  if (!vendor) {
+    return '';
+  }
 
   const allowedVendors = ALLOWED_VENDORS[type]?.[category];
 
   // null/undefined means any vendor is allowed
-  if (!allowedVendors) return vendor;
+  if (!allowedVendors) {
+    return vendor;
+  }
 
   // Check if vendor is in the allowed list
   return allowedVendors.includes(vendor) ? vendor : '';
@@ -308,9 +326,15 @@ export function extractTrafficHints(bundle) {
  */
 export function classifyVendor(referrer, utmSource, utmMedium) {
   const result = vendorClassifications.find(({ regex }) => {
-    if (regex.test(referrer)) return true;
-    if (regex.test(utmSource)) return true;
-    if (regex.test(utmMedium)) return true;
+    if (regex.test(referrer)) {
+      return true;
+    }
+    if (regex.test(utmSource)) {
+      return true;
+    }
+    if (regex.test(utmMedium)) {
+      return true;
+    }
     return false;
   });
   return result ? result.result : '';

--- a/packages/spacecat-shared-rum-api-client/src/functions/experiment.js
+++ b/packages/spacecat-shared-rum-api-client/src/functions/experiment.js
@@ -50,7 +50,9 @@ function handler(bundles) {
   const result = {};
   experiments.forEach((uev) => {
     const [url, experiment] = uev.value.split(DELIMITER);
-    if (!result[url]) result[url] = [];
+    if (!result[url]) {
+      result[url] = [];
+    }
     result[url].push({
       experiment,
       variants: [],

--- a/packages/spacecat-shared-rum-api-client/src/functions/opportunities/high-organic-low-ctr.js
+++ b/packages/spacecat-shared-rum-api-client/src/functions/opportunities/high-organic-low-ctr.js
@@ -112,7 +112,9 @@ function convertToOpportunity(traffic) {
  * @returns {Array} List of pages sorted by joint strength
  */
 function sortPagesByEarnedAndOverallTraffic(pages) {
-  if (!Array.isArray(pages) || pages.length === 0) return [];
+  if (!Array.isArray(pages) || pages.length === 0) {
+    return [];
+  }
 
   const sortedOverall = [...pages].sort((a, b) => a.total - b.total);
   const sortedEarned = [...pages].sort((a, b) => {

--- a/packages/spacecat-shared-rum-api-client/src/functions/traffic-analysis.js
+++ b/packages/spacecat-shared-rum-api-client/src/functions/traffic-analysis.js
@@ -57,16 +57,24 @@ function getClicked(bundle) {
   const latestClickEvent = bundle.events
     .filter((e) => e.checkpoint === 'click')
     .reduce((latest, current) => {
-      if (!latest || !latest.timeDelta) return current;
-      if (current?.timeDelta > latest.timeDelta) return current;
+      if (!latest || !latest.timeDelta) {
+        return current;
+      }
+      if (current?.timeDelta > latest.timeDelta) {
+        return current;
+      }
       return latest;
     }, null);
 
-  if (!latestClickEvent) return 0;
+  if (!latestClickEvent) {
+    return 0;
+  }
 
   const isConsentClick = !!utils.reclassifyConsent(latestClickEvent).vendor;
 
-  if (isConsentClick) return 0;
+  if (isConsentClick) {
+    return 0;
+  }
 
   return 1;
 }
@@ -78,14 +86,18 @@ function getConsent(bundle) {
 
   const consentClick = bundle.events.find((e) => e.checkpoint === 'click' && utils.reclassifyConsent(e).vendor);
 
-  if (!consentClick) return consentBannerStatus || null;
+  if (!consentClick) {
+    return consentBannerStatus || null;
+  }
 
   return utils.reclassifyConsent(consentClick).target;
 }
 
 function trafficType(bundle, memo) {
   const key = `${bundle.id}${bundle.url}${bundle.time}`;
-  if (memo[key]) return memo[key];
+  if (memo[key]) {
+    return memo[key];
+  }
 
   const type = classifyTraffic(bundle);
   // eslint-disable-next-line no-param-reassign

--- a/packages/spacecat-shared-rum-api-client/src/index.js
+++ b/packages/spacecat-shared-rum-api-client/src/index.js
@@ -65,7 +65,9 @@ export default class RUMAPIClient {
     const { env, log = console } = context;
     const { RUM_ADMIN_KEY: rumAdminKey } = env;
 
-    if (context.rumApiClient) return context.rumApiClient;
+    if (context.rumApiClient) {
+      return context.rumApiClient;
+    }
 
     const client = new RUMAPIClient({ rumAdminKey }, log);
     context.rumApiClient = client;
@@ -126,7 +128,9 @@ export default class RUMAPIClient {
   // eslint-disable-next-line class-methods-use-this
   async query(query, opts) {
     const { handler, checkpoints } = HANDLERS[query] || {};
-    if (!handler) throw new Error(`Unknown query ${query}`);
+    if (!handler) {
+      throw new Error(`Unknown query ${query}`);
+    }
 
     try {
       const domainkey = await this._getDomainkey(opts);
@@ -186,7 +190,9 @@ export default class RUMAPIClient {
 
   async queryStream(query, opts) {
     const { handler, checkpoints } = HANDLERS[query] || {};
-    if (!handler) throw new Error(`Unknown query ${query}`);
+    if (!handler) {
+      throw new Error(`Unknown query ${query}`);
+    }
 
     try {
       const domainkey = await this._getDomainkey(opts);

--- a/packages/spacecat-shared-rum-api-client/test/common/page.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/common/page.test.js
@@ -9,8 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import { getPageType, isConsentClick } from '../../src/common/page.js';
 

--- a/packages/spacecat-shared-rum-api-client/test/common/rum-bundler-client.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/common/rum-bundler-client.test.js
@@ -9,8 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';

--- a/packages/spacecat-shared-rum-api-client/test/common/traffic.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/common/traffic.test.js
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-env mocha */
 /* eslint-disable object-curly-newline */
 
 import { expect } from 'chai';

--- a/packages/spacecat-shared-rum-api-client/test/cwv.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/cwv.test.js
@@ -9,8 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import cwv from '../src/functions/cwv.js';
 import bundlesForUrls from './fixtures/bundles.json' with { type: 'json' };

--- a/packages/spacecat-shared-rum-api-client/test/functions.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/functions.test.js
@@ -9,8 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import notfound from '../src/functions/404.js';
 import internalLinks404 from '../src/functions/404-internal-links.js';

--- a/packages/spacecat-shared-rum-api-client/test/index.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/index.test.js
@@ -9,8 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';
@@ -153,7 +151,9 @@ describe('RUMAPIClient#queryStream', () => {
     while (true) {
       // eslint-disable-next-line no-await-in-loop
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        break;
+      }
       received.push(value);
     }
 
@@ -191,7 +191,9 @@ describe('RUMAPIClient#queryStream', () => {
     while (true) {
       // eslint-disable-next-line no-await-in-loop
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        break;
+      }
       received.push(value);
     }
 
@@ -237,7 +239,9 @@ describe('RUMAPIClient#queryStream', () => {
     while (true) {
       // eslint-disable-next-line no-await-in-loop
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        break;
+      }
       received.push(value);
     }
 

--- a/packages/spacecat-shared-rum-api-client/test/optimization-graph.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/optimization-graph.test.js
@@ -18,8 +18,6 @@ import optimizationGraph from '../src/functions/reports/optimization/graph.js';
 const filename = fileURLToPath(import.meta.url);
 const dirnamePath = dirname(filename);
 const bundlesForUrls = JSON.parse(readFileSync(join(dirnamePath, './fixtures/bundles.json'), 'utf8'));
-/* eslint-env mocha */
-
 describe('Optimization Report Graph', () => {
   describe('handler', () => {
     it('should return default structure when no opts provided', () => {

--- a/packages/spacecat-shared-rum-api-client/test/optimization-metrics.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/optimization-metrics.test.js
@@ -18,8 +18,6 @@ import optimizationMetrics from '../src/functions/reports/optimization/metrics.j
 const filename = fileURLToPath(import.meta.url);
 const dirnamePath = dirname(filename);
 const bundlesForUrls = JSON.parse(readFileSync(join(dirnamePath, './fixtures/bundles.json'), 'utf8'));
-/* eslint-env mocha */
-
 describe('Optimization Report Metrics', () => {
   describe('handler', () => {
     it('should process real RUM bundles and return metrics', () => {

--- a/packages/spacecat-shared-rum-api-client/test/optimization-utils.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/optimization-utils.test.js
@@ -11,7 +11,6 @@
  */
 import { expect } from 'chai';
 import { initializeDataChunks, calculateMetrics, filterBundles } from '../src/functions/reports/optimization/utils.js';
-/* eslint-env mocha */
 
 describe('Optimization Utils', () => {
   describe('initializeDataChunks', () => {

--- a/packages/spacecat-shared-rum-api-client/test/total-metrics.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/total-metrics.test.js
@@ -12,7 +12,6 @@
 import { expect } from 'chai';
 import totalMetrics from '../src/functions/total-metrics.js';
 import bundlesForUrls from './fixtures/bundles.json' with { type: 'json' };
-/* eslint-env mocha */
 
 describe('Total Metrics Queries', () => {
   it('crunches CWV data', async () => {

--- a/packages/spacecat-shared-rum-api-client/test/traffic-metrics.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/traffic-metrics.test.js
@@ -9,8 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import trafficMetrics from '../src/functions/traffic-metrics.js';
 import bundlesWithTraffic from './fixtures/bundles.json' with { type: 'json' };

--- a/packages/spacecat-shared-rum-api-client/test/user-engagement.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/user-engagement.test.js
@@ -9,8 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import userEngagement from '../src/functions/user-engagement.js';
 

--- a/packages/spacecat-shared-scrape-client/test/index.test.js
+++ b/packages/spacecat-shared-scrape-client/test/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { use, expect, assert } from 'chai';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';

--- a/packages/spacecat-shared-slack-client/test/clients/base-slack-client.test.js
+++ b/packages/spacecat-shared-slack-client/test/clients/base-slack-client.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';

--- a/packages/spacecat-shared-slack-client/test/clients/elevated-slack-client.test.js
+++ b/packages/spacecat-shared-slack-client/test/clients/elevated-slack-client.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';

--- a/packages/spacecat-shared-slack-client/test/index.test.js
+++ b/packages/spacecat-shared-slack-client/test/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import {
   SLACK_STATUSES,

--- a/packages/spacecat-shared-slack-client/test/wrappers/elevated-client-wrapper.test.js
+++ b/packages/spacecat-shared-slack-client/test/wrappers/elevated-client-wrapper.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';

--- a/packages/spacecat-shared-splunk-client/package.json
+++ b/packages/spacecat-shared-splunk-client/package.json
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/fetch": "4.2.3",
+    "@adobe/fetch": "4.3.0",
     "@adobe/helix-universal": "5.4.0",
     "@adobe/spacecat-shared-utils": "1.81.1",
     "xml-js": "1.6.11"

--- a/packages/spacecat-shared-splunk-client/test/index.test.js
+++ b/packages/spacecat-shared-splunk-client/test/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';

--- a/packages/spacecat-shared-tier-client/test/tier-client.test.js
+++ b/packages/spacecat-shared-tier-client/test/tier-client.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { use, expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-tokowaka-client/src/index.js
+++ b/packages/spacecat-shared-tokowaka-client/src/index.js
@@ -1348,8 +1348,12 @@ class TokowakaClient {
 
           if (regexPatterns.length > 0) {
             const covered = allSuggestions.filter((s) => {
-              if (s.getId() === suggestion.getId()) return false;
-              if (skippedInBatchIds.has(s.getId())) return false;
+              if (s.getId() === suggestion.getId()) {
+                return false;
+              }
+              if (skippedInBatchIds.has(s.getId())) {
+                return false;
+              }
               if (!isEdgeDeployableSuggestionStatus(s.getStatus())) {
                 return false;
               }

--- a/packages/spacecat-shared-tokowaka-client/src/mappers/commerce-page-enrichment-mapper.js
+++ b/packages/spacecat-shared-tokowaka-client/src/mappers/commerce-page-enrichment-mapper.js
@@ -58,26 +58,34 @@ function renderList(items, cls) {
 }
 
 function renderValue(key, value, cls) {
-  if (value == null) return '';
+  if (value == null) {
+    return '';
+  }
 
   if (key === 'facts.facets.category_path' || key === 'category') {
     return `<p class="${cls}">${renderCategoryPath(value)}</p>`;
   }
 
   if (Array.isArray(value)) {
-    if (value.length === 0) return '';
+    if (value.length === 0) {
+      return '';
+    }
     return renderList(value, cls);
   }
 
   if (typeof value === 'object') {
     const entries = Object.entries(value).filter(([, v]) => v != null && v !== '');
-    if (entries.length === 0) return '';
+    if (entries.length === 0) {
+      return '';
+    }
     const items = entries.map(([k, v]) => `${escapeHtml(k)}: ${escapeHtml(String(v))}`);
     return renderList(items, cls);
   }
 
   const str = String(value);
-  if (!str) return '';
+  if (!str) {
+    return '';
+  }
   return `<p class="${cls}">${escapeHtml(str)}</p>`;
 }
 

--- a/packages/spacecat-shared-tokowaka-client/src/mappers/generic-mapper.js
+++ b/packages/spacecat-shared-tokowaka-client/src/mappers/generic-mapper.js
@@ -36,8 +36,12 @@ export default class GenericMapper extends BaseOpportunityMapper {
 
   // eslint-disable-next-line class-methods-use-this
   #resolveValue(data) {
-    if (data.format === 'html') return htmlToHast(data.patchValue);
-    if (data.format === 'hast' || data.format === 'json') return JSON.parse(data.patchValue);
+    if (data.format === 'html') {
+      return htmlToHast(data.patchValue);
+    }
+    if (data.format === 'hast' || data.format === 'json') {
+      return JSON.parse(data.patchValue);
+    }
     return data.patchValue;
   }
 

--- a/packages/spacecat-shared-tokowaka-client/test/cdn/base-cdn-client.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/cdn/base-cdn-client.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import BaseCdnClient from '../../src/cdn/base-cdn-client.js';
 

--- a/packages/spacecat-shared-tokowaka-client/test/cdn/cdn-client-registry.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/cdn/cdn-client-registry.test.js
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
 /* eslint-disable max-classes-per-file */
 
 import { expect, use } from 'chai';

--- a/packages/spacecat-shared-tokowaka-client/test/cdn/cloudfront-cdn-client.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/cdn/cloudfront-cdn-client.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-tokowaka-client/test/cdn/fastly-cdn-client.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/cdn/fastly-cdn-client.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 import FastlyCdnClient from '../../src/cdn/fastly-cdn-client.js';

--- a/packages/spacecat-shared-tokowaka-client/test/fastly-kv-client.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/fastly-kv-client.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 import nock from 'nock';

--- a/packages/spacecat-shared-tokowaka-client/test/index.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-tokowaka-client/test/mappers/base-mapper.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/mappers/base-mapper.test.js
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
 /* eslint-disable max-classes-per-file, class-methods-use-this */
 
 import { expect } from 'chai';

--- a/packages/spacecat-shared-tokowaka-client/test/mappers/commerce-page-enrichment-mapper.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/mappers/commerce-page-enrichment-mapper.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 import CommercePageEnrichmentMapper from '../../src/mappers/commerce-page-enrichment-mapper.js';
@@ -20,11 +18,15 @@ import CommercePageEnrichmentMapper from '../../src/mappers/commerce-page-enrich
  * Recursively finds the first HAST element node matching a predicate.
  */
 function findNode(node, predicate) {
-  if (predicate(node)) return node;
+  if (predicate(node)) {
+    return node;
+  }
   if (node.children) {
     for (const child of node.children) {
       const found = findNode(child, predicate);
-      if (found) return found;
+      if (found) {
+        return found;
+      }
     }
   }
   return null;
@@ -35,7 +37,9 @@ function findNode(node, predicate) {
  */
 function findAllNodes(node, predicate) {
   const results = [];
-  if (predicate(node)) results.push(node);
+  if (predicate(node)) {
+    results.push(node);
+  }
   if (node.children) {
     for (const child of node.children) {
       results.push(...findAllNodes(child, predicate));
@@ -48,8 +52,12 @@ function findAllNodes(node, predicate) {
  * Extracts concatenated text content from a HAST subtree.
  */
 function textContent(node) {
-  if (node.type === 'text') return node.value;
-  if (node.children) return node.children.map(textContent).join('');
+  if (node.type === 'text') {
+    return node.value;
+  }
+  if (node.children) {
+    return node.children.map(textContent).join('');
+  }
   return '';
 }
 

--- a/packages/spacecat-shared-tokowaka-client/test/mappers/content-mapper.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/mappers/content-mapper.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import ContentMapper from '../../src/mappers/content-summarization-mapper.js';
 

--- a/packages/spacecat-shared-tokowaka-client/test/mappers/faq-mapper.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/mappers/faq-mapper.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import FaqMapper from '../../src/mappers/faq-mapper.js';
 

--- a/packages/spacecat-shared-tokowaka-client/test/mappers/generic-mapper.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/mappers/generic-mapper.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';

--- a/packages/spacecat-shared-tokowaka-client/test/mappers/headings-mapper.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/mappers/headings-mapper.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import HeadingsMapper from '../../src/mappers/headings-mapper.js';
 

--- a/packages/spacecat-shared-tokowaka-client/test/mappers/mapper-registry.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/mappers/mapper-registry.test.js
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
 /* eslint-disable max-classes-per-file */
 
 import { expect, use } from 'chai';

--- a/packages/spacecat-shared-tokowaka-client/test/mappers/prerender-mapper.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/mappers/prerender-mapper.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import PrerenderMapper from '../../src/mappers/prerender-mapper.js';
 

--- a/packages/spacecat-shared-tokowaka-client/test/mappers/readability-mapper.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/mappers/readability-mapper.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import ReadabilityMapper from '../../src/mappers/readability-mapper.js';
 

--- a/packages/spacecat-shared-tokowaka-client/test/mappers/semantic-value-visibility-mapper.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/mappers/semantic-value-visibility-mapper.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import { readFileSync } from 'fs';
 import { dirname, join } from 'path';

--- a/packages/spacecat-shared-tokowaka-client/test/mappers/toc-mapper.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/mappers/toc-mapper.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import TocMapper from '../../src/mappers/toc-mapper.js';
 

--- a/packages/spacecat-shared-tokowaka-client/test/utils/html-utils.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/utils/html-utils.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { fetchHtmlWithWarmup, calculateForwardedHost } from '../../src/utils/custom-html-utils.js';
@@ -656,8 +654,12 @@ describe('HTML Utils', () => {
         statusText: 'OK',
         headers: {
           get: (name) => {
-            if (name === 'x-edgeoptimize-cache') return 'HIT';
-            if (name === 'x-edgeoptimize-proxy') return 'true';
+            if (name === 'x-edgeoptimize-cache') {
+              return 'HIT';
+            }
+            if (name === 'x-edgeoptimize-proxy') {
+              return 'true';
+            }
             return null;
           },
         },
@@ -794,8 +796,12 @@ describe('HTML Utils', () => {
         statusText: 'OK',
         headers: {
           get: (name) => {
-            if (name === 'x-edgeoptimize-cache') return 'HIT';
-            if (name === 'x-edgeoptimize-proxy') return 'true';
+            if (name === 'x-edgeoptimize-cache') {
+              return 'HIT';
+            }
+            if (name === 'x-edgeoptimize-proxy') {
+              return 'true';
+            }
             return null;
           },
         },

--- a/packages/spacecat-shared-tokowaka-client/test/utils/htmlToHast.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/utils/htmlToHast.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import { htmlToHast } from '../../src/utils/html-utils.js';
 

--- a/packages/spacecat-shared-tokowaka-client/test/utils/patch-utils.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/utils/patch-utils.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import { mergePatches, removePatchesBySuggestionIds } from '../../src/utils/patch-utils.js';
 

--- a/packages/spacecat-shared-tokowaka-client/test/utils/s3-utils.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/utils/s3-utils.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import {
   normalizePath,

--- a/packages/spacecat-shared-tokowaka-client/test/utils/site-utils.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/utils/site-utils.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import { getEffectiveBaseURL } from '../../src/utils/site-utils.js';
 

--- a/packages/spacecat-shared-tokowaka-client/test/utils/suggestion-utils.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/utils/suggestion-utils.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import { groupSuggestionsByUrlPath, filterEligibleSuggestions } from '../../src/utils/suggestion-utils.js';
 

--- a/packages/spacecat-shared-utils/package.json
+++ b/packages/spacecat-shared-utils/package.json
@@ -83,7 +83,7 @@
     "sinon-chai": "4.0.1"
   },
   "dependencies": {
-    "@adobe/fetch": "4.2.3",
+    "@adobe/fetch": "4.3.0",
     "@aws-sdk/client-s3": "3.1024.0",
     "@aws-sdk/client-sqs": "3.1024.0",
     "@json2csv/plainjs": "7.0.6",

--- a/packages/spacecat-shared-utils/scripts/check-subpath-deps.js
+++ b/packages/spacecat-shared-utils/scripts/check-subpath-deps.js
@@ -74,4 +74,6 @@ for (const { entry, allowlist } of CHECKS) {
   }
 }
 
-if (anyFailure) process.exit(1);
+if (anyFailure) {
+  process.exit(1);
+}

--- a/packages/spacecat-shared-utils/src/bot-blocker-detect/bot-blocker-detect.js
+++ b/packages/spacecat-shared-utils/src/bot-blocker-detect/bot-blocker-detect.js
@@ -133,7 +133,9 @@ function analyzeResponse(response, html = null) {
 
   // Check HTML content for challenge page patterns (if HTML provided)
   const htmlHasChallenge = (patterns) => {
-    if (!html) return false;
+    if (!html) {
+      return false;
+    }
     return patterns.some((pattern) => pattern.test(html));
   };
 

--- a/packages/spacecat-shared-utils/src/calendar-week-helper.js
+++ b/packages/spacecat-shared-utils/src/calendar-week-helper.js
@@ -40,8 +40,12 @@ function has53CalendarWeeks(year) {
 }
 
 function isValidWeek(week, year) {
-  if (!Number.isInteger(year) || year < 100 || !Number.isInteger(week) || week < 1) return false;
-  if (week === 53) return has53CalendarWeeks(year);
+  if (!Number.isInteger(year) || year < 100 || !Number.isInteger(week) || week < 1) {
+    return false;
+  }
+  if (week === 53) {
+    return has53CalendarWeeks(year);
+  }
   return week <= 52;
 }
 

--- a/packages/spacecat-shared-utils/src/formcalc.js
+++ b/packages/spacecat-shared-utils/src/formcalc.js
@@ -157,7 +157,9 @@ export function getHighPageViewsLowFormCtrMetrics(formVitalsCollection) {
     }
 
     // Skip entry if no valid maxPageviewUrl is found
-    if (!maxPageviewUrl) return;
+    if (!maxPageviewUrl) {
+      return;
+    }
 
     // Calculate `y`: find the CTA with the highest clicks and include the source
     const y = maxPageviewUrl.CTAs.reduce((maxCta, cta) => {

--- a/packages/spacecat-shared-utils/src/functions.js
+++ b/packages/spacecat-shared-utils/src/functions.js
@@ -94,30 +94,48 @@ function isNonEmptyObject(value) {
  * @return {boolean} True if the objects or arrays are equal, false otherwise.
  */
 function deepEqual(x, y) {
-  if (x === y) return true;
+  if (x === y) {
+    return true;
+  }
 
   if (isArray(x) && isArray(y)) {
-    if (x.length !== y.length) return false;
+    if (x.length !== y.length) {
+      return false;
+    }
     for (let i = 0; i < x.length; i += 1) {
-      if (!deepEqual(x[i], y[i])) return false;
+      if (!deepEqual(x[i], y[i])) {
+        return false;
+      }
     }
     return true;
   }
 
-  if (!isObject(x) || !isObject(y)) return false;
+  if (!isObject(x) || !isObject(y)) {
+    return false;
+  }
 
-  if (x.constructor !== y.constructor) return false;
+  if (x.constructor !== y.constructor) {
+    return false;
+  }
 
-  if (x instanceof Date) return x.getTime() === y.getTime();
-  if (x instanceof RegExp) return x.toString() === y.toString();
+  if (x instanceof Date) {
+    return x.getTime() === y.getTime();
+  }
+  if (x instanceof RegExp) {
+    return x.toString() === y.toString();
+  }
 
   const xKeys = Object.keys(x).filter((key) => typeof x[key] !== 'function');
   const yKeys = Object.keys(y).filter((key) => typeof y[key] !== 'function');
 
-  if (xKeys.length !== yKeys.length) return false;
+  if (xKeys.length !== yKeys.length) {
+    return false;
+  }
 
   for (const key of xKeys) {
-    if (!Object.prototype.hasOwnProperty.call(y, key) || !deepEqual(x[key], y[key])) return false;
+    if (!Object.prototype.hasOwnProperty.call(y, key) || !deepEqual(x[key], y[key])) {
+      return false;
+    }
   }
 
   return true;

--- a/packages/spacecat-shared-utils/src/token-grant-config.js
+++ b/packages/spacecat-shared-utils/src/token-grant-config.js
@@ -90,9 +90,13 @@ export function getCurrentCycle(cycleFormat) {
  *   cycleFormat: string, currentCycle: string }|undefined}
  */
 export function getTokenGrantConfig(tokenType) {
-  if (!hasText(tokenType)) return undefined;
+  if (!hasText(tokenType)) {
+    return undefined;
+  }
   const entry = TOKEN_GRANT_CONFIG[tokenType];
-  if (!entry) return undefined;
+  if (!entry) {
+    return undefined;
+  }
   return { ...entry, currentCycle: getCurrentCycle(entry.cycleFormat) };
 }
 
@@ -105,9 +109,13 @@ export function getTokenGrantConfig(tokenType) {
  *   tokenType: string }|undefined}
  */
 export function getTokenGrantConfigByOpportunity(opportunityName) {
-  if (!hasText(opportunityName)) return undefined;
+  if (!hasText(opportunityName)) {
+    return undefined;
+  }
   const tokenType = getTokenTypeForOpportunity(opportunityName);
   const config = getTokenGrantConfig(tokenType);
-  if (!config) return undefined;
+  if (!config) {
+    return undefined;
+  }
   return { ...config, tokenType };
 }

--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -184,7 +184,9 @@ async function resolveCanonicalUrl(urlString, method = 'HEAD') {
  * @returns {string} The normalized URL
  */
 function normalizeUrl(url) {
-  if (!url || typeof url !== 'string') return url;
+  if (!url || typeof url !== 'string') {
+    return url;
+  }
   // Trim whitespace from beginning and end
   let normalized = url.trim();
   // Handle trailing slashes - normalize multiple trailing slashes to single slash
@@ -207,8 +209,12 @@ function normalizeUrl(url) {
  * @returns {string} The normalized pathname
  */
 function normalizePathname(pathname) {
-  if (!pathname || typeof pathname !== 'string') return pathname;
-  if (pathname === '/') return '/';
+  if (!pathname || typeof pathname !== 'string') {
+    return pathname;
+  }
+  if (pathname === '/') {
+    return '/';
+  }
   return pathname.replace(/\/+$/, '');
 }
 
@@ -219,7 +225,9 @@ function normalizePathname(pathname) {
  * @returns {boolean} True if URL matches any filter URL, false if any URL is invalid
  */
 function urlMatchesFilter(url, filterUrls) {
-  if (!filterUrls || filterUrls.length === 0) return true;
+  if (!filterUrls || filterUrls.length === 0) {
+    return true;
+  }
   try {
     // Normalize the input URL
     const normalizedInputUrl = normalizeUrl(url);
@@ -268,7 +276,9 @@ function hasNonWWWSubdomain(baseUrl) {
  * @returns {string} - The hostname with the www subdomain toggled.
  */
 function toggleWWWHostname(hostname) {
-  if (hasNonWWWSubdomain(`https://${hostname}`)) return hostname;
+  if (hasNonWWWSubdomain(`https://${hostname}`)) {
+    return hostname;
+  }
   return hostname.startsWith('www.') ? hostname.replace('www.', '') : `www.${hostname}`;
 }
 

--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -209,6 +209,7 @@ function normalizeUrl(url) {
  * @returns {string} The normalized pathname
  */
 function normalizePathname(pathname) {
+  /* c8 ignore next 3 */
   if (!pathname || typeof pathname !== 'string') {
     return pathname;
   }

--- a/packages/spacecat-shared-utils/test/aem-content-api-utils.test.js
+++ b/packages/spacecat-shared-utils/test/aem-content-api-utils.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 import nock from 'nock';

--- a/packages/spacecat-shared-utils/test/aem.test.js
+++ b/packages/spacecat-shared-utils/test/aem.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import { DELIVERY_TYPES, detectAEMVersion } from '../src/aem.js';
 

--- a/packages/spacecat-shared-utils/test/aggregation/aggregation-strategies.test.js
+++ b/packages/spacecat-shared-utils/test/aggregation/aggregation-strategies.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import * as chai from 'chai';
 import {
   Granularity,

--- a/packages/spacecat-shared-utils/test/bot-blocker-detect/bot-blocker-detect.test.js
+++ b/packages/spacecat-shared-utils/test/bot-blocker-detect/bot-blocker-detect.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import nock from 'nock';
 

--- a/packages/spacecat-shared-utils/test/browser.test.js
+++ b/packages/spacecat-shared-utils/test/browser.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import { prettifyLogForwardingConfig } from '../src/browser.js';
 

--- a/packages/spacecat-shared-utils/test/calendar-week-helper.test.js
+++ b/packages/spacecat-shared-utils/test/calendar-week-helper.test.js
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
 import { expect } from 'chai';
 import sinon from 'sinon';
 import {

--- a/packages/spacecat-shared-utils/test/cdn-helpers.test.js
+++ b/packages/spacecat-shared-utils/test/cdn-helpers.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import { prettifyLogForwardingConfig } from '../src/cdn-helpers.js';
 

--- a/packages/spacecat-shared-utils/test/email.test.js
+++ b/packages/spacecat-shared-utils/test/email.test.js
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
 /* eslint-disable no-unused-expressions */
 
 import { expect } from 'chai';

--- a/packages/spacecat-shared-utils/test/formcalc.test.js
+++ b/packages/spacecat-shared-utils/test/formcalc.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import { formVitalsCollection, formVitalsCollection2 } from './fixtures/formcalcaudit.js';
 import {

--- a/packages/spacecat-shared-utils/test/functions.test.js
+++ b/packages/spacecat-shared-utils/test/functions.test.js
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
 /* eslint-disable no-unused-expressions */
 
 import { expect } from 'chai';

--- a/packages/spacecat-shared-utils/test/helpers.test.js
+++ b/packages/spacecat-shared-utils/test/helpers.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 
 import { promises as fs } from 'fs';

--- a/packages/spacecat-shared-utils/test/index.test.js
+++ b/packages/spacecat-shared-utils/test/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import * as allExports from '../src/index.js';
 

--- a/packages/spacecat-shared-utils/test/llmo-config.test.js
+++ b/packages/spacecat-shared-utils/test/llmo-config.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-utils/test/llmo-strategy.test.js
+++ b/packages/spacecat-shared-utils/test/llmo-strategy.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-utils/test/locale-detect/indicators.test.js
+++ b/packages/spacecat-shared-utils/test/locale-detect/indicators.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
 

--- a/packages/spacecat-shared-utils/test/locale-detect/locale-detect.test.js
+++ b/packages/spacecat-shared-utils/test/locale-detect/locale-detect.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import nock from 'nock';
 

--- a/packages/spacecat-shared-utils/test/locale-detect/utils.test.js
+++ b/packages/spacecat-shared-utils/test/locale-detect/utils.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 
 import { parseLocale } from '../../src/locale-detect/utils.js';

--- a/packages/spacecat-shared-utils/test/log-wrapper.test.js
+++ b/packages/spacecat-shared-utils/test/log-wrapper.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import sinon from 'sinon';
 import { expect } from 'chai';
 import esmock from 'esmock';

--- a/packages/spacecat-shared-utils/test/metrics-store.test.js
+++ b/packages/spacecat-shared-utils/test/metrics-store.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';

--- a/packages/spacecat-shared-utils/test/opportunity/audit-completion.test.js
+++ b/packages/spacecat-shared-utils/test/opportunity/audit-completion.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import { computeAuditCompletion } from '../../src/opportunity/audit-completion.js';
 

--- a/packages/spacecat-shared-utils/test/opportunity/audit-mapping.test.js
+++ b/packages/spacecat-shared-utils/test/opportunity/audit-mapping.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import {
   AUDIT_OPPORTUNITY_MAP,

--- a/packages/spacecat-shared-utils/test/opportunity/dependency-mapping.test.js
+++ b/packages/spacecat-shared-utils/test/opportunity/dependency-mapping.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import {
   DEPENDENCY_SOURCES,

--- a/packages/spacecat-shared-utils/test/opportunity/opportunity-titles.test.js
+++ b/packages/spacecat-shared-utils/test/opportunity/opportunity-titles.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import {
   OPPORTUNITY_TITLES,

--- a/packages/spacecat-shared-utils/test/s3.test.js
+++ b/packages/spacecat-shared-utils/test/s3.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { S3Client } from '@aws-sdk/client-s3';

--- a/packages/spacecat-shared-utils/test/schemas.test.js
+++ b/packages/spacecat-shared-utils/test/schemas.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 
 import { llmoConfig } from '../src/schemas.js';

--- a/packages/spacecat-shared-utils/test/sqs.test.js
+++ b/packages/spacecat-shared-utils/test/sqs.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { SQSClient } from '@aws-sdk/client-sqs';
 import wrap from '@adobe/helix-shared-wrap';
 import sinon from 'sinon';

--- a/packages/spacecat-shared-utils/test/strategy-schema.test.js
+++ b/packages/spacecat-shared-utils/test/strategy-schema.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 
 import { strategyWorkspaceData } from '../src/llmo-strategy.js';

--- a/packages/spacecat-shared-utils/test/token-grant-config.test.js
+++ b/packages/spacecat-shared-utils/test/token-grant-config.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/packages/spacecat-shared-utils/test/tracing-fetch.test.js
+++ b/packages/spacecat-shared-utils/test/tracing-fetch.test.js
@@ -9,8 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 import esmock from 'esmock';

--- a/packages/spacecat-shared-utils/test/url-extractors.test.js
+++ b/packages/spacecat-shared-utils/test/url-extractors.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 import esmock from 'esmock';

--- a/packages/spacecat-shared-utils/test/url-helpers.test.js
+++ b/packages/spacecat-shared-utils/test/url-helpers.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import nock from 'nock';
 import sinon from 'sinon';

--- a/packages/spacecat-shared-utils/test/xray.test.js
+++ b/packages/spacecat-shared-utils/test/xray.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 import AWSXray from 'aws-xray-sdk';

--- a/packages/spacecat-shared-vault-secrets/src/vault-client.js
+++ b/packages/spacecat-shared-vault-secrets/src/vault-client.js
@@ -61,8 +61,12 @@ export default class VaultClient {
   }
 
   isAuthenticated() {
-    if (!this.#token) return false;
-    if (this.#tokenExpiry && Date.now() >= this.#tokenExpiry) return false;
+    if (!this.#token) {
+      return false;
+    }
+    if (this.#tokenExpiry && Date.now() >= this.#tokenExpiry) {
+      return false;
+    }
     return true;
   }
 
@@ -129,7 +133,9 @@ export default class VaultClient {
   }
 
   isTokenExpiringSoon() {
-    if (!this.isAuthenticated()) return false;
+    if (!this.isAuthenticated()) {
+      return false;
+    }
     return (this.#tokenExpiry - Date.now()) <= TOKEN_RENEW_BUFFER;
   }
 

--- a/packages/spacecat-shared-vault-secrets/src/vault-secrets-wrapper.js
+++ b/packages/spacecat-shared-vault-secrets/src/vault-secrets-wrapper.js
@@ -19,17 +19,29 @@ const ALIAS_PATTERN = /^[a-z0-9][a-z0-9_-]{0,30}$/i;
 const CI_PATTERN = /^ci\d+$/i;
 
 function isDevAliasDeployment(ctx, env) {
-  if (env !== 'dev') return false;
+  if (env !== 'dev') {
+    return false;
+  }
   const { version } = ctx.func || {};
-  if (!version) return false;
-  if (version === 'latest' || version === '$LATEST') return false;
-  if (CI_PATTERN.test(version)) return false;
-  if (!ALIAS_PATTERN.test(version)) return false;
+  if (!version) {
+    return false;
+  }
+  if (version === 'latest' || version === '$LATEST') {
+    return false;
+  }
+  if (CI_PATTERN.test(version)) {
+    return false;
+  }
+  if (!ALIAS_PATTERN.test(version)) {
+    return false;
+  }
   return true;
 }
 
 function resolveBootstrapPath(ctx, opts) {
-  if (opts.bootstrapPath) return opts.bootstrapPath;
+  if (opts.bootstrapPath) {
+    return opts.bootstrapPath;
+  }
   return `/mysticat/bootstrap/${ctx.func.name}`;
 }
 

--- a/packages/spacecat-shared-vault-secrets/test/vault-client.test.js
+++ b/packages/spacecat-shared-vault-secrets/test/vault-client.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';

--- a/packages/spacecat-shared-vault-secrets/test/vault-secrets-wrapper.test.js
+++ b/packages/spacecat-shared-vault-secrets/test/vault-secrets-wrapper.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';


### PR DESCRIPTION
## Summary

- Enforce `curly` rule introduced by `@adobe/eslint-config-helix` 3.0.24 - expand all single-line `if`/`while`/`for` bodies to multi-line with braces
- Remove all redundant `/* eslint-env mocha */` comments from 242 test files (globals already configured by the helix eslint test preset; these comments will become errors in ESLint v10)
- Fix misplaced `eslint-disable-next-line no-undef` comments in `html-analyzer/src/utils.js` that broke after curly expansion
- Bump `@adobe/eslint-config-helix` 3.0.23 -> 3.0.24 and `@adobe/fetch` 4.2.3 -> 4.3.0 (from renovate PR #1503)

## Test plan

- [x] `npm run lint` passes (only pre-existing `no-undef` in html-analyzer now fixed)
- [x] `npm test` passes across all 22 packages
- [ ] CI passes on this branch