### PR TITLE
feat(data-access): forward customHeaders in SCRAPE_CLIENT payload

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
+++ b/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
@@ -223,6 +223,10 @@ class Audit extends BaseModel {
           },
         };
 
+        if (stepResult.customHeaders) {
+          payload.customHeaders = stepResult.customHeaders;
+        }
+
         // Propagate traceId for cross-worker tracing continuity
         // This allows the scrape client to maintain the same trace across multiple workers
         if (context.traceId) {

--- a/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
@@ -362,6 +362,41 @@ describe('AuditModel', () => {
       });
     });
 
+    it('forwards customHeaders in the scrape client payload when present', () => {
+      const stepResult = {
+        urls: [{ url: 'someUrl' }],
+        siteId: 'someSiteId',
+        options: { someOption: 'someValue' },
+        processingType: 'someProcessingType',
+        customHeaders: { 'User-Agent': 'GPTBot/1.2' },
+      };
+      const context = {
+        env: { AUDIT_JOBS_QUEUE_URL: 'audit-jobs-queue-url' },
+      };
+      const auditContext = { some: 'context' };
+      const formattedPayload = auditStepDestinationConfigs[auditStepDestinations.SCRAPE_CLIENT]
+        .formatPayload(stepResult, auditContext, context);
+
+      expect(formattedPayload.customHeaders).to.deep.equal({ 'User-Agent': 'GPTBot/1.2' });
+    });
+
+    it('omits customHeaders from the scrape client payload when absent', () => {
+      const stepResult = {
+        urls: [{ url: 'someUrl' }],
+        siteId: 'someSiteId',
+        options: { someOption: 'someValue' },
+        processingType: 'someProcessingType',
+      };
+      const context = {
+        env: { AUDIT_JOBS_QUEUE_URL: 'audit-jobs-queue-url' },
+      };
+      const auditContext = { some: 'context' };
+      const formattedPayload = auditStepDestinationConfigs[auditStepDestinations.SCRAPE_CLIENT]
+        .formatPayload(stepResult, auditContext, context);
+
+      expect(formattedPayload).to.not.have.property('customHeaders');
+    });
+
     it('formats scrape client payload with traceId when present in context', () => {
       const stepResult = {
         urls: [{ url: 'someUrl' }],


### PR DESCRIPTION
## Summary

`AUDIT_STEP_DESTINATION_CONFIGS[SCRAPE_CLIENT].formatPayload` silently dropped `stepResult.customHeaders`, so audit-worker steps that set custom request headers (e.g. a GPTBot user-agent for LLM-perspective scrapes) never reached the scrape client. The field is now forwarded when present, matching the existing `traceId` pattern.

## What this PR does

In `packages/spacecat-shared-data-access/src/models/audit/audit.model.js`:

- `formatPayload` for `SCRAPE_CLIENT` now copies `stepResult.customHeaders` onto the outgoing payload when it is truthy. Falsy values (`undefined`, `null`, empty) produce no `customHeaders` key — identical behavior to before for audits that don't set the field.

## Test plan

- [x] New unit test: `forwards customHeaders in the scrape client payload when present`
- [x] New unit test: `omits customHeaders from the scrape client payload when absent`
- [x] Existing `formats scrape client payload correctly` and traceId tests still pass unchanged
- [x] `npx mocha test/unit/models/audit/audit.model.test.js` — 29 passing
- [x] Lint clean on edited files

## Why this was hard to catch

The scrape-job supervisor logs `customHeaders: ${JSON.stringify(customHeaders)}`. `JSON.stringify(undefined)` produces the literal string `"undefined"`, which looked visually identical to "working but no headers" in Coralogix. The bug was only discovered by setting a real header value in `commerce-product-enrichments` and observing the log still said `undefined`.

After this PR, audits that do set `customHeaders` will see their actual header object in the supervisor log; audits that don't set it continue to see `undefined` (unchanged).