### PR TITLE
fix(data-access): replace hard-coded IT hook timeout with shared constant

### DIFF
--- a/packages/spacecat-shared-data-access/test/it/access-grant-log/access-grant-log.test.js
+++ b/packages/spacecat-shared-data-access/test/it/access-grant-log/access-grant-log.test.js
@@ -17,6 +17,7 @@ import { sanitizeTimestamps } from '../../../src/util/util.js';
 import DataAccessError from '../../../src/errors/data-access.error.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -25,7 +26,7 @@ describe('AccessGrantLog IT', async () => {
   let AccessGrantLog;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/api-key/api-key.test.js
+++ b/packages/spacecat-shared-data-access/test/it/api-key/api-key.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
 import { sanitizeIdAndAuditFields, sanitizeTimestamps } from '../../../src/util/util.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -24,7 +25,7 @@ describe('ApiKey IT', async () => {
   let ApiKey;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/async-job/async-job.test.js
+++ b/packages/spacecat-shared-data-access/test/it/async-job/async-job.test.js
@@ -16,6 +16,7 @@ import AsyncJobModel from '../../../src/models/async-job/async-job.model.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
 import { DataAccessError } from '../../../src/index.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -34,7 +35,7 @@ describe('AsyncJob IT', async () => {
   let newJobData;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
     const dataAccess = getDataAccess();
     AsyncJob = dataAccess.AsyncJob;

--- a/packages/spacecat-shared-data-access/test/it/audit-url/audit-url.test.js
+++ b/packages/spacecat-shared-data-access/test/it/audit-url/audit-url.test.js
@@ -15,6 +15,7 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -36,7 +37,7 @@ describe('AuditUrl IT', function () {
 
   // eslint-disable-next-line prefer-arrow-callback
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/audit/audit.test.js
+++ b/packages/spacecat-shared-data-access/test/it/audit/audit.test.js
@@ -15,6 +15,7 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -35,7 +36,7 @@ describe('Audit IT', async () => {
   let Audit;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/configuration/configuration.test.js
+++ b/packages/spacecat-shared-data-access/test/it/configuration/configuration.test.js
@@ -16,6 +16,7 @@ import sinon from 'sinon';
 
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -60,7 +61,7 @@ describe('Configuration IT', async () => {
   };
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/consumer/consumer.test.js
+++ b/packages/spacecat-shared-data-access/test/it/consumer/consumer.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { sanitizeIdAndAuditFields, sanitizeTimestamps } from '../../../src/util/util.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -24,7 +25,7 @@ describe('Consumer IT', async () => {
   let Consumer;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/contact-sales-lead/contact-sales-lead.test.js
+++ b/packages/spacecat-shared-data-access/test/it/contact-sales-lead/contact-sales-lead.test.js
@@ -18,6 +18,7 @@ import fixtures from '../../fixtures/index.fixtures.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
 import { sanitizeTimestamps } from '../../../src/util/util.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -39,7 +40,7 @@ describe('ContactSalesLead IT', async () => {
   let ContactSalesLead;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/entitlement/entitlement.test.js
+++ b/packages/spacecat-shared-data-access/test/it/entitlement/entitlement.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { sanitizeIdAndAuditFields, sanitizeTimestamps } from '../../../src/util/util.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -25,7 +26,7 @@ describe('Entitlement IT', async () => {
   let SiteEnrollment;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/experiment/experiment.test.js
+++ b/packages/spacecat-shared-data-access/test/it/experiment/experiment.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
 import { sanitizeIdAndAuditFields } from '../../../src/util/util.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -39,7 +40,7 @@ describe('Experiment IT', async () => {
   let Experiment;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/fix-entity-suggestion/fix-entity-suggestion.test.js
+++ b/packages/spacecat-shared-data-access/test/it/fix-entity-suggestion/fix-entity-suggestion.test.js
@@ -16,6 +16,7 @@ import sinon from 'sinon';
 
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -27,7 +28,7 @@ describe('FixEntity-Suggestion Many-to-Many Relationship IT', async () => {
   let mockLogger;
 
   beforeEach(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
     mockLogger = {
       debug: sinon.stub(),

--- a/packages/spacecat-shared-data-access/test/it/fix-entity/fix-entity.test.js
+++ b/packages/spacecat-shared-data-access/test/it/fix-entity/fix-entity.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
 import fixEntityFixtures from '../../fixtures/fix-entity.fixture.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -43,7 +44,7 @@ describe('FixEntity IT', async () => {
   let sampleData;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/import-job/import-job.test.js
+++ b/packages/spacecat-shared-data-access/test/it/import-job/import-job.test.js
@@ -17,6 +17,7 @@ import ImportJobModel from '../../../src/models/import-job/import-job.model.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
 import { DataAccessError } from '../../../src/index.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -43,7 +44,7 @@ describe('ImportJob IT', async () => {
   let newJobData;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/import-url/import-url.test.js
+++ b/packages/spacecat-shared-data-access/test/it/import-url/import-url.test.js
@@ -15,6 +15,7 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -31,7 +32,7 @@ describe('ImportUrl IT', async () => {
   let ImportUrl;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/key-events/key-events.test.js
+++ b/packages/spacecat-shared-data-access/test/it/key-events/key-events.test.js
@@ -15,6 +15,7 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -22,7 +23,7 @@ describe('KeyEvent IT', async () => {
   let KeyEvent;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/latest-audit/latest-audit.test.js
+++ b/packages/spacecat-shared-data-access/test/it/latest-audit/latest-audit.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { sanitizeIdAndAuditFields, sanitizeTimestamps } from '../../../src/util/util.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -39,7 +40,7 @@ describe('LatestAudit IT', async () => {
   let dataAccess;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/opportunity/opportunity.test.js
+++ b/packages/spacecat-shared-data-access/test/it/opportunity/opportunity.test.js
@@ -23,6 +23,7 @@ import fixtures from '../../fixtures/index.fixtures.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
 import { sanitizeIdAndAuditFields, sanitizeTimestamps } from '../../../src/util/util.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 use(sinonChai);
@@ -39,7 +40,7 @@ describe('Opportunity IT', async () => {
   let FixEntitySuggestion;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     mockLogger = {

--- a/packages/spacecat-shared-data-access/test/it/organization/organization.test.js
+++ b/packages/spacecat-shared-data-access/test/it/organization/organization.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { sanitizeIdAndAuditFields, sanitizeTimestamps } from '../../../src/util/util.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -24,7 +25,7 @@ describe('Organization IT', async () => {
   let Organization;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/page-citability/page-citability.test.js
+++ b/packages/spacecat-shared-data-access/test/it/page-citability/page-citability.test.js
@@ -15,6 +15,7 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -58,7 +59,7 @@ describe('PageCitability IT', async () => {
   let siteId;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
     siteId = sampleData.sites[0].getId();
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/page-intent/page-intent.test.js
+++ b/packages/spacecat-shared-data-access/test/it/page-intent/page-intent.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
 import { sanitizeTimestamps } from '../../../src/util/util.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -34,7 +35,7 @@ describe('PageIntent IT', async () => {
   let PageIntent;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/project/project.test.js
+++ b/packages/spacecat-shared-data-access/test/it/project/project.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { sanitizeIdAndAuditFields, sanitizeTimestamps } from '../../../src/util/util.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -24,7 +25,7 @@ describe('Project IT', async () => {
   let Project;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
     const dataAccess = getDataAccess();
     Project = dataAccess.Project;

--- a/packages/spacecat-shared-data-access/test/it/report/report.test.js
+++ b/packages/spacecat-shared-data-access/test/it/report/report.test.js
@@ -18,6 +18,7 @@ import fixtures from '../../fixtures/index.fixtures.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
 import { sanitizeTimestamps } from '../../../src/util/util.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -42,7 +43,7 @@ describe('Report IT', async () => {
   let Report;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/scrape-job/scrape-job.test.js
+++ b/packages/spacecat-shared-data-access/test/it/scrape-job/scrape-job.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import ScrapeJobModel from '../../../src/models/scrape-job/scrape-job.model.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -43,7 +44,7 @@ describe('ScrapeJob IT', async () => {
   let newJobData;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/scrape-url/scrape-url.test.js
+++ b/packages/spacecat-shared-data-access/test/it/scrape-url/scrape-url.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
 import { ScrapeJob } from '../../../src/index.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -32,7 +33,7 @@ describe('ScrapeUrl IT', async () => {
   let ScrapeUrl;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/sentiment-guideline/sentiment-guideline.test.js
+++ b/packages/spacecat-shared-data-access/test/it/sentiment-guideline/sentiment-guideline.test.js
@@ -15,6 +15,7 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -39,7 +40,7 @@ describe('SentimentGuideline IT', function () {
 
   // eslint-disable-next-line prefer-arrow-callback
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/sentiment-topic/sentiment-topic.test.js
+++ b/packages/spacecat-shared-data-access/test/it/sentiment-topic/sentiment-topic.test.js
@@ -15,6 +15,7 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -35,7 +36,7 @@ describe('SentimentTopic IT', function () {
 
   // eslint-disable-next-line prefer-arrow-callback
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/site-candidate/site-candidate.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site-candidate/site-candidate.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
 import { sanitizeTimestamps } from '../../../src/util/util.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -33,7 +34,7 @@ describe('SiteCandidate IT', async () => {
   let SiteCandidate;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/site-enrollment/site-enrollment.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site-enrollment/site-enrollment.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { sanitizeIdAndAuditFields, sanitizeTimestamps } from '../../../src/util/util.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -24,7 +25,7 @@ describe('SiteEnrollment IT', async () => {
   let SiteEnrollment;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/site-ims-org-access/site-ims-org-access.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site-ims-org-access/site-ims-org-access.test.js
@@ -18,6 +18,7 @@ import DataAccessError from '../../../src/errors/data-access.error.js';
 import SiteImsOrgAccessCollection from '../../../src/models/site-ims-org-access/site-ims-org-access.collection.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -26,7 +27,7 @@ describe('SiteImsOrgAccess IT', async () => {
   let SiteImsOrgAccess;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/site-top-form/site-top-form.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site-top-form/site-top-form.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
 import { sanitizeTimestamps } from '../../../src/util/util.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -43,7 +44,7 @@ describe('SiteTopForm IT', async () => {
   let SiteTopForm;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/site-top-page/site-top-page.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site-top-page/site-top-page.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
 import { sanitizeTimestamps } from '../../../src/util/util.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -36,7 +37,7 @@ describe('SiteTopPage IT', async () => {
   let SiteTopPage;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/site/site.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site/site.test.js
@@ -23,6 +23,7 @@ import { sanitizeTimestamps } from '../../../src/util/util.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
 import { Config } from '../../../src/models/site/config.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -49,7 +50,7 @@ describe('Site IT', async () => {
   let Site;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/suggestion-grant/suggestion-grant.test.js
+++ b/packages/spacecat-shared-data-access/test/it/suggestion-grant/suggestion-grant.test.js
@@ -14,6 +14,7 @@ import { expect } from 'chai';
 
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 describe('SuggestionGrant IT', () => {
   let sampleData;
@@ -29,7 +30,7 @@ describe('SuggestionGrant IT', () => {
   let grantedSuggestionId;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();
@@ -90,7 +91,7 @@ describe('SuggestionGrant IT', () => {
 
   describe('invokeGrantSuggestionsRpc', () => {
     it('inserts suggestion_grants and returns success when token is available', async function () {
-      this.timeout(10000);
+      this.timeout(IT_HOOK_TIMEOUT);
       // Use a suggestion not yet granted
       const suggestionToGrant = sampleData.suggestions[3];
       const suggestionId = suggestionToGrant.getId();
@@ -128,7 +129,7 @@ describe('SuggestionGrant IT', () => {
 
   describe('revokeSuggestionGrant', () => {
     it('revokes a granted suggestion and refunds the token', async function () {
-      this.timeout(10000);
+      this.timeout(IT_HOOK_TIMEOUT);
 
       // Grant a fresh suggestion so we have a known grant to revoke
       const suggestionToRevoke = sampleData.suggestions[5];
@@ -167,7 +168,7 @@ describe('SuggestionGrant IT', () => {
     });
 
     it('returns success false for a non-existent grant ID', async function () {
-      this.timeout(10000);
+      this.timeout(IT_HOOK_TIMEOUT);
 
       const fakeGrantId = '00000000-0000-0000-0000-000000000000';
       const result = await SuggestionGrant.revokeSuggestionGrant(fakeGrantId);
@@ -179,7 +180,7 @@ describe('SuggestionGrant IT', () => {
 
   describe('invokeRevokeSuggestionGrantRpc', () => {
     it('returns grant_not_found for a non-existent grant ID', async function () {
-      this.timeout(10000);
+      this.timeout(IT_HOOK_TIMEOUT);
 
       const fakeGrantId = '00000000-0000-0000-0000-000000000000';
       const rpcResult = await SuggestionGrant.invokeRevokeSuggestionGrantRpc(fakeGrantId);
@@ -194,7 +195,7 @@ describe('SuggestionGrant IT', () => {
     });
 
     it('deletes suggestion_grants rows and decrements token used by 1', async function () {
-      this.timeout(10000);
+      this.timeout(IT_HOOK_TIMEOUT);
 
       // Grant two suggestions under one grant_id
       const sugg0 = sampleData.suggestions[0];
@@ -234,7 +235,7 @@ describe('SuggestionGrant IT', () => {
     });
 
     it('revoking the same grant_id twice returns grant_not_found on second call', async function () {
-      this.timeout(10000);
+      this.timeout(IT_HOOK_TIMEOUT);
 
       const sugg = sampleData.suggestions[2];
       const suggId = sugg.getId();
@@ -261,7 +262,7 @@ describe('SuggestionGrant IT', () => {
     });
 
     it('revoke only affects the targeted grant_id, not other grants', async function () {
-      this.timeout(10000);
+      this.timeout(IT_HOOK_TIMEOUT);
 
       // Use separate token types so each grant gets its own fresh token pool
       const tokenTypeA = 'grant_broken_backlinks';
@@ -306,7 +307,7 @@ describe('SuggestionGrant IT', () => {
     });
 
     it('revoke with a single suggestion returns revoked_count of 1', async function () {
-      this.timeout(10000);
+      this.timeout(IT_HOOK_TIMEOUT);
 
       // Use a fresh token type to avoid exhausting the grant_cwv pool
       const freshTokenType = 'grant_alt_text';

--- a/packages/spacecat-shared-data-access/test/it/suggestion/suggestion.test.js
+++ b/packages/spacecat-shared-data-access/test/it/suggestion/suggestion.test.js
@@ -20,6 +20,7 @@ import { sanitizeIdAndAuditFields, sanitizeTimestamps } from '../../../src/util/
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
 import ValidationError from '../../../src/errors/validation.error.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -29,7 +30,7 @@ describe('Suggestion IT', async () => {
   let FixEntitySuggestion;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();
@@ -388,7 +389,7 @@ describe('Suggestion IT', async () => {
     /** One suggestion granted in before(); shared by tests that need a granted suggestion */
     let preGrantedSuggestion;
     before(async function () {
-      this.timeout(10000);
+      this.timeout(IT_HOOK_TIMEOUT);
       expect(sampleData.suggestions.length).to.be.at.least(6);
       const { Token } = getDataAccess();
       await Token.findBySiteIdAndTokenType(siteId, tokenType, { createIfNotFound: true });

--- a/packages/spacecat-shared-data-access/test/it/token/token.test.js
+++ b/packages/spacecat-shared-data-access/test/it/token/token.test.js
@@ -17,6 +17,7 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -26,7 +27,7 @@ describe('Token IT', () => {
   let SuggestionGrant;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/trial-user-activity/trial-user-activities.test.js
+++ b/packages/spacecat-shared-data-access/test/it/trial-user-activity/trial-user-activities.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { sanitizeIdAndAuditFields, sanitizeTimestamps } from '../../../src/util/util.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -24,7 +25,7 @@ describe('TrialUserActivity IT', async () => {
   let TrialUserActivity;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/trial-user/trial-user.test.js
+++ b/packages/spacecat-shared-data-access/test/it/trial-user/trial-user.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { sanitizeIdAndAuditFields, sanitizeTimestamps } from '../../../src/util/util.js';
 import { getDataAccess } from '../util/db.js';
 import { seedDatabase } from '../util/seed.js';
+import { IT_HOOK_TIMEOUT } from '../util/util.js';
 
 use(chaiAsPromised);
 
@@ -24,7 +25,7 @@ describe('TrialUser IT', async () => {
   let TrialUser;
 
   before(async function () {
-    this.timeout(10000);
+    this.timeout(IT_HOOK_TIMEOUT);
     sampleData = await seedDatabase();
 
     const dataAccess = getDataAccess();

--- a/packages/spacecat-shared-data-access/test/it/util/util.js
+++ b/packages/spacecat-shared-data-access/test/it/util/util.js
@@ -11,6 +11,10 @@
  */
 import { removeElectroProperties } from '../../../src/util/util.js';
 
+// Generous hook timeout for IT before/after hooks — the v5.x image runs
+// dbmate migrations on startup, which makes cold CI runs slower than 10 s.
+export const IT_HOOK_TIMEOUT = 30000;
+
 const randomDate = (start, end) => {
   if (start.getTime() >= end.getTime()) {
     throw new Error('start must be before end');


### PR DESCRIPTION
## Session Summary

### PR #1573 — `feat(data-access): add readAll capability to Consumer.CAPABILITIES`

**Review comments addressed (pushed to branch, now merged):**
1. Added JSDoc on `Consumer.CAPABILITIES` explaining `readAll` is a scope+verb hybrid, only meaningful on opted-in routes
2. Renamed test: `"accepts the readAll action for any registered entity"` → `"accepts site:readAll and organization:readAll capabilities"`
3. Strengthened test assertion: added `expect(mockElectroService.entities.consumer.create).to.have.been.calledOnce`

---

### CI failures investigated

| Failure                                             | Root cause                                        | Verdict                       |
| --------------------------------------------------- | ------------------------------------------------- | ----------------------------- |
| `mysticat-data-service:v1.67.8 not found`           | Image removed from ECR                            | Infrastructure issue          |
| `TrialUser/TrialUserActivity IT timeout`            | 10s hook timeout too tight for v5.x image startup | Code fix needed               |
| `HTML Utils warmup delay: expected 749 to be ≥ 750` | Wall-clock timing flake in `tokowaka-client`      | Pre-existing flake, unrelated |

---

### New PR branch — `fix/it-timeout-constant` (from main)

- Bumped default docker image tag to `v5.1.1` in `docker-compose.yml`
- Introduced `IT_HOOK_TIMEOUT = 30000` constant in `test/it/util/util.js`
- Updated all 37 IT test files to import and use the constant instead of the hard-coded `10000`