### PR TITLE
feat: add type, experimentId, baselinePrompts to strategy schema | LLMO-4643

### DIFF
--- a/packages/spacecat-shared-utils/src/strategy-schema.js
+++ b/packages/spacecat-shared-utils/src/strategy-schema.js
@@ -166,12 +166,16 @@ export const strategyWorkspaceData = z.object({
       });
     }
 
-    // Evolving must have a non-empty baselinePrompts array
-    if (strat.type === 'evolving' && (!Array.isArray(strat.baselinePrompts) || strat.baselinePrompts.length === 0)) {
+    // Evolving: if baselinePrompts is provided, it must be non-empty.
+    // Soft rule by design — does NOT require the field to be present, so
+    // pre-GA strategies (which lack baselinePrompts) parse cleanly. The
+    // "newly-created Evolving strategies must include baselinePrompts" rule
+    // is enforced at the API layer in saveStrategy (see PR C2).
+    if (strat.type === 'evolving' && Array.isArray(strat.baselinePrompts) && strat.baselinePrompts.length === 0) {
       ctx.addIssue({
         code: 'custom',
         path: ['strategies', strategyIndex, 'baselinePrompts'],
-        message: 'Evolving strategies require a non-empty baselinePrompts array',
+        message: 'Evolving strategies must not have an empty baselinePrompts array (omit the field if not yet set)',
       });
     }
   });

--- a/packages/spacecat-shared-utils/src/strategy-schema.js
+++ b/packages/spacecat-shared-utils/src/strategy-schema.js
@@ -165,17 +165,16 @@ export const strategyWorkspaceData = z.object({
       });
     }
 
-    // Evolving: if selectedPrompts is provided, it must be non-empty.
-    // Soft rule by design — does NOT require the field to be present, so
-    // pre-GA strategies (which lack selectedPrompts) parse cleanly. The
-    // "newly-created Evolving strategies must include selectedPrompts" rule
-    // is enforced at the API layer in saveStrategy (see PR C2).
-    if (strat.type === 'evolving' && Array.isArray(strat.selectedPrompts) && strat.selectedPrompts.length === 0) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['strategies', strategyIndex, 'selectedPrompts'],
-        message: 'Evolving strategies must not have an empty selectedPrompts array (omit the field if not yet set)',
-      });
-    }
+    // Evolving: schema is intentionally permissive on `selectedPrompts`. Today's
+    // CreateStrategyDialog initializes selectedPrompts as `[]` for newly-created
+    // Evolving strategies (no prompt-selection UI yet). Enforcing "must be
+    // non-empty" at the schema would reject those in-flight reads + writes.
+    //
+    // The "newly-created Evolving strategies must include selectedPrompts" rule
+    // is deferred to the milestone where Evolving promotes out of co-innovation
+    // mode — at that point the schema tightens, the API layer (saveStrategy)
+    // adds the creation-time check, and the prompt-selection screen ships.
+    // All three land together. Until then, selectedPrompts on Evolving is
+    // structurally validated only.
   });
 });

--- a/packages/spacecat-shared-utils/src/strategy-schema.js
+++ b/packages/spacecat-shared-utils/src/strategy-schema.js
@@ -96,7 +96,6 @@ const strategy = z.object({
   completedAt: z.string().optional(), // ISO 8601 date string
   goalType: strategyGoalType.optional(),
   experimentId: z.uuid().nullable().optional(),
-  baselinePrompts: z.array(strategyPromptSelection).optional(),
 });
 
 /**
@@ -157,25 +156,25 @@ export const strategyWorkspaceData = z.object({
       });
     }
 
-    // Atomic must not carry baselinePrompts (those come from GeoExperiment)
-    if (strat.type === 'atomic' && Array.isArray(strat.baselinePrompts) && strat.baselinePrompts.length > 0) {
+    // Atomic must not carry selectedPrompts (those come from GeoExperiment)
+    if (strat.type === 'atomic' && Array.isArray(strat.selectedPrompts) && strat.selectedPrompts.length > 0) {
       ctx.addIssue({
         code: 'custom',
-        path: ['strategies', strategyIndex, 'baselinePrompts'],
-        message: 'Atomic strategies must not carry baselinePrompts (use GeoExperiment.promptsLocation)',
+        path: ['strategies', strategyIndex, 'selectedPrompts'],
+        message: 'Atomic strategies must not carry selectedPrompts (use GeoExperiment.promptsLocation)',
       });
     }
 
-    // Evolving: if baselinePrompts is provided, it must be non-empty.
+    // Evolving: if selectedPrompts is provided, it must be non-empty.
     // Soft rule by design — does NOT require the field to be present, so
-    // pre-GA strategies (which lack baselinePrompts) parse cleanly. The
-    // "newly-created Evolving strategies must include baselinePrompts" rule
+    // pre-GA strategies (which lack selectedPrompts) parse cleanly. The
+    // "newly-created Evolving strategies must include selectedPrompts" rule
     // is enforced at the API layer in saveStrategy (see PR C2).
-    if (strat.type === 'evolving' && Array.isArray(strat.baselinePrompts) && strat.baselinePrompts.length === 0) {
+    if (strat.type === 'evolving' && Array.isArray(strat.selectedPrompts) && strat.selectedPrompts.length === 0) {
       ctx.addIssue({
         code: 'custom',
-        path: ['strategies', strategyIndex, 'baselinePrompts'],
-        message: 'Evolving strategies must not have an empty baselinePrompts array (omit the field if not yet set)',
+        path: ['strategies', strategyIndex, 'selectedPrompts'],
+        message: 'Evolving strategies must not have an empty selectedPrompts array (omit the field if not yet set)',
       });
     }
   });

--- a/packages/spacecat-shared-utils/src/strategy-schema.js
+++ b/packages/spacecat-shared-utils/src/strategy-schema.js
@@ -38,6 +38,10 @@ const strategyGoalType = z.union([
   z.string(), // Catchall for future goal types
 ]);
 
+// Discriminator between Atomic (experiment-driven) and Evolving (iterative) strategies.
+// Existing pre-GA strategies have no `type` field and default to 'evolving' for backward compat.
+const strategyType = z.enum(['atomic', 'evolving']);
+
 /**
  * Library opportunity - user-created reusable opportunity template
  */
@@ -76,6 +80,7 @@ const strategyPromptSelection = z.object({
  */
 const strategy = z.object({
   id: nonEmptyString,
+  type: strategyType.default('evolving'),
   name: nonEmptyString,
   status: workflowStatus,
   url: z.union([z.string(), z.array(z.string())]),
@@ -90,6 +95,8 @@ const strategy = z.object({
   createdBy: z.string().optional(), // Email of strategy creator/owner
   completedAt: z.string().optional(), // ISO 8601 date string
   goalType: strategyGoalType.optional(),
+  experimentId: z.uuid().nullable().optional(),
+  baselinePrompts: z.array(strategyPromptSelection).optional(),
 });
 
 /**
@@ -137,5 +144,35 @@ export const strategyWorkspaceData = z.object({
         });
       }
     });
+  });
+
+  // Validate type-based invariants (Atomic vs Evolving)
+  strategies.forEach((strat, strategyIndex) => {
+    // Atomic must have a non-null experimentId
+    if (strat.type === 'atomic' && (strat.experimentId === undefined || strat.experimentId === null)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['strategies', strategyIndex, 'experimentId'],
+        message: 'Atomic strategies require a non-null experimentId',
+      });
+    }
+
+    // Atomic must not carry baselinePrompts (those come from GeoExperiment)
+    if (strat.type === 'atomic' && Array.isArray(strat.baselinePrompts) && strat.baselinePrompts.length > 0) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['strategies', strategyIndex, 'baselinePrompts'],
+        message: 'Atomic strategies must not carry baselinePrompts (use GeoExperiment.promptsLocation)',
+      });
+    }
+
+    // Evolving must have a non-empty baselinePrompts array
+    if (strat.type === 'evolving' && (!Array.isArray(strat.baselinePrompts) || strat.baselinePrompts.length === 0)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['strategies', strategyIndex, 'baselinePrompts'],
+        message: 'Evolving strategies require a non-empty baselinePrompts array',
+      });
+    }
   });
 });

--- a/packages/spacecat-shared-utils/test/llmo-strategy.test.js
+++ b/packages/spacecat-shared-utils/test/llmo-strategy.test.js
@@ -56,7 +56,7 @@ describe('llmo-strategy utilities', () => {
             assignee: 'user@example.com',
           },
         ],
-        baselinePrompts: [{ prompt: 'p', regions: ['us'] }],
+        selectedPrompts: [{ prompt: 'p', regions: ['us'] }],
       },
     ],
   };
@@ -236,7 +236,7 @@ describe('llmo-strategy utilities', () => {
                 assignee: 'user@example.com',
               },
             ],
-            baselinePrompts: [{ prompt: 'p', regions: ['us'] }],
+            selectedPrompts: [{ prompt: 'p', regions: ['us'] }],
           },
         ],
       };

--- a/packages/spacecat-shared-utils/test/llmo-strategy.test.js
+++ b/packages/spacecat-shared-utils/test/llmo-strategy.test.js
@@ -41,6 +41,7 @@ describe('llmo-strategy utilities', () => {
     strategies: [
       {
         id: 'strat-1',
+        type: 'evolving',
         name: 'Q1 Optimization',
         status: 'in_progress',
         url: '/strategies/q1-optimization',
@@ -55,6 +56,7 @@ describe('llmo-strategy utilities', () => {
             assignee: 'user@example.com',
           },
         ],
+        baselinePrompts: [{ prompt: 'p', regions: ['us'] }],
       },
     ],
   };
@@ -217,6 +219,7 @@ describe('llmo-strategy utilities', () => {
         strategies: [
           {
             id: 'strat-2',
+            type: 'evolving',
             name: 'Multi-URL Strategy',
             status: 'planning',
             url: ['/strategies/url-a', '/strategies/url-b'],
@@ -233,6 +236,7 @@ describe('llmo-strategy utilities', () => {
                 assignee: 'user@example.com',
               },
             ],
+            baselinePrompts: [{ prompt: 'p', regions: ['us'] }],
           },
         ],
       };

--- a/packages/spacecat-shared-utils/test/strategy-schema.test.js
+++ b/packages/spacecat-shared-utils/test/strategy-schema.test.js
@@ -47,8 +47,8 @@ describe('strategyWorkspaceData', () => {
             assignee: 'user@example.com',
           },
         ],
-        // Evolving strategies (the default type) require a non-empty baselinePrompts array
-        baselinePrompts: [
+        // Evolving strategies (the default type) require a non-empty selectedPrompts array
+        selectedPrompts: [
           { prompt: 'best photo editor', regions: ['us'] },
         ],
       },
@@ -115,7 +115,7 @@ describe('strategyWorkspaceData', () => {
               assignee: 'user@example.com',
             },
           ],
-          baselinePrompts: [{ prompt: 'p', regions: ['us'] }],
+          selectedPrompts: [{ prompt: 'p', regions: ['us'] }],
         },
       ],
     };
@@ -563,7 +563,7 @@ describe('strategyWorkspaceData', () => {
           topic: 'T',
           createdAt: '2025-01-01T00:00:00Z',
           opportunities: [],
-          baselinePrompts: [{ prompt: 'p', regions: ['us'] }],
+          selectedPrompts: [{ prompt: 'p', regions: ['us'] }],
         }],
       };
       const result = strategyWorkspaceData.safeParse(data);
@@ -630,7 +630,7 @@ describe('strategyWorkspaceData', () => {
           topic: 'T',
           createdAt: '2025-01-01T00:00:00Z',
           opportunities: [],
-          baselinePrompts: [{ prompt: 'p', regions: ['us'] }],
+          selectedPrompts: [{ prompt: 'p', regions: ['us'] }],
         }],
       };
       const result = strategyWorkspaceData.safeParse(data);
@@ -651,7 +651,7 @@ describe('strategyWorkspaceData', () => {
           topic: 'T',
           createdAt: '2025-01-01T00:00:00Z',
           opportunities: [],
-          baselinePrompts: [{ prompt: 'p', regions: ['us'] }],
+          selectedPrompts: [{ prompt: 'p', regions: ['us'] }],
         }],
       };
       const result = strategyWorkspaceData.safeParse(data);
@@ -672,14 +672,14 @@ describe('strategyWorkspaceData', () => {
           topic: 'T',
           createdAt: '2025-01-01T00:00:00Z',
           opportunities: [],
-          baselinePrompts: [{ prompt: 'p', regions: ['us'] }],
+          selectedPrompts: [{ prompt: 'p', regions: ['us'] }],
         }],
       };
       const result = strategyWorkspaceData.safeParse(data);
       expect(result.success).false;
     });
 
-    it('accepts baselinePrompts array on Evolving', () => {
+    it('accepts selectedPrompts array on Evolving', () => {
       const data = {
         opportunities: [],
         strategies: [{
@@ -692,7 +692,7 @@ describe('strategyWorkspaceData', () => {
           topic: 'T',
           createdAt: '2025-01-01T00:00:00Z',
           opportunities: [],
-          baselinePrompts: [
+          selectedPrompts: [
             { prompt: 'best photo editor', regions: ['us', 'uk'] },
             { prompt: 'photo editing software', regions: ['us'] },
           ],
@@ -701,7 +701,7 @@ describe('strategyWorkspaceData', () => {
       const result = strategyWorkspaceData.safeParse(data);
       expect(result.success).true;
       if (result.success) {
-        expect(result.data.strategies[0].baselinePrompts).length(2);
+        expect(result.data.strategies[0].selectedPrompts).length(2);
       }
     });
   });
@@ -752,14 +752,14 @@ describe('strategyWorkspaceData', () => {
       expect(result.success).false;
     });
 
-    it('rejects Atomic with non-empty baselinePrompts', () => {
+    it('rejects Atomic with non-empty selectedPrompts', () => {
       const data = {
         opportunities: [],
         strategies: [{
           id: 'strat-bad-3',
           type: 'atomic',
           experimentId: '550e8400-e29b-41d4-a716-446655440000',
-          baselinePrompts: [{ prompt: 'x', regions: ['us'] }],
+          selectedPrompts: [{ prompt: 'x', regions: ['us'] }],
           name: 'Atomic with baseline prompts',
           status: 'in_progress',
           url: '/x',
@@ -773,19 +773,19 @@ describe('strategyWorkspaceData', () => {
       expect(result.success).false;
       if (!result.success) {
         expect(result.error.issues.some(
-          (i) => i.message.includes('must not carry baselinePrompts'),
+          (i) => i.message.includes('must not carry selectedPrompts'),
         )).true;
       }
     });
 
-    it('accepts Atomic with empty baselinePrompts array (treated as none)', () => {
+    it('accepts Atomic with empty selectedPrompts array (treated as none)', () => {
       const data = {
         opportunities: [],
         strategies: [{
           id: 'strat-edge-1',
           type: 'atomic',
           experimentId: '550e8400-e29b-41d4-a716-446655440000',
-          baselinePrompts: [],
+          selectedPrompts: [],
           name: 'Atomic with empty baseline prompts',
           status: 'in_progress',
           url: '/x',
@@ -799,9 +799,9 @@ describe('strategyWorkspaceData', () => {
       expect(result.success).true;
     });
 
-    it('accepts Evolving without baselinePrompts (backward-compat for legacy data)', () => {
+    it('accepts Evolving without selectedPrompts (backward-compat for legacy data)', () => {
       // Schema invariant is intentionally soft: pre-GA strategies in S3 lack
-      // baselinePrompts and must parse cleanly. The "must have baselinePrompts
+      // selectedPrompts and must parse cleanly. The "must have selectedPrompts
       // on creation" rule is enforced at the API layer in saveStrategy (PR C2),
       // not in the schema.
       const data = {
@@ -809,7 +809,7 @@ describe('strategyWorkspaceData', () => {
         strategies: [{
           id: 'strat-legacy-1',
           type: 'evolving',
-          // baselinePrompts missing — legacy/pre-GA shape
+          // selectedPrompts missing — legacy/pre-GA shape
           name: 'Legacy Evolving strategy',
           status: 'in_progress',
           url: '/x',
@@ -823,7 +823,7 @@ describe('strategyWorkspaceData', () => {
       expect(result.success).true;
     });
 
-    it('rejects Evolving with empty baselinePrompts array', () => {
+    it('rejects Evolving with empty selectedPrompts array', () => {
       // Field present but empty is malformed — distinguishable from "field
       // absent" which is legacy-tolerated.
       const data = {
@@ -831,7 +831,7 @@ describe('strategyWorkspaceData', () => {
         strategies: [{
           id: 'strat-bad-5',
           type: 'evolving',
-          baselinePrompts: [],
+          selectedPrompts: [],
           name: 'Evolving with empty baseline',
           status: 'in_progress',
           url: '/x',
@@ -845,14 +845,14 @@ describe('strategyWorkspaceData', () => {
       expect(result.success).false;
       if (!result.success) {
         expect(result.error.issues.some(
-          (i) => i.message.includes('must not have an empty baselinePrompts array'),
+          (i) => i.message.includes('must not have an empty selectedPrompts array'),
         )).true;
       }
     });
 
-    it('accepts Evolving with default type (no type field) and baselinePrompts', () => {
+    it('accepts Evolving with default type (no type field) and selectedPrompts', () => {
       // Backward-compat path: existing strategies lack `type`, default kicks
-      // in to 'evolving'. With the soft invariant, baselinePrompts can also be
+      // in to 'evolving'. With the soft invariant, selectedPrompts can also be
       // absent and the strategy still parses.
       const data = {
         opportunities: [],
@@ -866,16 +866,16 @@ describe('strategyWorkspaceData', () => {
           topic: 'T',
           createdAt: '2025-01-01T00:00:00Z',
           opportunities: [],
-          baselinePrompts: [{ prompt: 'p', regions: ['us'] }], // explicit
+          selectedPrompts: [{ prompt: 'p', regions: ['us'] }], // explicit
         }],
       };
       const result = strategyWorkspaceData.safeParse(data);
       expect(result.success).true;
     });
 
-    it('accepts Evolving with default type and no baselinePrompts (true legacy shape)', () => {
+    it('accepts Evolving with default type and no selectedPrompts (true legacy shape)', () => {
       // The actual shape of pre-GA strategies in S3 — no `type`, no
-      // `baselinePrompts`. The schema must accept this.
+      // `selectedPrompts`. The schema must accept this.
       const data = {
         opportunities: [],
         strategies: [{
@@ -893,7 +893,7 @@ describe('strategyWorkspaceData', () => {
       expect(result.success).true;
       if (result.success) {
         expect(result.data.strategies[0].type).equal('evolving');
-        expect(result.data.strategies[0].baselinePrompts).undefined;
+        expect(result.data.strategies[0].selectedPrompts).undefined;
       }
     });
   });

--- a/packages/spacecat-shared-utils/test/strategy-schema.test.js
+++ b/packages/spacecat-shared-utils/test/strategy-schema.test.js
@@ -799,14 +799,18 @@ describe('strategyWorkspaceData', () => {
       expect(result.success).true;
     });
 
-    it('rejects Evolving without baselinePrompts', () => {
+    it('accepts Evolving without baselinePrompts (backward-compat for legacy data)', () => {
+      // Schema invariant is intentionally soft: pre-GA strategies in S3 lack
+      // baselinePrompts and must parse cleanly. The "must have baselinePrompts
+      // on creation" rule is enforced at the API layer in saveStrategy (PR C2),
+      // not in the schema.
       const data = {
         opportunities: [],
         strategies: [{
-          id: 'strat-bad-4',
+          id: 'strat-legacy-1',
           type: 'evolving',
-          // baselinePrompts missing
-          name: 'Evolving without baseline',
+          // baselinePrompts missing — legacy/pre-GA shape
+          name: 'Legacy Evolving strategy',
           status: 'in_progress',
           url: '/x',
           description: '',
@@ -816,15 +820,12 @@ describe('strategyWorkspaceData', () => {
         }],
       };
       const result = strategyWorkspaceData.safeParse(data);
-      expect(result.success).false;
-      if (!result.success) {
-        expect(result.error.issues.some(
-          (i) => i.message.includes('Evolving strategies require a non-empty baselinePrompts'),
-        )).true;
-      }
+      expect(result.success).true;
     });
 
     it('rejects Evolving with empty baselinePrompts array', () => {
+      // Field present but empty is malformed — distinguishable from "field
+      // absent" which is legacy-tolerated.
       const data = {
         opportunities: [],
         strategies: [{
@@ -842,12 +843,17 @@ describe('strategyWorkspaceData', () => {
       };
       const result = strategyWorkspaceData.safeParse(data);
       expect(result.success).false;
+      if (!result.success) {
+        expect(result.error.issues.some(
+          (i) => i.message.includes('must not have an empty baselinePrompts array'),
+        )).true;
+      }
     });
 
     it('accepts Evolving with default type (no type field) and baselinePrompts', () => {
-      // Backward-compat path: existing strategies will lack `type`, default kicks in to 'evolving'.
-      // The Evolving invariant fires regardless of whether `type` was provided or defaulted, so
-      // backward-compat consumers must include baselinePrompts (or be migrated to do so).
+      // Backward-compat path: existing strategies lack `type`, default kicks
+      // in to 'evolving'. With the soft invariant, baselinePrompts can also be
+      // absent and the strategy still parses.
       const data = {
         opportunities: [],
         strategies: [{
@@ -865,6 +871,30 @@ describe('strategyWorkspaceData', () => {
       };
       const result = strategyWorkspaceData.safeParse(data);
       expect(result.success).true;
+    });
+
+    it('accepts Evolving with default type and no baselinePrompts (true legacy shape)', () => {
+      // The actual shape of pre-GA strategies in S3 — no `type`, no
+      // `baselinePrompts`. The schema must accept this.
+      const data = {
+        opportunities: [],
+        strategies: [{
+          id: 'strat-true-legacy',
+          name: 'True pre-GA strategy',
+          status: 'in_progress',
+          url: '/x',
+          description: '',
+          topic: 'T',
+          createdAt: '2025-01-01T00:00:00Z',
+          opportunities: [],
+        }],
+      };
+      const result = strategyWorkspaceData.safeParse(data);
+      expect(result.success).true;
+      if (result.success) {
+        expect(result.data.strategies[0].type).equal('evolving');
+        expect(result.data.strategies[0].baselinePrompts).undefined;
+      }
     });
   });
 });

--- a/packages/spacecat-shared-utils/test/strategy-schema.test.js
+++ b/packages/spacecat-shared-utils/test/strategy-schema.test.js
@@ -47,6 +47,10 @@ describe('strategyWorkspaceData', () => {
             assignee: 'user@example.com',
           },
         ],
+        // Evolving strategies (the default type) require a non-empty baselinePrompts array
+        baselinePrompts: [
+          { prompt: 'best photo editor', regions: ['us'] },
+        ],
       },
     ],
   };
@@ -111,6 +115,7 @@ describe('strategyWorkspaceData', () => {
               assignee: 'user@example.com',
             },
           ],
+          baselinePrompts: [{ prompt: 'p', regions: ['us'] }],
         },
       ],
     };
@@ -542,6 +547,324 @@ describe('strategyWorkspaceData', () => {
 
       const result = strategyWorkspaceData.safeParse(data);
       expect(result.success).false;
+    });
+  });
+
+  describe('strategy type discriminator', () => {
+    it('defaults type to "evolving" when missing (backward compat)', () => {
+      const data = {
+        opportunities: [],
+        strategies: [{
+          id: 'strat-1',
+          name: 'Existing strategy without type field',
+          status: 'in_progress',
+          url: '/x',
+          description: '',
+          topic: 'T',
+          createdAt: '2025-01-01T00:00:00Z',
+          opportunities: [],
+          baselinePrompts: [{ prompt: 'p', regions: ['us'] }],
+        }],
+      };
+      const result = strategyWorkspaceData.safeParse(data);
+      expect(result.success).true;
+      if (result.success) {
+        expect(result.data.strategies[0].type).equal('evolving');
+      }
+    });
+
+    it('accepts type "atomic"', () => {
+      const data = {
+        opportunities: [],
+        strategies: [{
+          id: 'strat-2',
+          type: 'atomic',
+          experimentId: '550e8400-e29b-41d4-a716-446655440000',
+          name: 'Atomic strategy',
+          status: 'in_progress',
+          url: '/x',
+          description: '',
+          topic: 'T',
+          createdAt: '2025-01-01T00:00:00Z',
+          opportunities: [],
+        }],
+      };
+      const result = strategyWorkspaceData.safeParse(data);
+      expect(result.success).true;
+      if (result.success) {
+        expect(result.data.strategies[0].type).equal('atomic');
+      }
+    });
+
+    it('rejects unknown type values', () => {
+      const data = {
+        opportunities: [],
+        strategies: [{
+          id: 'strat-3',
+          type: 'something-else',
+          name: 'Bad type',
+          status: 'in_progress',
+          url: '/x',
+          description: '',
+          topic: 'T',
+          createdAt: '2025-01-01T00:00:00Z',
+          opportunities: [],
+        }],
+      };
+      const result = strategyWorkspaceData.safeParse(data);
+      expect(result.success).false;
+    });
+
+    it('accepts a valid UUID experimentId', () => {
+      const data = {
+        opportunities: [],
+        strategies: [{
+          id: 'strat-4',
+          type: 'evolving',
+          experimentId: '550e8400-e29b-41d4-a716-446655440000',
+          name: 'Strategy with experiment',
+          status: 'completed',
+          completedAt: '2025-02-01T00:00:00Z',
+          url: '/x',
+          description: '',
+          topic: 'T',
+          createdAt: '2025-01-01T00:00:00Z',
+          opportunities: [],
+          baselinePrompts: [{ prompt: 'p', regions: ['us'] }],
+        }],
+      };
+      const result = strategyWorkspaceData.safeParse(data);
+      expect(result.success).true;
+    });
+
+    it('accepts null experimentId on Evolving (no opt-in yet)', () => {
+      const data = {
+        opportunities: [],
+        strategies: [{
+          id: 'strat-5',
+          type: 'evolving',
+          experimentId: null,
+          name: 'Evolving without opt-in',
+          status: 'in_progress',
+          url: '/x',
+          description: '',
+          topic: 'T',
+          createdAt: '2025-01-01T00:00:00Z',
+          opportunities: [],
+          baselinePrompts: [{ prompt: 'p', regions: ['us'] }],
+        }],
+      };
+      const result = strategyWorkspaceData.safeParse(data);
+      expect(result.success).true;
+    });
+
+    it('rejects non-UUID experimentId', () => {
+      const data = {
+        opportunities: [],
+        strategies: [{
+          id: 'strat-6',
+          type: 'evolving',
+          experimentId: 'not-a-uuid',
+          name: 'Bad experiment id',
+          status: 'in_progress',
+          url: '/x',
+          description: '',
+          topic: 'T',
+          createdAt: '2025-01-01T00:00:00Z',
+          opportunities: [],
+          baselinePrompts: [{ prompt: 'p', regions: ['us'] }],
+        }],
+      };
+      const result = strategyWorkspaceData.safeParse(data);
+      expect(result.success).false;
+    });
+
+    it('accepts baselinePrompts array on Evolving', () => {
+      const data = {
+        opportunities: [],
+        strategies: [{
+          id: 'strat-7',
+          type: 'evolving',
+          name: 'With baseline prompts',
+          status: 'in_progress',
+          url: '/x',
+          description: '',
+          topic: 'T',
+          createdAt: '2025-01-01T00:00:00Z',
+          opportunities: [],
+          baselinePrompts: [
+            { prompt: 'best photo editor', regions: ['us', 'uk'] },
+            { prompt: 'photo editing software', regions: ['us'] },
+          ],
+        }],
+      };
+      const result = strategyWorkspaceData.safeParse(data);
+      expect(result.success).true;
+      if (result.success) {
+        expect(result.data.strategies[0].baselinePrompts).length(2);
+      }
+    });
+  });
+
+  describe('strategy type invariants (superRefine)', () => {
+    it('rejects Atomic without experimentId', () => {
+      const data = {
+        opportunities: [],
+        strategies: [{
+          id: 'strat-bad-1',
+          type: 'atomic',
+          // experimentId missing
+          name: 'Bad atomic',
+          status: 'in_progress',
+          url: '/x',
+          description: '',
+          topic: 'T',
+          createdAt: '2025-01-01T00:00:00Z',
+          opportunities: [],
+        }],
+      };
+      const result = strategyWorkspaceData.safeParse(data);
+      expect(result.success).false;
+      if (!result.success) {
+        expect(result.error.issues.some(
+          (i) => i.message.includes('Atomic strategies require a non-null experimentId'),
+        )).true;
+      }
+    });
+
+    it('rejects Atomic with null experimentId', () => {
+      const data = {
+        opportunities: [],
+        strategies: [{
+          id: 'strat-bad-2',
+          type: 'atomic',
+          experimentId: null,
+          name: 'Atomic with null exp',
+          status: 'in_progress',
+          url: '/x',
+          description: '',
+          topic: 'T',
+          createdAt: '2025-01-01T00:00:00Z',
+          opportunities: [],
+        }],
+      };
+      const result = strategyWorkspaceData.safeParse(data);
+      expect(result.success).false;
+    });
+
+    it('rejects Atomic with non-empty baselinePrompts', () => {
+      const data = {
+        opportunities: [],
+        strategies: [{
+          id: 'strat-bad-3',
+          type: 'atomic',
+          experimentId: '550e8400-e29b-41d4-a716-446655440000',
+          baselinePrompts: [{ prompt: 'x', regions: ['us'] }],
+          name: 'Atomic with baseline prompts',
+          status: 'in_progress',
+          url: '/x',
+          description: '',
+          topic: 'T',
+          createdAt: '2025-01-01T00:00:00Z',
+          opportunities: [],
+        }],
+      };
+      const result = strategyWorkspaceData.safeParse(data);
+      expect(result.success).false;
+      if (!result.success) {
+        expect(result.error.issues.some(
+          (i) => i.message.includes('must not carry baselinePrompts'),
+        )).true;
+      }
+    });
+
+    it('accepts Atomic with empty baselinePrompts array (treated as none)', () => {
+      const data = {
+        opportunities: [],
+        strategies: [{
+          id: 'strat-edge-1',
+          type: 'atomic',
+          experimentId: '550e8400-e29b-41d4-a716-446655440000',
+          baselinePrompts: [],
+          name: 'Atomic with empty baseline prompts',
+          status: 'in_progress',
+          url: '/x',
+          description: '',
+          topic: 'T',
+          createdAt: '2025-01-01T00:00:00Z',
+          opportunities: [],
+        }],
+      };
+      const result = strategyWorkspaceData.safeParse(data);
+      expect(result.success).true;
+    });
+
+    it('rejects Evolving without baselinePrompts', () => {
+      const data = {
+        opportunities: [],
+        strategies: [{
+          id: 'strat-bad-4',
+          type: 'evolving',
+          // baselinePrompts missing
+          name: 'Evolving without baseline',
+          status: 'in_progress',
+          url: '/x',
+          description: '',
+          topic: 'T',
+          createdAt: '2025-01-01T00:00:00Z',
+          opportunities: [],
+        }],
+      };
+      const result = strategyWorkspaceData.safeParse(data);
+      expect(result.success).false;
+      if (!result.success) {
+        expect(result.error.issues.some(
+          (i) => i.message.includes('Evolving strategies require a non-empty baselinePrompts'),
+        )).true;
+      }
+    });
+
+    it('rejects Evolving with empty baselinePrompts array', () => {
+      const data = {
+        opportunities: [],
+        strategies: [{
+          id: 'strat-bad-5',
+          type: 'evolving',
+          baselinePrompts: [],
+          name: 'Evolving with empty baseline',
+          status: 'in_progress',
+          url: '/x',
+          description: '',
+          topic: 'T',
+          createdAt: '2025-01-01T00:00:00Z',
+          opportunities: [],
+        }],
+      };
+      const result = strategyWorkspaceData.safeParse(data);
+      expect(result.success).false;
+    });
+
+    it('accepts Evolving with default type (no type field) and baselinePrompts', () => {
+      // Backward-compat path: existing strategies will lack `type`, default kicks in to 'evolving'.
+      // The Evolving invariant fires regardless of whether `type` was provided or defaulted, so
+      // backward-compat consumers must include baselinePrompts (or be migrated to do so).
+      const data = {
+        opportunities: [],
+        strategies: [{
+          id: 'strat-existing',
+          // type defaults to 'evolving'
+          name: 'Pre-GA strategy',
+          status: 'in_progress',
+          url: '/x',
+          description: '',
+          topic: 'T',
+          createdAt: '2025-01-01T00:00:00Z',
+          opportunities: [],
+          baselinePrompts: [{ prompt: 'p', regions: ['us'] }], // explicit
+        }],
+      };
+      const result = strategyWorkspaceData.safeParse(data);
+      expect(result.success).true;
     });
   });
 });

--- a/packages/spacecat-shared-utils/test/strategy-schema.test.js
+++ b/packages/spacecat-shared-utils/test/strategy-schema.test.js
@@ -823,16 +823,20 @@ describe('strategyWorkspaceData', () => {
       expect(result.success).true;
     });
 
-    it('rejects Evolving with empty selectedPrompts array', () => {
-      // Field present but empty is malformed — distinguishable from "field
-      // absent" which is legacy-tolerated.
+    it('accepts Evolving with empty selectedPrompts array (FE init shape)', () => {
+      // Today's CreateStrategyDialog initializes selectedPrompts as [] for
+      // newly-created Evolving strategies (no prompt-selection screen yet).
+      // The schema is intentionally permissive here. The "must include
+      // selectedPrompts" rule lands at the milestone where Evolving promotes
+      // out of co-innovation mode (schema tightening + saveStrategy rule +
+      // prompt-selection screen all ship together).
       const data = {
         opportunities: [],
         strategies: [{
-          id: 'strat-bad-5',
+          id: 'strat-fe-init',
           type: 'evolving',
           selectedPrompts: [],
-          name: 'Evolving with empty baseline',
+          name: 'Evolving with FE-initialized empty array',
           status: 'in_progress',
           url: '/x',
           description: '',
@@ -842,12 +846,7 @@ describe('strategyWorkspaceData', () => {
         }],
       };
       const result = strategyWorkspaceData.safeParse(data);
-      expect(result.success).false;
-      if (!result.success) {
-        expect(result.error.issues.some(
-          (i) => i.message.includes('must not have an empty selectedPrompts array'),
-        )).true;
-      }
+      expect(result.success).true;
     });
 
     it('accepts Evolving with default type (no type field) and selectedPrompts', () => {


### PR DESCRIPTION
## Summary
Adds three new fields to the strategy Zod schema in support of the Opportunity Workspace GA: `type` (`atomic` | `evolving` discriminator with `evolving` default for backward compat), `experimentId` (optional, nullable UUID linking to GeoExperiment), and `baselinePrompts` (Evolving-only prompt set, reuses existing `strategyPromptSelection`). Adds a `superRefine` block enforcing three type-based invariants. Fourteen new unit tests; lint clean; 100% line/statement/branch coverage maintained on `strategy-schema.js`.

## Why
Foundation PR for the Opportunity Workspace GA program (epic [LLMO-2703](https://jira.corp.adobe.com/browse/LLMO-2703)).
Implements: [LLMO-4643](https://jira.corp.adobe.com/browse/LLMO-4643) — F1 Strategy schema additions.

This PR must merge + npm publish before any other GA PR opens — they all depend on `@adobe/spacecat-shared-utils@<new-version>` for the new schema.

## Self-review summary
Self-review surfaced one substantive item that's out of plan scope and one minor wording note:

- **Backward compatibility risk (deferred to reviewer focus below):** the new "Evolving requires non-empty baselinePrompts" invariant fires uniformly on `parse()`. Existing pre-GA strategies in S3 are Evolving (defaulted) but lack `baselinePrompts`, so `readStrategy()` will throw on those documents after this PR publishes. The plan does not include a data migration. Needs reviewer confirmation that an S3 migration is queued before downstream consumers bump the dep, OR that the F1 plan should ship with a transitional looser rule. Existing test fixtures were updated to include `baselinePrompts` so tests pass; that does not address the S3 case.
- **Error message wording:** `Atomic strategies must not carry baselinePrompts (use GeoExperiment.promptsLocation)` references a field name that isn't defined in this PR (it lands later in the GA program). Kept the plan's wording — will make sense once downstream PRs land.

## Verification
```bash
cd packages/spacecat-shared-utils
npm test           # 1049 passing, 100% line/statement/branch coverage on strategy-schema.js
npm run lint       # clean
```

Also verified at the monorepo level:
```bash
npm test           # all packages pass
npm run lint       # clean
node --input-type=module -e "import('./packages/spacecat-shared-utils/src/llmo-strategy.js').then(m => console.log(Object.keys(m)))"
# OK [readStrategy, strategyPath, strategyWorkspaceData, writeStrategy]
```

14 new tests added covering: type field default + atomic accept + unknown reject; experimentId valid UUID + null + non-UUID; baselinePrompts on Evolving; superRefine for Atomic-without-experimentId, Atomic-with-null-experimentId, Atomic-with-non-empty-baselinePrompts (rejection), Atomic-with-empty-baselinePrompts (acceptance), Evolving-without-baselinePrompts, Evolving-with-empty-baselinePrompts, default-type-Evolving-with-baselinePrompts.

## Reviewer focus
- **Backward compat with existing S3 documents** — see Self-review summary. Does the GA rollout already include an S3 migration that pre-seeds `baselinePrompts` on existing Evolving strategies? If not, we should consider weakening the Evolving invariant (or making it write-time only) until migration ships.
- **Default value `type.default('evolving')`** — semantically right? Pre-GA strategies are all manually created, so Evolving is correct.
- **The "Atomic must not carry baselinePrompts" rule** — too strict? Per spec: Atomic gets prompts from `GeoExperiment.promptsLocation`, never from the strategy object itself.
- **Field placement** — `experimentId` and `baselinePrompts` are appended after `goalType` rather than adjacent to `type`; preserves existing field ordering. Move them up if you prefer cohesion over ordering stability.
- **Test coverage of the seven superRefine branches** — anything missing? Each invariant has at least one accept and one reject test; coverage is 100%.

## Cross-repo PR links
First in the program — no upstream PRs. Downstream PRs (A1, A2+A3, B1, B3-BE, B3-FE, C2, C3+C4, A4, A5) will link back here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)