### PR TITLE
feat(seo-client): return keywords[] array from getPaidPages()

### DIFF
--- a/packages/mysticat-shared-seo-client/src/client.js
+++ b/packages/mysticat-shared-seo-client/src/client.js
@@ -424,9 +424,9 @@ export default class SeoClient {
             keyword: kw.Ph,
             traffic: kw.kwTraffic,
             cpc: coerceValue(kw.Cp, 'float') ?? null,
-            serpTitle: kw.Tt || null,
-            position: coerceValue(kw.Po, 'int') || 0,
-            volume: coerceValue(kw.Nq, 'int') || 0,
+            serp_title: kw.Tt || null,
+            position: coerceValue(kw.Po, 'int') ?? null,
+            volume: coerceValue(kw.Nq, 'int') ?? null,
             country: kw.db.toUpperCase(),
           })),
         };

--- a/packages/mysticat-shared-seo-client/src/client.js
+++ b/packages/mysticat-shared-seo-client/src/client.js
@@ -340,6 +340,23 @@ export default class SeoClient {
     };
   }
 
+  /**
+   * Fetch paid (PPC) pages and their keyword data from Semrush.
+   *
+   * Per-keyword CPC is returned as float dollars (e.g., 3.95) with null for unknown.
+   * This deliberately differs from getOrganicKeywords() which returns CPC as integer
+   * cents (e.g., 395) with 0 for unknown. The float-dollars convention was chosen for
+   * the keywords[] array because downstream consumers (import-worker, Mystique) expect
+   * dollars and the per-keyword CPC should not go through the cents round-trip used by
+   * the aggregate `value` field.
+   *
+   * @param {string} url - Domain to query
+   * @param {Object} [opts] - Options
+   * @param {string} [opts.date] - Report date
+   * @param {number} [opts.limit=200] - Max pages to return
+   * @param {string} [opts.region] - Limit to specific region
+   * @returns {Promise<{result: {pages: Array}, fullAuditRef: string}>}
+   */
   async getPaidPages(url, opts = {}) {
     if (typeof opts !== 'object' || opts === null) {
       throw new Error('Second argument must be an options object, not a positional value');

--- a/packages/mysticat-shared-seo-client/src/client.js
+++ b/packages/mysticat-shared-seo-client/src/client.js
@@ -420,6 +420,15 @@ export default class SeoClient {
             ),
             0,
           ),
+          keywords: page.keywords.map((kw) => ({
+            keyword: kw.Ph,
+            traffic: kw.kwTraffic,
+            cpc: coerceValue(kw.Cp, 'float') ?? null,
+            serpTitle: kw.Tt || null,
+            position: coerceValue(kw.Po, 'int') || 0,
+            volume: coerceValue(kw.Nq, 'int') || 0,
+            country: kw.db.toUpperCase(),
+          })),
         };
       });
 

--- a/packages/mysticat-shared-seo-client/test/client.test.js
+++ b/packages/mysticat-shared-seo-client/test/client.test.js
@@ -1240,11 +1240,11 @@ describe('SeoClient', () => {
       expect(topPage.keywords).to.have.lengthOf(2);
 
       const kw = topPage.keywords[0];
-      expect(kw).to.have.all.keys('keyword', 'traffic', 'cpc', 'serpTitle', 'position', 'volume', 'country');
+      expect(kw).to.have.all.keys('keyword', 'traffic', 'cpc', 'serp_title', 'position', 'volume', 'country');
       expect(kw.keyword).to.equal('adobe');
       expect(kw.traffic).to.equal(47000);
       expect(kw.cpc).to.equal(6.43);
-      expect(kw.serpTitle).to.equal('Adobe® - Official Site');
+      expect(kw.serp_title).to.equal('Adobe® - Official Site');
       expect(kw.position).to.equal(1);
       expect(kw.volume).to.equal(1000000);
       expect(kw.country).to.equal('US');
@@ -1306,10 +1306,10 @@ describe('SeoClient', () => {
 
       const result = await client.getPaidPages('example.com');
       const kw = result.result.pages[0].keywords[0];
-      expect(kw.position).to.equal(0);
-      expect(kw.volume).to.equal(0);
+      expect(kw.position).to.equal(null);
+      expect(kw.volume).to.equal(null);
       expect(kw.cpc).to.equal(null);
-      expect(kw.serpTitle).to.equal('Sparse');
+      expect(kw.serp_title).to.equal('Sparse');
       expect(kw.country).to.equal('US');
     });
   });

--- a/packages/mysticat-shared-seo-client/test/client.test.js
+++ b/packages/mysticat-shared-seo-client/test/client.test.js
@@ -1296,7 +1296,7 @@ describe('SeoClient', () => {
       expect(kw.cpc).to.equal(3.95);
     });
 
-    it('keywords[] handles missing position, volume, and defaults country to empty', async () => {
+    it('keywords[] returns null for missing position/volume/cpc and derives country from database key', async () => {
       const csv = [
         'Keyword;Url;Traffic;Search Volume;CPC;Position;Title',
         '"kw-sparse";"https://example.com/p";"50";"";"";"";"Sparse"',
@@ -1311,6 +1311,36 @@ describe('SeoClient', () => {
       expect(kw.cpc).to.equal(null);
       expect(kw.serp_title).to.equal('Sparse');
       expect(kw.country).to.equal('US');
+    });
+
+    it('keywords[] from multiple databases carry their respective country codes', async () => {
+      const usCsv = [
+        'Keyword;Url;Traffic;Search Volume;CPC;Position;Title',
+        '"shoes";"https://example.com/shoes";"100";"5000";"2.50";"1";"Buy Shoes"',
+      ].join('\n');
+      const gbCsv = [
+        'Keyword;Url;Traffic;Search Volume;CPC;Position;Title',
+        '"trainers";"https://example.com/shoes";"80";"3000";"1.80";"3";"Buy Trainers"',
+      ].join('\n');
+
+      const csvByDb = { us: usCsv, uk: gbCsv };
+      for (const db of BIG_MARKETS) {
+        nock(config.apiBaseUrl)
+          .get('/')
+          .query((q) => q.type === 'domain_adwords' && q.database === db)
+          .reply(200, csvByDb[db] || emptyPaidCsv);
+      }
+
+      const result = await client.getPaidPages('example.com');
+      const page = result.result.pages[0];
+      expect(page.keywords).to.have.lengthOf(2);
+
+      const usKw = page.keywords.find((k) => k.keyword === 'shoes');
+      const gbKw = page.keywords.find((k) => k.keyword === 'trainers');
+      expect(usKw.country).to.equal('US');
+      expect(gbKw.country).to.equal('UK');
+      expect(usKw.traffic).to.equal(100);
+      expect(gbKw.traffic).to.equal(80);
     });
   });
 

--- a/packages/mysticat-shared-seo-client/test/client.test.js
+++ b/packages/mysticat-shared-seo-client/test/client.test.js
@@ -1229,6 +1229,89 @@ describe('SeoClient', () => {
       expect(result.result.pages[0].top_keyword).to.equal('high-kw');
       expect(result.result.pages[0].top_keyword_best_position_title).to.equal('High Title');
     });
+
+    it('returns keywords[] with all expected fields per page', async () => {
+      nockPaidDatabases(BIG_MARKETS, paidKeywordsCsv, { targetDb: 'us' });
+
+      const result = await client.getPaidPages('adobe.com', { date: '2025-03-01', limit: 5 });
+      const topPage = result.result.pages[0];
+
+      // Pricing page has 2 keywords (both "adobe" rows)
+      expect(topPage.keywords).to.have.lengthOf(2);
+
+      const kw = topPage.keywords[0];
+      expect(kw).to.have.all.keys('keyword', 'traffic', 'cpc', 'serpTitle', 'position', 'volume', 'country');
+      expect(kw.keyword).to.equal('adobe');
+      expect(kw.traffic).to.equal(47000);
+      expect(kw.cpc).to.equal(6.43);
+      expect(kw.serpTitle).to.equal('Adobe® - Official Site');
+      expect(kw.position).to.equal(1);
+      expect(kw.volume).to.equal(1000000);
+      expect(kw.country).to.equal('US');
+
+      // Existing fields are unchanged
+      expect(topPage.top_keyword).to.equal('adobe');
+      expect(topPage.value).to.be.a('number');
+      expect(topPage.sum_traffic).to.equal(60000);
+    });
+
+    it('keywords[] length matches raw keyword count for multi-keyword page', async () => {
+      const csv = [
+        'Keyword;Url;Traffic;Search Volume;CPC;Position;Title',
+        '"kw1";"https://example.com/p";"100";"500";"1.00";"2";"Title 1"',
+        '"kw2";"https://example.com/p";"200";"600";"2.00";"3";"Title 2"',
+        '"kw3";"https://example.com/p";"300";"700";"3.00";"1";"Title 3"',
+      ].join('\n');
+
+      nockPaidDatabases(BIG_MARKETS, csv, { targetDb: 'us' });
+
+      const result = await client.getPaidPages('example.com');
+      expect(result.result.pages[0].keywords).to.have.lengthOf(3);
+    });
+
+    it('returns cpc: null when Cp is empty (nullish coalescing)', async () => {
+      const csv = [
+        'Keyword;Url;Traffic;Search Volume;CPC;Position;Title',
+        '"kw-no-cpc";"https://example.com/p";"100";"500";"";"3";"No CPC Title"',
+      ].join('\n');
+
+      nockPaidDatabases(BIG_MARKETS, csv, { targetDb: 'us' });
+
+      const result = await client.getPaidPages('example.com');
+      const kw = result.result.pages[0].keywords[0];
+      expect(kw.cpc).to.equal(null);
+      expect(kw.keyword).to.equal('kw-no-cpc');
+    });
+
+    it('returns cpc as float when Cp has a value', async () => {
+      const csv = [
+        'Keyword;Url;Traffic;Search Volume;CPC;Position;Title',
+        '"kw-with-cpc";"https://example.com/p";"100";"500";"3.95";"2";"CPC Title"',
+      ].join('\n');
+
+      nockPaidDatabases(BIG_MARKETS, csv, { targetDb: 'us' });
+
+      const result = await client.getPaidPages('example.com');
+      const kw = result.result.pages[0].keywords[0];
+      expect(kw.cpc).to.equal(3.95);
+    });
+
+    it('keywords[] handles missing position, volume, and defaults country to empty', async () => {
+      const csv = [
+        'Keyword;Url;Traffic;Search Volume;CPC;Position;Title',
+        '"kw-sparse";"https://example.com/p";"50";"";"";"";"Sparse"',
+      ].join('\n');
+
+      nockPaidDatabases(BIG_MARKETS, csv, { targetDb: 'us' });
+
+      const result = await client.getPaidPages('example.com');
+      const kw = result.result.pages[0].keywords[0];
+      expect(kw.position).to.equal(0);
+      expect(kw.volume).to.equal(0);
+      expect(kw.cpc).to.equal(null);
+      expect(kw.serpTitle).to.equal('Sparse');
+      expect(kw.country).to.equal('US');
+    });
   });
 
   // ===== getBrokenBacklinks =====


### PR DESCRIPTION
## Summary

- Add `keywords[]` array to the return value of `getPaidPages()` in `mysticat-shared-seo-client`
- Each keyword includes: `keyword`, `traffic`, `cpc`, `serp_title`, `position`, `volume`, `country`
- Per-keyword CPC uses `?? null` (nullish coalescing) to preserve "CPC unknown" semantics — NOT `|| 0`
- Per-keyword `position` and `volume` also use `?? null` for consistency (position is 1-indexed, so 0 is ambiguous)
- All field names use `snake_case` to match the rest of the `getPaidPages` response and `getOrganicKeywords`
- CPC unit is float dollars (documented in JSDoc) — deliberately different from `getOrganicKeywords` which uses integer cents
- Existing fields (`top_keyword`, `value`, `sum_traffic`, etc.) are unchanged — fully backward compatible
- The `page.keywords[]` array is already collected internally (line 397); this change simply includes it in the return value

This is part of the multi-keyword intent cluster feature for ad-intent-mismatch. The keywords array enables downstream clustering by search intent.

## Test plan

- [x] `keywords[]` returned with all expected fields
- [x] Empty `Cp` produces `cpc: null` (not `0`)
- [x] Valid `Cp: "3.95"` produces `cpc: 3.95`
- [x] `keywords[]` length matches raw keyword count
- [x] Existing `top_keyword` and `value` fields unchanged
- [x] Missing position/volume produce `null` (not `0`)
- [x] Multi-database test: keywords from US and UK carry correct country codes
- [x] 162 tests passing, 100% coverage (statements, branches, functions, lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)