### PR TITLE
fix(http-utils): address RO admin wrapper review findings

### DIFF
--- a/packages/spacecat-shared-http-utils/src/auth/read-only-admin-wrapper.js
+++ b/packages/spacecat-shared-http-utils/src/auth/read-only-admin-wrapper.js
@@ -11,7 +11,6 @@
  */
 
 import { Response } from '@adobe/fetch';
-import { isObject } from '@adobe/spacecat-shared-utils';
 import { LaunchDarklyClient } from '@adobe/spacecat-shared-launchdarkly-client';
 
 import { FF_READ_ONLY_ORG } from './constants.js';
@@ -29,17 +28,40 @@ function forbidden(message) {
 }
 
 /**
+ * Resolves a canonical identifier (e.g. 'siteId', 'organizationId') from a source map,
+ * preferring the canonical key, then trying any configured aliases that map to it.
+ *
+ * @param {Object|undefined} source - Path params or context.data
+ * @param {string} canonical - Canonical key name ('siteId' or 'organizationId')
+ * @param {Object<string, string>} aliases - Alias map (alias name -> canonical name)
+ * @returns {string|null} The resolved id, or null
+ */
+function resolveId(source, canonical, aliases) {
+  if (!source) return null;
+  if (source[canonical] !== undefined) return source[canonical];
+  for (const [alias, target] of Object.entries(aliases)) {
+    if (target === canonical && source[alias] !== undefined) {
+      return source[alias];
+    }
+  }
+  return null;
+}
+
+/**
  * Checks whether the authenticated read-only admin user owns the resource identified
  * by the path parameters or request body. Ownership is determined by whether the user's
  * IMS org matches the organization that owns the referenced site or organization entity.
  *
  * ID resolution order:
- * 1. Named path params (e.g. :siteId, :organizationId, :spaceCatId) — always preferred.
- *    spaceCatId is an alias for organizationId used by /v2/orgs/:spaceCatId/* routes
- *    in spacecat-api-service.
+ * 1. Named path params (e.g. :siteId, :organizationId, or any alias configured via
+ *    paramAliases such as :spaceCatId -> organizationId) — always preferred.
  * 2. context.data (parsed request body) — used only when the matched route has no path
  *    params at all (e.g. POST /preflight/jobs passes siteId in the body). Requires that
  *    the body-parser wrapper runs before readOnlyAdminWrapper in the .with() chain.
+ *
+ * Precedence: siteId wins over organizationId when both are resolvable; the site lookup
+ * is performed and organizationId is ignored. Routes that surface both should rely on
+ * siteId as the canonical owner reference.
  *
  * Fail-closed: returns false if dataAccess is unavailable, the entity is not found,
  * no recognizable ID can be resolved, or any lookup throws.
@@ -47,9 +69,10 @@ function forbidden(message) {
  * @param {Object} context - Universal context (must have context.dataAccess and context.log)
  * @param {Object} authInfo - The AuthInfo instance for the current user
  * @param {Object<string, string>} params - Named path params extracted from the route pattern
+ * @param {Object<string, string>} paramAliases - Alias map for canonical id resolution
  * @returns {Promise<boolean>}
  */
-async function isOwnerOfResource(context, authInfo, params) {
+async function isOwnerOfResource(context, authInfo, params, paramAliases) {
   const { dataAccess, log } = context;
   if (!dataAccess) {
     log.error({ tag: 'ro-admin' }, 'isOwnerOfResource: dataAccess not on context — ensure dataAccessWrapper runs before readOnlyAdminWrapper');
@@ -60,14 +83,17 @@ async function isOwnerOfResource(context, authInfo, params) {
   // When params has keys, the route does have path identifiers; relying on body data in that
   // case could allow a caller to spoof ownership by naming params differently than :siteId.
   const hasPathParams = Object.keys(params).length > 0;
-  const siteId = hasPathParams ? params.siteId : context.data?.siteId;
-  const organizationId = hasPathParams
-    ? (params.organizationId ?? params.spaceCatId)
-    : (context.data?.organizationId ?? context.data?.spaceCatId);
+  const source = hasPathParams ? params : context.data;
+  const siteId = resolveId(source, 'siteId', paramAliases);
+  const organizationId = resolveId(source, 'organizationId', paramAliases);
 
   try {
     if (siteId) {
-      const site = await dataAccess.Site?.findById(siteId);
+      if (!dataAccess.Site) {
+        log.error({ tag: 'ro-admin' }, 'isOwnerOfResource: dataAccess.Site accessor is missing');
+        return false;
+      }
+      const site = await dataAccess.Site.findById(siteId);
       if (!site) {
         return false;
       }
@@ -84,7 +110,11 @@ async function isOwnerOfResource(context, authInfo, params) {
     }
 
     if (organizationId) {
-      const org = await dataAccess.Organization?.findById(organizationId);
+      if (!dataAccess.Organization) {
+        log.error({ tag: 'ro-admin' }, 'isOwnerOfResource: dataAccess.Organization accessor is missing');
+        return false;
+      }
+      const org = await dataAccess.Organization.findById(organizationId);
       if (!org) {
         return false;
       }
@@ -96,7 +126,11 @@ async function isOwnerOfResource(context, authInfo, params) {
       return authInfo.hasOrganization(imsOrgId);
     }
   } catch (err) {
-    log.error({ tag: 'ro-admin', err }, 'Error checking resource ownership for RO admin');
+    log.error({
+      tag: 'ro-admin',
+      errMessage: err.message,
+      errName: err.name,
+    }, 'Error checking resource ownership for RO admin');
     return false;
   }
 
@@ -112,6 +146,13 @@ async function isOwnerOfResource(context, authInfo, params) {
  * Evaluates the read-only admin feature flag for the authenticated user's IMS org.
  * Uses {@link AuthInfo#getTenantIds} to resolve the org and
  * {@link LaunchDarklyClient#isFlagEnabledForIMSOrg} for evaluation.
+ *
+ * Tenant scoping semantics: this is a USER-ORG GATE. The flag is evaluated against the
+ * user's primary tenant (`getTenantIds()[0]`). For a multi-tenant user whose tenant list
+ * is `[A, B]`, the flag state for A decides access; B is not consulted. This is order-
+ * dependent: the same user with tenant list `[B, A]` would be gated by B's flag state.
+ * Resource-level org membership is enforced separately by the subsequent ownership check.
+ *
  * Fail-closed: returns false when the client/org is unavailable or evaluation errors.
  *
  * @param {Object} context - Universal context (lambda context)
@@ -135,7 +176,11 @@ async function evaluateFeatureFlag(context, authInfo) {
     const imsOrgId = `${ident}@AdobeOrg`;
     return await ldClient.isFlagEnabledForIMSOrg(FF_READ_ONLY_ORG, imsOrgId);
   } catch (err) {
-    log.error({ tag: 'ro-admin', err }, 'Feature flag evaluation failed for RO admin; defaulting to deny');
+    log.error({
+      tag: 'ro-admin',
+      errMessage: err.message,
+      errName: err.name,
+    }, 'Feature flag evaluation failed for RO admin; defaulting to deny');
     return false;
   }
 }
@@ -147,16 +192,18 @@ async function evaluateFeatureFlag(context, authInfo) {
  * wrapper), this wrapper checks whether the authenticated user is a read-only admin.
  * If so it:
  *
- * 1. Evaluates the `FT_READ_ONLY_ORG` LaunchDarkly feature flag (fail-closed).
+ * 1. Evaluates the `FT_READ_ONLY_ORG` LaunchDarkly feature flag (fail-closed). See
+ *    {@link evaluateFeatureFlag} for tenant scoping semantics (user-org gate).
  * 2. For read routes (capability 'read' or 'readAll'): allows immediately without an
  *    ownership DB lookup — capability alone permits.
  * 3. For write routes and unmapped routes (all non-read capabilities, including null):
  *    performs an ownership check on the referenced resource. Ownership is resolved from
- *    path params first (:siteId, :organizationId, :spaceCatId) and falls back to the
- *    request body (context.data) only when the matched route has no path params at all.
- *    This allows RO admins to operate on their own resources even when the specific
- *    route has no entry in routeCapabilities — the key invariant is ownership, not
- *    capability mapping. Routes with no resolvable resource ID are denied.
+ *    path params first (:siteId, :organizationId, plus any aliases declared in
+ *    paramAliases). It falls back to the request body (context.data) only when the
+ *    matched route has no path params AND the route has an explicit non-null capability
+ *    mapping. Unmapped routes (capability === null) with no path params are denied:
+ *    body-claimed ownership cannot be trusted when the wrapper has no record of the
+ *    route. This is defense-in-depth on top of consumer-side route exhaustiveness tests.
  * 4. Emits a structured access log (tag: ro-admin-access) when an allowed write is
  *    authorized by ownership. Emits an audit log (tag: ro-admin-audit) for all other
  *    allowed RO admin requests where an access log was not already emitted.
@@ -167,23 +214,47 @@ async function evaluateFeatureFlag(context, authInfo) {
  * - `dataAccessWrapper` must run before this wrapper so context.dataAccess is available.
  * - The body-parser wrapper must run before this wrapper for routes that authorize from
  *   context.data (collection writes where siteId/organizationId is in the body).
- * - Handlers behind body-fallback authorization MUST only mutate the declared
- *   siteId/organizationId resource; the wrapper cannot verify what the handler does
- *   with other fields in the request body.
+ *
+ * Handler contracts (the wrapper authorizes but does not enforce these — the handler must):
+ * - Body-fallback authorization: handlers MUST only mutate the declared siteId/
+ *   organizationId resource named in the body; the wrapper cannot verify what the
+ *   handler does with other fields.
+ * - Nested path params: when a route surfaces multiple resource ids (e.g.
+ *   PATCH /sites/:siteId/audits/:auditId), the wrapper authorizes on the parent
+ *   (siteId). Handlers MUST verify that nested resource ids belong to the authorized
+ *   parent (e.g. confirm audit.siteId === params.siteId) before mutating them.
+ *
+ * Sibling wrappers:
+ * - {@link s2sAuthWrapper} consumes the same `routeCapabilities` shape but uses a
+ *   strict capability gate (no ownership fallback). Their policies differ deliberately:
+ *   RO admin permits owner-on-unmapped routes via the body-fallback restriction above;
+ *   s2s denies anything not explicitly mapped.
+ *
+ * Performance: every RO admin write incurs a DB round trip for the ownership lookup
+ * (Site.findById + getOrganization() is two; Organization.findById is one). Read
+ * routes are not affected (read fast-path).
  *
  * @param {Function} fn - The handler to wrap.
- * @param {{ routeCapabilities: Object<string, string>, internalRoutes?: string[] }} opts -
- *   routeCapabilities: required map of route patterns to action strings ('read' | 'write').
- *   internalRoutes: optional array of route pattern strings (e.g. 'DELETE /sites/:siteId')
- *   for routes that exist in the service but are not listed in routeCapabilities. Used as a
- *   fallback by extractRouteParams so ownership checks can still resolve path params for
- *   unmapped routes instead of falling back to the request body.
+ * @param {Object} opts - Wrapper options.
+ * @param {Object<string, string>} opts.routeCapabilities - Required map of route
+ *   patterns (e.g. 'GET /sites/:siteId') to capability strings (e.g. 'site:read',
+ *   'site:write'). Must be a non-empty plain object.
+ * @param {string[]} [opts.internalRoutes=[]] - Route pattern strings for routes that
+ *   exist in the service but are not listed in routeCapabilities. Used as a fallback
+ *   by extractRouteParams so ownership can resolve path params for unmapped routes
+ *   instead of denying. Consumers are expected to maintain a complete enumeration of
+ *   routes across routeCapabilities + internalRoutes (test-enforced at the call site).
+ * @param {Object<string, string>} [opts.paramAliases={}] - Map of alias param names to
+ *   canonical names, e.g. { spaceCatId: 'organizationId' }. Lets a consumer's route
+ *   conventions (e.g. /v2/orgs/:spaceCatId) be authorized as the canonical resource
+ *   id without coupling this shared library to a specific service's routing.
  * @returns {Function} A wrapped handler.
  */
-export function readOnlyAdminWrapper(fn, { routeCapabilities, internalRoutes = [] } = {}) {
-  if (!routeCapabilities) {
-    throw new Error('readOnlyAdminWrapper: routeCapabilities is required');
-  }
+export function readOnlyAdminWrapper(fn, {
+  routeCapabilities,
+  internalRoutes = [],
+  paramAliases = {},
+} = {}) {
   guardNonEmptyRouteCapabilities('readOnlyAdminWrapper', routeCapabilities);
 
   return async (request, context) => {
@@ -197,82 +268,105 @@ export function readOnlyAdminWrapper(fn, { routeCapabilities, internalRoutes = [
           tag: 'ro-admin',
           email: authInfo.getProfile?.()?.email,
           org: authInfo.getTenantIds?.()[0],
+          reason: 'feature-flag-disabled',
         }, 'Feature flag disabled, denying RO admin access');
         return forbidden('Forbidden');
       }
 
-      if (isObject(routeCapabilities)) {
-        let accessLogged = false;
-        try {
-          const params = extractRouteParams(context, routeCapabilities, internalRoutes);
-          const hasPathParams = Object.keys(params).length > 0;
-          const capability = resolveRouteCapability(context, routeCapabilities);
-          // capability format: 'resource:action' (e.g. 'site:read', 'site:write').
-          // split(':').pop() extracts the action; a missing or malformed value yields
-          // undefined, which is not a read action and correctly triggers the ownership check.
-          const action = capability?.split(':').pop();
+      let accessLogged = false;
+      try {
+        const params = extractRouteParams(context, routeCapabilities, internalRoutes);
+        const hasPathParams = Object.keys(params).length > 0;
+        const capability = resolveRouteCapability(context, routeCapabilities);
+        // capability format: 'resource:action' (e.g. 'site:read', 'site:write').
+        // split(':').pop() extracts the action; a missing or malformed value yields
+        // undefined, which is not a read action and correctly triggers the ownership check.
+        const action = capability?.split(':').pop();
 
-          if (action !== 'read' && action !== 'readAll') {
-            // Write or unmapped route: verify ownership of the referenced resource.
-            // Ownership is the governing invariant — a null/absent capability is not an
-            // automatic deny; it means the route is not mapped, but RO admins who own
-            // the resource may still perform the operation. Routes with no resolvable
-            // resource ID (no path param and no body siteId/organizationId) fail-closed.
-            const isOwner = await isOwnerOfResource(context, authInfo, params);
-            if (isOwner) {
-              if (capability === null) {
-                log.warn({
-                  tag: 'ro-admin',
-                  reason: 'unmapped-route-allowed',
-                  method: context.pathInfo?.method,
-                  suffix: context.pathInfo?.suffix,
-                  org: authInfo.getTenantIds?.()[0],
-                }, 'RO admin allowed on unmapped route via ownership — add this route to routeCapabilities');
-              }
-              log.info({
-                tag: 'ro-admin-access',
-                email: authInfo.getProfile?.()?.email,
-                method: context.pathInfo?.method,
-                suffix: context.pathInfo?.suffix,
-                org: authInfo.getTenantIds?.()[0],
-                resolvedSiteId: hasPathParams
-                  ? (params.siteId ?? null)
-                  : (context.data?.siteId ?? null),
-                resolvedOrgId: hasPathParams
-                  ? (params.organizationId ?? params.spaceCatId ?? null)
-                  : (context.data?.organizationId ?? context.data?.spaceCatId ?? null),
-                idSource: hasPathParams ? 'path' : 'body',
-              }, 'RO admin access allowed on owned resource');
-              accessLogged = true;
-            } else {
+        if (action !== 'read' && action !== 'readAll') {
+          // Defense-in-depth: deny body-fallback authorization on unmapped routes.
+          // When the route is in NEITHER routeCapabilities NOR internalRoutes (capability
+          // is null AND no path params were extracted), the body's siteId claim cannot
+          // be trusted: the wrapper has no record of the route, so it cannot constrain
+          // what the handler may do with body data. Legitimate body-fallback routes
+          // (e.g. POST /preflight/jobs) are unaffected because they have an explicit
+          // capability mapping.
+          if (capability === null && !hasPathParams) {
+            log.warn({
+              tag: 'ro-admin',
+              reason: 'unmapped-no-path-params',
+              method: context.pathInfo?.method,
+              suffix: context.pathInfo?.suffix,
+              org: authInfo.getTenantIds?.()[0],
+            }, 'RO admin denied on unmapped route with no path params; add this route to routeCapabilities or internalRoutes');
+            return forbidden('Forbidden');
+          }
+
+          // Write or unmapped-with-path-params route: verify ownership of the referenced
+          // resource. For unmapped routes that carry path params (resolved via
+          // internalRoutes), ownership is the governing invariant — RO admins who own
+          // the resource may still perform the operation. A `unmapped-route-allowed`
+          // drift warn is emitted so consumers can detect routeCapabilities drift.
+          const isOwner = await isOwnerOfResource(context, authInfo, params, paramAliases);
+          if (isOwner) {
+            if (capability === null) {
               log.warn({
                 tag: 'ro-admin',
-                email: authInfo.getProfile?.()?.email,
+                reason: 'unmapped-route-allowed',
                 method: context.pathInfo?.method,
                 suffix: context.pathInfo?.suffix,
                 org: authInfo.getTenantIds?.()[0],
-                reason: 'not-owner',
-              }, 'Read-only admin blocked from route');
-              return forbidden('Forbidden');
+              }, 'RO admin allowed on unmapped route via ownership — add this route to routeCapabilities');
             }
+            const resolvedSiteId = hasPathParams
+              ? resolveId(params, 'siteId', paramAliases)
+              : resolveId(context.data, 'siteId', paramAliases);
+            const resolvedOrgId = hasPathParams
+              ? resolveId(params, 'organizationId', paramAliases)
+              : resolveId(context.data, 'organizationId', paramAliases);
+            log.info({
+              tag: 'ro-admin-access',
+              email: authInfo.getProfile?.()?.email,
+              method: context.pathInfo?.method,
+              suffix: context.pathInfo?.suffix,
+              org: authInfo.getTenantIds?.()[0],
+              resolvedSiteId,
+              resolvedOrgId,
+              idSource: hasPathParams ? 'path' : 'body',
+            }, 'RO admin access allowed on owned resource');
+            accessLogged = true;
+          } else {
+            log.warn({
+              tag: 'ro-admin',
+              email: authInfo.getProfile?.()?.email,
+              method: context.pathInfo?.method,
+              suffix: context.pathInfo?.suffix,
+              org: authInfo.getTenantIds?.()[0],
+              reason: 'not-owner',
+            }, 'Read-only admin blocked from route');
+            return forbidden('Forbidden');
           }
-          // Read action: capability alone permits — no ownership DB lookup needed.
-        } catch (err) {
-          log.error({ tag: 'ro-admin', err }, 'Unexpected error in RO admin authorization; denying access');
-          return forbidden('Forbidden');
         }
+        // Read action: capability alone permits — no ownership DB lookup needed.
+      } catch (err) {
+        log.error({
+          tag: 'ro-admin',
+          errMessage: err.message,
+          errName: err.name,
+        }, 'Unexpected error in RO admin authorization; denying access');
+        return forbidden('Forbidden');
+      }
 
-        // Emit audit log only when the richer access log was not already emitted
-        // (i.e. for reads and any path where ownership-based access was not recorded).
-        if (!accessLogged) {
-          log.info({
-            tag: 'ro-admin-audit',
-            email: authInfo.getProfile?.()?.email,
-            method: context.pathInfo?.method,
-            suffix: context.pathInfo?.suffix,
-            org: authInfo.getTenantIds?.()[0],
-          }, 'RO admin accessed route');
-        }
+      // Emit audit log only when the richer access log was not already emitted
+      // (i.e. for reads and any path where ownership-based access was not recorded).
+      if (!accessLogged) {
+        log.info({
+          tag: 'ro-admin-audit',
+          email: authInfo.getProfile?.()?.email,
+          method: context.pathInfo?.method,
+          suffix: context.pathInfo?.suffix,
+          org: authInfo.getTenantIds?.()[0],
+        }, 'RO admin accessed route');
       }
     }
 

--- a/packages/spacecat-shared-http-utils/src/auth/read-only-admin-wrapper.js
+++ b/packages/spacecat-shared-http-utils/src/auth/read-only-admin-wrapper.js
@@ -37,8 +37,12 @@ function forbidden(message) {
  * @returns {string|null} The resolved id, or null
  */
 function resolveId(source, canonical, aliases) {
-  if (!source) return null;
-  if (source[canonical] !== undefined) return source[canonical];
+  if (!source) {
+    return null;
+  }
+  if (source[canonical] !== undefined) {
+    return source[canonical];
+  }
   for (const [alias, target] of Object.entries(aliases)) {
     if (target === canonical && source[alias] !== undefined) {
       return source[alias];

--- a/packages/spacecat-shared-http-utils/src/auth/route-utils.js
+++ b/packages/spacecat-shared-http-utils/src/auth/route-utils.js
@@ -104,15 +104,16 @@ export function extractRouteParams(context, routeMap, fallbackRoutes = []) {
 }
 
 /**
- * Throws at wrapper creation time if routeCapabilities is an empty object.
- * An empty map would silently deny/block all requests, so this is a
- * fail-fast guard against misconfiguration.
+ * Throws at wrapper creation time if routeCapabilities is not a non-empty plain object.
+ * Rejects undefined, null, arrays, strings, numbers, and empty objects so a caller
+ * cannot accidentally pass a shape the wrapper's `if (isObject(...))` check would skip,
+ * which would silently disable the auth block.
  *
  * @param {string} wrapperName - Name of the wrapper (for the error message)
  * @param {Object} routeCapabilities - The route capabilities map
  */
 export function guardNonEmptyRouteCapabilities(wrapperName, routeCapabilities) {
-  if (isObject(routeCapabilities) && Object.keys(routeCapabilities).length === 0) {
-    throw new Error(`${wrapperName}: routeCapabilities must not be an empty object`);
+  if (!isObject(routeCapabilities) || Object.keys(routeCapabilities).length === 0) {
+    throw new Error(`${wrapperName}: routeCapabilities must be a non-empty object`);
   }
 }

--- a/packages/spacecat-shared-http-utils/test/auth/read-only-admin-wrapper.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/read-only-admin-wrapper.test.js
@@ -58,7 +58,17 @@ describe('readOnlyAdminWrapper', () => {
 
   it('throws at creation time when routeCapabilities is an empty object', () => {
     expect(() => readOnlyAdminWrapper(handler, { routeCapabilities: {} }))
-      .to.throw('routeCapabilities must not be an empty object');
+      .to.throw('routeCapabilities must be a non-empty object');
+  });
+
+  it('throws at creation time when routeCapabilities is an array', () => {
+    expect(() => readOnlyAdminWrapper(handler, { routeCapabilities: ['GET /sites'] }))
+      .to.throw('routeCapabilities must be a non-empty object');
+  });
+
+  it('throws at creation time when routeCapabilities is a string', () => {
+    expect(() => readOnlyAdminWrapper(handler, { routeCapabilities: 'GET /sites' }))
+      .to.throw('routeCapabilities must be a non-empty object');
   });
 
   describe('non-RO-admin passthrough', () => {
@@ -154,7 +164,7 @@ describe('readOnlyAdminWrapper', () => {
       expect(body.message).to.equal('Forbidden');
       expect(handler.called).to.be.false;
       expect(logStub.error.calledWithMatch(
-        { tag: 'ro-admin', err: sdkError },
+        { tag: 'ro-admin', errMessage: 'SDK key missing', errName: 'Error' },
         'Feature flag evaluation failed for RO admin; defaulting to deny',
       )).to.be.true;
     });
@@ -170,7 +180,7 @@ describe('readOnlyAdminWrapper', () => {
       expect(body.message).to.equal('Forbidden');
       expect(handler.called).to.be.false;
       expect(logStub.error.calledWithMatch(
-        { tag: 'ro-admin', err: ldError },
+        { tag: 'ro-admin', errMessage: 'LD unavailable', errName: 'Error' },
         'Feature flag evaluation failed for RO admin; defaulting to deny',
       )).to.be.true;
     });
@@ -202,6 +212,20 @@ describe('readOnlyAdminWrapper', () => {
       const [flagKey, imsOrgId] = ldClient.isFlagEnabledForIMSOrg.firstCall.args;
       expect(flagKey).to.equal('FT_LLMO-3008');
       expect(imsOrgId).to.equal('org-abc@AdobeOrg');
+    });
+
+    it('pins multi-tenant ordering: only the first tenant is checked (user-org gate semantics)', async () => {
+      // Order-dependent by design: this is a user-org gate, not a resource-org gate.
+      // Same user with reversed tenant list ['org-def', 'org-abc'] would be gated on org-def.
+      // This test exists to prevent a silent semantic flip in future changes.
+      context.attributes.authInfo.getTenantIds = () => ['org-def', 'org-abc'];
+      const wrapped = mockedWrapper(handler, { routeCapabilities });
+      await wrapped({}, context);
+
+      const [, imsOrgId] = ldClient.isFlagEnabledForIMSOrg.firstCall.args;
+      expect(imsOrgId).to.equal('org-def@AdobeOrg');
+      // tenantIds[1] must NOT be consulted
+      expect(ldClient.isFlagEnabledForIMSOrg.calledOnce).to.be.true;
     });
   });
 
@@ -299,7 +323,11 @@ describe('readOnlyAdminWrapper', () => {
       expect(result.status).to.equal(403);
       const body = await result.json();
       expect(body.message).to.equal('Forbidden');
-      expect(logStub.warn.calledWithMatch({ tag: 'ro-admin' }, 'Read-only admin blocked from route')).to.be.true;
+      // Defense-in-depth: unmapped route + no path params → denied with explicit reason.
+      expect(logStub.warn.calledWithMatch(
+        { tag: 'ro-admin', reason: 'unmapped-no-path-params' },
+        'RO admin denied on unmapped route with no path params; add this route to routeCapabilities or internalRoutes',
+      )).to.be.true;
       expect(handler.called).to.be.false;
     });
 
@@ -326,12 +354,12 @@ describe('readOnlyAdminWrapper', () => {
   describe('no routeCapabilities provided', () => {
     it('throws at creation time when routeCapabilities is not provided', () => {
       expect(() => readOnlyAdminWrapper(handler))
-        .to.throw('readOnlyAdminWrapper: routeCapabilities is required');
+        .to.throw('readOnlyAdminWrapper: routeCapabilities must be a non-empty object');
     });
 
     it('throws at creation time when routeCapabilities is null', () => {
       expect(() => readOnlyAdminWrapper(handler, { routeCapabilities: null }))
-        .to.throw('readOnlyAdminWrapper: routeCapabilities is required');
+        .to.throw('readOnlyAdminWrapper: routeCapabilities must be a non-empty object');
     });
   });
 
@@ -472,7 +500,10 @@ describe('readOnlyAdminWrapper', () => {
       context.dataAccess = {
         Organization: { findById: sinon.stub().resolves(orgStub) },
       };
-      const wrapped = mockedWrapper(handler, { routeCapabilities: orgRoutes });
+      const wrapped = mockedWrapper(handler, {
+        routeCapabilities: orgRoutes,
+        paramAliases: { spaceCatId: 'organizationId' },
+      });
       const result = await wrapped({}, context);
 
       expect(result).to.deep.equal({ status: 200 });
@@ -489,11 +520,56 @@ describe('readOnlyAdminWrapper', () => {
       context.dataAccess = {
         Organization: { findById: sinon.stub().resolves(orgStub) },
       };
-      const wrapped = mockedWrapper(handler, { routeCapabilities: orgRoutes });
+      const wrapped = mockedWrapper(handler, {
+        routeCapabilities: orgRoutes,
+        paramAliases: { spaceCatId: 'organizationId' },
+      });
       const result = await wrapped({}, context);
 
       expect(result).to.deep.equal({ status: 200 });
       expect(context.dataAccess.Organization.findById.calledWith('org-456')).to.be.true;
+    });
+
+    it('prefers canonical organizationId over spaceCatId alias when both are present in body', async () => {
+      // organizationId (canonical) wins over spaceCatId (alias) per resolveId precedence.
+      const orgRoutes = {
+        ...routeCapabilities,
+        'POST /some/org/action': 'organization:write',
+      };
+      context.pathInfo = { method: 'POST', suffix: '/some/org/action' };
+      context.data = { organizationId: 'org-canonical', spaceCatId: 'org-alias' };
+      context.dataAccess = {
+        Organization: { findById: sinon.stub().resolves(orgStub) },
+      };
+      const wrapped = mockedWrapper(handler, {
+        routeCapabilities: orgRoutes,
+        paramAliases: { spaceCatId: 'organizationId' },
+      });
+      await wrapped({}, context);
+
+      expect(context.dataAccess.Organization.findById.calledWith('org-canonical')).to.be.true;
+      expect(context.dataAccess.Organization.findById.calledWith('org-alias')).to.be.false;
+    });
+
+    it('ignores spaceCatId in body when paramAliases is not configured', async () => {
+      // Default paramAliases is {}: without an explicit alias declaration, spaceCatId is
+      // not recognised as an organization id. Decouples the shared wrapper from
+      // spacecat-api-service routing conventions.
+      const orgRoutes = {
+        ...routeCapabilities,
+        'POST /some/org/action': 'organization:write',
+      };
+      context.pathInfo = { method: 'POST', suffix: '/some/org/action' };
+      context.data = { spaceCatId: 'org-456' };
+      context.dataAccess = {
+        Organization: { findById: sinon.stub().resolves(orgStub) },
+      };
+      const wrapped = mockedWrapper(handler, { routeCapabilities: orgRoutes });
+      const result = await wrapped({}, context);
+
+      // No alias configured → spaceCatId is ignored → no resolvable id → denied
+      expect(result.status).to.equal(403);
+      expect(context.dataAccess.Organization.findById.called).to.be.false;
     });
 
     it('blocks write when the organization is not found', async () => {
@@ -570,7 +646,7 @@ describe('readOnlyAdminWrapper', () => {
       expect(result.status).to.equal(403);
       expect(handler.called).to.be.false;
       expect(logStub.error.calledWithMatch(
-        { tag: 'ro-admin', err: dbError },
+        { tag: 'ro-admin', errMessage: 'DB error', errName: 'Error' },
         'Error checking resource ownership for RO admin',
       )).to.be.true;
     });
@@ -672,7 +748,28 @@ describe('readOnlyAdminWrapper', () => {
       expect(logStub.info.calledWithMatch({
         tag: 'ro-admin-access',
         resolvedSiteId: 'abc-123',
+        resolvedOrgId: null,
         idSource: 'body',
+      }, 'RO admin access allowed on owned resource')).to.be.true;
+      // accessLogged=true suppresses the audit log on the body-fallback path too
+      expect(logStub.info.calledWithMatch(
+        { tag: 'ro-admin-audit' },
+        'RO admin accessed route',
+      )).to.be.false;
+    });
+
+    it('emits ro-admin-access log with resolvedOrgId when org route is authorized via path', async () => {
+      const orgRoutes = { ...routeCapabilities, 'PATCH /organizations/:organizationId': 'organization:write' };
+      context.pathInfo = { method: 'PATCH', suffix: '/organizations/org-789' };
+      context.dataAccess = { Organization: { findById: sinon.stub().resolves(orgStub) } };
+      const wrapped = mockedWrapper(handler, { routeCapabilities: orgRoutes });
+      await wrapped({}, context);
+
+      expect(logStub.info.calledWithMatch({
+        tag: 'ro-admin-access',
+        resolvedSiteId: null,
+        resolvedOrgId: 'org-789',
+        idSource: 'path',
       }, 'RO admin access allowed on owned resource')).to.be.true;
     });
 
@@ -704,7 +801,7 @@ describe('readOnlyAdminWrapper', () => {
       expect(result.status).to.equal(403);
       expect(handler.called).to.be.false;
       expect(logStub.error.calledWithMatch(
-        { tag: 'ro-admin', err: orgError },
+        { tag: 'ro-admin', errMessage: 'getOrganization failed', errName: 'Error' },
         'Error checking resource ownership for RO admin',
       )).to.be.true;
     });
@@ -720,7 +817,7 @@ describe('readOnlyAdminWrapper', () => {
       expect(result.status).to.equal(403);
       expect(handler.called).to.be.false;
       expect(logStub.error.calledWithMatch(
-        { tag: 'ro-admin', err: dbError },
+        { tag: 'ro-admin', errMessage: 'Org DB error', errName: 'Error' },
         'Error checking resource ownership for RO admin',
       )).to.be.true;
     });
@@ -733,51 +830,33 @@ describe('readOnlyAdminWrapper', () => {
 
       expect(result.status).to.equal(403);
       expect(handler.called).to.be.false;
-    });
-
-    it('allows access on unmapped route when siteId is supplied via body and RO admin owns it', async () => {
-      // Suffix POST /jobs/preflight has no entry in routeCapabilities → extractRouteParams
-      // returns {} → body fallback is used. Ownership of the body siteId grants access.
-      context.pathInfo = { method: 'POST', suffix: '/jobs/preflight' };
-      context.data = { siteId: 'abc-123' };
-      context.dataAccess = {
-        Site: { findById: sinon.stub().resolves(siteStub) },
-      };
-      const wrapped = mockedWrapper(handler, { routeCapabilities });
-      const result = await wrapped({}, context);
-
-      expect(result).to.deep.equal({ status: 200 });
-      expect(handler.calledOnce).to.be.true;
-      expect(context.dataAccess.Site.findById.calledWith('abc-123')).to.be.true;
-    });
-
-    it('emits drift-detection warn when an unmapped route is allowed via ownership', async () => {
-      // capability === null (route not in routeCapabilities) + ownership grants access.
-      // A log.warn with reason: 'unmapped-route-allowed' should be emitted as a drift signal.
-      context.pathInfo = { method: 'POST', suffix: '/jobs/preflight' };
-      context.data = { siteId: 'abc-123' };
-      context.dataAccess = {
-        Site: { findById: sinon.stub().resolves(siteStub) },
-      };
-      const wrapped = mockedWrapper(handler, { routeCapabilities });
-      await wrapped({}, context);
-
-      expect(logStub.warn.calledWithMatch(
-        {
-          tag: 'ro-admin',
-          reason: 'unmapped-route-allowed',
-          method: 'POST',
-          suffix: '/jobs/preflight',
-        },
-        'RO admin allowed on unmapped route via ownership — add this route to routeCapabilities',
+      expect(logStub.error.calledWithMatch(
+        { tag: 'ro-admin' },
+        'isOwnerOfResource: dataAccess.Site accessor is missing',
       )).to.be.true;
     });
 
-    it('blocks unmapped route for RO admin who does not own the resource', async () => {
-      // Same unmapped route; body siteId present but user does not own it.
+    it('blocks write when dataAccess has no Organization property (fail-closed)', async () => {
+      const orgRoutes = { ...routeCapabilities, 'PATCH /organizations/:organizationId': 'organization:write' };
+      context.pathInfo = { method: 'PATCH', suffix: '/organizations/org-456' };
+      context.dataAccess = {}; // Organization accessor absent
+      const wrapped = mockedWrapper(handler, { routeCapabilities: orgRoutes });
+      const result = await wrapped({}, context);
+
+      expect(result.status).to.equal(403);
+      expect(handler.called).to.be.false;
+      expect(logStub.error.calledWithMatch(
+        { tag: 'ro-admin' },
+        'isOwnerOfResource: dataAccess.Organization accessor is missing',
+      )).to.be.true;
+    });
+
+    it('denies access on unmapped route with no path params even when body claims ownership (Critical fix)', async () => {
+      // Defense-in-depth: route not in routeCapabilities or internalRoutes → no path params
+      // → body fallback would have authorized against body siteId, but the wrapper has no
+      // record of the route and cannot constrain what the handler does. Deny up-front.
       context.pathInfo = { method: 'POST', suffix: '/jobs/preflight' };
       context.data = { siteId: 'abc-123' };
-      context.attributes.authInfo.hasOrganization = sinon.stub().returns(false);
       context.dataAccess = {
         Site: { findById: sinon.stub().resolves(siteStub) },
       };
@@ -786,7 +865,57 @@ describe('readOnlyAdminWrapper', () => {
 
       expect(result.status).to.equal(403);
       expect(handler.called).to.be.false;
+      // No DB lookup happens because the deny is up-front, before ownership check.
+      expect(context.dataAccess.Site.findById.called).to.be.false;
+      expect(logStub.warn.calledWithMatch(
+        { tag: 'ro-admin', reason: 'unmapped-no-path-params' },
+        'RO admin denied on unmapped route with no path params; add this route to routeCapabilities or internalRoutes',
+      )).to.be.true;
+    });
+
+    it('allows access on unmapped route resolved via internalRoutes path params and emits drift-detection warn', async () => {
+      // PUT /sites/:siteId is unmapped (not in routeCapabilities), but internalRoutes covers
+      // it so extractRouteParams returns { siteId: 'abc-123' }. Ownership check runs against
+      // path params (not body), capability is null, drift warn fires.
+      context.pathInfo = { method: 'PUT', suffix: '/sites/abc-123' };
+      context.dataAccess = {
+        Site: { findById: sinon.stub().resolves(siteStub) },
+      };
+      const internalRoutes = ['PUT /sites/:siteId'];
+      const wrapped = mockedWrapper(handler, { routeCapabilities, internalRoutes });
+      const result = await wrapped({}, context);
+
+      expect(result).to.deep.equal({ status: 200 });
+      expect(handler.calledOnce).to.be.true;
       expect(context.dataAccess.Site.findById.calledWith('abc-123')).to.be.true;
+      expect(logStub.warn.calledWithMatch(
+        {
+          tag: 'ro-admin',
+          reason: 'unmapped-route-allowed',
+          method: 'PUT',
+          suffix: '/sites/abc-123',
+        },
+        'RO admin allowed on unmapped route via ownership — add this route to routeCapabilities',
+      )).to.be.true;
+    });
+
+    it('blocks unmapped route via internalRoutes path params when RO admin does not own the resource', async () => {
+      context.pathInfo = { method: 'PUT', suffix: '/sites/abc-123' };
+      context.attributes.authInfo.hasOrganization = sinon.stub().returns(false);
+      context.dataAccess = {
+        Site: { findById: sinon.stub().resolves(siteStub) },
+      };
+      const internalRoutes = ['PUT /sites/:siteId'];
+      const wrapped = mockedWrapper(handler, { routeCapabilities, internalRoutes });
+      const result = await wrapped({}, context);
+
+      expect(result.status).to.equal(403);
+      expect(handler.called).to.be.false;
+      expect(context.dataAccess.Site.findById.calledWith('abc-123')).to.be.true;
+      expect(logStub.warn.calledWithMatch(
+        { tag: 'ro-admin', reason: 'not-owner' },
+        'Read-only admin blocked from route',
+      )).to.be.true;
     });
 
     it('allows write on owned resource when siteId resolved via internalRoutes fallback', async () => {
@@ -842,7 +971,7 @@ describe('readOnlyAdminWrapper', () => {
       expect(result.status).to.equal(403);
       expect(handler.called).to.be.false;
       expect(logStub.error.calledWithMatch(
-        { tag: 'ro-admin', err: routeError },
+        { tag: 'ro-admin', errMessage: 'unexpected route error', errName: 'Error' },
         'Unexpected error in RO admin authorization; denying access',
       )).to.be.true;
     });

--- a/packages/spacecat-shared-http-utils/test/auth/route-utils.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/route-utils.test.js
@@ -188,7 +188,7 @@ describe('route-utils', () => {
   describe('guardNonEmptyRouteCapabilities', () => {
     it('throws when routeCapabilities is an empty object', () => {
       expect(() => guardNonEmptyRouteCapabilities('testWrapper', {}))
-        .to.throw('testWrapper: routeCapabilities must not be an empty object');
+        .to.throw('testWrapper: routeCapabilities must be a non-empty object');
     });
 
     it('does not throw when routeCapabilities is a non-empty object', () => {
@@ -196,14 +196,24 @@ describe('route-utils', () => {
         .to.not.throw();
     });
 
-    it('does not throw when routeCapabilities is undefined', () => {
+    it('throws when routeCapabilities is undefined', () => {
       expect(() => guardNonEmptyRouteCapabilities('testWrapper', undefined))
-        .to.not.throw();
+        .to.throw('testWrapper: routeCapabilities must be a non-empty object');
     });
 
-    it('does not throw when routeCapabilities is null', () => {
+    it('throws when routeCapabilities is null', () => {
       expect(() => guardNonEmptyRouteCapabilities('testWrapper', null))
-        .to.not.throw();
+        .to.throw('testWrapper: routeCapabilities must be a non-empty object');
+    });
+
+    it('throws when routeCapabilities is an array', () => {
+      expect(() => guardNonEmptyRouteCapabilities('testWrapper', ['GET /sites']))
+        .to.throw('testWrapper: routeCapabilities must be a non-empty object');
+    });
+
+    it('throws when routeCapabilities is a string', () => {
+      expect(() => guardNonEmptyRouteCapabilities('testWrapper', 'GET /sites'))
+        .to.throw('testWrapper: routeCapabilities must be a non-empty object');
     });
   });
 });

--- a/packages/spacecat-shared-http-utils/test/auth/s2s-wrapper.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/s2s-wrapper.test.js
@@ -93,7 +93,17 @@ describe('s2sAuthWrapper', () => {
 
   it('throws at creation time when routeCapabilities is an empty object', () => {
     expect(() => s2sAuthWrapper(handler, { routeCapabilities: {} }))
-      .to.throw('routeCapabilities must not be an empty object');
+      .to.throw('routeCapabilities must be a non-empty object');
+  });
+
+  it('throws at creation time when routeCapabilities is missing', () => {
+    expect(() => s2sAuthWrapper(handler))
+      .to.throw('routeCapabilities must be a non-empty object');
+  });
+
+  it('throws at creation time when routeCapabilities is an array', () => {
+    expect(() => s2sAuthWrapper(handler, { routeCapabilities: ['GET /sites'] }))
+      .to.throw('routeCapabilities must be a non-empty object');
   });
 
   it('passes through when no bearer token is provided', async () => {
@@ -353,18 +363,11 @@ describe('s2sAuthWrapper', () => {
       expect(handler.called).to.be.false;
     });
 
-    it('passes through when no routeCapabilities is provided', async () => {
-      const token = await createToken(createTokenPayload(s2sTokenPayload));
-      context.pathInfo = {
-        method: 'GET',
-        suffix: '/sites',
-        headers: { authorization: `Bearer ${token}` },
-      };
-      const wrapped = s2sAuthWrapper(handler);
-      const result = await wrapped({}, context);
-
-      expect(result).to.deep.equal({ status: 200 });
-      expect(handler.calledOnce).to.be.true;
+    it('requires routeCapabilities at construction time (no implicit pass-through)', () => {
+      // Tightened guard: passing no routeCapabilities throws immediately so a
+      // misconfigured wrapper cannot silently bypass capability checks.
+      expect(() => s2sAuthWrapper(handler))
+        .to.throw('routeCapabilities must be a non-empty object');
     });
 
     it('returns 403 when pathInfo is missing method or suffix', async () => {


### PR DESCRIPTION
## Summary

Follow-up to [PR #1595](https://github.com/adobe/spacecat-shared/pull/1595) addressing the Critical / Important / Minor findings from @solaris007's [review](https://github.com/adobe/spacecat-shared/pull/1595#pullrequestreview-4269055881).

## Changes

### Critical (defense-in-depth adopted)

The reviewer's attack scenario premise - "developer adds a new route and forgets BOTH `routeCapabilities` AND `internalRoutes`" - is prevented by an existing in-place test in `spacecat-api-service` that asserts every mounted route is enumerated in one of the two maps. The attack is therefore not reachable in practice.

However, the reviewer's recommended fix is a strict improvement to the wrapper's contract regardless of the api-service test, so it has been adopted as defense-in-depth:

- **Body fallback now requires an explicit capability mapping.** When `capability === null` AND no path params are resolvable (route is in NEITHER `routeCapabilities` NOR `internalRoutes`), the wrapper denies up-front with `reason: 'unmapped-no-path-params'`. The body's siteId/orgId claim is no longer consulted in that case.
- Legitimate body-fallback routes (e.g. `POST /preflight/jobs` with body siteId) are unaffected because they have an explicit capability mapping (`'POST /preflight/jobs': 'preflight:write'`).
- The wrapper is now safe to drop into a consumer that does not have route-exhaustiveness tests.

### Important

1. **Permissive default for unmapped writes** - The ownership-first model is preserved for routes in `internalRoutes` (path-params resolvable). The Critical fix above closes the body-fallback escape hatch. `unmapped-route-allowed` drift warn still fires so consumers can detect routeCapabilities drift.
2. **`routeCapabilities` non-object input silently fails open** - `guardNonEmptyRouteCapabilities` tightened to require a non-empty plain object. Rejects undefined, null, arrays, strings, numbers. `s2sAuthWrapper` inherits this guard.
3. **`spaceCatId` alias couples shared utils to api-service** - Added `paramAliases` option (default `{}`). Consumers declare `{ spaceCatId: 'organizationId' }` at the call site. The wrapper no longer hardcodes a service-specific routing convention.
4. **`internalRoutes` parallel source of truth** - Kept as designed. The api-service test prevents drift; collapsing to a single map would require a sentinel value scheme that adds its own complexity. Documented the relationship in JSDoc.
5. **Parent-child resource ambiguity** - Documented explicit handler contract in JSDoc: handlers behind path-param authorization MUST verify nested resource ids belong to the authorized parent before mutating them.
6. **Feature flag scoped to `tenantIds[0]`** - Documented the "user-org gate" semantics. Added a test pinning multi-tenant ordering behavior so the choice cannot silently flip later.

### Minor

1. **Silent failure on missing accessor** - `dataAccess.Site` / `dataAccess.Organization` absence now emits `log.error`.
2. **siteId-over-organizationId precedence** - Documented in `isOwnerOfResource` JSDoc.
3. **Stack-trace leakage** - Error logs now use `{ errMessage: err.message, errName: err.name }` instead of `{ err }` to avoid DB driver internals (table names, region, connection ids) leaking through the structured logger.
4. **Coverage refinements** - Body-fallback access-log test asserts `ro-admin-audit` is NOT emitted (suppression contract) and asserts `resolvedOrgId`. New test for org-route access log with `resolvedOrgId`.
5. **organizationId precedence over spaceCatId not pinned** - Added two tests: canonical wins over alias when both are set in body; spaceCatId is ignored when `paramAliases` is not configured.

### Recommendations addressed

- Cross-domain consistency note: JSDoc cross-references `s2sAuthWrapper` as a deliberately-different-policy sibling.
- Performance note: JSDoc documents per-write DB round-trip cost.
- FF-disabled denial now includes `reason: 'feature-flag-disabled'` field for SIEM filterability (also covers a prior Minor).

### Recommendations not adopted in this PR

- **Pluggable `isOwner` strategy** - Larger refactor; worth its own PR.
- **Startup-time invariant check of mounted routes vs `routeCapabilities`** - Already enforced at the consumer (api-service) level; not adding a duplicate check to the shared wrapper.

## Test plan

- [x] 344 tests passing, 100% lines / statements coverage, 97.64% branches (threshold 97%).
- [x] Lint clean.
- [ ] Verify api-service tests still pass against this version (test the wrapper with the existing routeCapabilities + internalRoutes maps; add `paramAliases: { spaceCatId: 'organizationId' }` at the call site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
