### PR TITLE
fix: BaseModel/Patcher record desync after save() causes silent sette…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21579,7 +21579,7 @@
     },
     "packages/mysticat-shared-seo-client": {
       "name": "@adobe/mysticat-shared-seo-client",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -26239,7 +26239,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "3.54.0",
+      "version": "3.55.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",
@@ -26439,7 +26439,7 @@
     },
     "packages/spacecat-shared-drs-client": {
       "name": "@adobe/spacecat-shared-drs-client",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.98.1"
@@ -28277,7 +28277,7 @@
     },
     "packages/spacecat-shared-html-analyzer": {
       "name": "@adobe/spacecat-shared-html-analyzer",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "license": "Apache-2.0",
       "dependencies": {
         "cheerio": "^1.0.0-rc.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21579,7 +21579,7 @@
     },
     "packages/mysticat-shared-seo-client": {
       "name": "@adobe/mysticat-shared-seo-client",
-      "version": "1.3.0",
+      "version": "1.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -26239,7 +26239,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "3.55.0",
+      "version": "3.54.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",
@@ -26439,7 +26439,7 @@
     },
     "packages/spacecat-shared-drs-client": {
       "name": "@adobe/spacecat-shared-drs-client",
-      "version": "1.5.0",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.98.1"
@@ -28277,7 +28277,7 @@
     },
     "packages/spacecat-shared-html-analyzer": {
       "name": "@adobe/spacecat-shared-html-analyzer",
-      "version": "1.2.10",
+      "version": "1.2.9",
       "license": "Apache-2.0",
       "dependencies": {
         "cheerio": "^1.0.0-rc.12",

--- a/packages/spacecat-shared-data-access/src/util/patcher.js
+++ b/packages/spacecat-shared-data-access/src/util/patcher.js
@@ -180,7 +180,7 @@ class Patcher {
       && typeof this.collection.applyUpdateWatchers === 'function'
       && typeof this.collection.updateByKeys === 'function') {
       const watched = this.collection.applyUpdateWatchers(this.record, updates);
-      this.record = watched.record;
+      Object.assign(this.record, watched.record);
       await this.collection.updateByKeys(keys, watched.updates);
       return;
     }

--- a/packages/spacecat-shared-data-access/test/it/site/site.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site/site.test.js
@@ -501,6 +501,31 @@ describe('Site IT', async () => {
     expect(updatedSite.getName()).to.equal(updates.name);
   });
 
+  it('reflects setter writes via getters after a prior save on the same instance', async () => {
+    const orgA = sampleData.organizations[0].getId();
+    const orgB = sampleData.organizations[1].getId();
+
+    const site = await Site.findById(sampleData.sites[1].getId());
+    site.setOrganizationId(orgA);
+    site.setName('first-cycle-name');
+    await site.save();
+
+    expect(site.getOrganizationId()).to.equal(orgA);
+    expect(site.getName()).to.equal('first-cycle-name');
+
+    site.setOrganizationId(orgB);
+    site.setName('second-cycle-name');
+
+    expect(site.getOrganizationId()).to.equal(orgB);
+    expect(site.getName()).to.equal('second-cycle-name');
+
+    await site.save();
+
+    const reloaded = await Site.findById(site.getId());
+    expect(reloaded.getOrganizationId()).to.equal(orgB);
+    expect(reloaded.getName()).to.equal('second-cycle-name');
+  });
+
   it('reads config of a site', async () => {
     const { config: configFixture } = siteFixtures[0];
     configFixture.imports[0].enabled = true; // set by joi schema default

--- a/packages/spacecat-shared-data-access/test/unit/util/patcher.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/util/patcher.test.js
@@ -261,6 +261,45 @@ describe('Patcher', () => {
     expect(mockEntity.patch().go.notCalled).to.be.true;
   });
 
+  it('preserves the record reference after a collection-strategy save', async () => {
+    const applyUpdateWatchers = sinon.stub().returns({
+      record: { ...mockRecord, name: 'CollectionUpdated', watchedField: 'derived' },
+      updates: { name: 'CollectionUpdated', updatedAt: '2026-01-01T00:00:00.000Z' },
+    });
+    const updateByKeys = sinon.stub().resolves();
+    patcher.collection = { applyUpdateWatchers, updateByKeys };
+
+    const recordRefBefore = patcher.record;
+    patcher.patchValue('name', 'UpdatedName');
+    await patcher.save();
+
+    expect(patcher.record).to.equal(recordRefBefore);
+    expect(patcher.record).to.equal(mockRecord);
+    expect(patcher.record.name).to.equal('CollectionUpdated');
+    expect(patcher.record.watchedField).to.equal('derived');
+  });
+
+  it('reflects subsequent patches on the same record after a save', async () => {
+    const applyUpdateWatchers = sinon.stub().callsFake((record, updates) => ({
+      record: { ...record, ...updates },
+      updates: { ...updates, updatedAt: new Date().toISOString() },
+    }));
+    const updateByKeys = sinon.stub().resolves();
+    patcher.collection = { applyUpdateWatchers, updateByKeys };
+
+    patcher.patchValue('name', 'FirstCycle');
+    await patcher.save();
+
+    patcher.patchValue('name', 'SecondCycle');
+    expect(mockRecord.name).to.equal('SecondCycle');
+    expect(patcher.record.name).to.equal('SecondCycle');
+
+    await patcher.save();
+    expect(updateByKeys.calledTwice).to.be.true;
+    const secondCallUpdates = updateByKeys.secondCall.args[1];
+    expect(secondCallUpdates.name).to.equal('SecondCycle');
+  });
+
   it('throws when no persistence strategy is available', async () => {
     patcher.patchValue('name', 'UpdatedName');
     patcher.collection = undefined;


### PR DESCRIPTION
## Summary

Fixes a bug in `@adobe/spacecat-shared-data-access` where setter writes are not visible via getters on the same model instance after a prior `save()`. Setters appear to silently no-op until the model is reloaded.

## Root cause

`BaseModel` and `Patcher` are constructed sharing a single `record` object reference (`base.model.js:64,72`). On `patcher.save()`, `collection.applyUpdateWatchers(this.record, updates)` returns a **shallow clone** (`base.collection.js:255` — `const nextRecord = { ...record }`). The patcher then reassigns `this.record = watched.record` (`patcher.js:183`), but the model's `this.record` is never updated.

After that point:
- setters write to `patcher.record` (the new clone)
- getters read `model.record` (the stale original)

The `_saveMany` path explicitly syncs the model (`base.collection.js:999` — `preparedItem.model.record = preparedItem.record`). The single `save()` path was missing the equivalent sync.

## Reproduction

```js
const site = await Site.findById(id);
site.setName('first');
await site.save();

site.setOrganizationId(otherOrgId);
site.getOrganizationId(); // returns the OLD org id
```

## Fix

`packages/spacecat-shared-data-access/src/util/patcher.js:183` — replace `this.record = watched.record` with `Object.assign(this.record, watched.record)`. This preserves the shared object reference between `Patcher.record` and `BaseModel.record`, so post-save setters and getters stay in sync. No public API change.

## Why it wasn't caught

- `test/unit/util/patcher.test.js` stubbed `applyUpdateWatchers` and asserted only `updateByKeys.calledOnce` — never constructed a real `BaseModel` to verify post-save getter reads.
- `test/unit/models/base/base.model.test.js` stubs `patcher.save` entirely, so the real reassignment never runs.
- No integration test exercised the `set → save → set → get` sequence.

## Test plan

- [x] Unit regression in `test/unit/util/patcher.test.js`:
  - `preserves the record reference after a collection-strategy save`
  - `reflects subsequent patches on the same record after a save`
- [x] Integration regression in `test/it/site/site.test.js`:
  - `reflects setter writes via getters after a prior save on the same instance`
- [x] `npm run lint -w packages/spacecat-shared-data-access`
- [ ] `npm test -w packages/spacecat-shared-data-access` (full unit suite, CI)
- [ ] `npm run test:it -w packages/spacecat-shared-data-access` (integration suite, CI/local Docker)

## Related Issues

- [SITES-43758](https://jira.corp.adobe.com/browse/SITES-43758)