### PR TITLE
feat(data-access): add preOnboarded flag to PLG onboarding steps schema

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/plg-onboarding/plg-onboarding.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/plg-onboarding/plg-onboarding.schema.js
@@ -68,6 +68,7 @@ const schema = new SchemaBuilder(PlgOnboarding, PlgOnboardingCollection)
       entitlementCreated: { type: 'boolean' },
       entitlementFailed: { type: 'boolean' },
       orgResolutionFailed: { type: 'boolean' },
+      preOnboarded: { type: 'boolean' },
     },
   })
   .addAttribute('error', {

--- a/packages/spacecat-shared-data-access/test/unit/models/plg-onboarding/plg-onboarding.schema.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/plg-onboarding/plg-onboarding.schema.test.js
@@ -178,6 +178,7 @@ describe('PlgOnboarding Schema', () => {
         'entitlementCreated',
         'entitlementFailed',
         'orgResolutionFailed',
+        'preOnboarded',
       ];
       expect(keys).to.have.members(expected);
     });


### PR DESCRIPTION
## Summary

- Adds `preOnboarded: boolean` to the `steps` map properties in the `PlgOnboarding` schema
- This flag is set to `true` by `spacecat-api-service` when a `PRE_ONBOARDING` record is fast-tracked to `ONBOARDED` during the self-service onboarding flow
- Without this flag, once a pre-onboarded record transitions to `ONBOARDED`, there is no way to tell it originated from pre-onboarding — the `PRE_ONBOARDING` status is overwritten and the origin is permanently lost

## Context

Pre-onboarding is done via a one-time admin script (`plg-preonboard-api.js`) that creates `PlgOnboarding` records with `status: PRE_ONBOARDING`. When the customer later signs up through the self-service flow, the record is fast-tracked directly to `ONBOARDED`. After that transition, fetching records that came from pre-onboarding becomes impossible without this persistent flag.

Schema change is purely additive — existing records without the flag are unaffected.

**Companion PR:** adobe/spacecat-api-service — `feat/plg-preonboarded-steps-flag`

## Test plan

- [ ] Schema change is additive — no migration needed, existing records without the flag are unaffected
- [ ] Verify `preOnboarded` persists correctly on fast-tracked records via the api-service companion PR