### PR TITLE
feat: use @adobe/fetch Response to prevent helix-universal crash on Vault failure

### DIFF
--- a/packages/spacecat-shared-vault-secrets/src/vault-secrets-wrapper.js
+++ b/packages/spacecat-shared-vault-secrets/src/vault-secrets-wrapper.js
@@ -10,6 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
+import { Response } from '@adobe/fetch';
+
 import VaultClient from './vault-client.js';
 import { loadBootstrapConfig } from './bootstrap.js';
 

--- a/packages/spacecat-shared-vault-secrets/test/vault-secrets-wrapper.test.js
+++ b/packages/spacecat-shared-vault-secrets/test/vault-secrets-wrapper.test.js
@@ -180,6 +180,97 @@ describe('vaultSecrets wrapper', () => {
       expect(innerFn.called).to.equal(false);
     });
 
+    it('502 response uses @adobe/fetch Headers — .raw() is available for helix-universal adapter', async () => {
+      // Regression test for: response.headers.raw is not a function
+      // helix-universal aws-adapter.js calls response.headers.raw() on every response.
+      // When vault fails, the wrapper must return a Response with @adobe/fetch Headers
+      // (which have .raw()), not native Node.js Headers (which do not).
+      nock(AWS_ENDPOINT)
+        .post('/')
+        .replyWithError('connection refused');
+
+      const ctx = makeContext();
+      const wrapped = vaultSecrets(sinon.stub(), { bootstrapPath: BOOTSTRAP_PATH });
+
+      const response = await wrapped(new Request('https://example.com'), ctx);
+
+      expect(response.status).to.equal(502);
+      // response.headers.raw must exist — native Node.js Headers lack it and break helix-universal
+      expect(typeof response.headers.raw).to.equal('function');
+      const raw = response.headers.raw();
+      expect(raw).to.be.an('object');
+      expect(raw['x-error']).to.equal('error fetching secrets.');
+    });
+
+    it('returns 502 when Vault AppRole login returns 403', async () => {
+      mockBootstrap();
+      nock(VAULT_ADDR)
+        .post('/v1/auth/approle/login')
+        .reply(403, { errors: ['permission denied'] });
+
+      const ctx = makeContext();
+      const innerFn = sinon.stub();
+      const wrapped = vaultSecrets(innerFn, { bootstrapPath: BOOTSTRAP_PATH });
+
+      const response = await wrapped(new Request('https://example.com'), ctx);
+
+      expect(response.status).to.equal(502);
+      expect(response.headers.get('x-error')).to.equal('error fetching secrets.');
+      expect(innerFn.called).to.equal(false);
+      expect(ctx.log.error.calledOnce).to.equal(true);
+    });
+
+    it('502 from Vault 403 also has @adobe/fetch Headers with .raw()', async () => {
+      // This is the exact production failure path:
+      // Vault NAT/WAF blocks egress → 403 → native Response → helix-universal crashes
+      mockBootstrap();
+      nock(VAULT_ADDR)
+        .post('/v1/auth/approle/login')
+        .reply(403, { errors: ['permission denied'] });
+
+      const ctx = makeContext();
+      const wrapped = vaultSecrets(sinon.stub(), { bootstrapPath: BOOTSTRAP_PATH });
+
+      const response = await wrapped(new Request('https://example.com'), ctx);
+
+      expect(response.status).to.equal(502);
+      expect(typeof response.headers.raw).to.equal('function');
+      const raw = response.headers.raw();
+      expect(raw['x-error']).to.equal('error fetching secrets.');
+    });
+
+    it('returns 502 when Vault secret read fails', async () => {
+      mockBootstrap();
+      mockAppRoleLogin();
+      nock(VAULT_ADDR)
+        .get(`/v1/${MOUNT_POINT}/data/prod/api-service`)
+        .reply(500, { errors: ['internal server error'] });
+
+      const ctx = makeContext();
+      const innerFn = sinon.stub();
+      const wrapped = vaultSecrets(innerFn, { bootstrapPath: BOOTSTRAP_PATH });
+
+      const response = await wrapped(new Request('https://example.com'), ctx);
+
+      expect(response.status).to.equal(502);
+      expect(response.headers.get('x-error')).to.equal('error fetching secrets.');
+      expect(innerFn.called).to.equal(false);
+    });
+
+    it('logs the error message when vault fails', async () => {
+      nock(AWS_ENDPOINT)
+        .post('/')
+        .replyWithError('ECONNREFUSED vault unreachable');
+
+      const ctx = makeContext();
+      const wrapped = vaultSecrets(sinon.stub(), { bootstrapPath: BOOTSTRAP_PATH });
+
+      await wrapped(new Request('https://example.com'), ctx);
+
+      expect(ctx.log.error.calledOnce).to.equal(true);
+      expect(ctx.log.error.firstCall.args[0]).to.include('Failed to load secrets:');
+    });
+
     it('returns empty object when VAULT_SECRETS_DISABLED is true', async () => {
       process.env.VAULT_SECRETS_DISABLED = 'true';
       const ctx = makeContext();


### PR DESCRIPTION
## Problem

When Vault egress is blocked (e.g. NAT/WAF returning 403) — as happened on dev **2026-04-22 ~22:10 UTC** — **every API endpoint returns HTTP 500** with:

```
x-error: response.headers.raw is not a function
```

Reported in Slack \`#spacecat-ops\` across \`spacecat-api-service\`, \`spacecat-audit-worker\`, and all other services using this package.

---

## Root Cause Chain

```
Vault 403
  └─ vaultSecrets catch block
       └─ returns new Response('', { status: 502 })   ← native Node.js Response
            └─ native Headers has NO .raw() method
                 └─ compressResponse returns it unchanged (empty body, not compressible)
                      └─ helix-universal aws-adapter.js calls response.headers.raw()
                           └─ 💥 TypeError: response.headers.raw is not a function
                                └─ HTTP 500 on ALL endpoints
```

The \`vault-secrets-wrapper.js\` error handler was using the **native Node.js \`new Response()\`** instead of the \`@adobe/fetch\` version. Native Web API \`Headers\` lack the \`.raw()\` method that \`helix-universal\`'s \`aws-adapter.js\` calls unconditionally on every response before sending it back through API Gateway.

Every other middleware in this repo already does this correctly:

| File | Imports Response from |
|---|---|
| \`auth-wrapper.js\` | ✅ \`@adobe/fetch\` |
| \`s2s-wrapper.js\` | ✅ \`@adobe/fetch\` |
| \`sqs.js\` | ✅ \`@adobe/fetch\` |
| \`vault-secrets-wrapper.js\` | ❌ native ← **this PR** |

---

## Fix

One-line import addition — \`@adobe/fetch\` is already a declared dependency of this package:

```diff
+import { Response } from '@adobe/fetch';
+
 import VaultClient from './vault-client.js';
 import { loadBootstrapConfig } from './bootstrap.js';
```

\`@adobe/fetch\`'s \`Headers\` class implements \`.raw()\`, restoring full compatibility with \`helix-universal\`'s \`aws-adapter.js\`.

---

## Tests Added

5 new regression tests in \`vault-secrets-wrapper.test.js\`:

| Test | What it verifies |
|---|---|
| \`502 response uses @adobe/fetch Headers — .raw() is available\` | **Regression guard** — asserts \`.raw()\` is callable and returns the correct header map |
| \`502 from Vault 403 also has @adobe/fetch Headers with .raw()\` | Exact production failure path: Vault NAT/WAF block → AppRole login 403 |
| \`returns 502 when Vault AppRole login returns 403\` | Auth failure scenario coverage |
| \`returns 502 when Vault secret read fails\` | Secret read failure coverage |
| \`logs the error message when vault fails\` | Confirms error is logged with correct message |

---

## Impact After Release

Once a new patch version of \`@adobe/spacecat-shared-vault-secrets\` is published, version bumps are needed in **13 services** — Renovate will auto-raise those PRs:

| Priority | Service |
|---|---|
| 🔴 High | \`spacecat-api-service\`, \`spacecat-audit-worker\` |
| 🟡 Others | \`spacecat-auth-service\`, \`mysticat-projector-service\`, \`spacecat-content-processor\`, \`spacecat-content-scraper\`, \`spacecat-fulfillment-worker\`, \`spacecat-import-job-manager\`, \`spacecat-import-worker\`, \`spacecat-jobs-dispatcher\`, \`spacecat-reporting-worker\`, \`spacecat-scrape-job-manager\` |

---

## Related

- Slack \`#spacecat-ops\` — "Vault authentication failed: 403" + \`response.headers.raw is not a function\` (2026-04-22)