### PR TITLE
fix(seo-client): omit display_date to avoid 5x historical pricing

### DIFF
--- a/docs/plans/2026-04-14-seo-provider-fix.md
+++ b/docs/plans/2026-04-14-seo-provider-fix.md
@@ -1,0 +1,307 @@
+# Fix: Omit `display_date` to avoid 5x historical pricing on SEO provider API
+
+**Package:** `@adobe/mysticat-shared-seo-client` (v1.2.1)
+**Date:** 2026-04-14
+**Author:** Daniel Huser
+
+## Problem
+
+The SEO provider API charges **5x more API units** when the `display_date` parameter is present — regardless of what date value is set. This was empirically verified:
+
+| Request | `display_date` | Cost |
+|---------|---------------|------|
+| `domain_rank` without `display_date` | omitted | **10 units** |
+| `domain_rank` with `display_date=20260315` (latest month) | present | **50 units** |
+
+This is a pre-existing issue (predating PR #1522), but the recent 30-DB fan-out amplifies it:
+
+| Scenario | DBs | Cost/DB | Total per call |
+|----------|-----|---------|----------------|
+| Before fan-out (hardcoded US, with display_date) | 1 | 50 | 50 |
+| Current (fan-out + display_date) | 30-31 | 50 | **1,500-1,550** |
+| Fixed (fan-out, no display_date) | 30-31 | 10 | **300-310** |
+
+(30 BIG_MARKETS databases; 31 when the site's region is not already in BIG_MARKETS.)
+
+**Net savings: 80% cost reduction on affected endpoints.**
+
+**Estimated monthly impact** (based on production data as of 2026-04-14):
+- 62 sites have `ahref-paid-pages` imports enabled (which calls both `getPaidPages` and `getMetrics`)
+- Per site per import run: `getPaidPages` (30 DBs) + `getMetrics` (30 DBs) = 60 API calls at the `domain_rank`/`domain_adwords` endpoints
+- For `getMetrics` (1 line/DB): current = 30 × 50 = 1,500 units; fixed = 30 × 10 = 300 units
+- For `getPaidPages`: cost scales with response lines per DB (up to `fetchLimit`), so savings scale proportionally
+- Total savings per run = at minimum 1,200 units/site (getMetrics alone) × 62 sites = **74,400 units/run**
+- Actual frequency depends on the jobs-dispatcher cron schedule in `global-config.json` (not checked — AWS session was expired)
+### SEO provider API documentation
+
+The SEO provider docs explicitly state: *"If you want to get the most recent data, don't use this parameter or leave the value empty."* Omitting `display_date` returns the latest available snapshot at "live" (non-historical) unit rates.
+
+## Affected methods
+
+Only two methods currently send `display_date` with a default:
+
+1. **`getPaidPages`** (client.js:347, 365) — defaults `date` to `lastMonthISO()`, always sends `display_date`
+2. **`getMetrics`** (client.js:428, 440) — defaults `date` to `lastMonthISO()`, always sends `display_date`
+
+**Not affected:**
+- `getTopPages` — does not use `display_date`
+- `getOrganicTraffic` — does not use `display_date` (uses full history endpoint, filters client-side)
+- `getBrokenBacklinks` — does not use `display_date`
+- `getMetricsByCountry` — stub, returns `STUB_RESPONSE`
+
+## Downstream callers
+
+### Import worker (`src/importer/seo.js`)
+
+```js
+seoClient.getPaidPages(domain, { date, limit, region })  // line 229
+seoClient.getMetrics(domain, { date, region })            // line 230
+```
+
+`date` comes from config. The `paidPagesConfigProvider` only sets `date` if the SQS message includes one (`message.date`). In normal scheduled imports, no date is provided, so `date` is `undefined` and the SEO client's default kicks in.
+
+After this fix: `undefined` date means `display_date` is omitted entirely (live pricing). Explicit date still sends `display_date` (historical pricing, which is correct — the caller explicitly requested a specific month).
+
+### API service (`src/controllers/llmo/llmo-onboarding.js`)
+
+```js
+seoClient.getTopPages(url, { limit: 1 })  // line 938
+```
+
+Not affected — `getTopPages` doesn't use `display_date`.
+
+### Audit worker
+
+Not affected — the audit worker depends on `@adobe/spacecat-shared-ahrefs-client`, not `@adobe/mysticat-shared-seo-client`. It does not consume the package being changed here.
+
+## Implementation plan
+
+### Step 1: Remove `lastMonthISO()` default, conditionally include `display_date`
+
+**File:** `packages/mysticat-shared-seo-client/src/client.js`
+
+#### 1a. `getPaidPages` (line 347, 361-369)
+
+Change:
+```js
+const { date = lastMonthISO(), limit = 200, region } = opts;
+```
+To:
+```js
+const { date, limit = 200, region } = opts;
+```
+
+Change the request params from:
+```js
+const dbResults = await this.fanOut(databases, (db) => this.sendRawRequest({
+  type: ep.type,
+  domain: url,
+  database: db,
+  display_date: toApiDate(date),
+  display_limit: fetchLimit,
+  export_columns: ep.columns,
+  ...ep.defaultParams,
+}, ep.path), 'getPaidPages');
+```
+To:
+```js
+const dbResults = await this.fanOut(databases, (db) => {
+  const params = {
+    type: ep.type,
+    domain: url,
+    database: db,
+    display_limit: fetchLimit,
+    export_columns: ep.columns,
+    ...ep.defaultParams,
+  };
+  if (date) {
+    params.display_date = toApiDate(date);
+  }
+  return this.sendRawRequest(params, ep.path);
+}, 'getPaidPages');
+```
+
+#### 1b. `getMetrics` (line 428, 436-443)
+
+Same pattern — remove `lastMonthISO()` default, conditionally include `display_date`:
+
+Change:
+```js
+const { date = lastMonthISO(), region } = opts;
+```
+To:
+```js
+const { date, region } = opts;
+```
+
+Change the request params from:
+```js
+const dbResults = await this.fanOut(databases, (db) => this.sendRawRequest({
+  type: ep.type,
+  domain: url,
+  database: db,
+  display_date: toApiDate(date),
+  export_columns: ep.columns,
+  ...ep.defaultParams,
+}, ep.path), 'getMetrics');
+```
+To:
+```js
+const dbResults = await this.fanOut(databases, (db) => {
+  const params = {
+    type: ep.type,
+    domain: url,
+    database: db,
+    export_columns: ep.columns,
+    ...ep.defaultParams,
+  };
+  if (date) {
+    params.display_date = toApiDate(date);
+  }
+  return this.sendRawRequest(params, ep.path);
+}, 'getMetrics');
+```
+
+#### 1c. `getMetricsByCountry` stub (line 761)
+
+Change:
+```js
+async getMetricsByCountry(url, date = lastMonthISO()) {
+```
+To:
+```js
+async getMetricsByCountry(url, date) {
+```
+
+This is a stub returning `STUB_RESPONSE`, so only the signature matters.
+
+### Step 2: Clean up imports
+
+**File:** `packages/mysticat-shared-seo-client/src/client.js` (line 18)
+
+After steps 1a-1c, `lastMonthISO` is no longer used in `client.js`. Remove it from the import:
+```js
+import {
+  parseCsvResponse, coerceValue, getLimit, toApiDate, fromApiDate, buildFilter,
+  extractBrand, INTENT_CODES,
+} from './utils.js';
+```
+
+Keep `lastMonthISO` exported from `index.js` and `utils.js` — callers may use it explicitly.
+
+### Step 3: Update TypeScript declarations
+
+**File:** `packages/mysticat-shared-seo-client/src/index.d.ts`
+
+No signature changes needed. `date?: string` is already optional in both `getPaidPages` and `getMetrics` options. The behavior change (omitting display_date when date is undefined) is internal.
+
+### Step 4: Update tests
+
+**File:** `packages/mysticat-shared-seo-client/test/client.test.js`
+
+#### 4a. Tests that assert `display_date` in `fullAuditRef`
+
+Two tests currently assert that `display_date` is present in `fullAuditRef`:
+- Line ~456: `expect(result.fullAuditRef).to.include('display_date=20250315');` (getMetrics with explicit date)
+- Line ~510: `expect(result.fullAuditRef).to.include('display_date=20250215');` (getMetrics default date test)
+
+The first test (explicit date) should still pass. The second test (default date) needs updating — when no date is provided, `display_date` should NOT appear in the request.
+
+#### 4b. Tests for "defaults to last month" behavior
+
+The test "defaults to last month when no date provided" (getMetrics) currently asserts:
+```js
+expect(result.fullAuditRef).to.include('display_date=20250215');
+```
+
+This should change to verify that `display_date` is NOT in the request:
+```js
+expect(result.fullAuditRef).to.not.include('display_date');
+```
+
+#### 4c. New tests: explicit date sends `display_date` (both methods)
+
+Add tests for both `getMetrics` AND `getPaidPages` confirming that explicit `date` sends `display_date`:
+```js
+// getMetrics
+it('sends display_date when explicit date is provided', async () => {
+  nockMetricsDatabases(BIG_MARKETS, metricsCsv, { targetDb: 'us' });
+  const result = await client.getMetrics('adobe.com', { date: '2025-03-01' });
+  expect(result.fullAuditRef).to.include('display_date=20250315');
+});
+
+// getPaidPages — replaces the existing assertion-less test at ~line 1176
+// ("sends custom date converted to API format") which has zero assertions
+it('sends display_date when explicit date is provided', async () => {
+  nockPaidDatabases(BIG_MARKETS, paidKeywordsCsv, { targetDb: 'us' });
+  const result = await client.getPaidPages('adobe.com', { date: '2025-03-01' });
+  expect(result.fullAuditRef).to.include('display_date=20250315');
+});
+```
+
+#### 4d. New tests: no date omits `display_date` (both methods)
+
+Add tests for both `getPaidPages` AND `getMetrics` confirming `display_date` is omitted when no date is passed:
+```js
+// getPaidPages
+it('omits display_date when no date provided (live pricing)', async () => {
+  nockPaidDatabases(BIG_MARKETS, paidKeywordsCsv, { targetDb: 'us' });
+  const result = await client.getPaidPages('adobe.com');
+  expect(result.fullAuditRef).to.not.include('display_date');
+});
+
+// getMetrics
+it('omits display_date when no date provided (live pricing)', async () => {
+  nockMetricsDatabases(BIG_MARKETS, metricsCsv, { targetDb: 'us' });
+  const result = await client.getMetrics('adobe.com');
+  expect(result.fullAuditRef).to.not.include('display_date');
+});
+```
+
+#### 4e. Update nock matchers
+
+The existing nock helpers (`nockMetricsDatabases`, `nockPaidDatabases`) use loose function matchers (`query((q) => q.type === '...' && q.database === db)`) that do not assert the presence or absence of `display_date`. This means nock will match requests regardless of whether `display_date` is present.
+
+Since the nock matchers don't gate on `display_date`, no nock changes are strictly required. The behavioral verification relies on `fullAuditRef` assertions in the tests above (steps 4b-4d). However, for tests with explicit dates, consider tightening the nock matcher to also verify `q.display_date === '20250315'` to prevent regressions.
+
+#### 4f. Update stale clock comment
+
+The test at `client.test.js:~509` has a comment `// Clock is 2025-03-12, so lastMonthISO() = 2025-02-01 → toApiDate = 20250215`. Since this test will change to verify the absence of `display_date`, update or remove this comment to reflect the new behavior.
+
+### Step 5: No downstream changes needed
+
+- **Import worker**: `date` is already `undefined` when no SQS message date is provided. Passing `{ date: undefined }` to the SEO client results in `date` being `undefined` in the destructured opts, which means `display_date` is omitted. No change needed.
+- **API service**: Doesn't call affected methods.
+- **Audit worker**: Doesn't call affected methods.
+
+## Verification
+
+- **Package manager**: npm (workspace `-w packages/mysticat-shared-seo-client`)
+- **Test command**: `npm test -w packages/mysticat-shared-seo-client`
+- **Lint command**: `npm run lint -w packages/mysticat-shared-seo-client`
+- **Coverage thresholds**: 100% lines, 100% branches, 100% statements (`.nycrc.json`)
+- **Pre-commit hooks**: yes (husky + lint-staged)
+- **Test cases for new/changed branches**:
+  - [ ] `getPaidPages` without date → `display_date` NOT in request params
+  - [ ] `getPaidPages` with explicit date → `display_date` IS in request params
+  - [ ] `getMetrics` without date → `display_date` NOT in request params
+  - [ ] `getMetrics` with explicit date → `display_date` IS in request params
+  - [ ] All existing tests still pass (backward compatibility)
+  - [ ] Coverage thresholds still met at 100%
+
+### Step 6: Post-deploy verification
+
+After the first production import cycle with the new version:
+1. Check the SEO provider's API unit usage dashboard (Query log) to confirm reduced unit consumption
+2. Compare unit consumption before/after for the same set of sites to validate the 80% cost reduction
+3. Verify that the data returned without `display_date` matches what was previously returned (same metrics, same freshness)
+
+## Known issues (out of scope)
+
+- **Ahrefs client** (`@adobe/spacecat-shared-ahrefs-client`) may have a similar `display_date` cost issue in its own `getPaidPages`/`getMetrics` — worth a separate investigation.
+
+## Risk assessment
+
+**Low risk.** The change is purely internal — no method signatures change, no new parameters. The only behavioral difference is that `display_date` is omitted from the HTTP request when no explicit date is provided. This makes the API return the latest snapshot (same data as before) at 5x lower cost.
+
+The only scenario where behavior changes is if the SEO provider's "latest" snapshot differs from `lastMonthISO()`. In early-month edge cases, the "latest" snapshot could theoretically be noisier than a pinned `lastMonthISO()` date. In practice, the provider's default snapshot selection is well-defined and this is the approach recommended by their own documentation. The date selection behavior is effectively deferred to the provider rather than computed client-side.

--- a/packages/mysticat-shared-seo-client/src/client.js
+++ b/packages/mysticat-shared-seo-client/src/client.js
@@ -15,7 +15,7 @@ import { context as h2, h1 } from '@adobe/fetch';
 
 import { ENDPOINTS } from './endpoints.js';
 import {
-  parseCsvResponse, coerceValue, getLimit, toApiDate, fromApiDate, lastMonthISO, buildFilter,
+  parseCsvResponse, coerceValue, getLimit, toApiDate, fromApiDate, buildFilter,
   extractBrand, INTENT_CODES,
 } from './utils.js';
 
@@ -344,7 +344,7 @@ export default class SeoClient {
     if (typeof opts !== 'object' || opts === null) {
       throw new Error('Second argument must be an options object, not a positional value');
     }
-    const { date = lastMonthISO(), limit = 200, region } = opts;
+    const { date, limit = 200, region } = opts;
     if (!hasText(url)) {
       throw new Error(`Invalid URL: ${url}`);
     }
@@ -358,15 +358,20 @@ export default class SeoClient {
     // Capped at MAX_PAID_KEYWORDS_FETCH to bound cost.
     const fetchLimit = Math.min(effectiveLimit * 10, MAX_PAID_KEYWORDS_FETCH);
 
-    const dbResults = await this.fanOut(databases, (db) => this.sendRawRequest({
-      type: ep.type,
-      domain: url,
-      database: db,
-      display_date: toApiDate(date),
-      display_limit: fetchLimit,
-      export_columns: ep.columns,
-      ...ep.defaultParams,
-    }, ep.path), 'getPaidPages');
+    const dbResults = await this.fanOut(databases, (db) => {
+      const params = {
+        type: ep.type,
+        domain: url,
+        database: db,
+        display_limit: fetchLimit,
+        export_columns: ep.columns,
+        ...ep.defaultParams,
+      };
+      if (date) {
+        params.display_date = toApiDate(date);
+      }
+      return this.sendRawRequest(params, ep.path);
+    }, 'getPaidPages');
 
     // Group keywords by URL across all databases
     const pageMap = new Map();
@@ -425,7 +430,7 @@ export default class SeoClient {
     if (typeof opts !== 'object' || opts === null) {
       throw new Error('Second argument must be an options object, not a positional value');
     }
-    const { date = lastMonthISO(), region } = opts;
+    const { date, region } = opts;
     if (!hasText(url)) {
       throw new Error(`Invalid URL: ${url}`);
     }
@@ -433,14 +438,19 @@ export default class SeoClient {
     const ep = ENDPOINTS.metrics;
     const databases = getDatabases(region);
 
-    const dbResults = await this.fanOut(databases, (db) => this.sendRawRequest({
-      type: ep.type,
-      domain: url,
-      database: db,
-      display_date: toApiDate(date),
-      export_columns: ep.columns,
-      ...ep.defaultParams,
-    }, ep.path), 'getMetrics');
+    const dbResults = await this.fanOut(databases, (db) => {
+      const params = {
+        type: ep.type,
+        domain: url,
+        database: db,
+        export_columns: ep.columns,
+        ...ep.defaultParams,
+      };
+      if (date) {
+        params.display_date = toApiDate(date);
+      }
+      return this.sendRawRequest(params, ep.path);
+    }, 'getMetrics');
 
     const metrics = {
       org_keywords: 0,
@@ -758,7 +768,7 @@ export default class SeoClient {
   }
 
   // eslint-disable-next-line no-unused-vars, class-methods-use-this
-  async getMetricsByCountry(url, date = lastMonthISO()) {
+  async getMetricsByCountry(url, date) {
     return STUB_RESPONSE;
   }
 }

--- a/packages/mysticat-shared-seo-client/src/client.js
+++ b/packages/mysticat-shared-seo-client/src/client.js
@@ -367,6 +367,9 @@ export default class SeoClient {
         export_columns: ep.columns,
         ...ep.defaultParams,
       };
+      // Omitting display_date returns the provider's latest snapshot at live pricing
+      // (5x cheaper). The exact month may vary during early-month windows, which is
+      // acceptable because downstream consumers do not assume a specific reporting period.
       if (date) {
         params.display_date = toApiDate(date);
       }
@@ -446,6 +449,9 @@ export default class SeoClient {
         export_columns: ep.columns,
         ...ep.defaultParams,
       };
+      // Omitting display_date returns the provider's latest snapshot at live pricing
+      // (5x cheaper). The exact month may vary during early-month windows, which is
+      // acceptable because downstream consumers do not assume a specific reporting period.
       if (date) {
         params.display_date = toApiDate(date);
       }

--- a/packages/mysticat-shared-seo-client/src/client.js
+++ b/packages/mysticat-shared-seo-client/src/client.js
@@ -368,8 +368,8 @@ export default class SeoClient {
         ...ep.defaultParams,
       };
       // Omitting display_date returns the provider's latest snapshot at live pricing
-      // (5x cheaper). The exact month may vary during early-month windows, which is
-      // acceptable because downstream consumers do not assume a specific reporting period.
+      // (5x cheaper). The latest snapshot is always last month's data, same as what
+      // lastMonthISO() was computing, so the returned data is identical.
       if (date) {
         params.display_date = toApiDate(date);
       }
@@ -450,8 +450,8 @@ export default class SeoClient {
         ...ep.defaultParams,
       };
       // Omitting display_date returns the provider's latest snapshot at live pricing
-      // (5x cheaper). The exact month may vary during early-month windows, which is
-      // acceptable because downstream consumers do not assume a specific reporting period.
+      // (5x cheaper). The latest snapshot is always last month's data, same as what
+      // lastMonthISO() was computing, so the returned data is identical.
       if (date) {
         params.display_date = toApiDate(date);
       }

--- a/packages/mysticat-shared-seo-client/src/client.js
+++ b/packages/mysticat-shared-seo-client/src/client.js
@@ -368,8 +368,8 @@ export default class SeoClient {
         ...ep.defaultParams,
       };
       // Omitting display_date returns the provider's latest snapshot at live pricing
-      // (5x cheaper). The latest snapshot is always last month's data, same as what
-      // lastMonthISO() was computing, so the returned data is identical.
+      // (5x cheaper). The returned data may differ slightly from a pinned monthly
+      // snapshot, which is acceptable for our use case.
       if (date) {
         params.display_date = toApiDate(date);
       }
@@ -450,8 +450,8 @@ export default class SeoClient {
         ...ep.defaultParams,
       };
       // Omitting display_date returns the provider's latest snapshot at live pricing
-      // (5x cheaper). The latest snapshot is always last month's data, same as what
-      // lastMonthISO() was computing, so the returned data is identical.
+      // (5x cheaper). The returned data may differ slightly from a pinned monthly
+      // snapshot, which is acceptable for our use case.
       if (date) {
         params.display_date = toApiDate(date);
       }

--- a/packages/mysticat-shared-seo-client/test/client.test.js
+++ b/packages/mysticat-shared-seo-client/test/client.test.js
@@ -502,6 +502,13 @@ describe('SeoClient', () => {
         .to.be.rejectedWith('options object');
     });
 
+    it('sends display_date when explicit date is provided', async () => {
+      nockMetricsDatabases(BIG_MARKETS, metricsCsv, { targetDb: 'us' });
+
+      const result = await client.getMetrics('adobe.com', { date: '2025-02-01' });
+      expect(result.fullAuditRef).to.include('display_date=20250215');
+    });
+
     it('omits display_date when no date provided (live pricing)', async () => {
       nockMetricsDatabases(BIG_MARKETS, metricsCsv, { targetDb: 'us' });
 

--- a/packages/mysticat-shared-seo-client/test/client.test.js
+++ b/packages/mysticat-shared-seo-client/test/client.test.js
@@ -502,12 +502,11 @@ describe('SeoClient', () => {
         .to.be.rejectedWith('options object');
     });
 
-    it('defaults to last month when no date provided', async () => {
+    it('omits display_date when no date provided (live pricing)', async () => {
       nockMetricsDatabases(BIG_MARKETS, metricsCsv, { targetDb: 'us' });
 
       const result = await client.getMetrics('adobe.com');
-      // Clock is 2025-03-12, so lastMonthISO() = 2025-02-01 → toApiDate = 20250215
-      expect(result.fullAuditRef).to.include('display_date=20250215');
+      expect(result.fullAuditRef).to.not.include('display_date');
       expect(result.result.metrics.org_traffic).to.equal(41042165);
     });
 
@@ -1173,10 +1172,18 @@ describe('SeoClient', () => {
       expect(result.result.pages[0].top_keyword_country).to.equal('DE');
     });
 
-    it('sends custom date converted to API format', async () => {
+    it('sends display_date when explicit date is provided', async () => {
       nockPaidDatabases(BIG_MARKETS, paidKeywordsCsv, { targetDb: 'us' });
 
-      await client.getPaidPages('adobe.com', { date: '2025-11-10', limit: 500 });
+      const result = await client.getPaidPages('adobe.com', { date: '2025-11-10', limit: 500 });
+      expect(result.fullAuditRef).to.include('display_date=20251115');
+    });
+
+    it('omits display_date when no date provided (live pricing)', async () => {
+      nockPaidDatabases(BIG_MARKETS, paidKeywordsCsv, { targetDb: 'us' });
+
+      const result = await client.getPaidPages('adobe.com');
+      expect(result.fullAuditRef).to.not.include('display_date');
     });
 
     it('respects upper limit of 1000 on output', async () => {


### PR DESCRIPTION
## Summary

The SEO provider API charges **5x more API units** when the `display_date` parameter is present in requests — regardless of the date value. With the recent 30-DB fan-out, this inflated costs from ~300 to ~1,500 units per call (~80% overhead).

This PR conditionally includes `display_date` only when an explicit date is passed by the caller. When no date is provided (the normal scheduled-import path), `display_date` is omitted entirely, which returns the latest available snapshot at live (non-historical) pricing — consistent with the provider's own recommendation.

- **`getPaidPages`** and **`getMetrics`**: removed `lastMonthISO()` default, `display_date` now only sent when caller provides a date
- **`getMetricsByCountry`** (stub): removed unused default parameter
- **No signature changes** — `date` was already optional in the TypeScript declarations
- **No downstream changes needed** — import-worker already passes `undefined` for date in normal runs

**Estimated savings**: ~74,400 API units per import run across 62 enabled sites (getMetrics alone).

See [`docs/plans/2026-04-14-seo-provider-fix.md`](https://github.com/adobe/spacecat-shared/blob/fix/seo-provider-costs/docs/plans/2026-04-14-seo-provider-fix.md) for the full cost analysis, affected method audit, and downstream caller verification.

## Test plan

- [x] `getPaidPages` without date → `display_date` NOT in request params
- [x] `getPaidPages` with explicit date → `display_date` IS in request params
- [x] `getMetrics` without date → `display_date` NOT in request params
- [x] `getMetrics` with explicit date → `display_date` IS in request params
- [x] All 155 existing tests pass
- [x] 100% coverage (lines, branches, statements)
- [ ] Post-deploy: verify reduced API unit consumption in SEO provider dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)