### PR TITLE
fix: grantSuggestions/revokeSuggestionGrant RPC calls hitting the REA…

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/suggestion-grant/suggestion-grant.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/suggestion-grant/suggestion-grant.collection.js
@@ -63,7 +63,7 @@ class SuggestionGrantCollection extends BaseCollection {
    * @returns {Promise<{ data: Array|null, error: object|null }>}
    */
   async invokeGrantSuggestionsRpc(suggestionIds, siteId, tokenType, cycle) {
-    return this.postgrestService.rpc('grant_suggestions', {
+    return this.postgrestService.rpc('wrpc_grant_suggestions', {
       p_suggestion_ids: suggestionIds,
       p_site_id: siteId,
       p_token_type: tokenType,
@@ -167,7 +167,7 @@ class SuggestionGrantCollection extends BaseCollection {
 
     if (error) {
       this.log.error('grantSuggestions: RPC failed', error);
-      throw new DataAccessError('Failed to grant suggestions (grant_suggestions)', this, error);
+      throw new DataAccessError('Failed to grant suggestions (wrpc_grant_suggestions)', this, error);
     }
 
     const row = Array.isArray(data) && data.length > 0 ? data[0] : null;
@@ -192,7 +192,7 @@ class SuggestionGrantCollection extends BaseCollection {
     if (!hasText(grantId)) {
       throw new DataAccessError('invokeRevokeSuggestionGrantRpc: grantId is required', this);
     }
-    return this.postgrestService.rpc('revoke_suggestion_grant', {
+    return this.postgrestService.rpc('wrpc_revoke_suggestion_grant', {
       p_grant_id: grantId,
     });
   }
@@ -216,7 +216,7 @@ class SuggestionGrantCollection extends BaseCollection {
 
     if (error) {
       this.log.error('revokeSuggestionGrant: RPC failed', error);
-      throw new DataAccessError('Failed to revoke suggestion grant (revoke_suggestion_grant)', this, error);
+      throw new DataAccessError('Failed to revoke suggestion grant (wrpc_revoke_suggestion_grant)', this, error);
     }
 
     const row = Array.isArray(data) && data.length > 0 ? data[0] : null;

--- a/packages/spacecat-shared-data-access/test/it/postgrest/docker-compose.yml
+++ b/packages/spacecat-shared-data-access/test/it/postgrest/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   data-service:
     platform: ${MYSTICAT_DATA_SERVICE_PLATFORM:-linux/amd64}
-    image: ${MYSTICAT_DATA_SERVICE_REPOSITORY:-682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service}:${MYSTICAT_DATA_SERVICE_TAG:-v1.50.0}
+    image: ${MYSTICAT_DATA_SERVICE_REPOSITORY:-682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service}:${MYSTICAT_DATA_SERVICE_TAG:-v1.61.0}
     depends_on:
       db:
         condition: service_healthy

--- a/packages/spacecat-shared-data-access/test/unit/models/suggestion-grant/suggestion-grant.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/suggestion-grant/suggestion-grant.collection.test.js
@@ -315,7 +315,7 @@ describe('SuggestionGrantCollection', () => {
       instance.invokeGrantSuggestionsRpc.resolves({ data: null, error: rpcError });
 
       await expect(instance.grantSuggestions(suggestionIds, siteId, tokenType))
-        .to.be.rejectedWith(DataAccessError, 'Failed to grant suggestions (grant_suggestions)');
+        .to.be.rejectedWith(DataAccessError, 'Failed to grant suggestions (wrpc_grant_suggestions)');
       expect(mockLogger.error).to.have.been.calledWith('grantSuggestions: RPC failed', rpcError);
     });
 
@@ -395,7 +395,7 @@ describe('SuggestionGrantCollection', () => {
       instance.invokeRevokeSuggestionGrantRpc.resolves({ data: null, error: rpcError });
 
       await expect(instance.revokeSuggestionGrant(grantId))
-        .to.be.rejectedWith(DataAccessError, 'Failed to revoke suggestion grant (revoke_suggestion_grant)');
+        .to.be.rejectedWith(DataAccessError, 'Failed to revoke suggestion grant (wrpc_revoke_suggestion_grant)');
       expect(mockLogger.error).to.have.been.calledWith('revokeSuggestionGrant: RPC failed', rpcError);
     });
 
@@ -440,7 +440,7 @@ describe('SuggestionGrantCollection', () => {
 
       await instance.invokeRevokeSuggestionGrantRpc(grantId);
 
-      expect(rpcStub).to.have.been.calledOnceWith('revoke_suggestion_grant', {
+      expect(rpcStub).to.have.been.calledOnceWith('wrpc_revoke_suggestion_grant', {
         p_grant_id: grantId,
       });
     });
@@ -473,7 +473,7 @@ describe('SuggestionGrantCollection', () => {
 
       await instance.invokeGrantSuggestionsRpc(suggestionIds, siteId, tokenType, cycle);
 
-      expect(rpcStub).to.have.been.calledOnceWith('grant_suggestions', {
+      expect(rpcStub).to.have.been.calledOnceWith('wrpc_grant_suggestions', {
         p_suggestion_ids: suggestionIds,
         p_site_id: siteId,
         p_token_type: tokenType,


### PR DESCRIPTION
## Summary

- Renames PostgREST RPC calls from `grant_suggestions` → `wrpc_grant_suggestions` and `revoke_suggestion_grant` → `wrpc_revoke_suggestion_grant`
- The `wrpc_` prefix ensures ALB routing rules correctly direct these write operations to the **writer fleet** instead of the read replica
- Corresponding DB migration in [adobe/mysticat-data-service#SITES-42988-fix](https://github.com/adobe/mysticat-data-service) renames the functions and adds deprecated backward-compatible aliases for the old names

## Related Issues

- SITES-42988

## Test plan

- [ ] Unit tests updated to assert new RPC names
- [ ] Integration tests pass against local `mysticat-data-service:local` image (built from `SITES-42988-fix` branch) via `npm run test:it:local -w packages/spacecat-shared-data-access`

> **Note:** mysticat-data-service migration must be deployed before this package version is promoted to production.