### PR TITLE
feat: rename semantic-value-visibility opportunity to image-enrichment

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
+++ b/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
@@ -95,7 +95,7 @@ class Audit extends BaseModel {
     COMMERCE_PRODUCT_CATALOG_ENRICHMENT_AUTO_FIX: 'commerce-product-catalog-enrichment-auto-fix',
     CWV_TRENDS_AUDIT: 'cwv-trends-audit',
     OFFSITE_BRAND_PRESENCE: 'offsite-brand-presence',
-    SEMANTIC_VALUE_VISIBILITY: 'semantic-value-visibility',
+    IMAGE_ENRICHMENT: 'image-enrichment',
   };
 
   static AUDIT_TYPE_PROPERTIES = {

--- a/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
+++ b/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
@@ -96,6 +96,8 @@ class Audit extends BaseModel {
     CWV_TRENDS_AUDIT: 'cwv-trends-audit',
     OFFSITE_BRAND_PRESENCE: 'offsite-brand-presence',
     IMAGE_ENRICHMENT: 'image-enrichment',
+    // @deprecated use IMAGE_ENRICHMENT — remove after producer cutover
+    SEMANTIC_VALUE_VISIBILITY: 'image-enrichment',
   };
 
   static AUDIT_TYPE_PROPERTIES = {

--- a/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
@@ -220,7 +220,7 @@ describe('AuditModel', () => {
       COMMERCE_PRODUCT_CATALOG_ENRICHMENT_AUTO_FIX: 'commerce-product-catalog-enrichment-auto-fix',
       CWV_TRENDS_AUDIT: 'cwv-trends-audit',
       OFFSITE_BRAND_PRESENCE: 'offsite-brand-presence',
-      SEMANTIC_VALUE_VISIBILITY: 'semantic-value-visibility',
+      IMAGE_ENRICHMENT: 'image-enrichment',
     };
 
     it('should have all audit types present in AUDIT_TYPES', () => {

--- a/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
@@ -221,6 +221,7 @@ describe('AuditModel', () => {
       CWV_TRENDS_AUDIT: 'cwv-trends-audit',
       OFFSITE_BRAND_PRESENCE: 'offsite-brand-presence',
       IMAGE_ENRICHMENT: 'image-enrichment',
+      SEMANTIC_VALUE_VISIBILITY: 'image-enrichment',
     };
 
     it('should have all audit types present in AUDIT_TYPES', () => {

--- a/packages/spacecat-shared-tokowaka-client/src/mappers/image-enrichment-mapper.js
+++ b/packages/spacecat-shared-tokowaka-client/src/mappers/image-enrichment-mapper.js
@@ -16,13 +16,13 @@ import BaseOpportunityMapper from './base-mapper.js';
 import { htmlToHast } from '../utils/html-utils.js';
 
 /**
- * Mapper for semantic-value-visibility opportunity
+ * Mapper for image-enrichment opportunity
  * Handles conversion of image semantic HTML suggestions to Tokowaka patches
  */
-export default class SemanticValueVisibilityMapper extends BaseOpportunityMapper {
+export default class ImageEnrichmentMapper extends BaseOpportunityMapper {
   constructor(log) {
     super(log);
-    this.opportunityType = 'semantic-value-visibility';
+    this.opportunityType = 'image-enrichment';
     this.prerenderRequired = true;
     this.validActions = ['insertAfter', 'insertBefore', 'appendChild'];
   }
@@ -48,7 +48,7 @@ export default class SemanticValueVisibilityMapper extends BaseOpportunityMapper
     suggestions.forEach((suggestion) => {
       const eligibility = this.canDeploy(suggestion);
       if (!eligibility.eligible) {
-        this.log.warn(`Semantic-value-visibility suggestion ${suggestion.getId()} cannot be deployed: ${eligibility.reason}`);
+        this.log.warn(`Image-enrichment suggestion ${suggestion.getId()} cannot be deployed: ${eligibility.reason}`);
         return;
       }
 
@@ -74,7 +74,7 @@ export default class SemanticValueVisibilityMapper extends BaseOpportunityMapper
   }
 
   /**
-   * Checks if a semantic-value-visibility suggestion can be deployed
+   * Checks if an image-enrichment suggestion can be deployed
    * @param {Object} suggestion - Suggestion object
    * @returns {Object} { eligible: boolean, reason?: string }
    */

--- a/packages/spacecat-shared-tokowaka-client/src/mappers/mapper-registry.js
+++ b/packages/spacecat-shared-tokowaka-client/src/mappers/mapper-registry.js
@@ -52,6 +52,12 @@ export default class MapperRegistry {
       const mapper = new MapperClass(this.log);
       this.registerMapper(mapper);
     });
+
+    // Deprecated alias — remove after mystique PR 1704 producer cutover
+    const imageEnrichmentInstance = this.mappers.get('image-enrichment');
+    if (imageEnrichmentInstance) {
+      this.mappers.set('semantic-value-visibility', imageEnrichmentInstance);
+    }
   }
 
   /**

--- a/packages/spacecat-shared-tokowaka-client/src/mappers/mapper-registry.js
+++ b/packages/spacecat-shared-tokowaka-client/src/mappers/mapper-registry.js
@@ -18,7 +18,7 @@ import TocMapper from './toc-mapper.js';
 import GenericMapper from './generic-mapper.js';
 import PrerenderMapper from './prerender-mapper.js';
 import CommercePageEnrichmentMapper from './commerce-page-enrichment-mapper.js';
-import SemanticValueVisibilityMapper from './semantic-value-visibility-mapper.js';
+import ImageEnrichmentMapper from './image-enrichment-mapper.js';
 
 /**
  * Registry for opportunity mappers
@@ -45,7 +45,7 @@ export default class MapperRegistry {
       GenericMapper,
       PrerenderMapper,
       CommercePageEnrichmentMapper,
-      SemanticValueVisibilityMapper,
+      ImageEnrichmentMapper,
     ];
 
     defaultMappers.forEach((MapperClass) => {

--- a/packages/spacecat-shared-tokowaka-client/test/fixtures/image-enrichment/Carahsoft.json
+++ b/packages/spacecat-shared-tokowaka-client/test/fixtures/image-enrichment/Carahsoft.json
@@ -1,6 +1,6 @@
 {
   "url": "https://carahsoft.com/",
-  "opportunityType": "semantic-value-visibility",
+  "opportunityType": "image-enrichment",
   "suggestions": [
     {
       "data": {

--- a/packages/spacecat-shared-tokowaka-client/test/fixtures/image-enrichment/Koffievoordeel.json
+++ b/packages/spacecat-shared-tokowaka-client/test/fixtures/image-enrichment/Koffievoordeel.json
@@ -1,6 +1,6 @@
 {
   "url": "https://koffievoordeel.nl/",
-  "opportunityType": "semantic-value-visibility",
+  "opportunityType": "image-enrichment",
   "suggestions": [
     {
       "data": {

--- a/packages/spacecat-shared-tokowaka-client/test/fixtures/image-enrichment/Krisshop.json
+++ b/packages/spacecat-shared-tokowaka-client/test/fixtures/image-enrichment/Krisshop.json
@@ -1,6 +1,6 @@
 {
   "url": "https://www.krisshop.com/en",
-  "opportunityType": "semantic-value-visibility",
+  "opportunityType": "image-enrichment",
   "suggestions": [
     {
       "data": {

--- a/packages/spacecat-shared-tokowaka-client/test/fixtures/image-enrichment/Veseris.json
+++ b/packages/spacecat-shared-tokowaka-client/test/fixtures/image-enrichment/Veseris.json
@@ -1,6 +1,6 @@
 {
   "url": "https://veseris.com/default/",
-  "opportunityType": "semantic-value-visibility",
+  "opportunityType": "image-enrichment",
   "suggestions": [
     {
       "data": {

--- a/packages/spacecat-shared-tokowaka-client/test/fixtures/image-enrichment/Vuse.json
+++ b/packages/spacecat-shared-tokowaka-client/test/fixtures/image-enrichment/Vuse.json
@@ -1,6 +1,6 @@
 {
   "url": "https://www.vuse.com/ch/en",
-  "opportunityType": "semantic-value-visibility",
+  "opportunityType": "image-enrichment",
   "suggestions": [
     {
       "data": {

--- a/packages/spacecat-shared-tokowaka-client/test/mappers/generic-mapper.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/mappers/generic-mapper.test.js
@@ -17,7 +17,7 @@ import { expect } from 'chai';
 import GenericMapper from '../../src/mappers/generic-mapper.js';
 
 const filename = fileURLToPath(import.meta.url);
-const fixturesPath = join(dirname(filename), '../fixtures/semantic-value-visibility');
+const fixturesPath = join(dirname(filename), '../fixtures/image-enrichment');
 const carahsoftFixture = JSON.parse(
   readFileSync(join(fixturesPath, 'Carahsoft.json'), 'utf8'),
 );

--- a/packages/spacecat-shared-tokowaka-client/test/mappers/image-enrichment-mapper.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/mappers/image-enrichment-mapper.test.js
@@ -14,10 +14,10 @@ import { expect } from 'chai';
 import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import SemanticValueVisibilityMapper from '../../src/mappers/semantic-value-visibility-mapper.js';
+import ImageEnrichmentMapper from '../../src/mappers/image-enrichment-mapper.js';
 
 const filename = fileURLToPath(import.meta.url);
-const fixturesPath = join(dirname(filename), '../fixtures/semantic-value-visibility');
+const fixturesPath = join(dirname(filename), '../fixtures/image-enrichment');
 
 // Load real Mystique response fixtures
 // Carahsoft proves the logic is correct, others prove it doesn't crash with different real inputs.
@@ -27,7 +27,7 @@ const krisshopFixture = JSON.parse(readFileSync(join(fixturesPath, 'Krisshop.jso
 const veserisFixture = JSON.parse(readFileSync(join(fixturesPath, 'Veseris.json'), 'utf8'));
 const vuseFixture = JSON.parse(readFileSync(join(fixturesPath, 'Vuse.json'), 'utf8'));
 
-describe('SemanticValueVisibilityMapper', () => {
+describe('ImageEnrichmentMapper', () => {
   let mapper;
   let log;
 
@@ -38,12 +38,12 @@ describe('SemanticValueVisibilityMapper', () => {
       warn: () => {},
       error: () => {},
     };
-    mapper = new SemanticValueVisibilityMapper(log);
+    mapper = new ImageEnrichmentMapper(log);
   });
 
   describe('getOpportunityType', () => {
-    it('should return semantic-value-visibility', () => {
-      expect(mapper.getOpportunityType()).to.equal('semantic-value-visibility');
+    it('should return image-enrichment', () => {
+      expect(mapper.getOpportunityType()).to.equal('image-enrichment');
     });
   });
 


### PR DESCRIPTION
## Summary

Renames the audit/opportunity type from `semantic-value-visibility` to `image-enrichment` to align with `multimedia-enrichment` (video transcripts) naming convention. Decision per Slack alignment with Dirk + Yaashi.

## Changes in this repo
- Renames `SemanticValueVisibilityMapper` class → `ImageEnrichmentMapper` in `spacecat-shared-tokowaka-client`
- Renames mapper file, test file, and fixtures folder accordingly
- Updates `mapper-registry` import + registration
- Updates `audit.model.js` enum: `SEMANTIC_VALUE_VISIBILITY: 'semantic-value-visibility'` → `IMAGE_ENRICHMENT: 'image-enrichment'`
- Updates `opportunityType` value in 5 fixture JSONs and matching test expectations

## Cross-repo PRs (must merge in this order)
1. **adobe/spacecat-shared#1570** ← this PR
2. adobe/spacecat-audit-worker#2447 (depends on this — uses new enum + folder structure)
3. https://git.corp.adobe.com/experience-platform/mystique/pull/1704 (mystique — renames OpportunityTypeEnum + agent folder + crew class)
4. adobe/project-elmo-ui#1643 (UI route alias)

## Test plan
- [x] `npm test` — all unit tests pass (2540 tests across tokowaka-client + data-access)
- [x] CI green: full Test job passed across all 18 packages
- [x] End-to-end demo on kashi.com verified locally via mysticat: mystique → SQS → bridge → DDB persists `type: image-enrichment` → elmo UI renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
