### PR TITLE
feat(drs-client): add S3 upload and SNS publish for brand presence analysis

### DIFF
--- a/docs/plans/2026-04-22-geo-brand-presence-drs-sns-migration.md
+++ b/docs/plans/2026-04-22-geo-brand-presence-drs-sns-migration.md
@@ -1,0 +1,254 @@
+# Implementation Plan: Geo-Brand-Presence DRS SNS Migration (PR B — `spacecat-shared`)
+
+## Context
+
+The `spacecat-audit-worker` (PR D) is migrating from calling DRS's HTTP endpoint
+`POST /sites/{siteId}/brand-presence/analyze` to a direct S3 upload + SNS publish pattern.
+This repo (PR B) must add two new methods to `DrsClient` to support that.
+
+**New flow:**
+1. Audit worker downloads Excel from SharePoint
+2. Calls `drsClient.uploadExcelToDrs(...)` → `PutObject` to DRS S3 bucket at `external/spacecat/{siteId}/{brandSlug}/{jobId}/source.xlsx`
+3. Calls `drsClient.publishBrandPresenceAnalyze(...)` → publishes `JOB_COMPLETED` SNS message to `DRS_SNS_TOPIC_ARN`
+4. DRS's new Lambda (PR A) picks it up, creates a synthetic DynamoDB job, and triggers Fargate
+
+The SNS message format is derived from DRS's existing `_publish_analysis_sns` function in
+`src/pipelines/brand_presence/handlers/brand_presence_analyze.py`.
+
+**Cross-repo PRs:**
+- **PR A** (`adobe-rnd/llmo-data-retrieval-service`) — extends `fargate_trigger.py`; deletes HTTP endpoint
+- **PR B** (this repo) — adds `uploadExcelToDrs()` and `publishBrandPresenceAnalyze()` to `DrsClient`
+- **PR C** (`spacecat-infrastructure`) — IAM policy updates for S3/SNS access + new env vars
+- **PR D** (`spacecat-audit-worker`) — replaces Mystique callback with direct DRS integration; depends on B and C
+
+---
+
+## Step 1 — Add AWS SDK dependencies to `package.json`
+
+File: `packages/spacecat-shared-drs-client/package.json`
+
+Add to `dependencies`:
+```json
+"@aws-sdk/client-s3": "^3.x.x",
+"@aws-sdk/client-sns": "^3.x.x"
+```
+
+> `instrumentAWSClient` is already available via the existing `@adobe/spacecat-shared-utils`
+> dependency — no new import needed for that.
+
+---
+
+## Step 2 — New environment variables
+
+Two new env vars are required. Both must be provisioned in PR C (infrastructure/CDK) alongside
+the existing `DRS_API_URL` and `DRS_API_KEY`.
+
+| Env var | New? | Purpose |
+|---|---|---|
+| `DRS_API_URL` | existing | HTTP API base URL |
+| `DRS_API_KEY` | existing | API key for HTTP requests |
+| `DRS_S3_BUCKET` | **new** | DRS bucket name SpaceCat uploads into |
+| `DRS_SNS_TOPIC_ARN` | **new** | DRS job-notifications topic SpaceCat publishes to |
+| `AWS_REGION` | existing | Standard Lambda env var, already consumed by `s3Wrapper` in `spacecat-shared-utils` |
+
+PR C must also grant IAM permissions to the audit worker Lambda:
+- `s3:PutObject` on `arn:aws:s3:::${DRS_S3_BUCKET}/external/spacecat/*`
+- `sns:Publish` on `${DRS_SNS_TOPIC_ARN}`
+
+If `DRS_S3_BUCKET` or `DRS_SNS_TOPIC_ARN` are absent at runtime, `isS3Configured()` returns
+false and both new methods throw early — existing HTTP method behaviour is unaffected.
+
+---
+
+## Step 3 — Extend `DrsClient` in `src/index.js`
+
+File: `packages/spacecat-shared-drs-client/src/index.js`
+
+### 3a. New imports at the top
+```js
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { PublishCommand, SNSClient } from '@aws-sdk/client-sns';
+import { hasText, instrumentAWSClient } from '@adobe/spacecat-shared-utils';
+```
+
+### 3b. New constants
+```js
+const EXTERNAL_SPACECAT_PROVIDER_ID = 'external_spacecat';
+const DRS_S3_KEY_PREFIX = 'external/spacecat';
+```
+
+### 3c. Update constructor signature and body
+```js
+constructor({ apiBaseUrl, apiKey, s3Bucket, snsTopicArn, awsRegion, s3Client, snsClient }, log = console) {
+  // existing url stripping ...
+  this.s3Bucket = s3Bucket;
+  this.snsTopicArn = snsTopicArn;
+  this.s3Client = s3Client ?? instrumentAWSClient(new S3Client({ region: awsRegion }));
+  this.snsClient = snsClient ?? instrumentAWSClient(new SNSClient({ region: awsRegion }));
+}
+```
+
+`s3Client`/`snsClient` are optional injection points for sinon stubs in tests.
+
+### 3d. Update `createFrom()`
+```js
+const {
+  DRS_API_URL: apiBaseUrl,
+  DRS_API_KEY: apiKey,
+  DRS_S3_BUCKET: s3Bucket,
+  DRS_SNS_TOPIC_ARN: snsTopicArn,
+  AWS_REGION: awsRegion,
+} = env;
+```
+
+### 3e. Add `isS3Configured()` method
+```js
+isS3Configured() {
+  return hasText(this.s3Bucket) && hasText(this.snsTopicArn);
+}
+```
+
+### 3f. Add `uploadExcelToDrs({ siteId, brandSlug, jobId, excelBuffer })`
+- Validates `siteId`, `jobId`, `excelBuffer` are present; `isS3Configured()` is true
+- Builds key: `` `${DRS_S3_KEY_PREFIX}/${siteId}/${brandSlug}/${jobId}/source.xlsx` ``
+- Calls:
+```js
+s3Client.send(new PutObjectCommand({
+  Bucket: this.s3Bucket,
+  Key: key,
+  Body: excelBuffer,
+  ContentType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  ServerSideEncryption: 'AES256',
+}))
+```
+- Returns S3 URI: `` `s3://${this.s3Bucket}/${key}` ``
+
+### 3g. Add `publishBrandPresenceAnalyze({ jobId, siteId, brandName, imsOrgId, resultLocation, platform, week, year })`
+- Validates required fields (`jobId`, `siteId`, `resultLocation`) and `isS3Configured()`
+- Builds message matching DRS's `_publish_analysis_sns` format exactly:
+```js
+{
+  event_type: 'JOB_COMPLETED',
+  job_id: jobId,
+  provider_id: EXTERNAL_SPACECAT_PROVIDER_ID,
+  result_location: resultLocation,
+  reanalysis: true,
+  metadata: { site: siteId, brand: brandName, imsOrgId },
+  ...(platform && { platform }),
+  ...(week != null && { week }),
+  ...(year != null && { year }),
+}
+```
+- Calls:
+```js
+snsClient.send(new PublishCommand({
+  TopicArn: this.snsTopicArn,
+  Message: JSON.stringify(message),
+  MessageAttributes: {
+    event_type: { DataType: 'String', StringValue: 'JOB_COMPLETED' },
+    provider_id: { DataType: 'String', StringValue: EXTERNAL_SPACECAT_PROVIDER_ID },
+  },
+}))
+```
+
+---
+
+## Step 4 — Update TypeScript declarations in `src/index.d.ts`
+
+File: `packages/spacecat-shared-drs-client/src/index.d.ts`
+
+Add to `DrsClientConfig`:
+```ts
+s3Bucket?: string;
+snsTopicArn?: string;
+awsRegion?: string;
+```
+
+Add new interfaces:
+```ts
+interface UploadExcelParams {
+  siteId: string;
+  brandSlug: string;
+  jobId: string;
+  excelBuffer: Buffer | Uint8Array;
+}
+
+interface PublishBrandPresenceParams {
+  jobId: string;
+  siteId: string;
+  brandName?: string;
+  imsOrgId?: string;
+  resultLocation: string;
+  platform?: string;
+  week?: number;
+  year?: number;
+}
+```
+
+Add to `DrsClient` declaration:
+```ts
+isS3Configured(): boolean;
+uploadExcelToDrs(params: UploadExcelParams): Promise<string>;
+publishBrandPresenceAnalyze(params: PublishBrandPresenceParams): Promise<void>;
+```
+
+---
+
+## Step 5 — Update tests in `test/index.test.js`
+
+File: `packages/spacecat-shared-drs-client/test/index.test.js`
+
+Inject stubbed AWS clients via constructor for all new-method tests:
+
+```js
+let s3ClientStub, snsClientStub;
+beforeEach(() => {
+  s3ClientStub = { send: sinon.stub() };
+  snsClientStub = { send: sinon.stub() };
+  client = new DrsClient(
+    { ...config, s3Bucket, snsTopicArn, s3Client: s3ClientStub, snsClient: snsClientStub },
+    log,
+  );
+});
+```
+
+### `isS3Configured` tests
+- missing bucket → false
+- missing topicArn → false
+- both set → true
+
+### `uploadExcelToDrs` tests
+- Success: verifies `PutObjectCommand` called with correct bucket/key/ContentType/ServerSideEncryption; returns correct S3 URI
+- Not configured (`isS3Configured()` false): throws
+- Missing `siteId`/`jobId`/`excelBuffer`: throws
+- S3 `send` throws: error propagates
+
+### `publishBrandPresenceAnalyze` tests
+- Success: verifies `PublishCommand` called with correct TopicArn, message shape
+  (`event_type`, `provider_id`, `result_location`, `reanalysis: true`, metadata), and MessageAttributes
+- Optional fields (`platform`, `week`, `year`): present when passed, absent when not
+- Not configured: throws
+- Missing required fields (`jobId`, `siteId`, `resultLocation`): throws
+- SNS `send` throws: error propagates
+
+### Updated `createFrom` tests
+- Reads `DRS_S3_BUCKET` and `DRS_SNS_TOPIC_ARN` from env and passes them through
+
+---
+
+## Step 6 — Verify 100% coverage
+
+```bash
+npm test -w packages/spacecat-shared-drs-client
+```
+
+The `.nycrc.json` requires 100% lines/statements and 97% branches. Every new branch
+(optional params, error guards) must have a corresponding test.
+
+---
+
+## Deployment order
+
+This PR (B) must be **published before** the audit worker PR (D) can be merged.
+`DRS_S3_BUCKET`, `DRS_SNS_TOPIC_ARN`, and the IAM grants must land in the infrastructure
+PR (C) before the audit worker goes live.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1473,6 +1473,56 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sns": {
+      "version": "3.1035.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1035.0.tgz",
+      "integrity": "sha512-eUQKKT2DzAPYLgAwH1/71RP88VvGAFY0h/mEqP4LCEGJ2fBv0arnNuPTYsiltDJxo9ZCde4h8sxM50dbQFfPfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/credential-provider-node": "^3.972.35",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.34",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.20",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.16",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.31",
+        "@smithy/middleware-retry": "^4.5.4",
+        "@smithy/middleware-serde": "^4.2.19",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.48",
+        "@smithy/util-defaults-mode-node": "^4.2.53",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.3",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sqs": {
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.940.0.tgz",
@@ -2200,22 +2250,23 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.26.tgz",
-      "integrity": "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==",
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.4.tgz",
+      "integrity": "sha512-EbVgyzQ83/Lf6oh1O4vYY47tuYw3Aosthh865LNU77KyotKz+uvEBNmsl/bSVS/vG+IU39mCqcOHrnhmhF4lug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/xml-builder": "^3.972.16",
-        "@smithy/core": "^3.23.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.18",
+        "@smithy/core": "^3.23.16",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.3",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -2237,15 +2288,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.24.tgz",
-      "integrity": "sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.30.tgz",
+      "integrity": "sha512-dHpeqa29a0cBYq/h59IC2EK3AphLY96nKy4F35kBtiz9GuKDc32UYRTgjZaF8uuJCnqgw9omUZKR+9myyDHC2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2253,20 +2304,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.26.tgz",
-      "integrity": "sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.32.tgz",
+      "integrity": "sha512-A+ZTT//Mswkf9DFEM6XlngwOtYdD8X4CUcoZ2wdpgI8cCs9mcGeuhgTwbGJvealub/MeONOaUr3FbRPMKmTDjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.21",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.24",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2274,24 +2325,24 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.28.tgz",
-      "integrity": "sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.34.tgz",
+      "integrity": "sha512-MoRc7tLnx3JpFkV2R826enEfBUVN8o9Cc7y3hnbMwiWzL/VJhgfxRQzHkEL9vWorMWP7tibltsRcLoid9fsVdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-env": "^3.972.24",
-        "@aws-sdk/credential-provider-http": "^3.972.26",
-        "@aws-sdk/credential-provider-login": "^3.972.28",
-        "@aws-sdk/credential-provider-process": "^3.972.24",
-        "@aws-sdk/credential-provider-sso": "^3.972.28",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/credential-provider-env": "^3.972.30",
+        "@aws-sdk/credential-provider-http": "^3.972.32",
+        "@aws-sdk/credential-provider-login": "^3.972.34",
+        "@aws-sdk/credential-provider-process": "^3.972.30",
+        "@aws-sdk/credential-provider-sso": "^3.972.34",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.34",
+        "@aws-sdk/nested-clients": "^3.997.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2299,18 +2350,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.28.tgz",
-      "integrity": "sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.34.tgz",
+      "integrity": "sha512-XVSklkRRQ/CQDmv3VVFdZRl5hTFgncFhZrLyi0Ai4LZk5o3jpY5HIfuTK7ad7tixPKa+iQmL9+vg9qNyYZB+nw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/nested-clients": "^3.997.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2318,22 +2369,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.29.tgz",
-      "integrity": "sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.35.tgz",
+      "integrity": "sha512-nVrY7AdGfzYgAa/jd9m06p3ES7QQDaB7zN9c+vXnVXxBRkAs9MjRDPB5AKogWuC6phddltfvHGFqLDJmyU9u/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.24",
-        "@aws-sdk/credential-provider-http": "^3.972.26",
-        "@aws-sdk/credential-provider-ini": "^3.972.28",
-        "@aws-sdk/credential-provider-process": "^3.972.24",
-        "@aws-sdk/credential-provider-sso": "^3.972.28",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/credential-provider-env": "^3.972.30",
+        "@aws-sdk/credential-provider-http": "^3.972.32",
+        "@aws-sdk/credential-provider-ini": "^3.972.34",
+        "@aws-sdk/credential-provider-process": "^3.972.30",
+        "@aws-sdk/credential-provider-sso": "^3.972.34",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.34",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2341,16 +2392,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.24.tgz",
-      "integrity": "sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.30.tgz",
+      "integrity": "sha512-McJPomNTSEo+C6UA3Zq6pFrcyTUaVsoPPBOvbOHAoIFPc8Z2CMLndqFJOnB+9bVFiBTWQLutlVGmrocBbvv4MQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2358,18 +2409,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.28.tgz",
-      "integrity": "sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.34.tgz",
+      "integrity": "sha512-WngYb2K+/yhkDOmDfAOjoCa9Ja3he0DZiAraboKwgWoVRkajDIcDYBCVbUTxtTUldvQoe7VvHLTrBNxvftN1aQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/token-providers": "3.1021.0",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/nested-clients": "^3.997.2",
+        "@aws-sdk/token-providers": "3.1035.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2377,17 +2428,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.28.tgz",
-      "integrity": "sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.34.tgz",
+      "integrity": "sha512-5KLUH+XmSNRj6amJiJSrPsCxU5l/PYDfxyqPa1MxWhHoQC3sxvGPrSib3IE+HQlfRA4e2kO0bnJy7HJdjvpuuA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/nested-clients": "^3.997.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2585,14 +2636,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
-      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2614,13 +2665,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
-      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2628,15 +2679,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
-      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/types": "^3.973.8",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2644,23 +2695,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.27.tgz",
-      "integrity": "sha512-gomO6DZwx+1D/9mbCpcqO5tPBqYBK7DtdgjTIjZ4yvfh/S7ETwAPS0XbJgP2JD8Ycr5CwVrEkV1sFtu3ShXeOw==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.33.tgz",
+      "integrity": "sha512-n8Eh/+kq3u/EodLr8n6sQupu03QGjf122RHXCTGLaHSkavz/2beSKpRlq2oDgfmJZNkAkWF113xbyaUmyOd+YA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.23.16",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.24",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -2713,18 +2764,18 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.28.tgz",
-      "integrity": "sha512-cfWZFlVh7Va9lRay4PN2A9ARFzaBYcA097InT5M2CdRS05ECF5yaz86jET8Wsl2WcyKYEvVr/QNmKtYtafUHtQ==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.34.tgz",
+      "integrity": "sha512-jrmJHyYlTQocR7H4VhvSFhaoedMb2rmlOTvFWD6tNBQ/EVQhTsrNfQUYFuPiOc2wUGxbm5LgCHtnvVmCPgODHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@smithy/core": "^3.23.13",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-retry": "^4.2.13",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.16",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2732,47 +2783,48 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.18.tgz",
-      "integrity": "sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==",
+      "version": "3.997.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.2.tgz",
+      "integrity": "sha512-uGGQO08YetrqfInOKG5atRMrCDRQWRuZ9gGfKY6svPmuE4K7ac+XcbCkpWpjcA7yCYsBaKB/Nly4XKgPXUO1PA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.34",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.21",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.20",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.16",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.31",
+        "@smithy/middleware-retry": "^4.5.4",
+        "@smithy/middleware-serde": "^4.2.19",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-defaults-mode-browser": "^4.3.48",
+        "@smithy/util-defaults-mode-node": "^4.2.53",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.3",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -2781,15 +2833,15 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
-      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2797,16 +2849,16 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.15.tgz",
-      "integrity": "sha512-Ukw2RpqvaL96CjfH/FgfBmy/ZosHBqoHBCFsN61qGg99F33vpntIVii8aNeh65XuOja73arSduskoa4OJea9RQ==",
+      "version": "3.996.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.21.tgz",
+      "integrity": "sha512-3EpT+C0QdmTMB5aVeJ5odWSLt9vg2oGzUXl1xvUazKGlkr9OBYnegNWqhhjGgZdv8RmSi5eS8nqqB+euNP2aqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.27",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/signature-v4": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.33",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2814,17 +2866,17 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1021.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1021.0.tgz",
-      "integrity": "sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==",
+      "version": "3.1035.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1035.0.tgz",
+      "integrity": "sha512-E6IO3Cn+OzBe6Sb5pnubd5Y8qSUMAsVKkD5QSwFfIx5fV1g5SkYwUDRDyPlm90RuIVcCo28wpMJU6W8wXH46Aw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/nested-clients": "^3.997.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2832,12 +2884,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
-      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2872,15 +2924,15 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
-      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-endpoints": "^3.3.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2900,27 +2952,27 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
-      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.14.tgz",
-      "integrity": "sha512-vNSB/DYaPOyujVZBg/zUznH9QC142MaTHVmaFlF7uzzfg3CgT9f/l4C0Yi+vU/tbBhxVcXVB90Oohk5+o+ZbWw==",
+      "version": "3.973.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.20.tgz",
+      "integrity": "sha512-owEqyKr0z5hWwk+uHwudwNhyFMZ9f9eSWr/k/XD6yeDCI7hHyc56s4UOY1iBQmoramTbdAY4UCuLLEuKmjVXrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/middleware-user-agent": "^3.972.34",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -2937,12 +2989,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
-      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
+      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "fast-xml-parser": "5.5.8",
         "tslib": "^2.6.2"
       },
@@ -5929,16 +5981,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
-      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5946,18 +5998,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.13",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.13.tgz",
-      "integrity": "sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==",
+      "version": "3.23.16",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.16.tgz",
+      "integrity": "sha512-JStomOrINQA1VqNEopLsgcdgwd42au7mykKqVr30XFw89wLt9sDxJDi4djVPRwQmmzyTGy/uOvTc2ultMpFi1w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.24",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -5967,15 +6019,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
-      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6053,14 +6105,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.15",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
-      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -6084,12 +6136,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
-      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -6113,12 +6165,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
-      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6152,13 +6204,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
-      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6166,18 +6218,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.28",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.28.tgz",
-      "integrity": "sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==",
+      "version": "4.4.31",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.31.tgz",
+      "integrity": "sha512-KJPdCIN2kOE2aGmqZd7eUTr4WQwOGgtLWgUkswGJggs7rBcQYQjcZMEDa3C0DwbOiXS9L8/wDoQHkfxBYLfiLw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.13",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
-        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/core": "^3.23.16",
+        "@smithy/middleware-serde": "^4.2.19",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6185,18 +6237,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.46",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.46.tgz",
-      "integrity": "sha512-SpvWNNOPOrKQGUqZbEPO+es+FRXMWvIyzUKUOYdDgdlA6BdZj/R58p4umoQ76c2oJC44PiM7mKizyyex1IJzow==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.4.tgz",
+      "integrity": "sha512-/z7nIFK+ZRW3Ie/l3NEVGdy34LvmEOzBrtBAvgWZ/4PrKX0xP3kWm8pkfcwUk523SqxZhdbQP9JSXgjF77Uhpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/service-error-classification": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
+        "@smithy/core": "^3.23.16",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.0",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.3",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
@@ -6205,14 +6258,14 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.16",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.16.tgz",
-      "integrity": "sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==",
+      "version": "4.2.19",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.19.tgz",
+      "integrity": "sha512-Q6y+W9h3iYVMCKWDoVge+OC1LKFqbEKaq8SIWG2X2bWJRpd/6dDLyICcNLT6PbjH3Rr6bmg/SeDB25XFOFfeEw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.13",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/core": "^3.23.16",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6220,12 +6273,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
-      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6233,14 +6286,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
-      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6248,14 +6301,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.1.tgz",
-      "integrity": "sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.0.tgz",
+      "integrity": "sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/querystring-builder": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6263,12 +6316,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
-      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6276,12 +6329,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
-      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6289,12 +6342,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
-      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -6303,12 +6356,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
-      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6316,24 +6369,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
-      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.0.tgz",
+      "integrity": "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1"
+        "@smithy/types": "^4.14.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
-      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6341,16 +6394,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.12",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
-      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.14",
         "@smithy/util-uri-escape": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
@@ -6360,17 +6413,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.8.tgz",
-      "integrity": "sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.12.tgz",
+      "integrity": "sha512-daO7SJn4eM6ArbmrEs+/BTbH7af8AEbSL3OMQdcRvvn8tuUcR5rU2n6DgxIV53aXMS42uwK8NgKKCh5XgqYOPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.13",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/types": "^4.13.1",
-        "@smithy/util-stream": "^4.5.21",
+        "@smithy/core": "^3.23.16",
+        "@smithy/middleware-endpoint": "^4.4.31",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.24",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6378,9 +6431,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6390,13 +6443,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
-      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6467,14 +6520,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.44",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.44.tgz",
-      "integrity": "sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==",
+      "version": "4.3.48",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.48.tgz",
+      "integrity": "sha512-hxVRVPYaRDWa6YQdse1aWX1qrksmLsvNyGBKdc32q4jFzSjxYVNWfstknAfR228TnzS4tzgswXRuYIbhXBuXFQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6482,17 +6535,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.48",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.48.tgz",
-      "integrity": "sha512-FqOKTlqSaoV3nzO55pMs5NBnZX8EhoI0DGmn9kbYeXWppgHD6dchyuj2HLqp4INJDJbSrj6OFYJkAh/WhSzZPg==",
+      "version": "4.2.53",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.53.tgz",
+      "integrity": "sha512-ybgCk+9JdBq8pYC8Y6U5fjyS8e4sboyAShetxPNL0rRBtaVl56GSFAxsolVBIea1tXR4LPIzL8i6xqmcf0+DCQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.12",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6500,13 +6553,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
-      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6526,12 +6579,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
-      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6539,13 +6592,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.13.tgz",
-      "integrity": "sha512-qQQsIvL0MGIbUjeSrg0/VlQ3jGNKyM3/2iU3FPNgy01z+Sp4OvcaxbgIoFOTvB61ZoohtutuOvOcgmhbD0katQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.3.tgz",
+      "integrity": "sha512-idjUvd4M9Jj6rXkhqw4H4reHoweuK4ZxYWyOrEp4N2rOF5VtaOlQGLDQJva/8WanNXk9ScQtsAb7o5UHGvFm4A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.12",
-        "@smithy/types": "^4.13.1",
+        "@smithy/service-error-classification": "^4.3.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6553,14 +6606,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.21.tgz",
-      "integrity": "sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==",
+      "version": "4.5.24",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.24.tgz",
+      "integrity": "sha512-na5vv2mBSDzXewLEEoWGI7LQQkfpmFEomBsmOpzLFjqGctm0iMwXY5lAwesY9pIaErkccW0qzEOUcYP+WKneXg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/types": "^4.13.1",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.0",
+        "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-hex-encoding": "^4.2.2",
@@ -10578,9 +10631,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -17382,9 +17435,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.1.tgz",
-      "integrity": "sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -26429,7 +26482,9 @@
       "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/spacecat-shared-utils": "1.98.1"
+        "@adobe/spacecat-shared-utils": "1.98.1",
+        "@aws-sdk/client-s3": "^3.775.0",
+        "@aws-sdk/client-sns": "^3.775.0"
       },
       "devDependencies": {
         "chai": "6.2.2",

--- a/packages/spacecat-shared-drs-client/package.json
+++ b/packages/spacecat-shared-drs-client/package.json
@@ -35,7 +35,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@adobe/spacecat-shared-utils": "1.98.1"
+    "@adobe/spacecat-shared-utils": "1.98.1",
+    "@aws-sdk/client-s3": "^3.775.0",
+    "@aws-sdk/client-sns": "^3.775.0"
   },
   "devDependencies": {
     "chai": "6.2.2",

--- a/packages/spacecat-shared-drs-client/src/index.d.ts
+++ b/packages/spacecat-shared-drs-client/src/index.d.ts
@@ -71,6 +71,7 @@ export interface ScrapeLookupResponse {
 
 interface PublishBrandPresenceParams {
   resultLocation: string;
+  jobId?: string;
   webSearchProvider?: string;
   configVersion?: string;
   week?: number;

--- a/packages/spacecat-shared-drs-client/src/index.d.ts
+++ b/packages/spacecat-shared-drs-client/src/index.d.ts
@@ -69,22 +69,15 @@ export interface ScrapeLookupResponse {
   summary: ScrapeLookupSummary;
 }
 
-interface UploadExcelParams {
-  siteId: string;
-  brandSlug: string;
-  jobId: string;
-  excelBuffer: Buffer | Uint8Array;
-}
-
 interface PublishBrandPresenceParams {
-  jobId: string;
-  siteId: string;
-  brandName?: string;
-  imsOrgId?: string;
   resultLocation: string;
-  platform?: string;
+  webSearchProvider?: string;
+  configVersion?: string;
   week?: number;
   year?: number;
+  runFrequency?: 'daily' | 'weekly';
+  brand?: string;
+  imsOrgId?: string;
 }
 
 interface BrandDetectionOptions {
@@ -135,8 +128,8 @@ declare class DrsClient {
   constructor(config: DrsClientConfig, log?: Console);
   isConfigured(): boolean;
   isS3Configured(): boolean;
-  uploadExcelToDrs(params: UploadExcelParams): Promise<string>;
-  publishBrandPresenceAnalyze(params: PublishBrandPresenceParams): Promise<void>;
+  uploadExcelToDrs(siteId: string, jobId: string, excelBuffer: Buffer | Uint8Array): Promise<string>;
+  publishBrandPresenceAnalyze(siteId: string, params: PublishBrandPresenceParams): Promise<string>;
   submitJob(params: Record<string, unknown>): Promise<DrsJobResult>;
   submitPromptGenerationJob(params: PromptGenerationParams): Promise<DrsJobResult>;
   submitScrapeJob(params: ScrapeJobParams): Promise<DrsJobResult>;

--- a/packages/spacecat-shared-drs-client/src/index.d.ts
+++ b/packages/spacecat-shared-drs-client/src/index.d.ts
@@ -13,6 +13,9 @@
 interface DrsClientConfig {
   apiBaseUrl: string;
   apiKey: string;
+  s3Bucket?: string;
+  snsTopicArn?: string;
+  awsRegion?: string;
 }
 
 interface PromptGenerationParams {
@@ -66,6 +69,24 @@ export interface ScrapeLookupResponse {
   summary: ScrapeLookupSummary;
 }
 
+interface UploadExcelParams {
+  siteId: string;
+  brandSlug: string;
+  jobId: string;
+  excelBuffer: Buffer | Uint8Array;
+}
+
+interface PublishBrandPresenceParams {
+  jobId: string;
+  siteId: string;
+  brandName?: string;
+  imsOrgId?: string;
+  resultLocation: string;
+  platform?: string;
+  week?: number;
+  year?: number;
+}
+
 interface BrandDetectionOptions {
   batchId?: string;
   priority?: string;
@@ -113,6 +134,9 @@ declare class DrsClient {
   static createFrom(context: { env: Record<string, string>; log?: Console }): DrsClient;
   constructor(config: DrsClientConfig, log?: Console);
   isConfigured(): boolean;
+  isS3Configured(): boolean;
+  uploadExcelToDrs(params: UploadExcelParams): Promise<string>;
+  publishBrandPresenceAnalyze(params: PublishBrandPresenceParams): Promise<void>;
   submitJob(params: Record<string, unknown>): Promise<DrsJobResult>;
   submitPromptGenerationJob(params: PromptGenerationParams): Promise<DrsJobResult>;
   submitScrapeJob(params: ScrapeJobParams): Promise<DrsJobResult>;

--- a/packages/spacecat-shared-drs-client/src/index.js
+++ b/packages/spacecat-shared-drs-client/src/index.js
@@ -13,6 +13,7 @@
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { PublishCommand, SNSClient } from '@aws-sdk/client-sns';
 import { hasText, instrumentAWSClient, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import { randomUUID } from 'crypto';
 
 const EXTERNAL_SPACECAT_PROVIDER_ID = 'external_spacecat';
 const DRS_S3_KEY_PREFIX = 'external/spacecat';
@@ -411,16 +412,12 @@ export default class DrsClient {
 
   /**
    * Uploads a brand presence Excel file directly to the DRS S3 bucket.
-   * @param {object} params
-   * @param {string} params.siteId - SpaceCat site ID
-   * @param {string} params.brandSlug - URL-safe brand slug
-   * @param {string} params.jobId - Unique job ID (used to derive the S3 key)
-   * @param {Buffer|Uint8Array} params.excelBuffer - Raw Excel file bytes
+   * @param {string} siteId - SpaceCat site ID
+   * @param {string} jobId - Unique job ID (used to derive the S3 key)
+   * @param {Buffer|Uint8Array} excelBuffer - Raw Excel file bytes
    * @returns {Promise<string>} S3 URI of the uploaded file (s3://bucket/key)
    */
-  async uploadExcelToDrs({
-    siteId, brandSlug, jobId, excelBuffer,
-  }) {
+  async uploadExcelToDrs(siteId, jobId, excelBuffer) {
     if (!this.isS3Configured()) {
       throw new Error('DRS S3 is not configured. Set DRS_S3_BUCKET and DRS_SNS_TOPIC_ARN environment variables.');
     }
@@ -434,7 +431,7 @@ export default class DrsClient {
       throw new Error('excelBuffer is required and must be non-empty');
     }
 
-    const key = `${DRS_S3_KEY_PREFIX}/${siteId}/${brandSlug}/${jobId}/source.xlsx`;
+    const key = `${DRS_S3_KEY_PREFIX}/${siteId}/${jobId}/source.xlsx`;
     this.log.info(`Uploading Excel to DRS S3`, { siteId, jobId, key });
 
     await this.s3Client.send(new PutObjectCommand({
@@ -452,32 +449,31 @@ export default class DrsClient {
 
   /**
    * Publishes a JOB_COMPLETED SNS event to trigger DRS Fargate brand presence analysis.
+   * Generates a unique job ID internally and returns it so the caller can correlate logs.
+   * @param {string} siteId - SpaceCat site ID
    * @param {object} params
-   * @param {string} params.jobId - Job ID (must match the one used in uploadExcelToDrs)
-   * @param {string} params.siteId - SpaceCat site ID
-   * @param {string} [params.brandName] - Brand name
-   * @param {string} [params.imsOrgId] - IMS organization ID
    * @param {string} params.resultLocation - S3 URI of the uploaded Excel file
-   * @param {string} [params.platform] - Canonical platform string (e.g. 'chatgpt_free')
+   * @param {string} [params.webSearchProvider] - Provider string (e.g. 'chatgpt', 'google_ai_overviews')
+   * @param {string} [params.configVersion] - SpaceCat config schema version
    * @param {number} [params.week] - ISO week number
    * @param {number} [params.year] - Year
-   * @returns {Promise<void>}
+   * @param {string} [params.runFrequency] - 'daily' | 'weekly'
+   * @param {string} [params.brand] - Brand name
+   * @param {string} [params.imsOrgId] - IMS organization ID
+   * @returns {Promise<string>} The generated job ID
    */
-  async publishBrandPresenceAnalyze({
-    jobId,
-    siteId,
-    brandName,
-    imsOrgId,
+  async publishBrandPresenceAnalyze(siteId, {
     resultLocation,
-    platform,
+    webSearchProvider,
+    configVersion,
     week,
     year,
-  }) {
+    runFrequency,
+    brand,
+    imsOrgId,
+  } = {}) {
     if (!this.isS3Configured()) {
       throw new Error('DRS S3 is not configured. Set DRS_S3_BUCKET and DRS_SNS_TOPIC_ARN environment variables.');
-    }
-    if (!hasText(jobId)) {
-      throw new Error('jobId is required');
     }
     if (!hasText(siteId)) {
       throw new Error('siteId is required');
@@ -486,6 +482,8 @@ export default class DrsClient {
       throw new Error('resultLocation is required');
     }
 
+    const jobId = `spacecat-${randomUUID()}`;
+
     const message = {
       event_type: 'JOB_COMPLETED',
       job_id: jobId,
@@ -493,11 +491,13 @@ export default class DrsClient {
       result_location: resultLocation,
       reanalysis: true,
       metadata: {
-        site: siteId,
-        brand: brandName,
+        site_id: siteId,
+        brand,
         imsOrgId,
+        web_search_provider: webSearchProvider,
+        config_version: configVersion,
+        ...(runFrequency && { run_frequency: runFrequency }),
       },
-      ...(platform && { platform }),
       ...(week != null && { week }),
       ...(year != null && { year }),
     };
@@ -514,5 +514,6 @@ export default class DrsClient {
     }));
 
     this.log.info(`Brand presence analyze SNS event published`, { jobId });
+    return jobId;
   }
 }

--- a/packages/spacecat-shared-drs-client/src/index.js
+++ b/packages/spacecat-shared-drs-client/src/index.js
@@ -432,7 +432,7 @@ export default class DrsClient {
     }
 
     const key = `${DRS_S3_KEY_PREFIX}/${siteId}/${jobId}/source.xlsx`;
-    this.log.info(`Uploading Excel to DRS S3`, { siteId, jobId, key });
+    this.log.info('Uploading Excel to DRS S3', { siteId, jobId, key });
 
     await this.s3Client.send(new PutObjectCommand({
       Bucket: this.s3Bucket,
@@ -443,7 +443,7 @@ export default class DrsClient {
     }));
 
     const uri = `s3://${this.s3Bucket}/${key}`;
-    this.log.info(`Excel uploaded to DRS S3`, { uri });
+    this.log.info('Excel uploaded to DRS S3', { uri });
     return uri;
   }
 
@@ -453,7 +453,7 @@ export default class DrsClient {
    * @param {string} siteId - SpaceCat site ID
    * @param {object} params
    * @param {string} params.resultLocation - S3 URI of the uploaded Excel file
-   * @param {string} [params.webSearchProvider] - Provider string (e.g. 'chatgpt', 'google_ai_overviews')
+   * @param {string} [params.webSearchProvider] - Provider string (e.g. 'chatgpt', 'gemini')
    * @param {string} [params.configVersion] - SpaceCat config schema version
    * @param {number} [params.week] - ISO week number
    * @param {number} [params.year] - Year
@@ -502,7 +502,7 @@ export default class DrsClient {
       ...(year != null && { year }),
     };
 
-    this.log.info(`Publishing brand presence analyze SNS event`, { jobId, siteId, resultLocation });
+    this.log.info('Publishing brand presence analyze SNS event', { jobId, siteId, resultLocation });
 
     await this.snsClient.send(new PublishCommand({
       TopicArn: this.snsTopicArn,
@@ -513,7 +513,7 @@ export default class DrsClient {
       },
     }));
 
-    this.log.info(`Brand presence analyze SNS event published`, { jobId });
+    this.log.info('Brand presence analyze SNS event published', { jobId });
     return jobId;
   }
 }

--- a/packages/spacecat-shared-drs-client/src/index.js
+++ b/packages/spacecat-shared-drs-client/src/index.js
@@ -488,10 +488,13 @@ export default class DrsClient {
 
   /**
    * Publishes a JOB_COMPLETED SNS event to trigger DRS Fargate brand presence analysis.
-   * Generates a unique job ID internally and returns it so the caller can correlate logs.
+   * Returns the job ID used in the SNS message so the caller can correlate logs.
    * @param {string} siteId - SpaceCat site ID
    * @param {object} params
    * @param {string} params.resultLocation - S3 URI of the uploaded Excel file
+   * @param {string} [params.jobId] - Job ID that matches the one used in uploadExcelToDrs.
+   *   When omitted a new spacecat-{uuid} is generated — only safe when the caller does not
+   *   need the SNS job_id to match an existing S3 key.
    * @param {string} [params.webSearchProvider] - Provider string (e.g. 'chatgpt', 'gemini')
    * @param {string} [params.configVersion] - SpaceCat config schema version
    * @param {number} [params.week] - ISO week number
@@ -499,9 +502,10 @@ export default class DrsClient {
    * @param {string} [params.runFrequency] - 'daily' | 'weekly'
    * @param {string} [params.brand] - Brand name
    * @param {string} [params.imsOrgId] - IMS organization ID
-   * @returns {Promise<string>} The generated job ID
+   * @returns {Promise<string>} The job ID used in the SNS message
    */
   async publishBrandPresenceAnalyze(siteId, {
+    jobId = `spacecat-${randomUUID()}`,
     resultLocation,
     webSearchProvider,
     configVersion,
@@ -520,8 +524,6 @@ export default class DrsClient {
     if (!hasText(resultLocation)) {
       throw new Error('resultLocation is required');
     }
-
-    const jobId = `spacecat-${randomUUID()}`;
 
     const message = {
       event_type: 'JOB_COMPLETED',

--- a/packages/spacecat-shared-drs-client/src/index.js
+++ b/packages/spacecat-shared-drs-client/src/index.js
@@ -10,7 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
-import { hasText, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { PublishCommand, SNSClient } from '@aws-sdk/client-sns';
+import { hasText, instrumentAWSClient, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+
+const EXTERNAL_SPACECAT_PROVIDER_ID = 'external_spacecat';
+const DRS_S3_KEY_PREFIX = 'external/spacecat';
 
 export const EXPERIMENT_PHASES = Object.freeze({
   PRE: 'pre',
@@ -38,18 +43,34 @@ export default class DrsClient {
    */
   static createFrom(context) {
     const { env, log = console } = context;
-    const { DRS_API_URL: apiBaseUrl, DRS_API_KEY: apiKey } = env;
+    const {
+      DRS_API_URL: apiBaseUrl,
+      DRS_API_KEY: apiKey,
+      DRS_S3_BUCKET: s3Bucket,
+      DRS_SNS_TOPIC_ARN: snsTopicArn,
+      AWS_REGION: awsRegion,
+    } = env;
 
     if (context.drsClient) {
       return context.drsClient;
     }
 
-    const client = new DrsClient({ apiBaseUrl, apiKey }, log);
+    const client = new DrsClient({
+      apiBaseUrl, apiKey, s3Bucket, snsTopicArn, awsRegion,
+    }, log);
     context.drsClient = client;
     return client;
   }
 
-  constructor({ apiBaseUrl, apiKey }, log = console) {
+  constructor({
+    apiBaseUrl,
+    apiKey,
+    s3Bucket,
+    snsTopicArn,
+    awsRegion,
+    s3Client,
+    snsClient,
+  }, log = console) {
     // Strip trailing slashes without regex (CodeQL flags /\/+$/ as polynomial)
     let url = apiBaseUrl;
     if (url) {
@@ -59,6 +80,10 @@ export default class DrsClient {
     }
     this.apiBaseUrl = url || undefined;
     this.apiKey = apiKey;
+    this.s3Bucket = s3Bucket;
+    this.snsTopicArn = snsTopicArn;
+    this.s3Client = s3Client ?? instrumentAWSClient(new S3Client({ region: awsRegion }));
+    this.snsClient = snsClient ?? instrumentAWSClient(new SNSClient({ region: awsRegion }));
     this.log = log;
   }
 
@@ -67,6 +92,13 @@ export default class DrsClient {
    */
   isConfigured() {
     return hasText(this.apiBaseUrl) && hasText(this.apiKey);
+  }
+
+  /**
+   * @returns {boolean} True if DRS_S3_BUCKET and DRS_SNS_TOPIC_ARN are set
+   */
+  isS3Configured() {
+    return hasText(this.s3Bucket) && hasText(this.snsTopicArn);
   }
 
   async #request(method, path, body = undefined) {
@@ -375,5 +407,112 @@ export default class DrsClient {
    */
   async getJob(jobId) {
     return this.#request('GET', `/jobs/${jobId}`);
+  }
+
+  /**
+   * Uploads a brand presence Excel file directly to the DRS S3 bucket.
+   * @param {object} params
+   * @param {string} params.siteId - SpaceCat site ID
+   * @param {string} params.brandSlug - URL-safe brand slug
+   * @param {string} params.jobId - Unique job ID (used to derive the S3 key)
+   * @param {Buffer|Uint8Array} params.excelBuffer - Raw Excel file bytes
+   * @returns {Promise<string>} S3 URI of the uploaded file (s3://bucket/key)
+   */
+  async uploadExcelToDrs({
+    siteId, brandSlug, jobId, excelBuffer,
+  }) {
+    if (!this.isS3Configured()) {
+      throw new Error('DRS S3 is not configured. Set DRS_S3_BUCKET and DRS_SNS_TOPIC_ARN environment variables.');
+    }
+    if (!hasText(siteId)) {
+      throw new Error('siteId is required');
+    }
+    if (!hasText(jobId)) {
+      throw new Error('jobId is required');
+    }
+    if (!excelBuffer || excelBuffer.length === 0) {
+      throw new Error('excelBuffer is required and must be non-empty');
+    }
+
+    const key = `${DRS_S3_KEY_PREFIX}/${siteId}/${brandSlug}/${jobId}/source.xlsx`;
+    this.log.info(`Uploading Excel to DRS S3`, { siteId, jobId, key });
+
+    await this.s3Client.send(new PutObjectCommand({
+      Bucket: this.s3Bucket,
+      Key: key,
+      Body: excelBuffer,
+      ContentType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      ServerSideEncryption: 'AES256',
+    }));
+
+    const uri = `s3://${this.s3Bucket}/${key}`;
+    this.log.info(`Excel uploaded to DRS S3`, { uri });
+    return uri;
+  }
+
+  /**
+   * Publishes a JOB_COMPLETED SNS event to trigger DRS Fargate brand presence analysis.
+   * @param {object} params
+   * @param {string} params.jobId - Job ID (must match the one used in uploadExcelToDrs)
+   * @param {string} params.siteId - SpaceCat site ID
+   * @param {string} [params.brandName] - Brand name
+   * @param {string} [params.imsOrgId] - IMS organization ID
+   * @param {string} params.resultLocation - S3 URI of the uploaded Excel file
+   * @param {string} [params.platform] - Canonical platform string (e.g. 'chatgpt_free')
+   * @param {number} [params.week] - ISO week number
+   * @param {number} [params.year] - Year
+   * @returns {Promise<void>}
+   */
+  async publishBrandPresenceAnalyze({
+    jobId,
+    siteId,
+    brandName,
+    imsOrgId,
+    resultLocation,
+    platform,
+    week,
+    year,
+  }) {
+    if (!this.isS3Configured()) {
+      throw new Error('DRS S3 is not configured. Set DRS_S3_BUCKET and DRS_SNS_TOPIC_ARN environment variables.');
+    }
+    if (!hasText(jobId)) {
+      throw new Error('jobId is required');
+    }
+    if (!hasText(siteId)) {
+      throw new Error('siteId is required');
+    }
+    if (!hasText(resultLocation)) {
+      throw new Error('resultLocation is required');
+    }
+
+    const message = {
+      event_type: 'JOB_COMPLETED',
+      job_id: jobId,
+      provider_id: EXTERNAL_SPACECAT_PROVIDER_ID,
+      result_location: resultLocation,
+      reanalysis: true,
+      metadata: {
+        site: siteId,
+        brand: brandName,
+        imsOrgId,
+      },
+      ...(platform && { platform }),
+      ...(week != null && { week }),
+      ...(year != null && { year }),
+    };
+
+    this.log.info(`Publishing brand presence analyze SNS event`, { jobId, siteId, resultLocation });
+
+    await this.snsClient.send(new PublishCommand({
+      TopicArn: this.snsTopicArn,
+      Message: JSON.stringify(message),
+      MessageAttributes: {
+        event_type: { DataType: 'String', StringValue: 'JOB_COMPLETED' },
+        provider_id: { DataType: 'String', StringValue: EXTERNAL_SPACECAT_PROVIDER_ID },
+      },
+    }));
+
+    this.log.info(`Brand presence analyze SNS event published`, { jobId });
   }
 }

--- a/packages/spacecat-shared-drs-client/test/index.test.js
+++ b/packages/spacecat-shared-drs-client/test/index.test.js
@@ -772,28 +772,23 @@ describe('DrsClient', () => {
       }, log);
 
       const excelBuffer = Buffer.from('fake-excel-bytes');
-      const result = await client.uploadExcelToDrs({
-        siteId: 'site-1',
-        brandSlug: 'acme',
-        jobId: 'job-abc',
-        excelBuffer,
-      });
+      const result = await client.uploadExcelToDrs('site-1', 'job-abc', excelBuffer);
 
-      expect(result).to.equal('s3://drs-bucket/external/spacecat/site-1/acme/job-abc/source.xlsx');
+      expect(result).to.equal('s3://drs-bucket/external/spacecat/site-1/job-abc/source.xlsx');
       expect(s3ClientStub).to.have.been.calledOnce;
       const [cmd] = s3ClientStub.args[0];
       expect(cmd.input.Bucket).to.equal(S3_BUCKET);
-      expect(cmd.input.Key).to.equal('external/spacecat/site-1/acme/job-abc/source.xlsx');
+      expect(cmd.input.Key).to.equal('external/spacecat/site-1/job-abc/source.xlsx');
       expect(cmd.input.ContentType).to.equal('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
       expect(cmd.input.ServerSideEncryption).to.equal('AES256');
       expect(cmd.input.Body).to.equal(excelBuffer);
-      expect(log.info).to.have.been.calledWith('Uploading Excel to DRS S3', { siteId: 'site-1', jobId: 'job-abc', key: 'external/spacecat/site-1/acme/job-abc/source.xlsx' });
+      expect(log.info).to.have.been.calledWith('Uploading Excel to DRS S3', { siteId: 'site-1', jobId: 'job-abc', key: 'external/spacecat/site-1/job-abc/source.xlsx' });
       expect(log.info).to.have.been.calledWith('Excel uploaded to DRS S3', { uri: result });
     });
 
     it('throws when not S3 configured', async () => {
       const client = new DrsClient({ apiBaseUrl: DRS_API_URL, apiKey: DRS_API_KEY }, log);
-      await expect(client.uploadExcelToDrs({ siteId: 'site-1', brandSlug: 'acme', jobId: 'job-1', excelBuffer: Buffer.from('x') }))
+      await expect(client.uploadExcelToDrs('site-1', 'job-1', Buffer.from('x')))
         .to.be.rejectedWith('DRS S3 is not configured');
     });
 
@@ -801,7 +796,7 @@ describe('DrsClient', () => {
       const client = new DrsClient({
         s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, s3Client,
       }, log);
-      await expect(client.uploadExcelToDrs({ brandSlug: 'acme', jobId: 'job-1', excelBuffer: Buffer.from('x') }))
+      await expect(client.uploadExcelToDrs(undefined, 'job-1', Buffer.from('x')))
         .to.be.rejectedWith('siteId is required');
     });
 
@@ -809,7 +804,7 @@ describe('DrsClient', () => {
       const client = new DrsClient({
         s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, s3Client,
       }, log);
-      await expect(client.uploadExcelToDrs({ siteId: 'site-1', brandSlug: 'acme', excelBuffer: Buffer.from('x') }))
+      await expect(client.uploadExcelToDrs('site-1', undefined, Buffer.from('x')))
         .to.be.rejectedWith('jobId is required');
     });
 
@@ -817,7 +812,7 @@ describe('DrsClient', () => {
       const client = new DrsClient({
         s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, s3Client,
       }, log);
-      await expect(client.uploadExcelToDrs({ siteId: 'site-1', brandSlug: 'acme', jobId: 'job-1' }))
+      await expect(client.uploadExcelToDrs('site-1', 'job-1', undefined))
         .to.be.rejectedWith('excelBuffer is required and must be non-empty');
     });
 
@@ -825,7 +820,7 @@ describe('DrsClient', () => {
       const client = new DrsClient({
         s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, s3Client,
       }, log);
-      await expect(client.uploadExcelToDrs({ siteId: 'site-1', brandSlug: 'acme', jobId: 'job-1', excelBuffer: Buffer.alloc(0) }))
+      await expect(client.uploadExcelToDrs('site-1', 'job-1', Buffer.alloc(0)))
         .to.be.rejectedWith('excelBuffer is required and must be non-empty');
     });
 
@@ -840,12 +835,8 @@ describe('DrsClient', () => {
         s3Client,
       }, log);
 
-      await expect(client.uploadExcelToDrs({
-        siteId: 'site-1',
-        brandSlug: 'acme',
-        jobId: 'job-1',
-        excelBuffer: Buffer.from('x'),
-      })).to.be.rejectedWith('S3 access denied');
+      await expect(client.uploadExcelToDrs('site-1', 'job-1', Buffer.from('x')))
+        .to.be.rejectedWith('S3 access denied');
     });
   });
 
@@ -860,7 +851,7 @@ describe('DrsClient', () => {
       snsClient = { send: snsClientStub };
     });
 
-    it('publishes JOB_COMPLETED SNS event with all fields', async () => {
+    it('publishes JOB_COMPLETED SNS event with all fields and returns jobId', async () => {
       snsClientStub.resolves({});
 
       const client = new DrsClient({
@@ -871,75 +862,74 @@ describe('DrsClient', () => {
         snsClient,
       }, log);
 
-      await client.publishBrandPresenceAnalyze({
-        jobId: 'job-abc',
-        siteId: 'site-1',
-        brandName: 'Acme',
-        imsOrgId: 'org-123',
-        resultLocation: 's3://drs-bucket/external/spacecat/site-1/acme/job-abc/source.xlsx',
-        platform: 'chatgpt_free',
+      const jobId = await client.publishBrandPresenceAnalyze('site-1', {
+        resultLocation: 's3://drs-bucket/external/spacecat/site-1/job-abc/source.xlsx',
+        webSearchProvider: 'chatgpt',
+        configVersion: 'v1',
         week: 12,
         year: 2026,
+        runFrequency: 'weekly',
+        brand: 'Acme',
+        imsOrgId: 'org-123',
       });
 
+      expect(jobId).to.be.a('string').and.match(/^spacecat-/);
       expect(snsClientStub).to.have.been.calledOnce;
       const [cmd] = snsClientStub.args[0];
       expect(cmd.input.TopicArn).to.equal(SNS_TOPIC_ARN);
       const message = JSON.parse(cmd.input.Message);
       expect(message.event_type).to.equal('JOB_COMPLETED');
-      expect(message.job_id).to.equal('job-abc');
+      expect(message.job_id).to.equal(jobId);
       expect(message.provider_id).to.equal('external_spacecat');
-      expect(message.result_location).to.equal('s3://drs-bucket/external/spacecat/site-1/acme/job-abc/source.xlsx');
+      expect(message.result_location).to.equal('s3://drs-bucket/external/spacecat/site-1/job-abc/source.xlsx');
       expect(message.reanalysis).to.be.true;
-      expect(message.metadata).to.deep.equal({ site: 'site-1', brand: 'Acme', imsOrgId: 'org-123' });
-      expect(message.platform).to.equal('chatgpt_free');
+      expect(message.metadata).to.deep.equal({
+        site_id: 'site-1',
+        brand: 'Acme',
+        imsOrgId: 'org-123',
+        web_search_provider: 'chatgpt',
+        config_version: 'v1',
+        run_frequency: 'weekly',
+      });
       expect(message.week).to.equal(12);
       expect(message.year).to.equal(2026);
       expect(cmd.input.MessageAttributes.event_type.StringValue).to.equal('JOB_COMPLETED');
       expect(cmd.input.MessageAttributes.provider_id.StringValue).to.equal('external_spacecat');
     });
 
-    it('omits optional fields when not provided', async () => {
+    it('omits optional metadata fields when not provided', async () => {
       snsClientStub.resolves({});
 
       const client = new DrsClient({
         s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, snsClient,
       }, log);
 
-      await client.publishBrandPresenceAnalyze({
-        jobId: 'job-1',
-        siteId: 'site-1',
-        resultLocation: 's3://drs-bucket/external/spacecat/site-1/acme/job-1/source.xlsx',
+      await client.publishBrandPresenceAnalyze('site-1', {
+        resultLocation: 's3://drs-bucket/external/spacecat/site-1/job-1/source.xlsx',
       });
 
       const [cmd] = snsClientStub.args[0];
       const message = JSON.parse(cmd.input.Message);
-      expect(message).to.not.have.property('platform');
       expect(message).to.not.have.property('week');
       expect(message).to.not.have.property('year');
+      expect(message.metadata).to.not.have.property('run_frequency');
     });
 
     it('throws when not S3 configured', async () => {
       const client = new DrsClient({ apiBaseUrl: DRS_API_URL, apiKey: DRS_API_KEY }, log);
-      await expect(client.publishBrandPresenceAnalyze({ jobId: 'j', siteId: 's', resultLocation: 's3://x' }))
+      await expect(client.publishBrandPresenceAnalyze('s', { resultLocation: 's3://x' }))
         .to.be.rejectedWith('DRS S3 is not configured');
-    });
-
-    it('throws when jobId is missing', async () => {
-      const client = new DrsClient({ s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, snsClient }, log);
-      await expect(client.publishBrandPresenceAnalyze({ siteId: 'site-1', resultLocation: 's3://x' }))
-        .to.be.rejectedWith('jobId is required');
     });
 
     it('throws when siteId is missing', async () => {
       const client = new DrsClient({ s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, snsClient }, log);
-      await expect(client.publishBrandPresenceAnalyze({ jobId: 'job-1', resultLocation: 's3://x' }))
+      await expect(client.publishBrandPresenceAnalyze(undefined, { resultLocation: 's3://x' }))
         .to.be.rejectedWith('siteId is required');
     });
 
     it('throws when resultLocation is missing', async () => {
       const client = new DrsClient({ s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, snsClient }, log);
-      await expect(client.publishBrandPresenceAnalyze({ jobId: 'job-1', siteId: 'site-1' }))
+      await expect(client.publishBrandPresenceAnalyze('site-1', {}))
         .to.be.rejectedWith('resultLocation is required');
     });
 
@@ -950,10 +940,8 @@ describe('DrsClient', () => {
         s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, snsClient,
       }, log);
 
-      await expect(client.publishBrandPresenceAnalyze({
-        jobId: 'job-1',
-        siteId: 'site-1',
-        resultLocation: 's3://drs-bucket/external/spacecat/site-1/acme/job-1/source.xlsx',
+      await expect(client.publishBrandPresenceAnalyze('site-1', {
+        resultLocation: 's3://drs-bucket/external/spacecat/site-1/job-1/source.xlsx',
       })).to.be.rejectedWith('SNS publish failed');
     });
   });

--- a/packages/spacecat-shared-drs-client/test/index.test.js
+++ b/packages/spacecat-shared-drs-client/test/index.test.js
@@ -726,6 +726,264 @@ describe('DrsClient', () => {
     });
   });
 
+  describe('isS3Configured', () => {
+    it('returns false when s3Bucket is missing', () => {
+      const client = new DrsClient({
+        apiBaseUrl: DRS_API_URL, apiKey: DRS_API_KEY, snsTopicArn: 'arn:aws:sns:us-east-1:123:topic',
+      }, log);
+      expect(client.isS3Configured()).to.be.false;
+    });
+
+    it('returns false when snsTopicArn is missing', () => {
+      const client = new DrsClient({
+        apiBaseUrl: DRS_API_URL, apiKey: DRS_API_KEY, s3Bucket: 'drs-bucket',
+      }, log);
+      expect(client.isS3Configured()).to.be.false;
+    });
+
+    it('returns true when both s3Bucket and snsTopicArn are set', () => {
+      const client = new DrsClient({
+        apiBaseUrl: DRS_API_URL, apiKey: DRS_API_KEY, s3Bucket: 'drs-bucket', snsTopicArn: 'arn:aws:sns:us-east-1:123:topic',
+      }, log);
+      expect(client.isS3Configured()).to.be.true;
+    });
+  });
+
+  describe('uploadExcelToDrs', () => {
+    const S3_BUCKET = 'drs-bucket';
+    const SNS_TOPIC_ARN = 'arn:aws:sns:us-east-1:123456789:drs-topic';
+    let s3ClientStub;
+    let s3Client;
+
+    beforeEach(() => {
+      s3ClientStub = sinon.stub();
+      s3Client = { send: s3ClientStub };
+    });
+
+    it('uploads Excel and returns the S3 URI', async () => {
+      s3ClientStub.resolves({});
+
+      const client = new DrsClient({
+        apiBaseUrl: DRS_API_URL,
+        apiKey: DRS_API_KEY,
+        s3Bucket: S3_BUCKET,
+        snsTopicArn: SNS_TOPIC_ARN,
+        s3Client,
+      }, log);
+
+      const excelBuffer = Buffer.from('fake-excel-bytes');
+      const result = await client.uploadExcelToDrs({
+        siteId: 'site-1',
+        brandSlug: 'acme',
+        jobId: 'job-abc',
+        excelBuffer,
+      });
+
+      expect(result).to.equal('s3://drs-bucket/external/spacecat/site-1/acme/job-abc/source.xlsx');
+      expect(s3ClientStub).to.have.been.calledOnce;
+      const [cmd] = s3ClientStub.args[0];
+      expect(cmd.input.Bucket).to.equal(S3_BUCKET);
+      expect(cmd.input.Key).to.equal('external/spacecat/site-1/acme/job-abc/source.xlsx');
+      expect(cmd.input.ContentType).to.equal('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+      expect(cmd.input.ServerSideEncryption).to.equal('AES256');
+      expect(cmd.input.Body).to.equal(excelBuffer);
+      expect(log.info).to.have.been.calledWith('Uploading Excel to DRS S3', { siteId: 'site-1', jobId: 'job-abc', key: 'external/spacecat/site-1/acme/job-abc/source.xlsx' });
+      expect(log.info).to.have.been.calledWith('Excel uploaded to DRS S3', { uri: result });
+    });
+
+    it('throws when not S3 configured', async () => {
+      const client = new DrsClient({ apiBaseUrl: DRS_API_URL, apiKey: DRS_API_KEY }, log);
+      await expect(client.uploadExcelToDrs({ siteId: 'site-1', brandSlug: 'acme', jobId: 'job-1', excelBuffer: Buffer.from('x') }))
+        .to.be.rejectedWith('DRS S3 is not configured');
+    });
+
+    it('throws when siteId is missing', async () => {
+      const client = new DrsClient({
+        s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, s3Client,
+      }, log);
+      await expect(client.uploadExcelToDrs({ brandSlug: 'acme', jobId: 'job-1', excelBuffer: Buffer.from('x') }))
+        .to.be.rejectedWith('siteId is required');
+    });
+
+    it('throws when jobId is missing', async () => {
+      const client = new DrsClient({
+        s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, s3Client,
+      }, log);
+      await expect(client.uploadExcelToDrs({ siteId: 'site-1', brandSlug: 'acme', excelBuffer: Buffer.from('x') }))
+        .to.be.rejectedWith('jobId is required');
+    });
+
+    it('throws when excelBuffer is missing', async () => {
+      const client = new DrsClient({
+        s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, s3Client,
+      }, log);
+      await expect(client.uploadExcelToDrs({ siteId: 'site-1', brandSlug: 'acme', jobId: 'job-1' }))
+        .to.be.rejectedWith('excelBuffer is required and must be non-empty');
+    });
+
+    it('throws when excelBuffer is empty', async () => {
+      const client = new DrsClient({
+        s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, s3Client,
+      }, log);
+      await expect(client.uploadExcelToDrs({ siteId: 'site-1', brandSlug: 'acme', jobId: 'job-1', excelBuffer: Buffer.alloc(0) }))
+        .to.be.rejectedWith('excelBuffer is required and must be non-empty');
+    });
+
+    it('propagates S3 send errors', async () => {
+      s3ClientStub.rejects(new Error('S3 access denied'));
+
+      const client = new DrsClient({
+        apiBaseUrl: DRS_API_URL,
+        apiKey: DRS_API_KEY,
+        s3Bucket: S3_BUCKET,
+        snsTopicArn: SNS_TOPIC_ARN,
+        s3Client,
+      }, log);
+
+      await expect(client.uploadExcelToDrs({
+        siteId: 'site-1',
+        brandSlug: 'acme',
+        jobId: 'job-1',
+        excelBuffer: Buffer.from('x'),
+      })).to.be.rejectedWith('S3 access denied');
+    });
+  });
+
+  describe('publishBrandPresenceAnalyze', () => {
+    const S3_BUCKET = 'drs-bucket';
+    const SNS_TOPIC_ARN = 'arn:aws:sns:us-east-1:123456789:drs-topic';
+    let snsClientStub;
+    let snsClient;
+
+    beforeEach(() => {
+      snsClientStub = sinon.stub();
+      snsClient = { send: snsClientStub };
+    });
+
+    it('publishes JOB_COMPLETED SNS event with all fields', async () => {
+      snsClientStub.resolves({});
+
+      const client = new DrsClient({
+        apiBaseUrl: DRS_API_URL,
+        apiKey: DRS_API_KEY,
+        s3Bucket: S3_BUCKET,
+        snsTopicArn: SNS_TOPIC_ARN,
+        snsClient,
+      }, log);
+
+      await client.publishBrandPresenceAnalyze({
+        jobId: 'job-abc',
+        siteId: 'site-1',
+        brandName: 'Acme',
+        imsOrgId: 'org-123',
+        resultLocation: 's3://drs-bucket/external/spacecat/site-1/acme/job-abc/source.xlsx',
+        platform: 'chatgpt_free',
+        week: 12,
+        year: 2026,
+      });
+
+      expect(snsClientStub).to.have.been.calledOnce;
+      const [cmd] = snsClientStub.args[0];
+      expect(cmd.input.TopicArn).to.equal(SNS_TOPIC_ARN);
+      const message = JSON.parse(cmd.input.Message);
+      expect(message.event_type).to.equal('JOB_COMPLETED');
+      expect(message.job_id).to.equal('job-abc');
+      expect(message.provider_id).to.equal('external_spacecat');
+      expect(message.result_location).to.equal('s3://drs-bucket/external/spacecat/site-1/acme/job-abc/source.xlsx');
+      expect(message.reanalysis).to.be.true;
+      expect(message.metadata).to.deep.equal({ site: 'site-1', brand: 'Acme', imsOrgId: 'org-123' });
+      expect(message.platform).to.equal('chatgpt_free');
+      expect(message.week).to.equal(12);
+      expect(message.year).to.equal(2026);
+      expect(cmd.input.MessageAttributes.event_type.StringValue).to.equal('JOB_COMPLETED');
+      expect(cmd.input.MessageAttributes.provider_id.StringValue).to.equal('external_spacecat');
+    });
+
+    it('omits optional fields when not provided', async () => {
+      snsClientStub.resolves({});
+
+      const client = new DrsClient({
+        s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, snsClient,
+      }, log);
+
+      await client.publishBrandPresenceAnalyze({
+        jobId: 'job-1',
+        siteId: 'site-1',
+        resultLocation: 's3://drs-bucket/external/spacecat/site-1/acme/job-1/source.xlsx',
+      });
+
+      const [cmd] = snsClientStub.args[0];
+      const message = JSON.parse(cmd.input.Message);
+      expect(message).to.not.have.property('platform');
+      expect(message).to.not.have.property('week');
+      expect(message).to.not.have.property('year');
+    });
+
+    it('throws when not S3 configured', async () => {
+      const client = new DrsClient({ apiBaseUrl: DRS_API_URL, apiKey: DRS_API_KEY }, log);
+      await expect(client.publishBrandPresenceAnalyze({ jobId: 'j', siteId: 's', resultLocation: 's3://x' }))
+        .to.be.rejectedWith('DRS S3 is not configured');
+    });
+
+    it('throws when jobId is missing', async () => {
+      const client = new DrsClient({ s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, snsClient }, log);
+      await expect(client.publishBrandPresenceAnalyze({ siteId: 'site-1', resultLocation: 's3://x' }))
+        .to.be.rejectedWith('jobId is required');
+    });
+
+    it('throws when siteId is missing', async () => {
+      const client = new DrsClient({ s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, snsClient }, log);
+      await expect(client.publishBrandPresenceAnalyze({ jobId: 'job-1', resultLocation: 's3://x' }))
+        .to.be.rejectedWith('siteId is required');
+    });
+
+    it('throws when resultLocation is missing', async () => {
+      const client = new DrsClient({ s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, snsClient }, log);
+      await expect(client.publishBrandPresenceAnalyze({ jobId: 'job-1', siteId: 'site-1' }))
+        .to.be.rejectedWith('resultLocation is required');
+    });
+
+    it('propagates SNS send errors', async () => {
+      snsClientStub.rejects(new Error('SNS publish failed'));
+
+      const client = new DrsClient({
+        s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, snsClient,
+      }, log);
+
+      await expect(client.publishBrandPresenceAnalyze({
+        jobId: 'job-1',
+        siteId: 'site-1',
+        resultLocation: 's3://drs-bucket/external/spacecat/site-1/acme/job-1/source.xlsx',
+      })).to.be.rejectedWith('SNS publish failed');
+    });
+  });
+
+  describe('createFrom with S3/SNS config', () => {
+    it('reads DRS_S3_BUCKET and DRS_SNS_TOPIC_ARN from env', () => {
+      const context = {
+        env: {
+          DRS_API_URL,
+          DRS_API_KEY,
+          DRS_S3_BUCKET: 'drs-bucket',
+          DRS_SNS_TOPIC_ARN: 'arn:aws:sns:us-east-1:123:topic',
+          AWS_REGION: 'us-east-1',
+        },
+        log,
+      };
+      const client = DrsClient.createFrom(context);
+      expect(client.isS3Configured()).to.be.true;
+    });
+
+    it('isS3Configured returns false when S3 env vars are absent', () => {
+      const context = {
+        env: { DRS_API_URL, DRS_API_KEY },
+        log,
+      };
+      const client = DrsClient.createFrom(context);
+      expect(client.isS3Configured()).to.be.false;
+    });
+  });
+
   describe('trailing slash handling', () => {
     it('strips trailing slash from apiBaseUrl', async () => {
       const scope = nock(DRS_API_URL)

--- a/packages/spacecat-shared-drs-client/test/index.test.js
+++ b/packages/spacecat-shared-drs-client/test/index.test.js
@@ -922,13 +922,17 @@ describe('DrsClient', () => {
     });
 
     it('throws when siteId is missing', async () => {
-      const client = new DrsClient({ s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, snsClient }, log);
+      const client = new DrsClient({
+        s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, snsClient,
+      }, log);
       await expect(client.publishBrandPresenceAnalyze(undefined, { resultLocation: 's3://x' }))
         .to.be.rejectedWith('siteId is required');
     });
 
     it('throws when resultLocation is missing', async () => {
-      const client = new DrsClient({ s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, snsClient }, log);
+      const client = new DrsClient({
+        s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, snsClient,
+      }, log);
       await expect(client.publishBrandPresenceAnalyze('site-1', {}))
         .to.be.rejectedWith('resultLocation is required');
     });

--- a/packages/spacecat-shared-drs-client/test/index.test.js
+++ b/packages/spacecat-shared-drs-client/test/index.test.js
@@ -988,6 +988,24 @@ describe('DrsClient', () => {
       expect(cmd.input.MessageAttributes.provider_id.StringValue).to.equal('external_spacecat');
     });
 
+    it('uses caller-supplied jobId so SNS job_id matches the S3 key', async () => {
+      snsClientStub.resolves({});
+
+      const client = new DrsClient({
+        s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, snsClient,
+      }, log);
+
+      const returnedId = await client.publishBrandPresenceAnalyze('site-1', {
+        jobId: 'job-abc',
+        resultLocation: 's3://drs-bucket/external/spacecat/site-1/job-abc/source.xlsx',
+      });
+
+      expect(returnedId).to.equal('job-abc');
+      const [cmd] = snsClientStub.args[0];
+      const message = JSON.parse(cmd.input.Message);
+      expect(message.job_id).to.equal('job-abc');
+    });
+
     it('omits optional metadata fields when not provided', async () => {
       snsClientStub.resolves({});
 


### PR DESCRIPTION
## Summary

- Adds `uploadExcelToDrs()` to `DrsClient` — uploads a brand presence Excel file directly to the DRS S3 bucket at `external/spacecat/{siteId}/{brandSlug}/{jobId}/source.xlsx`
- Adds `publishBrandPresenceAnalyze()` to `DrsClient` — publishes a `JOB_COMPLETED` SNS event to `DRS_SNS_TOPIC_ARN` to trigger DRS Fargate analysis
- Adds `isS3Configured()` guard method (checks `DRS_S3_BUCKET` + `DRS_SNS_TOPIC_ARN`)
- Updates TypeScript declarations and adds `@aws-sdk/client-s3` + `@aws-sdk/client-sns` dependencies
- Adds implementation plan doc at `docs/plans/2026-04-22-geo-brand-presence-drs-sns-migration.md`

This is **PR B** of the geo-brand-presence DRS SNS migration. It unblocks the `spacecat-audit-worker` (PR D) to replace the existing HTTP call to `POST /sites/{siteId}/brand-presence/analyze` with a direct S3 + SNS pattern.

## Cross-repo dependencies

| PR | Repo | Description |
|---|---|---|
| PR A | `llmo-data-retrieval-service` | Extends `fargate_trigger.py`; deletes HTTP endpoint |
| **PR B (this)** | `spacecat-shared` | Adds `uploadExcelToDrs()` and `publishBrandPresenceAnalyze()` to `DrsClient` |
| PR C | `spacecat-infrastructure` | Provisions `DRS_S3_BUCKET`, `DRS_SNS_TOPIC_ARN` env vars and IAM grants |
| [PR D #2410](https://github.com/adobe/spacecat-audit-worker/pull/2410) | `spacecat-audit-worker` | Replaces Mystique callback with direct DRS integration — depends on this PR and PR C |

## Test plan

- [x] 71 tests passing, 100% line/statement/branch/function coverage
- [x] `isS3Configured()` — missing bucket, missing topicArn, both set
- [x] `uploadExcelToDrs()` — success (verifies bucket, key, ContentType, SSE), not configured, missing required fields, empty buffer, S3 error propagation
- [x] `publishBrandPresenceAnalyze()` — success (verifies TopicArn, full message shape, MessageAttributes), optional fields absent when not passed, not configured, missing required fields, SNS error propagation
- [x] `createFrom()` — reads `DRS_S3_BUCKET` and `DRS_SNS_TOPIC_ARN` from env

🤖 Generated with [Claude Code](https://claude.com/claude-code)