### PR TITLE
fix(tokowaka-client): do not set edgeDeployed on domain-wide covered suggestions

### DIFF
--- a/packages/spacecat-shared-tokowaka-client/src/index.js
+++ b/packages/spacecat-shared-tokowaka-client/src/index.js
@@ -1417,6 +1417,9 @@ class TokowakaClient {
               if (s.getData()?.isDomainWide === true) {
                 return false;
               }
+              if (s.getData()?.edgeDeployed) {
+                return false;
+              }
               const url = s.getData()?.url;
               return url && regexPatterns.some((r) => r.test(url));
             });
@@ -1427,7 +1430,6 @@ class TokowakaClient {
                 await Promise.all(covered.map(async (cs) => {
                   cs.setData({
                     ...cs.getData(),
-                    edgeDeployed: deploymentTimestamp,
                     coveredByDomainWide: suggestion.getId(),
                   });
                   cs.setUpdatedBy(updatedBy);
@@ -1450,11 +1452,9 @@ class TokowakaClient {
     // Mark same-batch skipped suggestions individually so a single save failure
     // surfaces as a per-item failure rather than swallowing the whole batch.
     if (skippedInBatch.length > 0) {
-      const deploymentTimestamp = Date.now();
       const results = await Promise.allSettled(skippedInBatch.map(async (s) => {
         s.setData({
           ...s.getData(),
-          edgeDeployed: deploymentTimestamp,
           coveredByDomainWide: 'same-batch-deployment',
           skippedInDeployment: true,
         });


### PR DESCRIPTION
## Summary

- Add `edgeDeployed` guard to prevent stamping `coveredByDomainWide` on suggestions already individually deployed at the edge
- Remove `edgeDeployed` from covered suggestion data — only `coveredByDomainWide` should be set, keeping the two fields mutually exclusive
- Remove `edgeDeployed` from same-batch skipped suggestion data for the same reason

## Analysis

### The Invariant

`edgeDeployed` and `coveredByDomainWide` are semantically mutually exclusive:

| Field | Meaning |
|---|---|
| `edgeDeployed` | This suggestion's fix was **individually deployed** at the edge |
| `coveredByDomainWide` | This URL is covered by a **domain-wide rule**; the suggestion itself was never individually deployed |

### How This Was Already Enforced Elsewhere

**Audit worker ([handler.js#L163](https://github.com/adobe/spacecat-audit-worker/blob/f289eddaaea0ce0831b361c18e1c4da653b91a44/src/prerender/handler.js#L163))** — already guards correctly:
```javascript
// Explicitly skips suggestions with edgeDeployed before stamping coveredByDomainWide
return deployedAtEdgeUrls.has(data?.url) && !data?.edgeDeployed;
```

**UI ([ExpandableURLSuggestionsTable.tsx#L282-L284](https://github.com/adobe/project-elmo-ui/blob/1fd9c17c1c4455168a95a0ab70622707455eada4/src/components/ui/ExpandableURLSuggestionsTable.tsx#L282-L284))** — assumes mutual exclusivity:
```typescript
// coveredByDomainWide only applies if edgeDeployed is NOT set
const isCoveredByDomainWideDeployment = (suggestion) =>
  !!suggestion.data?.coveredByDomainWide && !suggestion.data?.edgeDeployed;
```

The UI's `isSuggestionFixed` check (`edgeDeployed || isDeployed`) takes precedence, meaning covered suggestions with both fields set would fall into the **Fixed tab** instead of being treated as domain-wide covered — masking the correct state.

### What Was Broken

When a domain-wide suggestion was deployed, the `covered` filter had no guard for `edgeDeployed`:

```javascript
// Before — missing edgeDeployed guard
const covered = allSuggestions.filter((s) => {
  if (s.getId() === suggestion.getId()) return false;
  if (skippedInBatchIds.has(s.getId())) return false;
  if (!isEdgeDeployableSuggestionStatus(s.getStatus())) return false;
  if (s.getData()?.isDomainWide === true) return false;
  // ← no check for s.getData()?.edgeDeployed
  const url = s.getData()?.url;
  return url && regexPatterns.some((r) => r.test(url));
});
```

And covered suggestions received both fields:
```javascript
// Before — both fields set on covered suggestions
cs.setData({ ...cs.getData(), edgeDeployed: deploymentTimestamp, coveredByDomainWide: suggestion.getId() });
```

### The Fix

```javascript
// After — guard added
if (s.getData()?.edgeDeployed) return false;

// After — only coveredByDomainWide set
cs.setData({ ...cs.getData(), coveredByDomainWide: suggestion.getId() });
```

### Rollback Compatibility

The rollback path in `spacecat-api-service` (`rollbackSuggestionFromEdge`) is unaffected:
- It finds covered suggestions via `coveredByDomainWide === suggestion.getId()` — still correct
- It calls `delete coveredData.edgeDeployed` — becomes a no-op for covered suggestions but remains harmless
- It calls `delete coveredData.coveredByDomainWide` — still correctly clears the field

## Test plan

- [ ] Deploy a domain-wide prerender suggestion — verify covered suggestions have only `coveredByDomainWide` set and no `edgeDeployed`
- [ ] Deploy a domain-wide suggestion when some matching suggestions already have `edgeDeployed` set — verify those are skipped and not stamped with `coveredByDomainWide`
- [ ] Rollback the domain-wide suggestion — verify `coveredByDomainWide` is cleared from all covered suggestions
- [ ] Verify covered suggestions appear correctly in UI (excluded from Current tab, not shown as Optimized in Fixed tab)
- [ ] Unit tests for the updated filter and data-stamping logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)
