### PR TITLE
feat(drs-client): implement URL batching for scrape results lookup

### DIFF
--- a/packages/spacecat-shared-drs-client/src/index.js
+++ b/packages/spacecat-shared-drs-client/src/index.js
@@ -30,6 +30,8 @@ export const SCRAPE_DATASET_IDS = Object.freeze({
 
 const VALID_SCRAPE_DATASET_IDS = new Set(Object.values(SCRAPE_DATASET_IDS));
 
+const URL_LOOKUP_BATCH_SIZE = 100;
+
 export default class DrsClient {
   /**
    * Creates a DrsClient from a universal context object.
@@ -211,6 +213,8 @@ export default class DrsClient {
 
   /**
    * Looks up scraping results for an array of URLs.
+   * Transparently batches requests when the URL list exceeds URL_LOOKUP_BATCH_SIZE (100),
+   * merging all results into a single response with aggregated summary counts.
    * @param {object} params
    * @param {string} params.datasetId - One of SCRAPE_DATASET_IDS values
    * @param {string} params.siteId - SpaceCat site ID
@@ -230,11 +234,46 @@ export default class DrsClient {
 
     this.log.info(`Looking up scrape results for dataset ${datasetId}`, { datasetId, siteId, urlCount: urls.length });
 
-    return this.#request('POST', '/url-lookup', {
-      dataset_id: datasetId,
-      site_id: siteId,
-      urls,
-    });
+    if (urls.length <= URL_LOOKUP_BATCH_SIZE) {
+      return this.#request('POST', '/url-lookup', {
+        dataset_id: datasetId,
+        site_id: siteId,
+        urls,
+      });
+    }
+
+    const batches = [];
+    for (let i = 0; i < urls.length; i += URL_LOOKUP_BATCH_SIZE) {
+      batches.push(urls.slice(i, i + URL_LOOKUP_BATCH_SIZE));
+    }
+
+    this.log.info(`URL list exceeds batch size, splitting into ${batches.length} batches`, { datasetId, siteId, batchCount: batches.length });
+
+    const responses = await Promise.all(
+      batches.map((batch) => this.#request('POST', '/url-lookup', {
+        dataset_id: datasetId,
+        site_id: siteId,
+        urls: batch,
+      })),
+    );
+
+    const mergedResults = responses.flatMap((r) => r.results ?? []);
+    const mergedSummary = responses.reduce(
+      (acc, r) => {
+        const s = r.summary ?? {};
+        return {
+          total: acc.total + (s.total ?? 0),
+          available: acc.available + (s.available ?? 0),
+          scraping: acc.scraping + (s.scraping ?? 0),
+          not_found: acc.not_found + (s.not_found ?? 0),
+        };
+      },
+      {
+        total: 0, available: 0, scraping: 0, not_found: 0,
+      },
+    );
+
+    return { results: mergedResults, summary: mergedSummary };
   }
 
   /**

--- a/packages/spacecat-shared-drs-client/test/index.test.js
+++ b/packages/spacecat-shared-drs-client/test/index.test.js
@@ -460,6 +460,97 @@ describe('DrsClient', () => {
       scope.done();
     });
 
+    it('batches requests when urls exceed 100 and merges results', async () => {
+      const batch1Urls = Array.from({ length: 100 }, (_, i) => `https://youtube.com/watch?v=${i}`);
+      const batch2Urls = Array.from({ length: 20 }, (_, i) => `https://youtube.com/watch?v=${i + 100}`);
+      const allUrls = [...batch1Urls, ...batch2Urls];
+
+      const batch1Response = {
+        results: batch1Urls.map((url) => ({ url, status: 'available' })),
+        summary: {
+          total: 100, available: 100, scraping: 0, not_found: 0,
+        },
+      };
+      const batch2Response = {
+        results: [
+          { url: batch2Urls[0], status: 'available' },
+          ...batch2Urls.slice(1).map((url) => ({ url, status: 'not_found' })),
+        ],
+        summary: {
+          total: 20, available: 1, scraping: 0, not_found: 19,
+        },
+      };
+
+      const scope1 = nock(DRS_API_URL)
+        .post('/url-lookup', (body) => body.urls.length === 100 && body.urls[0] === batch1Urls[0])
+        .reply(200, batch1Response);
+      const scope2 = nock(DRS_API_URL)
+        .post('/url-lookup', (body) => body.urls.length === 20 && body.urls[0] === batch2Urls[0])
+        .reply(200, batch2Response);
+
+      const result = await client.lookupScrapeResults({
+        datasetId: SCRAPE_DATASET_IDS.YOUTUBE_VIDEOS,
+        siteId: 'site-1',
+        urls: allUrls,
+      });
+
+      expect(result.results).to.have.lengthOf(120);
+      expect(result.summary).to.deep.equal({
+        total: 120, available: 101, scraping: 0, not_found: 19,
+      });
+      expect(log.info).to.have.been.calledWithMatch(/splitting into 2 batches/);
+      scope1.done();
+      scope2.done();
+    });
+
+    it('handles missing results and summary fields gracefully when batching', async () => {
+      const batch1Urls = Array.from({ length: 100 }, (_, i) => `https://youtube.com/watch?v=${i}`);
+      const batch2Urls = ['https://youtube.com/watch?v=100'];
+      const allUrls = [...batch1Urls, ...batch2Urls];
+
+      nock(DRS_API_URL)
+        .post('/url-lookup', (body) => body.urls.length === 100)
+        .reply(200, { results: batch1Urls.map((url) => ({ url, status: 'available' })) });
+      nock(DRS_API_URL)
+        .post('/url-lookup', (body) => body.urls.length === 1)
+        .reply(200, {});
+
+      const result = await client.lookupScrapeResults({
+        datasetId: SCRAPE_DATASET_IDS.YOUTUBE_VIDEOS,
+        siteId: 'site-1',
+        urls: allUrls,
+      });
+
+      expect(result.results).to.have.lengthOf(100);
+      expect(result.summary).to.deep.equal({
+        total: 0, available: 0, scraping: 0, not_found: 0,
+      });
+    });
+
+    it('does not batch when urls are exactly at the limit', async () => {
+      const urls = Array.from({ length: 100 }, (_, i) => `https://youtube.com/watch?v=${i}`);
+      const responseBody = {
+        results: urls.map((url) => ({ url, status: 'available' })),
+        summary: {
+          total: 100, available: 100, scraping: 0, not_found: 0,
+        },
+      };
+
+      const scope = nock(DRS_API_URL)
+        .post('/url-lookup', (body) => body.urls.length === 100)
+        .reply(200, responseBody);
+
+      const result = await client.lookupScrapeResults({
+        datasetId: SCRAPE_DATASET_IDS.YOUTUBE_VIDEOS,
+        siteId: 'site-1',
+        urls,
+      });
+
+      expect(result.results).to.have.lengthOf(100);
+      expect(log.info).to.not.have.been.calledWithMatch(/splitting into/);
+      scope.done();
+    });
+
     it('throws on invalid datasetId', async () => {
       await expect(client.lookupScrapeResults({
         datasetId: 'bad', siteId: 'site-1', urls: ['https://example.com'],


### PR DESCRIPTION
- Added batching functionality to the `lookupScrapeResults` method in `DrsClient` to handle cases where the number of URLs exceeds the defined batch size of 100.
- Requests are now split into batches, and results are merged into a single response with aggregated summary counts.
- Enhanced tests to cover batching behavior, including scenarios for exceeding the limit, handling missing results, and ensuring no batching occurs when the URL count is exactly at the limit.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
