### PR TITLE
feat(utils/sqs): add MessageDeduplicationId support for FIFO sends

### DIFF
--- a/packages/spacecat-shared-utils/src/sqs.js
+++ b/packages/spacecat-shared-utils/src/sqs.js
@@ -57,9 +57,16 @@ class SQS {
    * @param {object} message - The message body to send.
    *   Can include traceId for propagation or set to null to opt-out.
    * @param {string} messageGroupId - (Optional) The message group ID for FIFO queues.
+   * @param {string} messageDeduplicationId - (Optional) The deduplication ID for FIFO
+   *   queues that have content-based deduplication disabled. Ignored on standard queues.
    * @return {Promise<void>}
    */
-  async sendMessage(queueUrl, message, messageGroupId = undefined) {
+  async sendMessage(
+    queueUrl,
+    message,
+    messageGroupId = undefined,
+    messageDeduplicationId = undefined,
+  ) {
     const body = {
       ...message,
       timestamp: new Date().toISOString(),
@@ -87,9 +94,14 @@ class SQS {
       QueueUrl: queueUrl,
     };
 
-    // Only include MessageGroupId if the queue is a FIFO queue
-    if (SQS.#isFifoQueue(queueUrl) && hasText(messageGroupId)) {
-      params.MessageGroupId = messageGroupId;
+    // Only include FIFO-specific attributes if the queue is a FIFO queue
+    if (SQS.#isFifoQueue(queueUrl)) {
+      if (hasText(messageGroupId)) {
+        params.MessageGroupId = messageGroupId;
+      }
+      if (hasText(messageDeduplicationId)) {
+        params.MessageDeduplicationId = messageDeduplicationId;
+      }
     }
 
     const msgCommand = new SendMessageCommand(params);

--- a/packages/spacecat-shared-utils/test/sqs.test.js
+++ b/packages/spacecat-shared-utils/test/sqs.test.js
@@ -318,6 +318,54 @@ describe('SQS', () => {
       expect(firstSendArg.input.MessageGroupId).to.be.undefined;
     });
 
+    it('should include a MessageDeduplicationId when the queue is a FIFO queue', async () => {
+      const action = wrap(async (req, ctx) => {
+        await ctx.sqs.sendMessage(
+          'fifo-queue.fifo',
+          { key: 'value' },
+          'job-id',
+          'dedup-id',
+        );
+      }).with(sqsWrapper);
+
+      await action({}, context);
+
+      const firstSendArg = sendStub.getCall(0).args[0];
+      expect(firstSendArg.input.MessageGroupId).to.equal('job-id');
+      expect(firstSendArg.input.MessageDeduplicationId).to.equal('dedup-id');
+    });
+
+    it('should not include a MessageDeduplicationId on a standard queue', async () => {
+      const action = wrap(async (req, ctx) => {
+        // Note: no .fifo suffix
+        await ctx.sqs.sendMessage(
+          'standard-queue',
+          { key: 'value' },
+          'job-id',
+          'dedup-id',
+        );
+      }).with(sqsWrapper);
+
+      await action({}, context);
+
+      const firstSendArg = sendStub.getCall(0).args[0];
+      expect(firstSendArg.input.MessageDeduplicationId).to.be.undefined;
+    });
+
+    it('should accept messageGroupId without messageDeduplicationId on FIFO', async () => {
+      // Backwards-compatible: callers who only pass groupId still work, no
+      // MessageDeduplicationId is set (caller relies on content-based dedup).
+      const action = wrap(async (req, ctx) => {
+        await ctx.sqs.sendMessage('fifo-queue.fifo', { key: 'value' }, 'job-id');
+      }).with(sqsWrapper);
+
+      await action({}, context);
+
+      const firstSendArg = sendStub.getCall(0).args[0];
+      expect(firstSendArg.input.MessageGroupId).to.equal('job-id');
+      expect(firstSendArg.input.MessageDeduplicationId).to.be.undefined;
+    });
+
     it('should include traceId in message when explicitly provided', async () => {
       const action = wrap(async (req, ctx) => {
         await ctx.sqs.sendMessage('https://sqs.mock-region-1.mockaws.com/123456789012/test-queue', { key: 'value', traceId: '1-explicit-traceid' });


### PR DESCRIPTION
## Summary

- Add an optional fourth parameter `messageDeduplicationId` to `SQS.sendMessage`.
- For FIFO queues, applies it as `MessageDeduplicationId` on the `SendMessageCommand` only when the caller passes a non-empty value.
- Ignored on standard queues and on FIFO queues where the caller relies on content-based dedup.

## Why

FIFO queues with `content_based_deduplication = false` require producers to supply an explicit `MessageDeduplicationId` on every publish — without one, SQS rejects the call. Today the helper has no way to pass it through, so callers either bypass the helper or rely on content-based dedup at the queue level.

This change unblocks producers (`spacecat-audit-worker`, `mysticat-projector-service`) that need to publish to the analytics ingestion FIFO queue introduced in [spacecat-infrastructure#480](https://github.com/adobe/spacecat-infrastructure/pull/480), where the topic and queue both have explicit dedup disabled per the design (`producer sets explicit MessageDeduplicationId`).

Backward compatible — existing 2/3-arg call sites are unchanged.

## Test plan

- [x] New unit tests cover: dedup-id applied on FIFO; dedup-id stripped on standard; group-id without dedup-id still works (back-compat).
- [x] `npx mocha --spec test/sqs.test.js --exit` — all 1035 utils tests pass.
- [x] Lint clean.

## Coordination

Pairs with consumer PRs that use the new parameter on the analytics FIFO publish path. This PR can land independently — it is purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)