### PR TITLE
fix(vault-secrets): raise branch coverage threshold to 100%

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21579,7 +21579,7 @@
     },
     "packages/mysticat-shared-seo-client": {
       "name": "@adobe/mysticat-shared-seo-client",
-      "version": "1.1.3",
+      "version": "1.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -26239,7 +26239,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "3.50.0",
+      "version": "3.52.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",
@@ -35287,7 +35287,7 @@
       "version": "1.3.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/fetch": "^4.2.3",
+        "@adobe/spacecat-shared-utils": "1.112.5",
         "aws4": "1.13.2"
       },
       "devDependencies": {

--- a/packages/spacecat-shared-vault-secrets/.nycrc.json
+++ b/packages/spacecat-shared-vault-secrets/.nycrc.json
@@ -5,7 +5,7 @@
   ],
   "check-coverage": true,
   "lines": 100,
-  "branches": 97,
+  "branches": 100,
   "statements": 100,
   "all": true,
   "include": [

--- a/packages/spacecat-shared-vault-secrets/package.json
+++ b/packages/spacecat-shared-vault-secrets/package.json
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/fetch": "^4.2.3",
+    "@adobe/spacecat-shared-utils": "1.112.5",
     "aws4": "1.13.2"
   },
   "devDependencies": {

--- a/packages/spacecat-shared-vault-secrets/src/bootstrap.js
+++ b/packages/spacecat-shared-vault-secrets/src/bootstrap.js
@@ -49,6 +49,7 @@ export async function loadBootstrapConfig({ bootstrapPath }) {
     headers: {
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.GetSecretValue',
+      'Cache-Control': 'no-store',
       Host: host,
     },
     body,

--- a/packages/spacecat-shared-vault-secrets/src/bootstrap.js
+++ b/packages/spacecat-shared-vault-secrets/src/bootstrap.js
@@ -10,13 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import { noCache, h1NoCache } from '@adobe/fetch';
+import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
 import aws4 from 'aws4';
-
-// Use @adobe/fetch for connection pooling instead of globalThis.fetch.
-// noCache() disables HTTP response caching; h1NoCache() in tests for nock compatibility.
-/* c8 ignore next */
-const { fetch } = process.env.HELIX_FETCH_FORCE_HTTP1 ? h1NoCache() : noCache();
 
 /**
  * Loads Vault AppRole bootstrap credentials from AWS Secrets Manager.

--- a/packages/spacecat-shared-vault-secrets/src/bootstrap.js
+++ b/packages/spacecat-shared-vault-secrets/src/bootstrap.js
@@ -15,6 +15,7 @@ import aws4 from 'aws4';
 
 // Use @adobe/fetch for connection pooling instead of globalThis.fetch.
 // noCache() disables HTTP response caching; h1NoCache() in tests for nock compatibility.
+/* c8 ignore next */
 const { fetch } = process.env.HELIX_FETCH_FORCE_HTTP1 ? h1NoCache() : noCache();
 
 /**

--- a/packages/spacecat-shared-vault-secrets/src/vault-client.js
+++ b/packages/spacecat-shared-vault-secrets/src/vault-client.js
@@ -15,6 +15,7 @@ import { noCache, h1NoCache } from '@adobe/fetch';
 // Use @adobe/fetch for connection pooling instead of globalThis.fetch.
 // noCache() disables HTTP response caching (prevents stale Vault reads).
 // h1NoCache() in tests for nock compatibility; noCache() in production for HTTP/2 over HTTPS.
+/* c8 ignore next */
 const { fetch } = process.env.HELIX_FETCH_FORCE_HTTP1 ? h1NoCache() : noCache();
 
 const TOKEN_RENEW_BUFFER = 5 * 60 * 1000;

--- a/packages/spacecat-shared-vault-secrets/src/vault-client.js
+++ b/packages/spacecat-shared-vault-secrets/src/vault-client.js
@@ -70,7 +70,7 @@ export default class VaultClient {
     try {
       response = await fetch(`${this.#vaultAddr}/v1/auth/approle/login`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
         body: JSON.stringify({ role_id: roleId, secret_id: secretId }),
       });
     } catch (err) {
@@ -95,7 +95,7 @@ export default class VaultClient {
     const url = `${this.#vaultAddr}/v1/${this.#mountPoint}/${path}`;
     return fetch(url, {
       method,
-      headers: { 'X-Vault-Token': this.#token },
+      headers: { 'X-Vault-Token': this.#token, 'Cache-Control': 'no-store' },
     });
   }
 
@@ -138,7 +138,7 @@ export default class VaultClient {
     try {
       const response = await fetch(`${this.#vaultAddr}/v1/auth/token/renew-self`, {
         method: 'POST',
-        headers: { 'X-Vault-Token': this.#token },
+        headers: { 'X-Vault-Token': this.#token, 'Cache-Control': 'no-store' },
       });
       if (response.ok) {
         const body = await response.json();

--- a/packages/spacecat-shared-vault-secrets/src/vault-client.js
+++ b/packages/spacecat-shared-vault-secrets/src/vault-client.js
@@ -10,13 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { noCache, h1NoCache } from '@adobe/fetch';
-
-// Use @adobe/fetch for connection pooling instead of globalThis.fetch.
-// noCache() disables HTTP response caching (prevents stale Vault reads).
-// h1NoCache() in tests for nock compatibility; noCache() in production for HTTP/2 over HTTPS.
-/* c8 ignore next */
-const { fetch } = process.env.HELIX_FETCH_FORCE_HTTP1 ? h1NoCache() : noCache();
+import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
 
 const TOKEN_RENEW_BUFFER = 5 * 60 * 1000;
 

--- a/packages/spacecat-shared-vault-secrets/src/vault-secrets-wrapper.js
+++ b/packages/spacecat-shared-vault-secrets/src/vault-secrets-wrapper.js
@@ -22,7 +22,7 @@ function isDevAliasDeployment(ctx, env) {
   if (env !== 'dev') {
     return false;
   }
-  const { version } = ctx.func || {};
+  const { version } = ctx.func;
   if (!version) {
     return false;
   }

--- a/packages/spacecat-shared-vault-secrets/test/vault-secrets-wrapper.test.js
+++ b/packages/spacecat-shared-vault-secrets/test/vault-secrets-wrapper.test.js
@@ -14,6 +14,7 @@ import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';
 import sinon from 'sinon';
+import { clearFetchCache } from '@adobe/spacecat-shared-utils';
 import vaultSecrets, { loadSecrets, reset } from '../src/vault-secrets-wrapper.js';
 
 use(chaiAsPromised);
@@ -108,6 +109,7 @@ describe('vaultSecrets wrapper', () => {
 
   afterEach(() => {
     reset();
+    clearFetchCache();
     sinon.restore();
     nock.cleanAll();
 


### PR DESCRIPTION
## Summary

- Bump `.nycrc.json` branch coverage from 97% to 100%
- Replace direct `@adobe/fetch` import + module-level `HELIX_FETCH_FORCE_HTTP1` ternary with `tracingFetch` from `@adobe/spacecat-shared-utils` - same pattern used by 8 other shared packages. Gets X-Ray tracing and timeout handling for free.
- Remove dead `|| {}` fallback in `isDevAliasDeployment` - `ctx.func` is always truthy at the callsite (guarded by early return on line 148)
- Add `clearFetchCache` to test teardown since `tracingFetch` uses the caching fetch context

## Test plan

- [x] `npm test -w packages/spacecat-shared-vault-secrets` - 76 passing, 100% coverage across all metrics
- [x] Lint passes