### PR TITLE
feat(tokowaka-client): add checkWafConnectivity method

### DIFF
--- a/packages/spacecat-shared-tokowaka-client/src/index.js
+++ b/packages/spacecat-shared-tokowaka-client/src/index.js
@@ -12,7 +12,9 @@
 
 import crypto from 'crypto';
 import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
-import { hasText, isNonEmptyObject, tracingFetch } from '@adobe/spacecat-shared-utils';
+import {
+  hasText, isNonEmptyObject, prependSchema, tracingFetch,
+} from '@adobe/spacecat-shared-utils';
 import { v4 as uuidv4 } from 'uuid';
 import MapperRegistry from './mappers/mapper-registry.js';
 import CdnClientRegistry from './cdn/cdn-client-registry.js';
@@ -33,6 +35,60 @@ export { calculateForwardedHost } from './utils/custom-html-utils.js';
 const HTTP_BAD_REQUEST = 400;
 const HTTP_INTERNAL_SERVER_ERROR = 500;
 const HTTP_NOT_IMPLEMENTED = 501;
+
+// ---------------------------------------------------------------------------
+// WAF / Bot-Manager connectivity probe
+// ---------------------------------------------------------------------------
+
+const EDGE_OPTIMIZE_PROXY_BASE_URL_DEFAULT = 'https://live.edgeoptimize.net';
+
+// Blocks loopback, link-local, and RFC1918 ranges — never forward these as probe targets.
+const PRIVATE_HOST_RE = /^(localhost$|127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|169\.254\.)/i;
+
+const WAF_PROBE_TIMEOUT_MS = 15000;
+
+// Soft-block detection: only phrases that appear exclusively in challenge pages.
+// Broad terms like 'blocked' or 'cloudflare' cause false positives on legitimate pages.
+const BOT_CHALLENGE_BODY_MAX_BYTES = 2048;
+const BOT_CHALLENGE_KEYWORDS = [
+  'challenge',
+  'captcha',
+  'bot manager',
+  'access denied',
+  'cf-chl-widget',
+  'completing the challenge',
+];
+
+// 403 and 429 are universal WAF block signals; 406 is used by Signal Sciences
+// (Fastly Next-Gen WAF) and some Imperva configurations as their block response.
+const HARD_BLOCK_STATUS_CODES = new Set([403, 406, 429]);
+
+async function classifyProbeResponse(response, targetHost, log) {
+  const { status } = response;
+
+  if (HARD_BLOCK_STATUS_CODES.has(status)) {
+    log.info(`[edge-optimize-probe] Hard block for ${targetHost}: HTTP ${status}`);
+    return { reachable: false, blocked: true, statusCode: status };
+  }
+
+  if (status >= 200 && status < 300) {
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('text/html')) {
+      const text = await response.text();
+      const snippet = text.slice(0, BOT_CHALLENGE_BODY_MAX_BYTES).toLowerCase();
+      const isSoftBlock = BOT_CHALLENGE_KEYWORDS.some((kw) => snippet.includes(kw));
+      if (isSoftBlock) {
+        log.info(`[edge-optimize-probe] Soft block (challenge page) for ${targetHost}: HTTP ${status}`);
+        return { reachable: false, blocked: true, statusCode: status };
+      }
+    }
+    log.info(`[edge-optimize-probe] Clean pass for ${targetHost}: HTTP ${status}`);
+    return { reachable: true, blocked: false, statusCode: status };
+  }
+
+  log.info(`[edge-optimize-probe] Unexpected status for ${targetHost}: HTTP ${status}`);
+  return { reachable: false, blocked: false, statusCode: status };
+}
 
 /** Matches SpaceCat API eligibility for edge deploy (non-domain-wide). */
 function isEdgeDeployableSuggestionStatus(status) {
@@ -1207,6 +1263,76 @@ class TokowakaClient {
       HTTP_INTERNAL_SERVER_ERROR,
     );
     /* c8 ignore stop */
+  }
+
+  /**
+   * Probes whether a WAF or Bot Manager is blocking AdobeEdgeOptimize/1.0 traffic for
+   * the site, then cross-checks the live edge-optimize routing status so a stale probe
+   * result never overrides a working deployment.
+   *
+   * Four probe outcomes:
+   * - Hard block: HTTP 403/406/429 → `{ reachable: false, blocked: true }`
+   * - Soft block: 2xx with bot-challenge HTML → `{ reachable: false, blocked: true }`
+   * - Pass: 2xx with real content → `{ reachable: true, blocked: false }`
+   * - Network/timeout error → `{ reachable: false, blocked: null, reason: 'timeout'|'error' }`
+   *
+   * When the probe does not pass, `edgeOptimizeEnabled` from `checkEdgeOptimizeStatus`
+   * is included in the result so callers can detect a self-healed deployment.
+   *
+   * This method never throws — all errors are captured into the return value.
+   *
+   * @param {Object} site - Site entity with a `getBaseURL()` method.
+   * @returns {Promise<Object>} WAF probe result, optionally extended with `edgeOptimizeEnabled`.
+   */
+  async checkWafConnectivity(site) {
+    const proxyBaseUrl = this.env.EDGE_OPTIMIZE_PROXY_BASE_URL
+      ?? EDGE_OPTIMIZE_PROXY_BASE_URL_DEFAULT;
+    const siteBaseUrl = site.getBaseURL();
+    let probeResult = { probedUrl: String(siteBaseUrl) };
+
+    try {
+      const normalizedUrl = prependSchema(siteBaseUrl);
+      const { host: targetHost, hostname, href: probedUrl } = new URL(normalizedUrl);
+      probeResult = { probedUrl };
+
+      if (PRIVATE_HOST_RE.test(hostname)) {
+        this.log.warn(`[edge-optimize-probe] Refusing to probe private/loopback host: ${hostname}`);
+        return {
+          ...probeResult, reachable: false, blocked: null, reason: 'error',
+        };
+      }
+
+      this.log.info(`[edge-optimize-probe] Probing ${targetHost} via edge optimize proxy at ${proxyBaseUrl}`);
+
+      const response = await tracingFetch(proxyBaseUrl, {
+        method: 'GET',
+        headers: { 'x-forwarded-host': targetHost },
+        signal: AbortSignal.timeout(WAF_PROBE_TIMEOUT_MS),
+      });
+
+      const classification = await classifyProbeResponse(response, targetHost, this.log);
+      probeResult = { ...probeResult, ...classification };
+    } catch (error) {
+      const isTimeout = error.name === 'TimeoutError' || error.name === 'AbortError';
+      const reason = isTimeout ? 'timeout' : 'error';
+      this.log.warn(`[edge-optimize-probe] ${reason} during WAF probe: ${error.message}`);
+      probeResult = {
+        ...probeResult, reachable: false, blocked: null, reason,
+      };
+    }
+
+    if (!probeResult.reachable) {
+      try {
+        const { edgeOptimizeEnabled } = await this.checkEdgeOptimizeStatus(site, '/');
+        this.log.info(`[edge-optimize-probe] Edge optimize status: edgeOptimizeEnabled=${edgeOptimizeEnabled}`);
+        return { ...probeResult, edgeOptimizeEnabled };
+      } catch (err) {
+        this.log.warn(`[edge-optimize-probe] Edge optimize status check failed: ${err.message}`);
+        return { ...probeResult, edgeOptimizeEnabled: null };
+      }
+    }
+
+    return probeResult;
   }
 
   /**

--- a/packages/spacecat-shared-tokowaka-client/src/index.js
+++ b/packages/spacecat-shared-tokowaka-client/src/index.js
@@ -28,6 +28,12 @@ import {
 import { groupSuggestionsByUrlPath, filterEligibleSuggestions } from './utils/suggestion-utils.js';
 import { getEffectiveBaseURL } from './utils/site-utils.js';
 import { fetchHtmlWithWarmup, calculateForwardedHost } from './utils/custom-html-utils.js';
+import {
+  EDGE_OPTIMIZE_PROXY_BASE_URL_DEFAULT,
+  PRIVATE_HOST_RE,
+  WAF_PROBE_TIMEOUT_MS,
+  classifyProbeResponse,
+} from './utils/waf-probe-utils.js';
 
 export { FastlyKVClient } from './fastly-kv-client.js';
 export { calculateForwardedHost } from './utils/custom-html-utils.js';
@@ -35,60 +41,6 @@ export { calculateForwardedHost } from './utils/custom-html-utils.js';
 const HTTP_BAD_REQUEST = 400;
 const HTTP_INTERNAL_SERVER_ERROR = 500;
 const HTTP_NOT_IMPLEMENTED = 501;
-
-// ---------------------------------------------------------------------------
-// WAF / Bot-Manager connectivity probe
-// ---------------------------------------------------------------------------
-
-const EDGE_OPTIMIZE_PROXY_BASE_URL_DEFAULT = 'https://live.edgeoptimize.net';
-
-// Blocks loopback, link-local, and RFC1918 ranges — never forward these as probe targets.
-const PRIVATE_HOST_RE = /^(localhost$|127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|169\.254\.)/i;
-
-const WAF_PROBE_TIMEOUT_MS = 15000;
-
-// Soft-block detection: only phrases that appear exclusively in challenge pages.
-// Broad terms like 'blocked' or 'cloudflare' cause false positives on legitimate pages.
-const BOT_CHALLENGE_BODY_MAX_BYTES = 2048;
-const BOT_CHALLENGE_KEYWORDS = [
-  'challenge',
-  'captcha',
-  'bot manager',
-  'access denied',
-  'cf-chl-widget',
-  'completing the challenge',
-];
-
-// 403 and 429 are universal WAF block signals; 406 is used by Signal Sciences
-// (Fastly Next-Gen WAF) and some Imperva configurations as their block response.
-const HARD_BLOCK_STATUS_CODES = new Set([403, 406, 429]);
-
-async function classifyProbeResponse(response, targetHost, log) {
-  const { status } = response;
-
-  if (HARD_BLOCK_STATUS_CODES.has(status)) {
-    log.info(`[edge-optimize-probe] Hard block for ${targetHost}: HTTP ${status}`);
-    return { reachable: false, blocked: true, statusCode: status };
-  }
-
-  if (status >= 200 && status < 300) {
-    const contentType = response.headers.get('content-type') || '';
-    if (contentType.includes('text/html')) {
-      const text = await response.text();
-      const snippet = text.slice(0, BOT_CHALLENGE_BODY_MAX_BYTES).toLowerCase();
-      const isSoftBlock = BOT_CHALLENGE_KEYWORDS.some((kw) => snippet.includes(kw));
-      if (isSoftBlock) {
-        log.info(`[edge-optimize-probe] Soft block (challenge page) for ${targetHost}: HTTP ${status}`);
-        return { reachable: false, blocked: true, statusCode: status };
-      }
-    }
-    log.info(`[edge-optimize-probe] Clean pass for ${targetHost}: HTTP ${status}`);
-    return { reachable: true, blocked: false, statusCode: status };
-  }
-
-  log.info(`[edge-optimize-probe] Unexpected status for ${targetHost}: HTTP ${status}`);
-  return { reachable: false, blocked: false, statusCode: status };
-}
 
 /** Matches SpaceCat API eligibility for edge deploy (non-domain-wide). */
 function isEdgeDeployableSuggestionStatus(status) {

--- a/packages/spacecat-shared-tokowaka-client/src/index.js
+++ b/packages/spacecat-shared-tokowaka-client/src/index.js
@@ -1218,27 +1218,23 @@ class TokowakaClient {
   }
 
   /**
-   * Probes whether a WAF or Bot Manager is blocking AdobeEdgeOptimize/1.0 traffic for
-   * the site, then cross-checks the live edge-optimize routing status so a stale probe
-   * result never overrides a working deployment.
+   * Probes whether a WAF or Bot Manager is blocking AdobeEdgeOptimize/1.0 traffic
+   * for the site.
    *
-   * Four probe outcomes:
-   * - Hard block: HTTP 403/406/429 → `{ reachable: false, blocked: true }`
+   * Probe outcomes:
+   * - Hard block: HTTP 401/403/406/429/503 → `{ reachable: false, blocked: true }`
+   * - CF challenge: cf-mitigated: challenge header → `{ reachable: false, blocked: true }`
    * - Soft block: 2xx with bot-challenge HTML → `{ reachable: false, blocked: true }`
    * - Pass: 2xx with real content → `{ reachable: true, blocked: false }`
-   * - Network/timeout error → `{ reachable: false, blocked: null, reason: 'timeout'|'error' }`
-   *
-   * When the probe does not pass, `edgeOptimizeEnabled` from `checkEdgeOptimizeStatus`
-   * is included in the result so callers can detect a self-healed deployment.
+   * - Network/timeout error → `{ reachable: false, blocked: null }`
    *
    * This method never throws — all errors are captured into the return value.
+   * Use the separate edge-optimize status API to determine if edge optimize is active.
    *
    * @param {Object} site - Site entity with a `getBaseURL()` method.
-   * @returns {Promise<Object>} WAF probe result, optionally extended with `edgeOptimizeEnabled`.
+   * @returns {Promise<Object>} WAF probe result.
    */
   async checkWafConnectivity(site) {
-    const proxyBaseUrl = this.env.EDGE_OPTIMIZE_PROXY_BASE_URL
-      ?? EDGE_OPTIMIZE_PROXY_BASE_URL_DEFAULT;
     const siteBaseUrl = site.getBaseURL();
     let probeResult = { probedUrl: String(siteBaseUrl) };
 
@@ -1249,14 +1245,12 @@ class TokowakaClient {
 
       if (PRIVATE_HOST_RE.test(hostname)) {
         this.log.warn(`[edge-optimize-probe] Refusing to probe private/loopback host: ${hostname}`);
-        return {
-          ...probeResult, reachable: false, blocked: null, reason: 'error',
-        };
+        return { ...probeResult, reachable: false, blocked: null };
       }
 
-      this.log.info(`[edge-optimize-probe] Probing ${targetHost} via edge optimize proxy at ${proxyBaseUrl}`);
+      this.log.info(`[edge-optimize-probe] Probing ${targetHost} via edge optimize proxy`);
 
-      const response = await tracingFetch(proxyBaseUrl, {
+      const response = await tracingFetch(EDGE_OPTIMIZE_PROXY_BASE_URL_DEFAULT, {
         method: 'GET',
         headers: { 'x-forwarded-host': targetHost },
         signal: AbortSignal.timeout(WAF_PROBE_TIMEOUT_MS),
@@ -1265,23 +1259,8 @@ class TokowakaClient {
       const classification = await classifyProbeResponse(response, targetHost, this.log);
       probeResult = { ...probeResult, ...classification };
     } catch (error) {
-      const isTimeout = error.name === 'TimeoutError' || error.name === 'AbortError';
-      const reason = isTimeout ? 'timeout' : 'error';
-      this.log.warn(`[edge-optimize-probe] ${reason} during WAF probe: ${error.message}`);
-      probeResult = {
-        ...probeResult, reachable: false, blocked: null, reason,
-      };
-    }
-
-    if (!probeResult.reachable) {
-      try {
-        const { edgeOptimizeEnabled } = await this.checkEdgeOptimizeStatus(site, '/');
-        this.log.info(`[edge-optimize-probe] Edge optimize status: edgeOptimizeEnabled=${edgeOptimizeEnabled}`);
-        return { ...probeResult, edgeOptimizeEnabled };
-      } catch (err) {
-        this.log.warn(`[edge-optimize-probe] Edge optimize status check failed: ${err.message}`);
-        return { ...probeResult, edgeOptimizeEnabled: null };
-      }
+      this.log.warn(`[edge-optimize-probe] Probe failed for ${siteBaseUrl}: ${error.message}`);
+      probeResult = { ...probeResult, reachable: false, blocked: null };
     }
 
     return probeResult;

--- a/packages/spacecat-shared-tokowaka-client/src/utils/waf-probe-utils.js
+++ b/packages/spacecat-shared-tokowaka-client/src/utils/waf-probe-utils.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export const EDGE_OPTIMIZE_PROXY_BASE_URL_DEFAULT = 'https://live.edgeoptimize.net';
+
+// Blocks loopback, link-local, and RFC1918 ranges — never forward these as probe targets.
+export const PRIVATE_HOST_RE = /^(localhost$|127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|169\.254\.)/i;
+
+export const WAF_PROBE_TIMEOUT_MS = 15000;
+
+// Soft-block detection: vendor-specific technical identifiers that only appear in
+// WAF-generated challenge pages, never in real page content. Broad natural-language
+// terms ('challenge', 'captcha', 'access denied') are intentionally excluded — they
+// match legitimate marketing copy and reCAPTCHA script tags, producing false positives
+// at any body scan depth.
+export const BOT_CHALLENGE_KEYWORDS = [
+  'cf-chl-widget', // Cloudflare challenge widget CSS class
+  'completing the challenge', // Cloudflare-specific challenge phrase
+  '_incapsula_resource', // Imperva/Incapsula JS artifact — only in WAF-generated pages
+  'errors.edgesuite.net', // Akamai error page domain
+  'errors.edgekey.net', // Akamai edge key domain
+];
+
+// 403 and 429 are universal WAF block signals; 406 is Fastly Next-Gen WAF (Signal Sciences)
+// and some Imperva configurations. 401 covers WAF-gated auth challenges. 503 is used by
+// Akamai and others as a block response in certain configurations.
+export const HARD_BLOCK_STATUS_CODES = new Set([401, 403, 406, 429, 503]);
+
+/**
+ * Classifies an already-fetched Tokowaka-proxied response into one of four probe outcomes:
+ *   - Hard block  : HTTP status in HARD_BLOCK_STATUS_CODES → { reachable: false, blocked: true }
+ *   - CF challenge: cf-mitigated: challenge header         → { reachable: false, blocked: true }
+ *   - Soft block  : 2xx HTML body with vendor keywords     → { reachable: false, blocked: true }
+ *   - Clean pass  : 2xx with real content                  → { reachable: true,  blocked: false }
+ *   - Other       : unexpected status (e.g. redirect)      → { reachable: false, blocked: false }
+ *
+ * @param {Response} response - Fetch response from the Tokowaka proxy.
+ * @param {string} targetHost - Customer hostname, used only for log messages.
+ * @param {Object} log - Logger with an `info` method.
+ * @returns {Promise<Object>} Classification result.
+ */
+export async function classifyProbeResponse(response, targetHost, log) {
+  const { status } = response;
+
+  if (HARD_BLOCK_STATUS_CODES.has(status)) {
+    log.info(`[edge-optimize-probe] Hard block for ${targetHost}: HTTP ${status}`);
+    return { reachable: false, blocked: true, statusCode: status };
+  }
+
+  // Cloudflare active challenge: present on any response where CF is serving a managed
+  // challenge — definitive block signal regardless of HTTP status code.
+  if (response.headers.get('cf-mitigated') === 'challenge') {
+    log.info(`[edge-optimize-probe] Cloudflare challenge for ${targetHost} (cf-mitigated: challenge)`);
+    return { reachable: false, blocked: true, statusCode: status };
+  }
+
+  if (status >= 200 && status < 300) {
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('text/html')) {
+      const text = await response.text();
+      const isSoftBlock = BOT_CHALLENGE_KEYWORDS.some((kw) => text.toLowerCase().includes(kw));
+      if (isSoftBlock) {
+        log.info(`[edge-optimize-probe] Soft block (challenge page) for ${targetHost}: HTTP ${status}`);
+        return { reachable: false, blocked: true, statusCode: status };
+      }
+    }
+    log.info(`[edge-optimize-probe] Clean pass for ${targetHost}: HTTP ${status}`);
+    return { reachable: true, blocked: false, statusCode: status };
+  }
+
+  log.info(`[edge-optimize-probe] Unexpected status for ${targetHost}: HTTP ${status}`);
+  return { reachable: false, blocked: false, statusCode: status };
+}

--- a/packages/spacecat-shared-tokowaka-client/test/index.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/index.test.js
@@ -4372,8 +4372,6 @@ describe('TokowakaClient', () => {
         getId: () => 'waf-site-id',
         getBaseURL: () => 'https://example.com',
       };
-
-      sinon.stub(esmockClient, 'checkEdgeOptimizeStatus').resolves({ edgeOptimizeEnabled: false });
     });
 
     const makeHeaders = (plain = {}) => new Headers(plain);
@@ -4491,20 +4489,20 @@ describe('TokowakaClient', () => {
     });
 
     describe('Network errors', () => {
-      it('returns blocked:null with reason:timeout on AbortError', async () => {
+      it('returns blocked:null on AbortError (timeout)', async () => {
         const err = new Error('The operation was aborted');
         err.name = 'TimeoutError';
         tracingFetchStub.rejects(err);
         const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
         expect(result.blocked).to.equal(null);
-        expect(result.reason).to.equal('timeout');
+        expect(result.reachable).to.equal(false);
       });
 
-      it('returns blocked:null with reason:error on network failure', async () => {
+      it('returns blocked:null on network failure', async () => {
         tracingFetchStub.rejects(new Error('ECONNREFUSED'));
         const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
         expect(result.blocked).to.equal(null);
-        expect(result.reason).to.equal('error');
+        expect(result.reachable).to.equal(false);
       });
     });
 
@@ -4515,16 +4513,6 @@ describe('TokowakaClient', () => {
         expect(result.blocked).to.equal(false);
         expect(result.reachable).to.equal(false);
         expect(result.statusCode).to.equal(301);
-      });
-    });
-
-    describe('Edge optimize status check failure', () => {
-      it('returns edgeOptimizeEnabled:null when checkEdgeOptimizeStatus throws', async () => {
-        esmockClient.checkEdgeOptimizeStatus.rejects(new Error('Status check failed'));
-        tracingFetchStub.resolves({ status: 403, headers: makeHeaders() });
-        const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
-        expect(result.blocked).to.equal(true);
-        expect(result.edgeOptimizeEnabled).to.equal(null);
       });
     });
 

--- a/packages/spacecat-shared-tokowaka-client/test/index.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/index.test.js
@@ -4338,6 +4338,206 @@ describe('TokowakaClient', () => {
     });
   });
 
+  describe('checkWafConnectivity', () => {
+    let tracingFetchStub;
+    let esmockClient;
+    let mockSiteWaf;
+
+    beforeEach(async () => {
+      tracingFetchStub = sinon.stub();
+
+      const MockedTokowakaClient = await esmock('../src/index.js', {
+        '@adobe/spacecat-shared-utils': {
+          hasText: (val) => typeof val === 'string' && val.trim().length > 0,
+          isNonEmptyObject: (val) => val !== null && typeof val === 'object' && Object.keys(val).length > 0,
+          prependSchema: (url) => (url.startsWith('http') ? url : `https://${url}`),
+          tracingFetch: tracingFetchStub,
+        },
+      });
+
+      esmockClient = new MockedTokowakaClient(
+        {
+          bucketName: 'test-bucket',
+          previewBucketName: 'test-preview-bucket',
+          s3Client: { send: sinon.stub().resolves() },
+          env: {
+            TOKOWAKA_CDN_PROVIDER: 'cloudfront',
+            TOKOWAKA_CDN_CONFIG: JSON.stringify({ cloudfront: { distributionId: 'E123456', region: 'us-east-1' } }),
+          },
+        },
+        log,
+      );
+
+      mockSiteWaf = {
+        getId: () => 'waf-site-id',
+        getBaseURL: () => 'https://example.com',
+      };
+
+      sinon.stub(esmockClient, 'checkEdgeOptimizeStatus').resolves({ edgeOptimizeEnabled: false });
+    });
+
+    const makeHeaders = (plain = {}) => new Headers(plain);
+
+    describe('Hard block — status codes', () => {
+      [401, 403, 406, 429, 503].forEach((status) => {
+        it(`returns blocked:true for HTTP ${status}`, async () => {
+          tracingFetchStub.resolves({ status, headers: makeHeaders() });
+          const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
+          expect(result.blocked).to.equal(true);
+          expect(result.reachable).to.equal(false);
+          expect(result.statusCode).to.equal(status);
+        });
+      });
+    });
+
+    describe('Cloudflare header detection', () => {
+      it('returns blocked:true when cf-mitigated: challenge header is present', async () => {
+        tracingFetchStub.resolves({
+          status: 200,
+          headers: makeHeaders({ 'cf-mitigated': 'challenge' }),
+          text: sinon.stub().resolves('<html>Just a moment</html>'),
+        });
+        const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
+        expect(result.blocked).to.equal(true);
+        expect(result.reachable).to.equal(false);
+        expect(result.statusCode).to.equal(200);
+      });
+
+      it('returns blocked:false when cf-mitigated header is absent (Cloudflare passing)', async () => {
+        tracingFetchStub.resolves({
+          status: 200,
+          headers: makeHeaders({ 'cf-ray': 'abc123-LHR' }),
+          text: sinon.stub().resolves('<html><body>Welcome</body></html>'),
+        });
+        const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
+        expect(result.blocked).to.equal(false);
+        expect(result.reachable).to.equal(true);
+      });
+    });
+
+    describe('Soft block — vendor-specific keyword detection', () => {
+      const makeSoftBlockResponse = (bodyKeyword) => ({
+        status: 200,
+        headers: makeHeaders({ 'content-type': 'text/html' }),
+        text: sinon.stub().resolves(`<html><body>${bodyKeyword}</body></html>`),
+      });
+
+      it('detects Cloudflare challenge via cf-chl-widget', async () => {
+        tracingFetchStub.resolves(makeSoftBlockResponse('<div class="cf-chl-widget"></div>'));
+        const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
+        expect(result.blocked).to.equal(true);
+      });
+
+      it('detects Imperva challenge via _Incapsula_Resource', async () => {
+        tracingFetchStub.resolves(makeSoftBlockResponse('window._incapsula_resource={}'));
+        const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
+        expect(result.blocked).to.equal(true);
+      });
+
+      it('detects Akamai error page via errors.edgesuite.net', async () => {
+        tracingFetchStub.resolves(makeSoftBlockResponse('<a href="https://errors.edgesuite.net/abc">Reference</a>'));
+        const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
+        expect(result.blocked).to.equal(true);
+      });
+
+      it('detects Akamai error page via errors.edgekey.net', async () => {
+        tracingFetchStub.resolves(makeSoftBlockResponse('<a href="https://errors.edgekey.net/abc">Reference</a>'));
+        const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
+        expect(result.blocked).to.equal(true);
+      });
+    });
+
+    describe('False positive prevention — broad natural-language terms no longer trigger block', () => {
+      const makeNormalPage = (text) => ({
+        status: 200,
+        headers: makeHeaders({ 'content-type': 'text/html' }),
+        text: sinon.stub().resolves(`<html><body>${text}</body></html>`),
+      });
+
+      it('does not flag page containing the word "challenge" in marketing copy', async () => {
+        tracingFetchStub.resolves(makeNormalPage('Take the 30-day challenge today!'));
+        const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
+        expect(result.blocked).to.equal(false);
+        expect(result.reachable).to.equal(true);
+      });
+
+      it('does not flag page containing "captcha" in reCAPTCHA script tag', async () => {
+        tracingFetchStub.resolves(makeNormalPage(
+          '<script src="https://www.google.com/recaptcha/api.js"></script>',
+        ));
+        const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
+        expect(result.blocked).to.equal(false);
+        expect(result.reachable).to.equal(true);
+      });
+
+      it('does not flag page containing "access denied" in help text', async () => {
+        tracingFetchStub.resolves(makeNormalPage(
+          '<p>If access is denied, contact your administrator.</p>',
+        ));
+        const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
+        expect(result.blocked).to.equal(false);
+        expect(result.reachable).to.equal(true);
+      });
+
+      it('does not flag 200 JSON response', async () => {
+        tracingFetchStub.resolves({
+          status: 200,
+          headers: makeHeaders({ 'content-type': 'application/json' }),
+        });
+        const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
+        expect(result.blocked).to.equal(false);
+        expect(result.reachable).to.equal(true);
+      });
+    });
+
+    describe('Network errors', () => {
+      it('returns blocked:null with reason:timeout on AbortError', async () => {
+        const err = new Error('The operation was aborted');
+        err.name = 'TimeoutError';
+        tracingFetchStub.rejects(err);
+        const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
+        expect(result.blocked).to.equal(null);
+        expect(result.reason).to.equal('timeout');
+      });
+
+      it('returns blocked:null with reason:error on network failure', async () => {
+        tracingFetchStub.rejects(new Error('ECONNREFUSED'));
+        const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
+        expect(result.blocked).to.equal(null);
+        expect(result.reason).to.equal('error');
+      });
+    });
+
+    describe('Unexpected status (e.g. redirect)', () => {
+      it('returns blocked:false for a 301 redirect response', async () => {
+        tracingFetchStub.resolves({ status: 301, headers: makeHeaders() });
+        const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
+        expect(result.blocked).to.equal(false);
+        expect(result.reachable).to.equal(false);
+        expect(result.statusCode).to.equal(301);
+      });
+    });
+
+    describe('Edge optimize status check failure', () => {
+      it('returns edgeOptimizeEnabled:null when checkEdgeOptimizeStatus throws', async () => {
+        esmockClient.checkEdgeOptimizeStatus.rejects(new Error('Status check failed'));
+        tracingFetchStub.resolves({ status: 403, headers: makeHeaders() });
+        const result = await esmockClient.checkWafConnectivity(mockSiteWaf);
+        expect(result.blocked).to.equal(true);
+        expect(result.edgeOptimizeEnabled).to.equal(null);
+      });
+    });
+
+    describe('Private host rejection', () => {
+      it('returns blocked:null without probing for private IP host', async () => {
+        const privateSite = { getId: () => 'p1', getBaseURL: () => 'http://192.168.1.1' };
+        const result = await esmockClient.checkWafConnectivity(privateSite);
+        expect(result.blocked).to.equal(null);
+        expect(tracingFetchStub).to.not.have.been.called;
+      });
+    });
+  });
+
   describe('deployToEdge', () => {
     let deploySuggestionsStub;
     let fetchMetaconfigStub;

--- a/packages/spacecat-shared-tokowaka-client/test/utils/waf-probe-utils.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/utils/waf-probe-utils.test.js
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import {
+  classifyProbeResponse,
+  BOT_CHALLENGE_KEYWORDS,
+  HARD_BLOCK_STATUS_CODES,
+  PRIVATE_HOST_RE,
+  WAF_PROBE_TIMEOUT_MS,
+  EDGE_OPTIMIZE_PROXY_BASE_URL_DEFAULT,
+} from '../../src/utils/waf-probe-utils.js';
+
+function makeResponse(status, headers = {}, body = '') {
+  return {
+    status,
+    headers: { get: (name) => headers[name.toLowerCase()] ?? null },
+    text: async () => body,
+  };
+}
+
+describe('waf-probe-utils', () => {
+  let log;
+
+  beforeEach(() => {
+    log = { info: sinon.stub() };
+  });
+
+  // ── Exported constants ──────────────────────────────────────────────────────
+
+  describe('constants', () => {
+    it('exports the correct proxy base URL', () => {
+      expect(EDGE_OPTIMIZE_PROXY_BASE_URL_DEFAULT).to.equal('https://live.edgeoptimize.net');
+    });
+
+    it('exports the correct timeout', () => {
+      expect(WAF_PROBE_TIMEOUT_MS).to.equal(15000);
+    });
+
+    it('HARD_BLOCK_STATUS_CODES covers expected codes', () => {
+      const hardCodes = [401, 403, 406, 429, 503];
+      expect(hardCodes.every((code) => HARD_BLOCK_STATUS_CODES.has(code))).to.be.true;
+      expect(HARD_BLOCK_STATUS_CODES.has(200)).to.be.false;
+    });
+
+    it('PRIVATE_HOST_RE blocks loopback, link-local, and RFC1918 ranges', () => {
+      ['localhost', '127.0.0.1', '10.0.0.1', '192.168.1.1', '172.16.0.1', '169.254.1.1'].forEach(
+        (host) => expect(PRIVATE_HOST_RE.test(host), host).to.be.true,
+      );
+      expect(PRIVATE_HOST_RE.test('example.com')).to.be.false;
+    });
+
+    it('BOT_CHALLENGE_KEYWORDS are all vendor-specific identifiers', () => {
+      expect(BOT_CHALLENGE_KEYWORDS).to.be.an('array').with.length.above(0);
+      // Broad natural-language terms must not appear — they cause false positives
+      ['challenge', 'captcha', 'access denied'].forEach(
+        (broad) => expect(BOT_CHALLENGE_KEYWORDS).to.not.include(broad),
+      );
+    });
+  });
+
+  // ── classifyProbeResponse ───────────────────────────────────────────────────
+
+  describe('classifyProbeResponse', () => {
+    describe('hard block status codes', () => {
+      [401, 403, 406, 429, 503].forEach((code) => {
+        it(`classifies HTTP ${code} as blocked`, async () => {
+          const result = await classifyProbeResponse(makeResponse(code), 'example.com', log);
+          expect(result).to.deep.equal({ reachable: false, blocked: true, statusCode: code });
+        });
+      });
+    });
+
+    describe('Cloudflare active challenge', () => {
+      it('classifies cf-mitigated: challenge header as blocked on 200', async () => {
+        const response = makeResponse(200, { 'cf-mitigated': 'challenge' });
+        const result = await classifyProbeResponse(response, 'example.com', log);
+        expect(result).to.deep.equal({ reachable: false, blocked: true, statusCode: 200 });
+      });
+
+      it('classifies cf-mitigated: challenge header as blocked on non-block status', async () => {
+        const response = makeResponse(202, { 'cf-mitigated': 'challenge' });
+        const result = await classifyProbeResponse(response, 'example.com', log);
+        expect(result).to.deep.equal({ reachable: false, blocked: true, statusCode: 202 });
+      });
+    });
+
+    describe('soft block — vendor keyword detection', () => {
+      [
+        ['Cloudflare widget class', 'cf-chl-widget', '<div class="cf-chl-widget"></div>'],
+        ['Cloudflare challenge phrase', 'completing the challenge', 'Please completing the challenge to continue'],
+        ['Imperva artifact', '_incapsula_resource', 'window._incapsula_resource={}'],
+        ['Akamai edgesuite domain', 'errors.edgesuite.net', 'See errors.edgesuite.net for details'],
+        ['Akamai edgekey domain', 'errors.edgekey.net', 'See errors.edgekey.net for details'],
+      ].forEach(([label, , body]) => {
+        it(`detects soft block: ${label}`, async () => {
+          const response = makeResponse(200, { 'content-type': 'text/html' }, body);
+          const result = await classifyProbeResponse(response, 'example.com', log);
+          expect(result).to.deep.equal({ reachable: false, blocked: true, statusCode: 200 });
+        });
+      });
+
+      it('is case-insensitive for keyword matching', async () => {
+        const response = makeResponse(200, { 'content-type': 'text/html' }, 'CF-CHL-WIDGET visible');
+        const result = await classifyProbeResponse(response, 'example.com', log);
+        expect(result).to.deep.equal({ reachable: false, blocked: true, statusCode: 200 });
+      });
+    });
+
+    describe('false positive prevention — real content must not trigger soft block', () => {
+      [
+        ['reCAPTCHA script tag', '<script src="recaptcha/api.js">'],
+        ['legitimate captcha link text', 'Complete the CAPTCHA to prove you are human'],
+        ['marketing copy with challenge', 'This challenge will test your creativity'],
+        ['access denied in content', '<p>Access denied to premium content without subscription</p>'],
+        ['JSON non-HTML response', '{"status":"ok"}'],
+        ['plain text non-HTML', 'Hello world'],
+      ].forEach(([label, body]) => {
+        it(`passes clean: ${label}`, async () => {
+          const response = makeResponse(200, { 'content-type': 'text/html' }, body);
+          const result = await classifyProbeResponse(response, 'example.com', log);
+          expect(result).to.deep.equal({ reachable: true, blocked: false, statusCode: 200 });
+        });
+      });
+
+      it('skips body scan for non-HTML content types', async () => {
+        const response = makeResponse(200, { 'content-type': 'application/json' }, 'cf-chl-widget');
+        const result = await classifyProbeResponse(response, 'example.com', log);
+        expect(result).to.deep.equal({ reachable: true, blocked: false, statusCode: 200 });
+      });
+
+      it('skips body scan when content-type header is absent', async () => {
+        const response = makeResponse(200, {}, 'cf-chl-widget');
+        const result = await classifyProbeResponse(response, 'example.com', log);
+        expect(result).to.deep.equal({ reachable: true, blocked: false, statusCode: 200 });
+      });
+    });
+
+    describe('clean pass', () => {
+      [200, 201, 204].forEach((code) => {
+        it(`classifies HTTP ${code} clean HTML as reachable`, async () => {
+          const response = makeResponse(code, { 'content-type': 'text/html' }, '<h1>Welcome</h1>');
+          const result = await classifyProbeResponse(response, 'example.com', log);
+          expect(result).to.deep.equal({ reachable: true, blocked: false, statusCode: code });
+        });
+      });
+    });
+
+    describe('unexpected / redirect status codes', () => {
+      [301, 302, 307].forEach((code) => {
+        it(`classifies HTTP ${code} as not reachable, not blocked`, async () => {
+          const result = await classifyProbeResponse(makeResponse(code), 'example.com', log);
+          expect(result).to.deep.equal({ reachable: false, blocked: false, statusCode: code });
+        });
+      });
+    });
+
+    describe('logging', () => {
+      it('logs hard block with status code', async () => {
+        await classifyProbeResponse(makeResponse(403), 'example.com', log);
+        expect(log.info.calledWithMatch('[edge-optimize-probe] Hard block for example.com: HTTP 403')).to.be.true;
+      });
+
+      it('logs Cloudflare challenge with header info', async () => {
+        await classifyProbeResponse(makeResponse(200, { 'cf-mitigated': 'challenge' }), 'example.com', log);
+        expect(log.info.calledWithMatch('cf-mitigated: challenge')).to.be.true;
+      });
+
+      it('logs soft block with status code', async () => {
+        const response = makeResponse(200, { 'content-type': 'text/html' }, 'cf-chl-widget');
+        await classifyProbeResponse(response, 'example.com', log);
+        expect(log.info.calledWithMatch('[edge-optimize-probe] Soft block')).to.be.true;
+      });
+
+      it('logs clean pass with status code', async () => {
+        const response = makeResponse(200, { 'content-type': 'text/html' }, '<h1>OK</h1>');
+        await classifyProbeResponse(response, 'example.com', log);
+        expect(log.info.calledWithMatch('[edge-optimize-probe] Clean pass for example.com: HTTP 200')).to.be.true;
+      });
+
+      it('logs unexpected status', async () => {
+        await classifyProbeResponse(makeResponse(302), 'example.com', log);
+        expect(log.info.calledWithMatch('[edge-optimize-probe] Unexpected status for example.com: HTTP 302')).to.be.true;
+      });
+    });
+  });
+});


### PR DESCRIPTION
Moves WAF/Bot-Manager probe logic from spacecat-api-service into TokowakaClient, where it belongs alongside checkEdgeOptimizeStatus and the existing edge-optimize infrastructure.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
