### PR TITLE
feat(data-access): add enableMoneyPageUrls flag to site config

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -401,6 +401,7 @@ export const configSchema = Joi.object({
   contentAiConfig: Joi.object({
     index: Joi.string().optional(),
   }).optional(),
+  enableMoneyPageUrls: Joi.boolean().optional(),
   auditTargetURLs: Joi.object({
     manual: Joi.array().items(Joi.object({
       url: Joi.string().uri().required(),
@@ -529,6 +530,11 @@ export const Config = (data = {}) => {
     if (!AUDIT_TARGET_SOURCES.includes(source)) {
       throw new Error(`Invalid audit target source: "${source}". Must be one of: ${AUDIT_TARGET_SOURCES.join(', ')}`);
     }
+  };
+
+  self.isMoneyPageUrlsEnabled = () => state?.enableMoneyPageUrls ?? true;
+  self.setEnableMoneyPageUrls = (value) => {
+    state.enableMoneyPageUrls = value;
   };
 
   self.getAuditTargetURLsConfig = () => state?.auditTargetURLs;
@@ -947,5 +953,6 @@ Config.toDynamoItem = (config) => ({
   edgeOptimizeConfig: config.getEdgeOptimizeConfig(),
   onboardConfig: config.getOnboardConfig?.(),
   commerceLlmoConfig: config.getCommerceLlmoConfig?.(),
+  enableMoneyPageUrls: config.isMoneyPageUrlsEnabled?.() === false ? false : undefined,
   auditTargetURLs: config.getAuditTargetURLsConfig?.(),
 });

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -3057,6 +3057,43 @@ describe('Config Tests', () => {
   });
 
   describe('Audit Target URLs', () => {
+    describe('isMoneyPageUrlsEnabled', () => {
+      it('returns true when flag is explicitly set to true', () => {
+        const config = Config({ enableMoneyPageUrls: true });
+        expect(config.isMoneyPageUrlsEnabled()).to.equal(true);
+      });
+
+      it('returns true when flag is absent from config', () => {
+        const config = Config();
+        expect(config.isMoneyPageUrlsEnabled()).to.equal(true);
+      });
+
+      it('returns false when flag is explicitly set to false', () => {
+        const config = Config({ enableMoneyPageUrls: false });
+        expect(config.isMoneyPageUrlsEnabled()).to.equal(false);
+      });
+
+      it('setter updates the flag and reflects in isMoneyPageUrlsEnabled', () => {
+        const config = Config();
+        expect(config.isMoneyPageUrlsEnabled()).to.equal(true);
+        config.setEnableMoneyPageUrls(false);
+        expect(config.isMoneyPageUrlsEnabled()).to.equal(false);
+      });
+
+      it('omits enableMoneyPageUrls from toDynamoItem when not set', () => {
+        const config = Config();
+        const item = Config.toDynamoItem(config);
+        expect(item.enableMoneyPageUrls).to.be.undefined;
+      });
+
+      it('persists enableMoneyPageUrls in toDynamoItem when set via setter', () => {
+        const config = Config();
+        config.setEnableMoneyPageUrls(false);
+        const item = Config.toDynamoItem(config);
+        expect(item.enableMoneyPageUrls).to.equal(false);
+      });
+    });
+
     it('returns empty array by default', () => {
       const config = Config();
       expect(config.getAuditTargetURLs()).to.deep.equal([]);


### PR DESCRIPTION
## Summary

- Adds optional `enableMoneyPageUrls` boolean to the site config Joi schema
- Exposes `isMoneyPageUrlsEnabled()` (returns `true` by default when flag is absent), `setEnableMoneyPageUrls()` (setter for future UI use), and `getEnableMoneyPageUrls()` (raw getter for serialization)
- Serializes the flag in `Config.toDynamoItem()` only when explicitly set — omits the field when absent so existing configs are unaffected

## Notes

- Flag is strictly read-only from the application's perspective; no code calls the setter today — it's provided for a future UI checkbox
- Default (`?? true`) ensures money page URLs remain enabled for all existing sites with no migration needed

## Test plan

- [x] `isMoneyPageUrlsEnabled()` returns `true` when explicitly `true`
- [x] `isMoneyPageUrlsEnabled()` returns `true` when flag is absent (default)
- [x] `isMoneyPageUrlsEnabled()` returns `false` when explicitly `false`
- [x] Setter updates the flag correctly
- [x] `toDynamoItem` omits field when unset, includes it when set via setter