### PR TITLE
feat(data-access): widen detectedCdn Joi schema to LLMO-supported tokens

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -345,7 +345,16 @@ export const configSchema = Joi.object({
       cdnProvider: Joi.string().optional(),
       region: Joi.string().pattern(AWS_REGION_PATTERN).optional(),
     }).optional(),
-    detectedCdn: Joi.string().valid('aem-cs-fastly', 'other').optional(),
+    detectedCdn: Joi.string().valid(
+      'aem-cs-fastly',
+      'commerce-fastly',
+      'byocdn-fastly',
+      'byocdn-akamai',
+      'byocdn-cloudflare',
+      'byocdn-imperva',
+      'byocdn-other',
+      'other',
+    ).optional(),
   }).optional(),
   cdnLogsConfig: Joi.object({
     bucketName: Joi.string().required(),

--- a/packages/spacecat-shared-data-access/test/it/postgrest/docker-compose.yml
+++ b/packages/spacecat-shared-data-access/test/it/postgrest/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   data-service:
     platform: ${MYSTICAT_DATA_SERVICE_PLATFORM:-linux/amd64}
-    image: ${MYSTICAT_DATA_SERVICE_REPOSITORY:-682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service}:${MYSTICAT_DATA_SERVICE_TAG:-v1.61.0}
+    image: ${MYSTICAT_DATA_SERVICE_REPOSITORY:-682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service}:${MYSTICAT_DATA_SERVICE_TAG:-v1.67.8}
     depends_on:
       db:
         condition: service_healthy

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -2581,6 +2581,41 @@ describe('Config Tests', () => {
       config.updateLlmoDetectedCdn('other');
       expect(config.getLlmoDetectedCdn()).to.equal('other');
     });
+
+    [
+      'aem-cs-fastly',
+      'commerce-fastly',
+      'byocdn-fastly',
+      'byocdn-akamai',
+      'byocdn-cloudflare',
+      'byocdn-imperva',
+      'byocdn-other',
+      'other',
+    ].forEach((token) => {
+      it(`accepts detectedCdn token "${token}" via validateConfiguration`, () => {
+        const config = {
+          llmo: {
+            dataFolder: '/test',
+            brand: 'testBrand',
+            detectedCdn: token,
+          },
+        };
+        const validated = validateConfiguration(config);
+        expect(validated.llmo.detectedCdn).to.equal(token);
+      });
+    });
+
+    it('rejects unknown detectedCdn token via validateConfiguration', () => {
+      const config = {
+        llmo: {
+          dataFolder: '/test',
+          brand: 'testBrand',
+          detectedCdn: 'byocdn-unknown',
+        },
+      };
+      expect(() => validateConfiguration(config))
+        .to.throw(/Configuration validation error: "llmo\.detectedCdn" must be one of/);
+    });
   });
 
   describe('Tokowaka Config', () => {


### PR DESCRIPTION
Onboarding/audit detectors emit a richer set of CDN classifications than the original 'aem-cs-fastly'/'other' pair. With only those two values permitted, every unrelated config write that touches site.llmo.detectedCdn threw a Joi validation error after the api-service detector started emitting commerce-fastly or any byocdn-* token.

Accepts the eight tokens the api-service detector can emit today: aem-cs-fastly, commerce-fastly, byocdn-{fastly,akamai,cloudflare,imperva, other}, and 'other'. byocdn-cloudfront is intentionally excluded so AMS vs BYOCDN CloudFront tenancy can be settled by a future detector once AMS-aware signatures land; until then CloudFront detections collapse to byocdn-other in the api-service detector.

Adds unit-level coverage for each accepted token plus a negative case for an unknown 'byocdn-unknown' string.

