### PR TITLE
fix(vault-secrets): use plain fetch instead of tracingFetch for Vault calls

### DIFF
--- a/packages/spacecat-shared-vault-secrets/src/bootstrap.js
+++ b/packages/spacecat-shared-vault-secrets/src/bootstrap.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import { fetch } from '@adobe/spacecat-shared-utils';
 import aws4 from 'aws4';
 
 /**

--- a/packages/spacecat-shared-vault-secrets/src/vault-client.js
+++ b/packages/spacecat-shared-vault-secrets/src/vault-client.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import { fetch } from '@adobe/spacecat-shared-utils';
 
 const TOKEN_RENEW_BUFFER = 5 * 60 * 1000;
 


### PR DESCRIPTION
## Summary

Reverts the use of `tracingFetch` in vault-secrets (introduced in #1538) back to the plain `fetch` export from `@adobe/spacecat-shared-utils`.

## Problem

After `vault-secrets@1.3.3` was deployed to `spacecat-api-service` at 12:07 UTC today, Vault authentication failures (403) spiked from single-digit baseline to ~7,000 in 3 hours:

| Window | Fastly 502 count (llmo.experiencecloud.live) |
|--------|----------------------------------------------|
| Yesterday (full day) | 6 |
| Today before deploy (00:00 - 12:07) | 10 |
| Today after deploy (12:07 - 15:00) | 6,934 |

Lambda logs show `Failed to load secrets: Vault authentication failed: 403` across 15+ concurrent instances during the spike.

## Root cause

`tracingFetch` wraps the underlying fetch with User-Agent injection, X-Ray tracing headers, a 10s default timeout, and Request object reconstruction. One or more of these modifications causes Vault's AppRole login endpoint to reject requests with 403. Investigation ongoing.

## Fix

Switch from `tracingFetch` to the plain `fetch` re-export from `@adobe/spacecat-shared-utils` (which is `@adobe/fetch` with connection pooling, same as what other shared packages use). This preserves the dependency on shared-utils (no need to re-add `@adobe/fetch` directly) while avoiding the tracingFetch wrapper behavior.

The `Cache-Control: no-store` headers added in #1538 are retained.

## Test plan

- [x] 76 tests passing, 100% coverage
- [ ] Deploy to api-service, monitor Vault 403 rate in Coralogix