### PR TITLE
fix(drs-client): reject non-XLSX uploads before writing to S3

### DIFF
--- a/packages/spacecat-shared-drs-client/src/index.js
+++ b/packages/spacecat-shared-drs-client/src/index.js
@@ -17,6 +17,8 @@ import { randomUUID } from 'crypto';
 
 const EXTERNAL_SPACECAT_PROVIDER_ID = 'external_spacecat';
 const DRS_S3_KEY_PREFIX = 'external/spacecat';
+// XLSX files are ZIP archives; all valid .xlsx start with PK\x03\x04
+const XLSX_MAGIC = Buffer.from([0x50, 0x4B, 0x03, 0x04]);
 
 export const EXPERIMENT_PHASES = Object.freeze({
   PRE: 'pre',
@@ -468,6 +470,9 @@ export default class DrsClient {
     }
     if (!excelBuffer || excelBuffer.length === 0) {
       throw new Error('excelBuffer is required and must be non-empty');
+    }
+    if (!Buffer.from(excelBuffer).slice(0, 4).equals(XLSX_MAGIC)) {
+      throw new Error(`Refusing to upload non-XLSX content to S3 (size=${excelBuffer.length})`);
     }
 
     const key = `${DRS_S3_KEY_PREFIX}/${siteId}/${jobId}/source.xlsx`;

--- a/packages/spacecat-shared-drs-client/src/index.js
+++ b/packages/spacecat-shared-drs-client/src/index.js
@@ -471,7 +471,7 @@ export default class DrsClient {
     if (!excelBuffer || excelBuffer.length === 0) {
       throw new Error('excelBuffer is required and must be non-empty');
     }
-    if (!Buffer.from(excelBuffer).slice(0, 4).equals(XLSX_MAGIC)) {
+    if (!Buffer.from(excelBuffer.subarray(0, 4)).equals(XLSX_MAGIC)) {
       throw new Error(`Refusing to upload non-XLSX content to S3 (size=${excelBuffer.length})`);
     }
 

--- a/packages/spacecat-shared-drs-client/test/index.test.js
+++ b/packages/spacecat-shared-drs-client/test/index.test.js
@@ -862,7 +862,7 @@ describe('DrsClient', () => {
         s3Client,
       }, log);
 
-      const excelBuffer = Buffer.from('fake-excel-bytes');
+      const excelBuffer = Buffer.concat([Buffer.from([0x50, 0x4B, 0x03, 0x04]), Buffer.from('fake-excel-body')]);
       const result = await client.uploadExcelToDrs('site-1', 'job-abc', excelBuffer);
 
       expect(result).to.equal('s3://drs-bucket/external/spacecat/site-1/job-abc/source.xlsx');
@@ -915,6 +915,15 @@ describe('DrsClient', () => {
         .to.be.rejectedWith('excelBuffer is required and must be non-empty');
     });
 
+    it('throws when excelBuffer does not start with XLSX magic bytes', async () => {
+      const client = new DrsClient({
+        s3Bucket: S3_BUCKET, snsTopicArn: SNS_TOPIC_ARN, s3Client,
+      }, log);
+      const htmlPage = Buffer.from('<!DOCTYPE html><html><body>error</body></html>');
+      await expect(client.uploadExcelToDrs('site-1', 'job-1', htmlPage))
+        .to.be.rejectedWith(`Refusing to upload non-XLSX content to S3 (size=${htmlPage.length})`);
+    });
+
     it('propagates S3 send errors', async () => {
       s3ClientStub.rejects(new Error('S3 access denied'));
 
@@ -926,7 +935,8 @@ describe('DrsClient', () => {
         s3Client,
       }, log);
 
-      await expect(client.uploadExcelToDrs('site-1', 'job-1', Buffer.from('x')))
+      const validXlsx = Buffer.concat([Buffer.from([0x50, 0x4B, 0x03, 0x04]), Buffer.from('body')]);
+      await expect(client.uploadExcelToDrs('site-1', 'job-1', validXlsx))
         .to.be.rejectedWith('S3 access denied');
     });
   });


### PR DESCRIPTION
## Summary

- Adds `XLSX_MAGIC` constant (`PK\x03\x04`) to `drs-client/src/index.js`
- Guards `uploadExcelToDrs()` with a magic-bytes check before `PutObjectCommand` is called — any buffer that doesn't start with the ZIP/XLSX signature is rejected with a descriptive error
- Prevents SharePoint HTML error pages (and other non-XLSX content) from being written to `s3://drs-v2-prod-bp/external/spacecat/{site_id}/{job_id}/source.xlsx`, which was causing DRS Fargate tasks to fail with `openpyxl: File is not a zip file`

## Root cause

SpaceCat Lambda followed an expired SharePoint URL, received an HTML error page, and uploaded it to S3 without content validation. Four brand presence analyses failed for Astral Pool and Zodiac Pool on 2026-05-05 across gemini, perplexity, and chatgpt_paid.

## Test plan

- [x] New test: `throws when excelBuffer does not start with XLSX magic bytes` — passes an HTML buffer, asserts rejection with size in message
- [x] Updated existing tests that used bare `Buffer.from('x')` / `'fake-excel-bytes'` to supply a valid `PK\x03\x04` prefix
- [x] All 76 tests pass, 100% line/branch/statement/function coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)