### PR TITLE
feat(data-access): add semantic-value-visibility audit type

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
+++ b/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
@@ -95,6 +95,7 @@ class Audit extends BaseModel {
     COMMERCE_PRODUCT_CATALOG_ENRICHMENT_AUTO_FIX: 'commerce-product-catalog-enrichment-auto-fix',
     CWV_TRENDS_AUDIT: 'cwv-trends-audit',
     OFFSITE_BRAND_PRESENCE: 'offsite-brand-presence',
+    SEMANTIC_VALUE_VISIBILITY: 'semantic-value-visibility',
   };
 
   static AUDIT_TYPE_PROPERTIES = {

--- a/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
@@ -220,6 +220,7 @@ describe('AuditModel', () => {
       COMMERCE_PRODUCT_CATALOG_ENRICHMENT_AUTO_FIX: 'commerce-product-catalog-enrichment-auto-fix',
       CWV_TRENDS_AUDIT: 'cwv-trends-audit',
       OFFSITE_BRAND_PRESENCE: 'offsite-brand-presence',
+      SEMANTIC_VALUE_VISIBILITY: 'semantic-value-visibility',
     };
 
     it('should have all audit types present in AUDIT_TYPES', () => {


### PR DESCRIPTION
## Description
Add the `semantic-value-visibility` audit type to Spacecat so it is recognized as a valid audit type.

### Changes
- Add `SEMANTIC_VALUE_VISIBILITY: 'semantic-value-visibility'` to `Audit.AUDIT_TYPES` in `audit.model.js`
- Add matching entry in `audit.model.test.js`

## Related Issues

Relates to [LLMO-2697](https://jira.corp.adobe.com/browse/LLMO-2697)                                                                                           
   
Companion PRs:                                                                                                                                                 
- [experience-platform/mystique#1432](https://git.corp.adobe.com/experience-platform/mystique/pull/1432)                                                       
- [adobe/spacecat-audit-worker#2409](https://github.com/adobe/spacecat-audit-worker/pull/2409)                                                                 
- [adobe/project-elmo-ui#1571](https://github.com/adobe/project-elmo-ui/pull/1571)   

## Test plan
- [x] Unit tests pass (27 passing)
- [x] CI pipeline passes