### PR TITLE
fix(vault-secrets): revert to dedicated noCache() fetch context

### DIFF
--- a/packages/spacecat-shared-vault-secrets/package.json
+++ b/packages/spacecat-shared-vault-secrets/package.json
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/spacecat-shared-utils": "1.112.5",
+    "@adobe/fetch": "4.3.0",
     "aws4": "1.13.2"
   },
   "devDependencies": {

--- a/packages/spacecat-shared-vault-secrets/src/bootstrap.js
+++ b/packages/spacecat-shared-vault-secrets/src/bootstrap.js
@@ -10,8 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
-import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import { noCache, h1NoCache } from '@adobe/fetch';
 import aws4 from 'aws4';
+
+const { fetch } = process.env.HELIX_FETCH_FORCE_HTTP1 ? h1NoCache() : noCache();
 
 /**
  * Loads Vault AppRole bootstrap credentials from AWS Secrets Manager.

--- a/packages/spacecat-shared-vault-secrets/src/vault-client.js
+++ b/packages/spacecat-shared-vault-secrets/src/vault-client.js
@@ -10,7 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import { noCache, h1NoCache } from '@adobe/fetch';
+
+const { fetch } = process.env.HELIX_FETCH_FORCE_HTTP1 ? h1NoCache() : noCache();
 
 const TOKEN_RENEW_BUFFER = 5 * 60 * 1000;
 

--- a/packages/spacecat-shared-vault-secrets/test/fetch-context.test.js
+++ b/packages/spacecat-shared-vault-secrets/test/fetch-context.test.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+
+/**
+ * Covers the noCache() branch of the HELIX_FETCH_FORCE_HTTP1 ternary
+ * in vault-client.js and bootstrap.js. The default test setup forces
+ * HTTP/1 for nock compatibility, so this test re-imports the modules
+ * with the env var unset to exercise the HTTP/2 noCache() path.
+ */
+describe('fetch context selection', () => {
+  const originalValue = process.env.HELIX_FETCH_FORCE_HTTP1;
+
+  after(() => {
+    process.env.HELIX_FETCH_FORCE_HTTP1 = originalValue;
+  });
+
+  it('vault-client uses noCache() when HELIX_FETCH_FORCE_HTTP1 is unset', async () => {
+    delete process.env.HELIX_FETCH_FORCE_HTTP1;
+    const mod = await import(`../src/vault-client.js?ctx=${Date.now()}`);
+    expect(mod.default).to.be.a('function');
+  });
+
+  it('bootstrap uses noCache() when HELIX_FETCH_FORCE_HTTP1 is unset', async () => {
+    delete process.env.HELIX_FETCH_FORCE_HTTP1;
+    const mod = await import(`../src/bootstrap.js?ctx=${Date.now()}`);
+    expect(mod.loadBootstrapConfig).to.be.a('function');
+  });
+});

--- a/packages/spacecat-shared-vault-secrets/test/vault-secrets-wrapper.test.js
+++ b/packages/spacecat-shared-vault-secrets/test/vault-secrets-wrapper.test.js
@@ -14,7 +14,6 @@ import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';
 import sinon from 'sinon';
-import { clearFetchCache } from '@adobe/spacecat-shared-utils';
 import vaultSecrets, { loadSecrets, reset } from '../src/vault-secrets-wrapper.js';
 
 use(chaiAsPromised);
@@ -109,7 +108,6 @@ describe('vaultSecrets wrapper', () => {
 
   afterEach(() => {
     reset();
-    clearFetchCache();
     sinon.restore();
     nock.cleanAll();
 


### PR DESCRIPTION
## Summary

Reverts vault-secrets from shared `tracingFetch` (introduced in #1538) back to a dedicated `noCache()` fetch context from `@adobe/fetch`, matching the original isolated design.

## Problem

After `vault-secrets@1.3.3` was deployed to `spacecat-api-service` at 12:07 UTC today, Vault authentication failures (403) spiked from single-digit baseline to ~7,000 in 3 hours:

| Window | Fastly 502 count (llmo.experiencecloud.live) |
|--------|----------------------------------------------|
| Yesterday (full day) | 6 |
| Today before deploy (00:00 - 12:07) | 10 |
| Today after deploy (12:07 - 15:00) | 6,934 |

Lambda logs show `Failed to load secrets: Vault authentication failed: 403` across 15+ concurrent instances during the spike.

## Root cause analysis

`tracingFetch` wraps the underlying fetch with:
1. **User-Agent injection** - a mobile browser UA string (`Mozilla/5.0 (Linux; Android 11; moto g power...)`) on every request
2. **X-Amzn-Trace-Id header** - AWS X-Ray tracing header on sampled requests
3. **10s timeout** via AbortSignal
4. **Shared fetch context** - all HTTP calls (PostgREST, Helix, Vault) share one connection pool

`vault-amer.adobe.net` sits behind a corporate WAF/proxy. The most likely cause is the injected headers triggering WAF rules - specifically the X-Ray trace header triggering SSRF protection (documented in [aws-xray-sdk-node#465](https://github.com/aws/aws-xray-sdk-node/issues/465)) and/or the mobile browser UA from data center IPs. The intermittency aligns with X-Ray sampling rates (only sampled requests carry the trace header).

## Fix

Revert to a dedicated `noCache()` fetch context from `@adobe/fetch`. This restores:
- **Isolated connection pool** - Vault HTTP calls have their own H2 sessions, separate from all other service traffic
- **No response caching** - `noCache()` disables HTTP response caching
- **No header injection** - no User-Agent, no X-Ray headers
- **No timeout signal** - Vault calls use natural TCP/TLS timeouts (adding explicit timeouts is a follow-up)

The `Cache-Control: no-store` headers added in #1538 are retained.

## Test plan

- [x] 78 tests passing, 100% coverage (including new test for `noCache()` branch)
- [ ] Deploy to api-service, monitor Vault 403 rate in Coralogix