### PR TITLE
feat(data-access): add readAll capability to Consumer.CAPABILITIES

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/consumer/consumer.model.js
+++ b/packages/spacecat-shared-data-access/src/models/consumer/consumer.model.js
@@ -51,7 +51,7 @@ class Consumer extends BaseModel {
     return super.save();
   }
 
-  static CAPABILITIES = ['read', 'write', 'delete'];
+  static CAPABILITIES = ['read', 'write', 'delete', 'readAll'];
 
   static IMS_ORG_ID_REGEX = /^[a-z0-9]{24}@AdobeOrg$/i;
 

--- a/packages/spacecat-shared-data-access/src/models/consumer/consumer.model.js
+++ b/packages/spacecat-shared-data-access/src/models/consumer/consumer.model.js
@@ -51,6 +51,11 @@ class Consumer extends BaseModel {
     return super.save();
   }
 
+  /**
+   * Valid capability actions. `readAll` is a scope+verb hybrid — it grants enumeration
+   * across all tenants and is only meaningful on routes that explicitly opt in
+   * (`site` and `organization`). Schema validity does not imply a reachable route.
+   */
   static CAPABILITIES = ['read', 'write', 'delete', 'readAll'];
 
   static IMS_ORG_ID_REGEX = /^[a-z0-9]{24}@AdobeOrg$/i;

--- a/packages/spacecat-shared-data-access/test/it/postgrest/docker-compose.yml
+++ b/packages/spacecat-shared-data-access/test/it/postgrest/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
   data-service:
     platform: ${MYSTICAT_DATA_SERVICE_PLATFORM:-linux/amd64}
-    image: ${MYSTICAT_DATA_SERVICE_REPOSITORY:-682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service}:${MYSTICAT_DATA_SERVICE_TAG:-v1.67.8}
+    image: ${MYSTICAT_DATA_SERVICE_REPOSITORY:-682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service}:${MYSTICAT_DATA_SERVICE_TAG:-v5.1.1}
     depends_on:
       db:
         condition: service_healthy

--- a/packages/spacecat-shared-data-access/test/unit/models/consumer/consumer.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/consumer/consumer.collection.test.js
@@ -131,7 +131,7 @@ describe('ConsumerCollection', () => {
       expect(mockElectroService.entities.consumer.create).to.not.have.been.called;
     });
 
-    it('accepts the readAll action for any registered entity', async () => {
+    it('accepts site:readAll and organization:readAll capabilities', async () => {
       const item = {
         clientId: 'client-readall',
         technicalAccountId: 'AABB00112233445566778899@techacct.adobe.com',
@@ -148,6 +148,7 @@ describe('ConsumerCollection', () => {
 
       const result = await instance.create(item);
       expect(result).to.not.be.null;
+      expect(mockElectroService.entities.consumer.create).to.have.been.calledOnce;
       instance.findByClientId.restore();
     });
 

--- a/packages/spacecat-shared-data-access/test/unit/models/consumer/consumer.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/consumer/consumer.collection.test.js
@@ -131,6 +131,26 @@ describe('ConsumerCollection', () => {
       expect(mockElectroService.entities.consumer.create).to.not.have.been.called;
     });
 
+    it('accepts the readAll action for any registered entity', async () => {
+      const item = {
+        clientId: 'client-readall',
+        technicalAccountId: 'AABB00112233445566778899@techacct.adobe.com',
+        consumerName: 'consumer-readall',
+        status: 'ACTIVE',
+        capabilities: ['site:readAll', 'organization:readAll'],
+        imsOrgId: '1234567890ABCDEF12345678@AdobeOrg',
+      };
+
+      stub(instance, 'findByClientId').resolves(null);
+      mockElectroService.entities.consumer.create.returns({
+        go: () => Promise.resolve({ data: sampleConsumer }),
+      });
+
+      const result = await instance.create(item);
+      expect(result).to.not.be.null;
+      instance.findByClientId.restore();
+    });
+
     it('throws ValidationError for unknown entity in capability', async () => {
       const item = {
         clientId: 'client-new',

--- a/packages/spacecat-shared-data-access/test/unit/models/consumer/consumer.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/consumer/consumer.model.test.js
@@ -62,7 +62,7 @@ describe('ConsumerModel', () => {
     });
 
     it('has CAPABILITIES', () => {
-      expect(Consumer.CAPABILITIES).to.deep.equal(['read', 'write', 'delete']);
+      expect(Consumer.CAPABILITIES).to.deep.equal(['read', 'write', 'delete', 'readAll']);
     });
 
     it('has TECHNICAL_ACCOUNT_ID_REGEX', () => {


### PR DESCRIPTION
Adds 'readAll' as a valid action in Consumer.CAPABILITIES, enabling capability strings of the form `<entity>:readAll` (e.g. `site:readAll`, `organization:readAll`) to pass `ConsumerCollection.validateCapabilities`.

This is the shared-lib half of the S2S readAll capability rollout. The api-service consumes this in a follow-up PR to remap GET /sites and GET /organizations from `<entity>:read` to `<entity>:readAll`, allowing platform-level S2S consumers to enumerate sites/organizations across tenants without weakening tenant isolation on per-resource operations.

See docs/s2s/READALL_CAPABILITY_DESIGN.md (in adobe/spacecat-api-service) for the full design and trust-boundary analysis.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
