### PR TITLE
fix(utils): update calculateCPCValue S3 path from ahrefs to seo

### DIFF
--- a/packages/spacecat-shared-utils/src/metrics-store.js
+++ b/packages/spacecat-shared-utils/src/metrics-store.js
@@ -106,7 +106,7 @@ export async function calculateCPCValue(context, siteId) {
   }
   const { s3Client, log } = context;
   const bucketName = context.env.S3_IMPORTER_BUCKET_NAME;
-  const key = `metrics/${siteId}/seo/organic-traffic.json`;
+  const key = createFilePath({ siteId, source: 'seo', metric: 'organic-traffic' });
   try {
     const organicTrafficData = await getObjectFromKey(s3Client, bucketName, key, log);
     if (!Array.isArray(organicTrafficData) || organicTrafficData.length === 0) {

--- a/packages/spacecat-shared-utils/src/metrics-store.js
+++ b/packages/spacecat-shared-utils/src/metrics-store.js
@@ -106,7 +106,7 @@ export async function calculateCPCValue(context, siteId) {
   }
   const { s3Client, log } = context;
   const bucketName = context.env.S3_IMPORTER_BUCKET_NAME;
-  const key = `metrics/${siteId}/ahrefs/organic-traffic.json`;
+  const key = `metrics/${siteId}/seo/organic-traffic.json`;
   try {
     const organicTrafficData = await getObjectFromKey(s3Client, bucketName, key, log);
     if (!Array.isArray(organicTrafficData) || organicTrafficData.length === 0) {

--- a/packages/spacecat-shared-utils/test/metrics-store.test.js
+++ b/packages/spacecat-shared-utils/test/metrics-store.test.js
@@ -84,13 +84,13 @@ describe('Metrics Store', () => {
     it('should return metrics when retrieval is successful', async () => {
       const expectedMetrics = [{
         siteId: '123',
-        source: 'ahrefs',
+        source: 'seo',
         time: '2023-03-12T00:00:00Z',
         name: 'organic-traffic',
         value: 100,
       }, {
         siteId: '123',
-        source: 'ahrefs',
+        source: 'seo',
         time: '2023-03-13T00:00:00Z',
         name: 'organic-traffic',
         value: 200,
@@ -159,13 +159,13 @@ describe('Metrics Store', () => {
     it('should return file path when upload is successful', async () => {
       const content = [{
         siteId: '123',
-        source: 'ahrefs',
+        source: 'seo',
         time: '2023-03-12T00:00:00Z',
         name: 'organic-traffic',
         value: 100,
       }, {
         siteId: '123',
-        source: 'ahrefs',
+        source: 'seo',
         time: '2023-03-13T00:00:00Z',
         name: 'organic-traffic',
         value: 200,
@@ -188,13 +188,13 @@ describe('Metrics Store', () => {
     it('should throw error when upload fails', async () => {
       const content = [{
         siteId: '123',
-        source: 'ahrefs',
+        source: 'seo',
         time: '2023-03-12T00:00:00Z',
         name: 'organic-traffic',
         value: 100,
       }, {
         siteId: '123',
-        source: 'ahrefs',
+        source: 'seo',
         time: '2023-03-13T00:00:00Z',
         name: 'organic-traffic',
         value: 200,
@@ -247,7 +247,7 @@ describe('Metrics Store', () => {
       expect(getObjectFromKeyStub).to.have.been.calledWith(
         context.s3Client,
         'test-bucket',
-        'metrics/test-site/ahrefs/organic-traffic.json',
+        'metrics/test-site/seo/organic-traffic.json',
         context.log,
       );
     });


### PR DESCRIPTION
## Summary
- Fixes the `calculateCPCValue` function in `spacecat-shared-utils/metrics-store.js` which still read metrics from the old `metrics/{siteId}/ahrefs/organic-traffic.json` S3 path
- The import-worker now writes to `metrics/{siteId}/seo/` paths after the ahrefs→seo rebrand (spacecat-shared#1499), causing this function to silently fall back to default CPC ($0.80)
- Updates test fixture data and assertion to match the new path

Refs: [SITES-43199](https://jira.corp.adobe.com/browse/SITES-43199)

## Test plan
- [x] `metrics-store.test.js` — all 16 tests pass
- [x] Full `spacecat-shared-utils` test suite — 100% coverage on `metrics-store.js`
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)