### PR TITLE
fix: change override condition of tier

### DIFF
--- a/packages/spacecat-shared-tier-client/src/tier-client.js
+++ b/packages/spacecat-shared-tier-client/src/tier-client.js
@@ -148,8 +148,9 @@ class TierClient {
       if (existing.entitlement) {
         const currentTier = existing.entitlement.getTier();
 
-        // If currentTier doesn't match with given tier and is not PAID, update it
-        if (currentTier !== tier && currentTier !== ENTITLEMENT_TIERS.PAID) {
+        // Only upgrade the tier when the customer is becoming PAID; otherwise keep as-is.
+        // Tiers: PRE_ONBOARD, PLG, FREE_TRIAL, PAID.
+        if (tier === ENTITLEMENT_TIERS.PAID && currentTier !== ENTITLEMENT_TIERS.PAID) {
           existing.entitlement.setTier(tier);
           await existing.entitlement.save();
         }

--- a/packages/spacecat-shared-tier-client/test/tier-client.test.js
+++ b/packages/spacecat-shared-tier-client/test/tier-client.test.js
@@ -486,7 +486,7 @@ describe('TierClient', () => {
       });
     });
 
-    it('should upgrade PLG entitlement to FREE_TRIAL (PLG is not PAID, so tier updates)', async () => {
+    it('should NOT change tier when upgrading PLG to FREE_TRIAL (only PAID upgrades are applied)', async () => {
       const mockPlgEntitlement = {
         ...mockEntitlement,
         getTier: () => 'PLG',
@@ -500,8 +500,8 @@ describe('TierClient', () => {
 
       const result = await tierClient.createEntitlement('FREE_TRIAL');
 
-      expect(mockPlgEntitlement.setTier).to.have.been.calledWith('FREE_TRIAL');
-      expect(mockPlgEntitlement.save).to.have.been.called;
+      expect(mockPlgEntitlement.setTier).to.not.have.been.called;
+      expect(mockPlgEntitlement.save).to.not.have.been.called;
       expect(result).to.deep.equal({
         entitlement: mockPlgEntitlement,
         siteEnrollment: mockSiteEnrollment,
@@ -550,7 +550,7 @@ describe('TierClient', () => {
       });
     });
 
-    it('should upgrade PRE_ONBOARD entitlement to PLG (PRE_ONBOARD is not PAID, so tier updates)', async () => {
+    it('should NOT change tier when upgrading PRE_ONBOARD to PLG (only PAID upgrades are applied)', async () => {
       const mockPreOnboardEntitlement = {
         ...mockEntitlement,
         getTier: () => 'PRE_ONBOARD',
@@ -564,8 +564,8 @@ describe('TierClient', () => {
 
       const result = await tierClient.createEntitlement('PLG');
 
-      expect(mockPreOnboardEntitlement.setTier).to.have.been.calledWith('PLG');
-      expect(mockPreOnboardEntitlement.save).to.have.been.called;
+      expect(mockPreOnboardEntitlement.setTier).to.not.have.been.called;
+      expect(mockPreOnboardEntitlement.save).to.not.have.been.called;
       expect(result).to.deep.equal({
         entitlement: mockPreOnboardEntitlement,
         siteEnrollment: mockSiteEnrollment,


### PR DESCRIPTION
## Summary

Update `TierClient.createEntitlement` so an existing entitlement's tier is only overridden when the customer is becoming **PAID**. Previously, any mismatch between the current and requested tier (as long as the current wasn't PAID) would trigger an override — which now doesn't fit with new additional tiers, we have four tiers now: `PRE_ONBOARD`, `PLG`, `FREE_TRIAL`, `PAID`.

## Changes

- `packages/spacecat-shared-tier-client/src/tier-client.js`
  - `createEntitlement`: change the upgrade guard from
    `currentTier !== tier && currentTier !== PAID` to
    `tier === PAID && currentTier !== PAID`.
  - All other tier transitions are now no-ops (existing entitlement is returned as-is).
- `packages/spacecat-shared-tier-client/test/tier-client.test.js`
  - Updated `PLG → FREE_TRIAL` test to assert `setTier`/`save` are NOT called.
  - Updated `PRE_ONBOARD → PLG` test to assert `setTier`/`save` are NOT called.
  - Existing upgrade-to-`PAID` tests continue to pass unchanged.

## Behavior Matrix

| current \ target | PRE_ONBOARD | PLG    | FREE_TRIAL | PAID             |
| ---------------- | ----------- | ------ | ---------- | ---------------- |
| PRE_ONBOARD      | keep        | keep   | keep       | **upgrade → PAID** |
| PLG              | keep        | keep   | keep       | **upgrade → PAID** |
| FREE_TRIAL       | keep        | keep   | keep       | **upgrade → PAID** |
| PAID             | keep        | keep   | keep       | keep             |

## Test Plan

- [x] `npm test -w packages/spacecat-shared-tier-client` — 77 passing, 100% line/branch/function coverage on `tier-client.js`.
- [x] Verified that only upgrades to `PAID` mutate the entitlement; all other transitions leave the existing entitlement untouched.
- [ ] Downstream consumers (`spacecat-api-service`, `spacecat-audit-worker`, `spacecat-import-worker`) to be re-validated after publish.

## Notes

- One pre-existing test (`should create entitlement with PRE_ONBOARD tier when nothing exists`) fails both before and after this change because `@mysticat/data-service-types` does not yet expose `PRE_ONBOARD` in the `ENTITLEMENT_TIER` enum. Out of scope for this PR; tracked separately.
