### PR TITLE
feat(AGENTCOM-634): PDP enrichment does not correctly format on the AI visibility tool checker

### DIFF
--- a/packages/spacecat-shared-tokowaka-client/src/mappers/commerce-page-enrichment-mapper.js
+++ b/packages/spacecat-shared-tokowaka-client/src/mappers/commerce-page-enrichment-mapper.js
@@ -19,6 +19,18 @@ const EXCLUDED_FIELDS = new Set([
   'rationale',
 ]);
 
+// Array-typed keys rendered as <ul> that should NOT get a wrapping <section> + <h3>.
+const HEADING_EXCLUDED_KEYS = new Set([
+  'facts.feature_bullets',
+  'facts.description_plain',
+]);
+
+function deriveHeadingLabel(key) {
+  const lastSegment = key.split('.').pop();
+  const spaced = lastSegment.replace(/_/g, ' ');
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
 // Fields rendered in fixed order at the top of the article.
 // Each entry: CSS class, display label, [source keys in priority order]
 const ORDERED_FIELDS = [
@@ -121,7 +133,12 @@ function enrichmentToHtml(enrichmentData) {
     const cls = sanitizeClassName(key);
     const html = renderValue(key, value, cls);
     if (html) {
-      parts.push(html);
+      if (Array.isArray(value) && !HEADING_EXCLUDED_KEYS.has(key)) {
+        const label = escapeHtml(deriveHeadingLabel(key));
+        parts.push(`<section class="${cls}"><h3 class="${cls}">${label}</h3>${html}</section>`);
+      } else {
+        parts.push(html);
+      }
     }
   }
 

--- a/packages/spacecat-shared-tokowaka-client/test/mappers/commerce-page-enrichment-mapper.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/mappers/commerce-page-enrichment-mapper.test.js
@@ -660,6 +660,146 @@ describe('CommercePageEnrichmentMapper', () => {
       expect(wrapper.properties.dataSku).to.be.undefined;
     });
 
+    it('should wrap each qualifying array field in a <section> with derived <h3>', () => {
+      const suggestion = makeSuggestion({
+        patchValue: JSON.stringify({
+          sku: 'BigOne_1935',
+          'facts.attributes.color_family': ['Black', 'Blue'],
+          'facts.attributes.fabric': ['Velvet'],
+          'facts.attributes.fabric_type': ['Charcoal Wombat Phur'],
+          'facts.options': ['Cover', 'Insert'],
+          'facts.configurations': ['BigOne Insert & Cover'],
+        }),
+        url: 'https://www.lovesac.com/products/bigone',
+      });
+
+      const patches = mapper.suggestionsToPatches('/products/bigone', [suggestion], opportunityId);
+      const article = findNode(patches[0].value, (n) => n.tagName === 'article');
+
+      const sections = findAllNodes(article, (n) => n.tagName === 'section');
+      expect(sections).to.have.length(5);
+
+      const expected = [
+        { cls: 'color-family', label: 'Color family' },
+        { cls: 'fabric', label: 'Fabric' },
+        { cls: 'fabric-type', label: 'Fabric type' },
+        { cls: 'facts-options', label: 'Options' },
+        { cls: 'facts-configurations', label: 'Configurations' },
+      ];
+      for (const { cls, label } of expected) {
+        const section = sections.find((s) => s.properties?.className?.includes(cls));
+        expect(section, `section.${cls}`).to.exist;
+
+        const h3 = findNode(section, (n) => n.tagName === 'h3');
+        expect(h3, `h3 in section.${cls}`).to.exist;
+        expect(h3.properties.className).to.include(cls);
+        expect(textContent(h3)).to.equal(label);
+
+        const ul = findNode(section, (n) => n.tagName === 'ul');
+        expect(ul, `ul in section.${cls}`).to.exist;
+        expect(ul.properties.className).to.include(cls);
+      }
+    });
+
+    it('should place <h3> immediately before <ul> inside the <section>', () => {
+      const suggestion = makeSuggestion({
+        patchValue: JSON.stringify({
+          sku: 'TEST',
+          'facts.attributes.fabric': ['Velvet', 'Phur'],
+        }),
+        url: 'https://example.com/page',
+      });
+
+      const patches = mapper.suggestionsToPatches('/page', [suggestion], opportunityId);
+      const section = findNode(patches[0].value, (n) => n.tagName === 'section'
+        && n.properties?.className?.includes('fabric'));
+      expect(section).to.exist;
+
+      const elementChildren = section.children.filter((c) => c.type === 'element');
+      expect(elementChildren).to.have.length(2);
+      expect(elementChildren[0].tagName).to.equal('h3');
+      expect(elementChildren[1].tagName).to.equal('ul');
+    });
+
+    it('should NOT wrap excluded array keys (facts.feature_bullets, facts.description_plain)', () => {
+      const suggestion = makeSuggestion({
+        patchValue: JSON.stringify({
+          sku: 'TEST',
+          'facts.feature_bullets': ['Bullet one', 'Bullet two'],
+          'facts.description_plain': 'A plain description.',
+        }),
+        url: 'https://example.com/page',
+      });
+
+      const patches = mapper.suggestionsToPatches('/page', [suggestion], opportunityId);
+      const article = findNode(patches[0].value, (n) => n.tagName === 'article');
+
+      expect(findAllNodes(article, (n) => n.tagName === 'section')).to.have.length(0);
+      expect(findAllNodes(article, (n) => n.tagName === 'h3')).to.have.length(0);
+
+      const ul = findNode(article, (n) => n.tagName === 'ul'
+        && n.properties?.className?.includes('facts-feature-bullets'));
+      expect(ul).to.exist;
+    });
+
+    it('should NOT wrap empty arrays in a <section>', () => {
+      const suggestion = makeSuggestion({
+        patchValue: JSON.stringify({
+          sku: 'TEST',
+          'facts.attributes.fabric': [],
+        }),
+        url: 'https://example.com/page',
+      });
+
+      const patches = mapper.suggestionsToPatches('/page', [suggestion], opportunityId);
+      const article = findNode(patches[0].value, (n) => n.tagName === 'article');
+
+      expect(findAllNodes(article, (n) => n.tagName === 'section')).to.have.length(0);
+      expect(findAllNodes(article, (n) => n.tagName === 'h3')).to.have.length(0);
+      expect(findAllNodes(article, (n) => n.tagName === 'ul'
+        && n.properties?.className?.includes('fabric'))).to.have.length(0);
+    });
+
+    it('should NOT wrap non-array values (string, object) in a <section>', () => {
+      const suggestion = makeSuggestion({
+        patchValue: JSON.stringify({
+          sku: 'TEST',
+          brand: 'Lovesac',
+          custom_attrs: { color: 'Blue', size: 'L' },
+        }),
+        url: 'https://example.com/page',
+      });
+
+      const patches = mapper.suggestionsToPatches('/page', [suggestion], opportunityId);
+      const article = findNode(patches[0].value, (n) => n.tagName === 'article');
+
+      expect(findAllNodes(article, (n) => n.tagName === 'section')).to.have.length(0);
+      expect(findAllNodes(article, (n) => n.tagName === 'h3')).to.have.length(0);
+
+      const brandP = findNode(article, (n) => n.tagName === 'p'
+        && n.properties?.className?.includes('brand'));
+      expect(brandP).to.exist;
+
+      const customUl = findNode(article, (n) => n.tagName === 'ul'
+        && n.properties?.className?.includes('custom-attrs'));
+      expect(customUl).to.exist;
+    });
+
+    it('should derive heading labels with only the first character uppercased', () => {
+      const suggestion = makeSuggestion({
+        patchValue: JSON.stringify({
+          sku: 'TEST',
+          'facts.attributes.fabric_type': ['Wombat Phur'],
+        }),
+        url: 'https://example.com/page',
+      });
+
+      const patches = mapper.suggestionsToPatches('/page', [suggestion], opportunityId);
+      const h3 = findNode(patches[0].value, (n) => n.tagName === 'h3');
+      expect(h3).to.exist;
+      expect(textContent(h3)).to.equal('Fabric type');
+    });
+
     it('should use ordered fields priority (category_path over category)', () => {
       const suggestion = makeSuggestion({
         patchValue: JSON.stringify({


### PR DESCRIPTION
## Summary
  - Wraps array-typed enrichment fields rendered in `commerce-page-enrichment-mapper.js` in a semantic `<section>` with an  
  `<h3>` heading, so AI agents reading the page can identify each attribute group (Color family, Fabric, Fabric type,     
  Options, Configurations, etc.) by name rather than only by CSS class.                                                     
  - Heading label is derived programmatically from the source key (last `.`-segment, underscores → spaces, first letter
  uppercased).                                                                                                              
  - `facts.feature_bullets` and `facts.description_plain` are excluded — they keep the existing flat rendering.             
                                                                                                               
  ## Test plan                                                                                                              
  - [x] `npm run lint -w packages/spacecat-shared-tokowaka-client` passes                   
  - [x] `npm test -w packages/spacecat-shared-tokowaka-client` passes (642 tests, 100% coverage)
  - [x] Six new test cases cover: section + h3 + ul shape, child order inside section, excluded keys, empty arrays,         
  non-array values, label derivation edge cases                                                                             
                                                                                                                            
  🤖 Generated with [Claude Code](https://claude.com/claude-code)                                                           
                                                                                                                            
  If you'd like me to retry the gh pr create after you switch accounts (gh auth switch to a non-EMU account that has API
  access to the public adobe/* org), let me know.                                                                           
   
  Summary of what's done locally:                                                                                           
  - Branch feat/pdp-enrichment-add-headings-for-attributes created and pushed to origin (commit 0c64e420).
  - Two files changed: commerce-page-enrichment-mapper.js (+19 lines) and its test (+140 lines). package-lock.json          
  deliberately excluded.                                                                                          
  - Lint clean, 642 tests passing, 100% coverage.            