### PR TITLE
feat: add rumConfig to Site config for deterministic RUM availability signal

### DIFF
--- a/packages/spacecat-shared-data-access/README.md
+++ b/packages/spacecat-shared-data-access/README.md
@@ -172,6 +172,25 @@ The `deliveryConfig` object on a Site stores delivery infrastructure details. It
 | `preferContentApi` | boolean | Whether to prefer the Content API for content retrieval |
 | `contentSourcePath` | string | AEM content root path for a site. Used to disambiguate multiple sites that share the same Cloud Manager program and environment. Corresponds to `/content/<site-name>` in the AEM repository. |
 
+## Site rumConfig
+
+The `rumConfig` object on a Site tracks Real User Monitoring (RUM) domain key availability. It is set automatically on site creation and refreshed weekly by the `rum-config-refresh` audit handler.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `hasDomainKey` | boolean | Whether the site's domain has an active RUM domain key registered |
+| `lastCheckedAt` | string (ISO 8601) | Timestamp of the most recent RUM domain key check |
+
+### Config model methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getRumConfig()` | `{ hasDomainKey, lastCheckedAt } \| undefined` | Returns the current rumConfig, or `undefined` if not yet set |
+| `hasRumDomainKey()` | `boolean` | Returns `true` if a RUM domain key is active, `false` otherwise |
+| `updateRumConfig(hasDomainKey)` | `void` | Sets `hasDomainKey` and updates `lastCheckedAt` to the current time |
+
+Sites created before the `rum-config-refresh` handler ran will have no `rumConfig` key — callers must treat `undefined` as "unknown" rather than "not set up".
+
 ## Architecture
 
 ```

--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -407,6 +407,10 @@ export const configSchema = Joi.object({
       startTime: Joi.number().optional(),
     })).optional(),
   }).optional(),
+  rumConfig: Joi.object({
+    hasDomainKey: Joi.boolean().required(),
+    lastCheckedAt: Joi.string().isoDate().required(),
+  }).optional(),
   commerceLlmoConfig: Joi.object().pattern(
     Joi.string(),
     Joi.object({
@@ -542,6 +546,8 @@ export const Config = (data = {}) => {
   self.getEdgeOptimizeConfig = () => state?.edgeOptimizeConfig;
   self.getOnboardConfig = () => state?.onboardConfig;
   self.getCommerceLlmoConfig = () => state?.commerceLlmoConfig;
+  self.getRumConfig = () => state?.rumConfig;
+  self.hasRumDomainKey = () => state?.rumConfig?.hasDomainKey === true;
   const AUDIT_TARGET_SOURCES = ['manual', 'moneyPages'];
   const auditTargetEntrySchema = Joi.object({
     url: Joi.string().uri().required(),
@@ -955,6 +961,13 @@ export const Config = (data = {}) => {
     state.commerceLlmoConfig = commerceLlmoConfig;
   };
 
+  self.updateRumConfig = (hasDomainKey) => {
+    state.rumConfig = {
+      hasDomainKey,
+      lastCheckedAt: new Date().toISOString(),
+    };
+  };
+
   return Object.freeze(self);
 };
 
@@ -974,6 +987,7 @@ Config.toDynamoItem = (config) => ({
   edgeOptimizeConfig: config.getEdgeOptimizeConfig(),
   onboardConfig: config.getOnboardConfig?.(),
   commerceLlmoConfig: config.getCommerceLlmoConfig?.(),
+  rumConfig: config.getRumConfig?.(),
   enableMoneyPageUrls: config.isMoneyPageUrlsEnabled?.() === false ? false : undefined,
   auditTargetURLs: config.getAuditTargetURLsConfig?.(),
 });

--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -546,7 +546,17 @@ export const Config = (data = {}) => {
   self.getEdgeOptimizeConfig = () => state?.edgeOptimizeConfig;
   self.getOnboardConfig = () => state?.onboardConfig;
   self.getCommerceLlmoConfig = () => state?.commerceLlmoConfig;
-  self.getRumConfig = () => state?.rumConfig;
+  /**
+   * Returns the RUM configuration for the site, or undefined if not set.
+   * Returns a shallow copy to prevent callers from mutating internal state.
+   * @returns {{ hasDomainKey: boolean, lastCheckedAt: string } | undefined}
+   */
+  self.getRumConfig = () => (state?.rumConfig ? { ...state.rumConfig } : undefined);
+
+  /**
+   * Returns true if RUM data collection is confirmed active for this site.
+   * @returns {boolean}
+   */
   self.hasRumDomainKey = () => state?.rumConfig?.hasDomainKey === true;
   const AUDIT_TARGET_SOURCES = ['manual', 'moneyPages'];
   const auditTargetEntrySchema = Joi.object({
@@ -961,10 +971,19 @@ export const Config = (data = {}) => {
     state.commerceLlmoConfig = commerceLlmoConfig;
   };
 
-  self.updateRumConfig = (hasDomainKey) => {
+  /**
+   * Records the outcome of a RUM domain-key check and updates the timestamp.
+   * @param {boolean} hasDomainKey - Whether the site has an active RUM domain key.
+   * @param {Date} [now=new Date()] - Timestamp for lastCheckedAt; injectable for tests.
+   * @throws {Error} if hasDomainKey is not a boolean.
+   */
+  self.updateRumConfig = (hasDomainKey, now = new Date()) => {
+    if (typeof hasDomainKey !== 'boolean') {
+      throw new TypeError(`updateRumConfig: hasDomainKey must be a boolean, got ${typeof hasDomainKey}`);
+    }
     state.rumConfig = {
       hasDomainKey,
-      lastCheckedAt: new Date().toISOString(),
+      lastCheckedAt: now.toISOString(),
     };
   };
 

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -3013,6 +3013,113 @@ describe('Config Tests', () => {
     });
   });
 
+  describe('rumConfig', () => {
+    describe('getRumConfig', () => {
+      it('returns rumConfig when set', () => {
+        const config = Config({
+          rumConfig: { hasDomainKey: true, lastCheckedAt: '2026-05-08T00:00:00.000Z' },
+        });
+        expect(config.getRumConfig()).to.deep.equal({
+          hasDomainKey: true,
+          lastCheckedAt: '2026-05-08T00:00:00.000Z',
+        });
+      });
+
+      it('returns undefined when rumConfig is absent', () => {
+        const config = Config({});
+        expect(config.getRumConfig()).to.be.undefined;
+      });
+    });
+
+    describe('hasRumDomainKey', () => {
+      it('returns true when hasDomainKey is true', () => {
+        const config = Config({
+          rumConfig: { hasDomainKey: true, lastCheckedAt: '2026-05-08T00:00:00.000Z' },
+        });
+        expect(config.hasRumDomainKey()).to.be.true;
+      });
+
+      it('returns false when hasDomainKey is false', () => {
+        const config = Config({
+          rumConfig: { hasDomainKey: false, lastCheckedAt: '2026-05-08T00:00:00.000Z' },
+        });
+        expect(config.hasRumDomainKey()).to.be.false;
+      });
+
+      it('returns false when rumConfig is absent', () => {
+        const config = Config({});
+        expect(config.hasRumDomainKey()).to.be.false;
+      });
+    });
+
+    describe('updateRumConfig', () => {
+      it('sets hasDomainKey to true and records lastCheckedAt', () => {
+        const before = new Date();
+        const config = Config({});
+        config.updateRumConfig(true);
+        const rum = config.getRumConfig();
+        expect(rum.hasDomainKey).to.be.true;
+        expect(new Date(rum.lastCheckedAt).getTime()).to.be.gte(before.getTime());
+      });
+
+      it('sets hasDomainKey to false and records lastCheckedAt', () => {
+        const config = Config({});
+        config.updateRumConfig(false);
+        expect(config.getRumConfig().hasDomainKey).to.be.false;
+        expect(config.getRumConfig().lastCheckedAt).to.match(/^\d{4}-\d{2}-\d{2}T/);
+      });
+
+      it('overwrites a previous rumConfig value', () => {
+        const config = Config({
+          rumConfig: { hasDomainKey: true, lastCheckedAt: '2025-01-01T00:00:00.000Z' },
+        });
+        config.updateRumConfig(false);
+        expect(config.hasRumDomainKey()).to.be.false;
+        expect(config.getRumConfig().lastCheckedAt).to.not.equal('2025-01-01T00:00:00.000Z');
+      });
+    });
+
+    describe('Joi schema validation', () => {
+      it('accepts a valid rumConfig', () => {
+        expect(() => Config({
+          rumConfig: { hasDomainKey: true, lastCheckedAt: '2026-05-08T00:00:00.000Z' },
+        })).to.not.throw();
+      });
+
+      it('rejects rumConfig missing hasDomainKey', () => {
+        expect(() => validateConfiguration({
+          rumConfig: { lastCheckedAt: '2026-05-08T00:00:00.000Z' },
+        })).to.throw(/hasDomainKey/);
+      });
+
+      it('rejects rumConfig with invalid lastCheckedAt', () => {
+        expect(() => validateConfiguration({
+          rumConfig: { hasDomainKey: true, lastCheckedAt: 'not-a-date' },
+        })).to.throw(/lastCheckedAt/);
+      });
+
+      it('treats absent rumConfig as valid (optional field)', () => {
+        expect(() => validateConfiguration({})).to.not.throw();
+      });
+    });
+
+    describe('toDynamoItem serialization', () => {
+      it('includes rumConfig when set', () => {
+        const config = Config({
+          rumConfig: { hasDomainKey: true, lastCheckedAt: '2026-05-08T00:00:00.000Z' },
+        });
+        const item = Config.toDynamoItem(config);
+        expect(item.rumConfig).to.deep.equal(config.getRumConfig());
+      });
+
+      it('omits rumConfig from toDynamoItem when not set', () => {
+        const config = Config({});
+        const item = Config.toDynamoItem(config);
+        expect(item.rumConfig).to.be.undefined;
+      });
+    });
+  });
+
   describe('LLMO Well Known Tags', () => {
     const { extractWellKnownTags } = Config();
 

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -3029,6 +3029,15 @@ describe('Config Tests', () => {
         const config = Config({});
         expect(config.getRumConfig()).to.be.undefined;
       });
+
+      it('returns a copy so mutating the result does not affect internal state', () => {
+        const config = Config({
+          rumConfig: { hasDomainKey: true, lastCheckedAt: '2026-05-08T00:00:00.000Z' },
+        });
+        const copy = config.getRumConfig();
+        copy.hasDomainKey = false;
+        expect(config.hasRumDomainKey()).to.be.true;
+      });
     });
 
     describe('hasRumDomainKey', () => {
@@ -3054,28 +3063,38 @@ describe('Config Tests', () => {
 
     describe('updateRumConfig', () => {
       it('sets hasDomainKey to true and records lastCheckedAt', () => {
-        const before = new Date();
+        const now = new Date('2026-05-08T12:00:00.000Z');
         const config = Config({});
-        config.updateRumConfig(true);
+        config.updateRumConfig(true, now);
         const rum = config.getRumConfig();
         expect(rum.hasDomainKey).to.be.true;
-        expect(new Date(rum.lastCheckedAt).getTime()).to.be.gte(before.getTime());
+        expect(rum.lastCheckedAt).to.equal('2026-05-08T12:00:00.000Z');
       });
 
       it('sets hasDomainKey to false and records lastCheckedAt', () => {
+        const now = new Date('2026-05-08T12:00:00.000Z');
         const config = Config({});
-        config.updateRumConfig(false);
+        config.updateRumConfig(false, now);
         expect(config.getRumConfig().hasDomainKey).to.be.false;
-        expect(config.getRumConfig().lastCheckedAt).to.match(/^\d{4}-\d{2}-\d{2}T/);
+        expect(config.getRumConfig().lastCheckedAt).to.equal('2026-05-08T12:00:00.000Z');
       });
 
       it('overwrites a previous rumConfig value', () => {
+        const now = new Date('2026-05-08T12:00:00.000Z');
         const config = Config({
           rumConfig: { hasDomainKey: true, lastCheckedAt: '2025-01-01T00:00:00.000Z' },
         });
-        config.updateRumConfig(false);
+        config.updateRumConfig(false, now);
         expect(config.hasRumDomainKey()).to.be.false;
-        expect(config.getRumConfig().lastCheckedAt).to.not.equal('2025-01-01T00:00:00.000Z');
+        expect(config.getRumConfig().lastCheckedAt).to.equal('2026-05-08T12:00:00.000Z');
+      });
+
+      it('throws TypeError when hasDomainKey is not a boolean', () => {
+        const config = Config({});
+        expect(() => config.updateRumConfig(null)).to.throw(TypeError, /hasDomainKey must be a boolean/);
+        expect(() => config.updateRumConfig(undefined)).to.throw(TypeError, /hasDomainKey must be a boolean/);
+        expect(() => config.updateRumConfig('true')).to.throw(TypeError, /hasDomainKey must be a boolean/);
+        expect(() => config.updateRumConfig(1)).to.throw(TypeError, /hasDomainKey must be a boolean/);
       });
     });
 


### PR DESCRIPTION


Adds rumConfig sub-config to the Site config object with hasDomainKey and lastCheckedAt fields, following the existing fetchConfig/onboardConfig pattern. Includes Joi schema, getRumConfig/hasRumDomainKey/updateRumConfig accessors, toDynamoItem serialization, and full unit test coverage.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
