### PR TITLE
fix(http-utils): allow readAll action in readOnlyAdminWrapper

### DIFF
--- a/packages/spacecat-shared-http-utils/src/auth/read-only-admin-wrapper.js
+++ b/packages/spacecat-shared-http-utils/src/auth/read-only-admin-wrapper.js
@@ -96,12 +96,12 @@ export function readOnlyAdminWrapper(fn, { routeCapabilities } = {}) {
 
       if (isObject(routeCapabilities)) {
         const capability = resolveRouteCapability(context, routeCapabilities);
-        // capability format is 'resource:action' (e.g. 'site:read', 'site:write').
+        // capability format is 'resource:action' (e.g. 'site:read', 'site:readAll', 'site:write').
         // split(':').pop() extracts the action; a missing or malformed value yields
-        // undefined, which is !== 'read' and correctly blocks the request.
+        // undefined, which is not a read action and correctly blocks the request.
         const action = capability?.split(':').pop();
 
-        if (action !== 'read') {
+        if (action !== 'read' && action !== 'readAll') {
           log.warn({
             tag: 'ro-admin',
             email: authInfo.getProfile?.()?.email,

--- a/packages/spacecat-shared-http-utils/test/auth/read-only-admin-wrapper.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/read-only-admin-wrapper.test.js
@@ -24,6 +24,7 @@ const routeCapabilities = {
   'DELETE /sites/:siteId': 'site:write',
   'GET /sites/:siteId/opportunities': 'opportunity:read',
   'POST /sites/:siteId/opportunities': 'opportunity:write',
+  'GET /organizations': 'organization:readAll',
 };
 
 describe('readOnlyAdminWrapper', () => {
@@ -223,6 +224,15 @@ describe('readOnlyAdminWrapper', () => {
 
     it('allows read-only admin on a read route (dynamic params)', async () => {
       context.pathInfo = { method: 'GET', suffix: '/sites/abc-123/opportunities' };
+      const wrapped = mockedWrapper(handler, { routeCapabilities });
+      const result = await wrapped({}, context);
+
+      expect(result).to.deep.equal({ status: 200 });
+      expect(handler.calledOnce).to.be.true;
+    });
+
+    it('allows read-only admin on a readAll route', async () => {
+      context.pathInfo = { method: 'GET', suffix: '/organizations' };
       const wrapped = mockedWrapper(handler, { routeCapabilities });
       const result = await wrapped({}, context);
 


### PR DESCRIPTION
The wrapper was only permitting 'read' actions for RO admins. Now that Consumer.CAPABILITIES includes 'readAll' (site:readAll, organization:readAll), routes mapped to a readAll capability must also be accessible to RO admins.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
