### PR TITLE
fix: Fix request params for the original results in SEO client

### DIFF
--- a/packages/mysticat-shared-seo-client/src/client.js
+++ b/packages/mysticat-shared-seo-client/src/client.js
@@ -704,7 +704,7 @@ export default class SeoClient {
     const { body: pagesBody, fullAuditRef } = await this.sendRawRequest({
       type: epPages.type,
       target: url,
-      target_type: 'root_domain',
+      target_type: 'domain',
       export_columns: epPages.columns,
       display_limit: effectiveLimit,
       display_filter: buildFilter([{


### PR DESCRIPTION
Apparently we filter by `root_domain`, which is different to mode: `prefix` with the old SEO provider in the past.
Apparently we can only filter by `domain`, as `url` does not return anything for `backlinks_pages`.
If we filter by `domain` we have to apply the pathname-specific filtering after we retrieve the data from the new SEO provider (multi-regional sites onboarded with a URL like `example.com/en-us/` for example).
This may require multiple fetch calls to the API, as the first batch may not contain anything — we will follow it up later to filter it.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
https://jira.corp.adobe.com/browse/SITES-43085

Thanks for contributing!
