### PR TITLE
SITES-41950: add experimental prefix fallback for AEM Content API resolve and edit URL calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21579,7 +21579,7 @@
     },
     "packages/mysticat-shared-seo-client": {
       "name": "@adobe/mysticat-shared-seo-client",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -22318,7 +22318,7 @@
     },
     "packages/spacecat-shared-ahrefs-client": {
       "name": "@adobe/spacecat-shared-ahrefs-client",
-      "version": "1.10.9",
+      "version": "1.10.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -23793,7 +23793,7 @@
     },
     "packages/spacecat-shared-brand-client": {
       "name": "@adobe/spacecat-shared-brand-client",
-      "version": "1.1.40",
+      "version": "1.1.41",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
@@ -25497,7 +25497,7 @@
     },
     "packages/spacecat-shared-content-client": {
       "name": "@adobe/spacecat-shared-content-client",
-      "version": "1.8.22",
+      "version": "1.8.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
@@ -26649,7 +26649,7 @@
     },
     "packages/spacecat-shared-example": {
       "name": "@adobe/spacecat-shared-example",
-      "version": "1.2.33",
+      "version": "1.2.34",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -26665,7 +26665,7 @@
     },
     "packages/spacecat-shared-google-client": {
       "name": "@adobe/spacecat-shared-google-client",
-      "version": "1.5.10",
+      "version": "1.5.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -27447,7 +27447,7 @@
     },
     "packages/spacecat-shared-gpt-client": {
       "name": "@adobe/spacecat-shared-gpt-client",
-      "version": "1.6.21",
+      "version": "1.6.22",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -29034,7 +29034,7 @@
     },
     "packages/spacecat-shared-ims-client": {
       "name": "@adobe/spacecat-shared-ims-client",
-      "version": "1.12.4",
+      "version": "1.12.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -29774,7 +29774,7 @@
     },
     "packages/spacecat-shared-launchdarkly-client": {
       "name": "@adobe/spacecat-shared-launchdarkly-client",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
@@ -30513,7 +30513,7 @@
     },
     "packages/spacecat-shared-rum-api-client": {
       "name": "@adobe/spacecat-shared-rum-api-client",
-      "version": "2.40.11",
+      "version": "2.40.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -31255,7 +31255,7 @@
     },
     "packages/spacecat-shared-scrape-client": {
       "name": "@adobe/spacecat-shared-scrape-client",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
@@ -31993,7 +31993,7 @@
     },
     "packages/spacecat-shared-slack-client": {
       "name": "@adobe/spacecat-shared-slack-client",
-      "version": "1.6.5",
+      "version": "1.6.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
@@ -32732,7 +32732,7 @@
     },
     "packages/spacecat-shared-splunk-client": {
       "name": "@adobe/spacecat-shared-splunk-client",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",

--- a/packages/spacecat-shared-utils/src/aem-content-api-utils.js
+++ b/packages/spacecat-shared-utils/src/aem-content-api-utils.js
@@ -13,6 +13,9 @@
 import { fetch } from './adobe-fetch.js';
 
 export const CONTENT_API_PREFIX = '/adobe';
+export const PSS_API_PREFIX = '/adobe/experimental/pss';
+export const CONTENT_API_EXPERIMENTAL_PREFIX = '/adobe/experimental/aspm-expires-20251231';
+export const PSS_API_EXPERIMENTAL_PREFIX = '/adobe/experimental/aso-expires-20251231';
 
 /**
  * Determines the AEM CS/AMS page ID for Content API, from the page URL
@@ -51,40 +54,46 @@ export async function determineAEMCSPageId(
       return null;
     }
     const contentPageRef = refMatch[1].trim();
-    try {
-      const base = preferContentApi
-        ? `${authorURL}${CONTENT_API_PREFIX}`
-        : `${authorURL}/adobe/experimental/pss`;
+    const prefixes = preferContentApi
+      ? [CONTENT_API_EXPERIMENTAL_PREFIX, CONTENT_API_PREFIX]
+      : [PSS_API_EXPERIMENTAL_PREFIX, PSS_API_PREFIX];
+
+    for (const prefix of prefixes) {
+      const base = `${authorURL}${prefix}`;
       const resolveUrl = `${base}/pages/resolve?pageRef=${contentPageRef}`;
       log.info(`Resolving content-page-ref via ${resolveUrl} (preferContentApi=${preferContentApi})`);
-      const resp = await fetch(resolveUrl, {
-        method: 'GET',
-        headers: { Authorization: bearerToken },
-        redirect: 'follow',
-      });
-      if (resp.status === 200) {
-        let pageId = null;
-        if (preferContentApi) {
-          const data = await resp.json();
-          pageId = data?.id || null;
-        } else {
-          const data = await resp.text();
-          pageId = data || null;
-        }
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const resp = await fetch(resolveUrl, {
+          method: 'GET',
+          headers: { Authorization: bearerToken },
+          redirect: 'follow',
+        });
+        if (resp.status === 200) {
+          let pageId = null;
+          if (preferContentApi) {
+            // eslint-disable-next-line no-await-in-loop
+            const data = await resp.json();
+            pageId = data?.id || null;
+          } else {
+            // eslint-disable-next-line no-await-in-loop
+            const data = await resp.text();
+            pageId = data || null;
+          }
 
-        if (pageId) {
-          log.info(`Resolved pageId: "${pageId}" from JSON directly for ref "${contentPageRef}"`);
-          return pageId;
+          if (pageId) {
+            log.info(`Resolved pageId: "${pageId}" from JSON directly for ref "${contentPageRef}"`);
+            return pageId;
+          }
+          log.error('resolve response did not contain an "id" property.');
+          return null;
         }
-        log.error('resolve response did not contain an "id" property.');
-        return null;
-      } else {
         log.warn(`Unexpected status ${resp.status} when resolving content-page-ref.`);
+      } catch (e) {
+        log.error(`Error while resolving content-page-ref: ${e.message}`);
       }
-    } catch (e) {
-      log.error(`Error while resolving content-page-ref: ${e.message}`);
     }
-    // If ref was present but resolution failed, return null per spec
+    // If ref was present but resolution failed on all prefixes, return null per spec
     return null;
   }
 
@@ -110,15 +119,19 @@ export async function determineAEMCSPageId(
  * @returns {string} The edit URL or null if the page ID is not found
  */
 export const getPageEditUrl = async (authorURL, bearerToken, pageId) => {
-  const PAGE_ID_API = `${authorURL}${CONTENT_API_PREFIX}/pages/${pageId}`;
-  const response = await fetch(PAGE_ID_API, {
-    method: 'GET',
-    headers: { Authorization: bearerToken },
-  });
-  if (response.ok) {
-    const responseData = await response.json();
-    // eslint-disable-next-line no-underscore-dangle
-    return responseData?._links?.edit;
+  for (const prefix of [CONTENT_API_EXPERIMENTAL_PREFIX, CONTENT_API_PREFIX]) {
+    const PAGE_ID_API = `${authorURL}${prefix}/pages/${pageId}`;
+    // eslint-disable-next-line no-await-in-loop
+    const response = await fetch(PAGE_ID_API, {
+      method: 'GET',
+      headers: { Authorization: bearerToken },
+    });
+    if (response.ok) {
+      // eslint-disable-next-line no-await-in-loop
+      const responseData = await response.json();
+      // eslint-disable-next-line no-underscore-dangle
+      return responseData?._links?.edit;
+    }
   }
   return null;
 };

--- a/packages/spacecat-shared-utils/test/aem-content-api-utils.test.js
+++ b/packages/spacecat-shared-utils/test/aem-content-api-utils.test.js
@@ -13,7 +13,14 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import nock from 'nock';
-import { determineAEMCSPageId, getPageEditUrl, CONTENT_API_PREFIX } from '../src/aem-content-api-utils.js';
+import {
+  determineAEMCSPageId,
+  getPageEditUrl,
+  CONTENT_API_PREFIX,
+  PSS_API_PREFIX,
+  CONTENT_API_EXPERIMENTAL_PREFIX,
+  PSS_API_EXPERIMENTAL_PREFIX,
+} from '../src/aem-content-api-utils.js';
 
 describe('determineAEMCSPageId', () => {
   let mockLog;
@@ -275,6 +282,10 @@ describe('determineAEMCSPageId', () => {
       .reply(200, htmlContent);
 
     nock('https://author.example.com')
+      .get(`${CONTENT_API_EXPERIMENTAL_PREFIX}/pages/resolve?pageRef=content-ref-abc123`)
+      .reply(404);
+
+    nock('https://author.example.com')
       .get(`${CONTENT_API_PREFIX}/pages/resolve?pageRef=content-ref-abc123`)
       .reply(200, { id: expectedPageId });
 
@@ -302,6 +313,10 @@ describe('determineAEMCSPageId', () => {
       .reply(200, htmlContent);
 
     nock('https://author.example.com')
+      .get(`${CONTENT_API_EXPERIMENTAL_PREFIX}/pages/resolve?pageRef=content-ref-abc123`)
+      .reply(404);
+
+    nock('https://author.example.com')
       .get(`${CONTENT_API_PREFIX}/pages/resolve?pageRef=content-ref-abc123`)
       .reply(200, { id: expectedPageId });
 
@@ -325,6 +340,10 @@ describe('determineAEMCSPageId', () => {
     nock('https://example.com')
       .get('/page')
       .reply(200, htmlContent);
+
+    nock('https://author.example.com')
+      .get(`${CONTENT_API_EXPERIMENTAL_PREFIX}/pages/resolve?pageRef=content-ref-no-id`)
+      .reply(404);
 
     nock('https://author.example.com')
       .get(`${CONTENT_API_PREFIX}/pages/resolve?pageRef=content-ref-no-id`)
@@ -352,6 +371,10 @@ describe('determineAEMCSPageId', () => {
       .reply(200, htmlContent);
 
     nock('https://author.example.com')
+      .get(`${CONTENT_API_EXPERIMENTAL_PREFIX}/pages/resolve?pageRef=content-ref-empty`)
+      .reply(404);
+
+    nock('https://author.example.com')
       .get(`${CONTENT_API_PREFIX}/pages/resolve?pageRef=content-ref-empty`)
       .reply(200, {});
 
@@ -375,6 +398,10 @@ describe('determineAEMCSPageId', () => {
     nock('https://example.com')
       .get('/page')
       .reply(200, htmlContent);
+
+    nock('https://author.example.com')
+      .get(`${CONTENT_API_EXPERIMENTAL_PREFIX}/pages/resolve?pageRef=content-ref-fail`)
+      .reply(404);
 
     nock('https://author.example.com')
       .get(`${CONTENT_API_PREFIX}/pages/resolve?pageRef=content-ref-fail`)
@@ -402,6 +429,10 @@ describe('determineAEMCSPageId', () => {
       .reply(200, htmlContent);
 
     nock('https://author.example.com')
+      .get(`${CONTENT_API_EXPERIMENTAL_PREFIX}/pages/resolve?pageRef=content-ref-fail-no-fallback`)
+      .reply(404);
+
+    nock('https://author.example.com')
       .get(`${CONTENT_API_PREFIX}/pages/resolve?pageRef=content-ref-fail-no-fallback`)
       .reply(500, 'Internal Server Error');
 
@@ -424,6 +455,10 @@ describe('determineAEMCSPageId', () => {
     nock('https://example.com')
       .get('/page')
       .reply(200, htmlContent);
+
+    nock('https://author.example.com')
+      .get(`${CONTENT_API_EXPERIMENTAL_PREFIX}/pages/resolve?pageRef=content-ref-network-error`)
+      .reply(404);
 
     nock('https://author.example.com')
       .get(`${CONTENT_API_PREFIX}/pages/resolve?pageRef=content-ref-network-error`)
@@ -453,7 +488,11 @@ describe('determineAEMCSPageId', () => {
       .reply(200, htmlContent);
 
     nock('https://author.example.com')
-      .get('/adobe/experimental/pss/pages/resolve?pageRef=content-ref-abc123')
+      .get(`${PSS_API_EXPERIMENTAL_PREFIX}/pages/resolve?pageRef=content-ref-abc123`)
+      .reply(404);
+
+    nock('https://author.example.com')
+      .get(`${PSS_API_PREFIX}/pages/resolve?pageRef=content-ref-abc123`)
       .reply(200, expectedPageId);
 
     const result = await determineAEMCSPageId(pageURL, 'https://author.example.com', 'Bearer token123', false, mockLog);
@@ -478,7 +517,11 @@ describe('determineAEMCSPageId', () => {
       .reply(200, htmlContent);
 
     nock('https://author.example.com')
-      .get('/adobe/experimental/pss/pages/resolve?pageRef=content-ref-empty')
+      .get(`${PSS_API_EXPERIMENTAL_PREFIX}/pages/resolve?pageRef=content-ref-empty`)
+      .reply(404);
+
+    nock('https://author.example.com')
+      .get(`${PSS_API_PREFIX}/pages/resolve?pageRef=content-ref-empty`)
       .reply(200, '');
 
     const result = await determineAEMCSPageId(pageURL, 'https://author.example.com', 'Bearer token123', false, mockLog);
@@ -503,7 +546,11 @@ describe('determineAEMCSPageId', () => {
       .reply(200, htmlContent);
 
     nock('https://author.example.com')
-      .get('/adobe/experimental/pss/pages/resolve?pageRef=content-ref-fail')
+      .get(`${PSS_API_EXPERIMENTAL_PREFIX}/pages/resolve?pageRef=content-ref-fail`)
+      .reply(404);
+
+    nock('https://author.example.com')
+      .get(`${PSS_API_PREFIX}/pages/resolve?pageRef=content-ref-fail`)
       .reply(500, 'Internal Server Error');
 
     const result = await determineAEMCSPageId(pageURL, 'https://author.example.com', 'Bearer token123', false, mockLog);
@@ -530,6 +577,10 @@ describe('determineAEMCSPageId', () => {
     nock('https://example.com')
       .get('/page')
       .reply(200, htmlContent);
+
+    nock('https://author.example.com')
+      .get(`${CONTENT_API_EXPERIMENTAL_PREFIX}/pages/resolve?pageRef=content-ref-priority`)
+      .reply(404);
 
     nock('https://author.example.com')
       .get(`${CONTENT_API_PREFIX}/pages/resolve?pageRef=content-ref-priority`)
@@ -580,6 +631,153 @@ describe('determineAEMCSPageId', () => {
     const result = await determineAEMCSPageId(pageURL, 'https://author.example.com', 'Bearer token123', true);
     expect(result).to.be.null;
   });
+
+  it('should use experimental Content API prefix when available', async () => {
+    const pageURL = 'https://example.com/page';
+    const contentPageRef = 'content-ref-exp';
+    const expectedPageId = 'exp-page-id';
+    const htmlContent = `
+      <html>
+        <head>
+          <meta name="content-page-ref" content="${contentPageRef}">
+          <title>Test Page</title>
+        </head>
+        <body>Content</body>
+      </html>
+    `;
+
+    nock('https://example.com')
+      .get('/page')
+      .reply(200, htmlContent);
+
+    nock('https://author.example.com')
+      .get(`${CONTENT_API_EXPERIMENTAL_PREFIX}/pages/resolve?pageRef=${contentPageRef}`)
+      .reply(200, { id: expectedPageId });
+
+    const result = await determineAEMCSPageId(pageURL, 'https://author.example.com', 'Bearer token123', true, mockLog);
+    expect(result).to.equal(expectedPageId);
+    expect(mockLog.info).to.have.been.calledWith(`Resolved pageId: "${expectedPageId}" from JSON directly for ref "${contentPageRef}"`);
+  });
+
+  it('should use experimental PSS API prefix when available', async () => {
+    const pageURL = 'https://example.com/page';
+    const contentPageRef = 'content-ref-exp-pss';
+    const expectedPageId = 'exp-pss-page-id';
+    const htmlContent = `
+      <html>
+        <head>
+          <meta name="content-page-ref" content="${contentPageRef}">
+          <title>Test Page</title>
+        </head>
+        <body>Content</body>
+      </html>
+    `;
+
+    nock('https://example.com')
+      .get('/page')
+      .reply(200, htmlContent);
+
+    nock('https://author.example.com')
+      .get(`${PSS_API_EXPERIMENTAL_PREFIX}/pages/resolve?pageRef=${contentPageRef}`)
+      .reply(200, expectedPageId);
+
+    const result = await determineAEMCSPageId(pageURL, 'https://author.example.com', 'Bearer token123', false, mockLog);
+    expect(result).to.equal(expectedPageId);
+    expect(mockLog.info).to.have.been.calledWith(`Resolved pageId: "${expectedPageId}" from JSON directly for ref "${contentPageRef}"`);
+  });
+
+  it('should fall back from experimental to standard Content API prefix', async () => {
+    const pageURL = 'https://example.com/page';
+    const contentPageRef = 'content-ref-fallback';
+    const expectedPageId = 'std-page-id';
+    const htmlContent = `
+      <html>
+        <head>
+          <meta name="content-page-ref" content="${contentPageRef}">
+          <title>Test Page</title>
+        </head>
+        <body>Content</body>
+      </html>
+    `;
+
+    nock('https://example.com')
+      .get('/page')
+      .reply(200, htmlContent);
+
+    nock('https://author.example.com')
+      .get(`${CONTENT_API_EXPERIMENTAL_PREFIX}/pages/resolve?pageRef=${contentPageRef}`)
+      .reply(404);
+
+    nock('https://author.example.com')
+      .get(`${CONTENT_API_PREFIX}/pages/resolve?pageRef=${contentPageRef}`)
+      .reply(200, { id: expectedPageId });
+
+    const result = await determineAEMCSPageId(pageURL, 'https://author.example.com', 'Bearer token123', true, mockLog);
+    expect(result).to.equal(expectedPageId);
+    expect(mockLog.info).to.have.been.calledWith(`Resolved pageId: "${expectedPageId}" from JSON directly for ref "${contentPageRef}"`);
+  });
+
+  it('should fall back from experimental to standard PSS API prefix', async () => {
+    const pageURL = 'https://example.com/page';
+    const contentPageRef = 'content-ref-pss-fallback';
+    const expectedPageId = 'std-pss-page-id';
+    const htmlContent = `
+      <html>
+        <head>
+          <meta name="content-page-ref" content="${contentPageRef}">
+          <title>Test Page</title>
+        </head>
+        <body>Content</body>
+      </html>
+    `;
+
+    nock('https://example.com')
+      .get('/page')
+      .reply(200, htmlContent);
+
+    nock('https://author.example.com')
+      .get(`${PSS_API_EXPERIMENTAL_PREFIX}/pages/resolve?pageRef=${contentPageRef}`)
+      .reply(404);
+
+    nock('https://author.example.com')
+      .get(`${PSS_API_PREFIX}/pages/resolve?pageRef=${contentPageRef}`)
+      .reply(200, expectedPageId);
+
+    const result = await determineAEMCSPageId(pageURL, 'https://author.example.com', 'Bearer token123', false, mockLog);
+    expect(result).to.equal(expectedPageId);
+    expect(mockLog.info).to.have.been.calledWith(`Resolved pageId: "${expectedPageId}" from JSON directly for ref "${contentPageRef}"`);
+  });
+
+  it('should fall back when experimental Content API has network error', async () => {
+    const pageURL = 'https://example.com/page';
+    const contentPageRef = 'content-ref-exp-network-err';
+    const expectedPageId = 'fallback-page-id';
+    const htmlContent = `
+      <html>
+        <head>
+          <meta name="content-page-ref" content="${contentPageRef}">
+          <title>Test Page</title>
+        </head>
+        <body>Content</body>
+      </html>
+    `;
+
+    nock('https://example.com')
+      .get('/page')
+      .reply(200, htmlContent);
+
+    nock('https://author.example.com')
+      .get(`${CONTENT_API_EXPERIMENTAL_PREFIX}/pages/resolve?pageRef=${contentPageRef}`)
+      .replyWithError('Experimental API network error');
+
+    nock('https://author.example.com')
+      .get(`${CONTENT_API_PREFIX}/pages/resolve?pageRef=${contentPageRef}`)
+      .reply(200, { id: expectedPageId });
+
+    const result = await determineAEMCSPageId(pageURL, 'https://author.example.com', 'Bearer token123', true, mockLog);
+    expect(result).to.equal(expectedPageId);
+    expect(mockLog.error).to.have.been.calledWith('Error while resolving content-page-ref: Experimental API network error');
+  });
 });
 
 describe('getPageEditUrl', () => {
@@ -606,6 +804,11 @@ describe('getPageEditUrl', () => {
     };
 
     nock(AUTHOR_URL)
+      .get(`${CONTENT_API_EXPERIMENTAL_PREFIX}/pages/${PAGE_ID}`)
+      .matchHeader('Authorization', BEARER_TOKEN)
+      .reply(404);
+
+    nock(AUTHOR_URL)
       .get(`${CONTENT_API_PREFIX}/pages/${PAGE_ID}`)
       .matchHeader('Authorization', BEARER_TOKEN)
       .reply(200, apiResponse);
@@ -615,6 +818,11 @@ describe('getPageEditUrl', () => {
   });
 
   it('should return null when API call fails', async () => {
+    nock(AUTHOR_URL)
+      .get(`${CONTENT_API_EXPERIMENTAL_PREFIX}/pages/${PAGE_ID}`)
+      .matchHeader('Authorization', BEARER_TOKEN)
+      .reply(500, 'Internal Server Error');
+
     nock(AUTHOR_URL)
       .get(`${CONTENT_API_PREFIX}/pages/${PAGE_ID}`)
       .matchHeader('Authorization', BEARER_TOKEN)
@@ -632,11 +840,57 @@ describe('getPageEditUrl', () => {
     };
 
     nock(AUTHOR_URL)
+      .get(`${CONTENT_API_EXPERIMENTAL_PREFIX}/pages/${PAGE_ID}`)
+      .matchHeader('Authorization', BEARER_TOKEN)
+      .reply(404);
+
+    nock(AUTHOR_URL)
       .get(`${CONTENT_API_PREFIX}/pages/${PAGE_ID}`)
       .matchHeader('Authorization', BEARER_TOKEN)
       .reply(200, apiResponse);
 
     const result = await getPageEditUrl(AUTHOR_URL, BEARER_TOKEN, PAGE_ID);
     expect(result).to.be.undefined;
+  });
+
+  it('should use experimental Content API prefix for edit URL when available', async () => {
+    const expectedEditUrl = 'https://author.example.com/editor.html/content/exp-page';
+    const apiResponse = {
+      id: 'exp-page-id',
+      _links: {
+        edit: expectedEditUrl,
+      },
+    };
+
+    nock(AUTHOR_URL)
+      .get(`${CONTENT_API_EXPERIMENTAL_PREFIX}/pages/${PAGE_ID}`)
+      .matchHeader('Authorization', BEARER_TOKEN)
+      .reply(200, apiResponse);
+
+    const result = await getPageEditUrl(AUTHOR_URL, BEARER_TOKEN, PAGE_ID);
+    expect(result).to.equal(expectedEditUrl);
+  });
+
+  it('should fall back to standard Content API prefix for edit URL', async () => {
+    const expectedEditUrl = 'https://author.example.com/editor.html/content/std-page';
+    const apiResponse = {
+      id: 'std-page-id',
+      _links: {
+        edit: expectedEditUrl,
+      },
+    };
+
+    nock(AUTHOR_URL)
+      .get(`${CONTENT_API_EXPERIMENTAL_PREFIX}/pages/${PAGE_ID}`)
+      .matchHeader('Authorization', BEARER_TOKEN)
+      .reply(404);
+
+    nock(AUTHOR_URL)
+      .get(`${CONTENT_API_PREFIX}/pages/${PAGE_ID}`)
+      .matchHeader('Authorization', BEARER_TOKEN)
+      .reply(200, apiResponse);
+
+    const result = await getPageEditUrl(AUTHOR_URL, BEARER_TOKEN, PAGE_ID);
+    expect(result).to.equal(expectedEditUrl);
   });
 });


### PR DESCRIPTION
With the introduction of the aem.adobe.experimental scopes, the API-Router will permit access to experimental endpoints only if they are properly addressed. Today it was possible to use the future production endpoint, e.g. /adobe/pages instead of /adobe/experimental/aspm-expires-20251231/pages .

We need to make sure in the Codebases that they use the proper experimental paths.

Try experimental API prefix first (CONTENT_API_EXPERIMENTAL_PREFIX / PSS_API_EXPERIMENTAL_PREFIX), then fall back to the standard prefix if the experimental endpoint returns a non-200 or a network error. Updates both determineAEMCSPageId and getPageEditUrl.


Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
[https://jira.corp.adobe.com/browse/SITES-41950](SITES-41950) 


Thanks for contributing!
