### PR TITLE
fix(html-analyzer): sort JSON-LD keys to suppress false prerender diffs (LLMO-4462)

### DIFF
--- a/packages/spacecat-shared-html-analyzer/src/html-filter.js
+++ b/packages/spacecat-shared-html-analyzer/src/html-filter.js
@@ -18,6 +18,27 @@
 import { isBrowser } from './utils.js';
 import { tokenize } from './tokenizer.js';
 
+/**
+ * Recursively sort all object keys alphabetically so that semantically
+ * equivalent JSON-LD blocks with different server-side key orderings
+ * produce identical strings after serialization (no false diff noise).
+ * Arrays are traversed but their element order is preserved, because
+ * JSON-LD @graph / @set ordering can be meaningful.
+ * @param {*} value - Value to sort
+ * @returns {*} Value with all object keys recursively sorted
+ */
+function deepSortKeys(value) {
+  if (Array.isArray(value)) {
+    return value.map(deepSortKeys);
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.keys(value).sort().map((k) => [k, deepSortKeys(value[k])]),
+    );
+  }
+  return value;
+}
+
 // Optimized navigation and footer selectors - combined for single DOM query performance
 // Ordered by frequency: semantic elements (most common) → classes → IDs → ARIA (least common)
 const NAVIGATION_FOOTER_SELECTOR = [
@@ -230,7 +251,7 @@ function filterHtmlBrowser(htmlContent, ignoreNavFooter, returnText, includeNosc
           }
 
           const parsedJson = JSON.parse(cleanJsonContent);
-          const formattedJson = JSON.stringify(parsedJson, null, 2);
+          const formattedJson = JSON.stringify(deepSortKeys(parsedJson), null, 2);
 
           // Create a pre/code block to preserve JSON-LD for markdown conversion
           const codeBlock = document.createElement('pre'); // eslint-disable-line no-undef
@@ -318,7 +339,7 @@ async function filterHtmlNode(htmlContent, ignoreNavFooter, returnText, includeN
           }
 
           const parsedJson = JSON.parse(cleanJsonContent);
-          const formattedJson = JSON.stringify(parsedJson, null, 2);
+          const formattedJson = JSON.stringify(deepSortKeys(parsedJson), null, 2);
           const codeBlock = `<pre><code class="ld-json">${formattedJson}</code></pre>`;
           $(this).before(codeBlock);
         } catch (e) {

--- a/packages/spacecat-shared-html-analyzer/test/index.test.js
+++ b/packages/spacecat-shared-html-analyzer/test/index.test.js
@@ -16,6 +16,7 @@ import {
   calculateStats,
   calculateBothScenarioStats,
   stripTagsToText,
+  filterHtmlContent,
 } from '../src/index.js';
 
 describe('HTML Visibility Analyzer', () => {
@@ -276,6 +277,59 @@ describe('HTML Visibility Analyzer', () => {
       expect(textWith).to.include('Content');
       expect(textWith).to.include('First noscript');
       expect(textWith).to.include('Second noscript');
+    });
+  });
+
+  describe('JSON-LD key-order normalization (filterHtmlContent)', () => {
+    const makeHtml = (jsonLd) => `<html><head><script type="application/ld+json">${JSON.stringify(jsonLd)}</script></head><body><p>Content</p></body></html>`;
+
+    it('produces identical output for JSON-LD objects with different key orderings', async () => {
+      const leftJsonLd = { '@type': 'WebPage', '@context': 'https://schema.org', name: 'HDFC FD Calculator' };
+      const rightJsonLd = { '@context': 'https://schema.org', name: 'HDFC FD Calculator', '@type': 'WebPage' };
+
+      const leftHtml = await filterHtmlContent(makeHtml(leftJsonLd), true, false);
+      const rightHtml = await filterHtmlContent(makeHtml(rightJsonLd), true, false);
+
+      // Both sides must produce the same ld-json block so no false diff is generated
+      const extractLdJson = (html) => {
+        const match = html.match(/<code class="ld-json">([\s\S]*?)<\/code>/);
+        return match ? match[1] : null;
+      };
+
+      expect(extractLdJson(leftHtml)).to.equal(extractLdJson(rightHtml));
+    });
+
+    it('sorts nested object keys recursively', async () => {
+      const jsonLd = {
+        '@type': 'Product',
+        '@context': 'https://schema.org',
+        offers: { '@type': 'Offer', price: '100', currency: 'USD' },
+      };
+
+      const html = await filterHtmlContent(makeHtml(jsonLd), true, false);
+      const match = html.match(/<code class="ld-json">([\s\S]*?)<\/code>/);
+      const parsed = JSON.parse(match[1]);
+      const keys = Object.keys(parsed);
+
+      expect(keys).to.deep.equal([...keys].sort());
+      expect(Object.keys(parsed.offers)).to.deep.equal([...Object.keys(parsed.offers)].sort());
+    });
+
+    it('preserves array element order within JSON-LD', async () => {
+      const jsonLd = {
+        '@context': 'https://schema.org',
+        '@graph': [
+          { '@type': 'WebPage', name: 'Page A' },
+          { '@type': 'Organization', name: 'Org B' },
+        ],
+      };
+
+      const html = await filterHtmlContent(makeHtml(jsonLd), true, false);
+      const match = html.match(/<code class="ld-json">([\s\S]*?)<\/code>/);
+      const parsed = JSON.parse(match[1]);
+
+      expect(parsed['@graph'][0].name).to.equal('Page A');
+      expect(parsed['@graph'][1].name).to.equal('Org B');
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause:** `filterHtmlContent` normalized JSON-LD with `JSON.parse` + `JSON.stringify(obj, null, 2)`, which preserves insertion order. HDFC's server returns the same JSON-LD with different key orderings between the curl (original) and lambda (prerendered) fetches, so two semantically identical blocks produced different strings → false diff in the pre/post compare UI.
- **Fix:** Added `deepSortKeys()` helper that recursively sorts all object keys alphabetically before serialization. Applied in both the browser (`filterHtmlBrowser`) and Node.js (`filterHtmlNode`) code paths.
- **Scope:** Arrays are traversed but element order is preserved (JSON-LD `@graph` ordering can be meaningful).

Fixes LLMO-4462 — confirmed via Slack thread in `#project-tokowaka-customers` (2026-04-23) where the team manually verified pre/post JSON-LD was identical on HDFC FD Calculator and Investor Relations pages but showed as a diff.

## Test plan

- [x] New unit test: two JSON-LD objects with identical data but different key orderings produce the same serialized `ld-json` code block
- [x] New unit test: nested object keys are sorted recursively
- [x] New unit test: array element order is preserved
- [x] All 76 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)