### PR TITLE
fix: allow cdnLogSource in edgeOptimizeConfig schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21579,7 +21579,7 @@
     },
     "packages/mysticat-shared-seo-client": {
       "name": "@adobe/mysticat-shared-seo-client",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -22318,7 +22318,7 @@
     },
     "packages/spacecat-shared-ahrefs-client": {
       "name": "@adobe/spacecat-shared-ahrefs-client",
-      "version": "1.10.9",
+      "version": "1.10.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -23793,7 +23793,7 @@
     },
     "packages/spacecat-shared-brand-client": {
       "name": "@adobe/spacecat-shared-brand-client",
-      "version": "1.1.40",
+      "version": "1.1.41",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
@@ -25497,7 +25497,7 @@
     },
     "packages/spacecat-shared-content-client": {
       "name": "@adobe/spacecat-shared-content-client",
-      "version": "1.8.22",
+      "version": "1.8.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
@@ -26649,7 +26649,7 @@
     },
     "packages/spacecat-shared-example": {
       "name": "@adobe/spacecat-shared-example",
-      "version": "1.2.33",
+      "version": "1.2.34",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -26665,7 +26665,7 @@
     },
     "packages/spacecat-shared-google-client": {
       "name": "@adobe/spacecat-shared-google-client",
-      "version": "1.5.10",
+      "version": "1.5.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -27447,7 +27447,7 @@
     },
     "packages/spacecat-shared-gpt-client": {
       "name": "@adobe/spacecat-shared-gpt-client",
-      "version": "1.6.21",
+      "version": "1.6.22",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -29034,7 +29034,7 @@
     },
     "packages/spacecat-shared-ims-client": {
       "name": "@adobe/spacecat-shared-ims-client",
-      "version": "1.12.4",
+      "version": "1.12.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -29774,7 +29774,7 @@
     },
     "packages/spacecat-shared-launchdarkly-client": {
       "name": "@adobe/spacecat-shared-launchdarkly-client",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
@@ -30513,7 +30513,7 @@
     },
     "packages/spacecat-shared-rum-api-client": {
       "name": "@adobe/spacecat-shared-rum-api-client",
-      "version": "2.40.11",
+      "version": "2.40.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -31255,7 +31255,7 @@
     },
     "packages/spacecat-shared-scrape-client": {
       "name": "@adobe/spacecat-shared-scrape-client",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
@@ -31993,7 +31993,7 @@
     },
     "packages/spacecat-shared-slack-client": {
       "name": "@adobe/spacecat-shared-slack-client",
-      "version": "1.6.5",
+      "version": "1.6.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.1",
@@ -32732,7 +32732,7 @@
     },
     "packages/spacecat-shared-splunk-client": {
       "name": "@adobe/spacecat-shared-splunk-client",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",

--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -369,6 +369,7 @@ export const configSchema = Joi.object({
       )
       .optional(),
     opted: Joi.number().optional(),
+    cdnLogSource: Joi.string().optional(),
     stagingDomains: Joi.array().items(
       Joi.object({
         domain: Joi.string().required(),

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -2715,6 +2715,31 @@ describe('Config Tests', () => {
       expect(config.getEdgeOptimizeConfig().opted).to.equal(optedTimestamp);
     });
 
+    it('should be able to create edgeOptimizeConfig with cdnLogSource field', () => {
+      const data = {
+        edgeOptimizeConfig: {
+          opted: Date.now(),
+          cdnLogSource: 'byocdn-imperva',
+        },
+      };
+      const config = Config(data);
+      expect(config.getEdgeOptimizeConfig()).to.deep.equal(data.edgeOptimizeConfig);
+      expect(config.getEdgeOptimizeConfig().cdnLogSource).to.equal('byocdn-imperva');
+    });
+
+    it('should be able to update edgeOptimizeConfig with cdnLogSource field', () => {
+      const config = Config({
+        edgeOptimizeConfig: {
+          opted: Date.now(),
+        },
+      });
+      config.updateEdgeOptimizeConfig({
+        ...config.getEdgeOptimizeConfig(),
+        cdnLogSource: 'byocdn-akamai',
+      });
+      expect(config.getEdgeOptimizeConfig().cdnLogSource).to.equal('byocdn-akamai');
+    });
+
     it('should be able to create and update edgeOptimizeConfig with stagingDomains', () => {
       const stagingDomains = [
         { domain: 'staging.lovesac.com', id: 'site-uuid-1' },


### PR DESCRIPTION
## Summary

- Adds `cdnLogSource` as an optional string field to the `edgeOptimizeConfig` 
  Joi schema in `config.js`.
- Without this, the field stored by `spacecat-auth-service` during CDN 
  provisioning was rejected with:
  `Configuration validation error: "edgeOptimizeConfig.cdnLogSource" is not allowed`
  — causing the field to be silently dropped from the site config.
- `spacecat-api-service` reads `cdnLogSource` when sending the opt-in 
  notification email (CDN name, doc link, guidance note). Without this fix, 
  the email would always show "Unknown CDN".

## Changes

- `src/models/site/config.js` — added `cdnLogSource: Joi.string().optional()` 
  to `edgeOptimizeConfig` schema
- `test/unit/models/site/config.test.js` — added 2 tests for `cdnLogSource` 
  create and update

## Related PRs

- `spacecat-auth-service` #555 — stores `cdnLogSource` during provisioning
- `spacecat-api-service` #2256 — reads `cdnLogSource` for opt-in email