### PR TITLE
feat(data-access): align detectedCdn Joi schema with CDN_TYPES taxonomy

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -345,14 +345,26 @@ export const configSchema = Joi.object({
       cdnProvider: Joi.string().optional(),
       region: Joi.string().pattern(AWS_REGION_PATTERN).optional(),
     }).optional(),
+    // Aligned with llmo-utils.js#CDN_TYPES in spacecat-api-service.
+    // Detector currently emits a 7-token subset of CDN_TYPES; the remaining
+    // three (`byocdn-cloudfront`, `ams-cloudfront`, `ams-frontdoor`) are
+    // valid CDN tokens the detector cannot yet identify from network signals
+    // and therefore collapses into `byocdn-other`. Listed here so the schema
+    // accepts them once detector revisions add AMS-aware signatures, without
+    // requiring a coupled shared-package release.
+    // `'other'` is retained for backward compatibility with records written
+    // by the original Phase-1-only detector and is no longer emitted.
     detectedCdn: Joi.string().valid(
       'aem-cs-fastly',
       'commerce-fastly',
       'byocdn-fastly',
       'byocdn-akamai',
+      'byocdn-cloudfront',
       'byocdn-cloudflare',
       'byocdn-imperva',
       'byocdn-other',
+      'ams-cloudfront',
+      'ams-frontdoor',
       'other',
     ).optional(),
   }).optional(),

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -2587,9 +2587,12 @@ describe('Config Tests', () => {
       'commerce-fastly',
       'byocdn-fastly',
       'byocdn-akamai',
+      'byocdn-cloudfront',
       'byocdn-cloudflare',
       'byocdn-imperva',
       'byocdn-other',
+      'ams-cloudfront',
+      'ams-frontdoor',
       'other',
     ].forEach((token) => {
       it(`accepts detectedCdn token "${token}" via validateConfiguration`, () => {


### PR DESCRIPTION
## Summary

Follow-up to #1559 (3.53.0). Aligns the `siteConfig.llmo.detectedCdn` Joi schema with the canonical `CDN_TYPES` vocabulary in [`spacecat-api-service/src/controllers/llmo/llmo-utils.js#L17`](https://github.com/adobe/spacecat-api-service/blob/main/src/controllers/llmo/llmo-utils.js#L17), so the same list of CDN-provider tokens applies whether the value is set by the detector or chosen by a user from the CDN radio in the UI.

Triggered by [adobe/spacecat-api-service#2245](https://github.com/adobe/spacecat-api-service/pull/2245#discussion_r3147314587).

## Changes

Schema now accepts the full 10-token `CDN_TYPES` set + `'other'` (legacy) + `null`:

| Token | Source | Detector emits today? |
|---|---|---|
| `aem-cs-fastly` | `CDN_TYPES.AEM_CS_FASTLY` | yes |
| `commerce-fastly` | `CDN_TYPES.COMMERCE_FASTLY` | yes |
| `byocdn-fastly` | `CDN_TYPES.BYOCDN_FASTLY` | yes |
| `byocdn-akamai` | `CDN_TYPES.BYOCDN_AKAMAI` | yes |
| `byocdn-cloudflare` | `CDN_TYPES.BYOCDN_CLOUDFLARE` | yes |
| `byocdn-imperva` | `CDN_TYPES.BYOCDN_IMPERVA` | yes |
| `byocdn-other` | `CDN_TYPES.BYOCDN_OTHER` | yes (catch-all) |
| `byocdn-cloudfront` | `CDN_TYPES.BYOCDN_CLOUDFRONT` | no — reserved |
| `ams-cloudfront` | `CDN_TYPES.AMS_CLOUDFRONT` | no — reserved |
| `ams-frontdoor` | `CDN_TYPES.AMS_FRONTDOOR` | no — reserved |
| `other` | legacy | no — back-compat with old records |

The three reserved tokens are valid CDN tokens the detector cannot identify from network signals today — CloudFront and Azure Front Door collapse to \`byocdn-other\` because the detector cannot disambiguate AMS vs BYO tenancy. Listing them in the schema now lets a future detector revision (once AMS-aware signatures land) ship without a coupled spacecat-shared release.

The legacy \`'other'\` stays to keep back-compat with records written by the original Phase-1-only detector (still found in dev/stage). The detector in adobe/spacecat-api-service#2245 no longer emits it; records naturally migrate to \`byocdn-other\` on next config write.

Will remove the "other" after running backward correct script

## Test plan

- [x] Unit tests in \`test/unit/models/site/config.test.js\` cover all 11 accepted tokens via \`validateConfiguration\` round-trip
- [x] Negative case: unknown tokens (e.g., \`byocdn-unknown\`) are rejected
- [x] \`npx mocha\` — 266 passing (full data-access test suite)
- [x] \`npx eslint\` — clean

