### PR TITLE
feat(brand-client): add BrandGovernanceClient for Brand Governance Agent API (LLMO-4920)

### DIFF
--- a/packages/spacecat-shared-brand-client/src/brand-governance-client.js
+++ b/packages/spacecat-shared-brand-client/src/brand-governance-client.js
@@ -17,8 +17,10 @@ import { ImsClient } from '@adobe/spacecat-shared-ims-client';
 const HTTP_BAD_REQUEST = 400;
 const HTTP_NOT_FOUND = 404;
 
+const CHECKS_PAGE_SIZE = 100;
+
 const API_GET_BRAND_FROM_URL = (url) => `/api/v1/brands/from-url?url=${encodeURIComponent(url)}`;
-const API_GET_BRAND_CHECKS = (brandId) => `/api/v1/brands/${brandId}/checks?status=ACTIVE&type=BRAND&pageSize=100`;
+const API_GET_BRAND_CHECKS = (brandId, page) => `/api/v1/brands/${brandId}/checks?status=ACTIVE&type=BRAND&scope=COPY&pageSize=${CHECKS_PAGE_SIZE}&page=${page}`;
 
 /**
  * Client for the Adobe Brand Governance Agent API.
@@ -127,22 +129,31 @@ export class BrandGovernanceClient {
     }
     const brand = await brandResponse.json();
 
-    const checksResponse = await fetch(
-      `${this.apiBaseUrl}${API_GET_BRAND_CHECKS(brand.id)}`,
-      { headers },
-    );
-    if (!checksResponse.ok) {
-      throw this.#createError(
-        `Error fetching brand checks for brand ${brand.id}: ${checksResponse.status}`,
-        checksResponse.status,
+    const allChecks = [];
+    let page = 1;
+    do {
+      // eslint-disable-next-line no-await-in-loop
+      const checksResponse = await fetch(
+        `${this.apiBaseUrl}${API_GET_BRAND_CHECKS(brand.id, page)}`,
+        { headers },
       );
-    }
-    const checksResult = await checksResponse.json();
-    const checks = checksResult.data || [];
+      if (!checksResponse.ok) {
+        throw this.#createError(
+          `Error fetching brand checks for brand ${brand.id}: ${checksResponse.status}`,
+          checksResponse.status,
+        );
+      }
+      // eslint-disable-next-line no-await-in-loop
+      const { data = [] } = await checksResponse.json();
+      allChecks.push(...data);
+      if (data.length < CHECKS_PAGE_SIZE) {
+        break;
+      }
+      page += 1;
+    // eslint-disable-next-line no-constant-condition
+    } while (true);
 
-    const guidelines = checks
-      .filter((check) => Array.isArray(check.scopes) && check.scopes.includes('COPY'))
-      .map((check) => ({ name: check.name, text: check.rule }));
+    const guidelines = allChecks.map((check) => ({ name: check.name, text: check.rule }));
 
     return {
       id: brand.id,

--- a/packages/spacecat-shared-brand-client/src/brand-governance-client.js
+++ b/packages/spacecat-shared-brand-client/src/brand-governance-client.js
@@ -18,6 +18,7 @@ const HTTP_BAD_REQUEST = 400;
 const HTTP_NOT_FOUND = 404;
 
 const CHECKS_PAGE_SIZE = 100;
+const MAX_PAGES = 20;
 
 const API_GET_BRAND_FROM_URL = (url) => `/api/v1/brands/from-url?url=${encodeURIComponent(url)}`;
 const API_GET_BRAND_CHECKS = (brandId, page) => `/api/v1/brands/${brandId}/checks?status=ACTIVE&type=BRAND&scope=COPY&pageSize=${CHECKS_PAGE_SIZE}&page=${page}`;
@@ -88,6 +89,12 @@ export class BrandGovernanceClient {
    * Fetches brand guidelines for a site URL from the Brand Governance Agent.
    * Returns null if the brand is not registered (404), allowing callers to fall back.
    *
+   * Org/tenant scoping for the domain lookup is enforced server-side by the Agent via the
+   * x-gw-ims-org-id request header. BrandResponse carries no org_id field, so the
+   * client-side ownership check performed by BrandClient is not possible here. Note that
+   * the imsOrgId field in the returned object is the requested org echoed for shape-parity
+   * with BrandClient — it is not a verified owner of the resolved brand.
+   *
    * @param {string} siteBaseUrl - The site's base URL to resolve brand by domain
    * @param {string} imsOrgId - The IMS org ID sent as x-gw-ims-org-id header
    * @param {object} imsConfig - IMS auth config: { host, clientId, clientCode, clientSecret }
@@ -153,6 +160,12 @@ export class BrandGovernanceClient {
         break;
       }
       page += 1;
+      if (page > MAX_PAGES) {
+        throw this.#createError(
+          `Brand checks pagination exceeded ${MAX_PAGES} pages for brand ${brand.id}`,
+          HTTP_BAD_REQUEST,
+        );
+      }
     // eslint-disable-next-line no-constant-condition
     } while (true);
 

--- a/packages/spacecat-shared-brand-client/src/brand-governance-client.js
+++ b/packages/spacecat-shared-brand-client/src/brand-governance-client.js
@@ -27,15 +27,15 @@ const API_GET_BRAND_CHECKS = (brandId) => `/api/v1/brands/${brandId}/checks?stat
  */
 export class BrandGovernanceClient {
   static createFrom(context) {
+    if (context.brandGovernanceClient) {
+      return context.brandGovernanceClient;
+    }
+
     const { env, log = console } = context;
     const {
       BRAND_GOV_API_BASE_URL: apiBaseUrl,
       BRAND_GOV_API_KEY: apiKey,
     } = env;
-
-    if (context.brandGovernanceClient) {
-      return context.brandGovernanceClient;
-    }
 
     const client = new BrandGovernanceClient({ apiBaseUrl, apiKey }, log);
     context.brandGovernanceClient = client;

--- a/packages/spacecat-shared-brand-client/src/brand-governance-client.js
+++ b/packages/spacecat-shared-brand-client/src/brand-governance-client.js
@@ -75,7 +75,11 @@ export class BrandGovernanceClient {
     };
     const imsClient = ImsClient.createFrom(imsContext);
     const response = await imsClient.getServiceAccessToken();
-    return response?.access_token;
+    const token = response?.access_token;
+    if (!hasText(token)) {
+      throw this.#createError('Failed to obtain IMS access token', HTTP_BAD_REQUEST);
+    }
+    return token;
   }
 
   /**

--- a/packages/spacecat-shared-brand-client/src/brand-governance-client.js
+++ b/packages/spacecat-shared-brand-client/src/brand-governance-client.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import {
+  isValidIMSOrgId, hasText, isValidUrl, tracingFetch as fetch,
+} from '@adobe/spacecat-shared-utils';
+import { ImsClient } from '@adobe/spacecat-shared-ims-client';
+
+const HTTP_BAD_REQUEST = 400;
+const HTTP_NOT_FOUND = 404;
+
+const API_GET_BRAND_FROM_URL = (url) => `/api/v1/brands/from-url?url=${encodeURIComponent(url)}`;
+const API_GET_BRAND_CHECKS = (brandId) => `/api/v1/brands/${brandId}/checks?status=ACTIVE&type=BRAND&pageSize=100`;
+
+/**
+ * Client for the Adobe Brand Governance Agent API.
+ * Resolves brand guidelines by site URL using COPY-scoped checks.
+ * Returns null when the brand is not registered — caller falls back to Brand Publish.
+ */
+export class BrandGovernanceClient {
+  static createFrom(context) {
+    const { env, log = console } = context;
+    const {
+      BRAND_GOV_API_BASE_URL: apiBaseUrl,
+      BRAND_GOV_API_KEY: apiKey,
+    } = env;
+
+    if (context.brandGovernanceClient) {
+      return context.brandGovernanceClient;
+    }
+
+    const client = new BrandGovernanceClient({ apiBaseUrl, apiKey }, log);
+    context.brandGovernanceClient = client;
+    return client;
+  }
+
+  constructor({ apiBaseUrl, apiKey }, log) {
+    this.log = log;
+    if (!isValidUrl(apiBaseUrl)) {
+      throw this.#createError(`Invalid Brand Governance API Base URL: ${apiBaseUrl}`, HTTP_BAD_REQUEST);
+    }
+    if (!hasText(apiKey)) {
+      throw this.#createError(`Invalid Brand Governance API Key: ${apiKey}`, HTTP_BAD_REQUEST);
+    }
+    this.apiBaseUrl = apiBaseUrl;
+    this.apiKey = apiKey;
+    this.serviceAccessToken = null;
+  }
+
+  #createError(message, status) {
+    const error = Object.assign(new Error(message), { status });
+    this.log.error(error.message);
+    return error;
+  }
+
+  async #getImsAccessToken(imsConfig) {
+    if (this.serviceAccessToken) {
+      return this.serviceAccessToken;
+    }
+    const {
+      host, clientId, clientCode, clientSecret,
+    } = imsConfig;
+    const imsContext = {
+      env: {
+        IMS_HOST: host,
+        IMS_CLIENT_ID: clientId,
+        IMS_CLIENT_CODE: clientCode,
+        IMS_CLIENT_SECRET: clientSecret,
+      },
+      log: this.log,
+    };
+    const imsClient = ImsClient.createFrom(imsContext);
+    const response = await imsClient.getServiceAccessToken();
+    this.serviceAccessToken = response?.access_token;
+    return this.serviceAccessToken;
+  }
+
+  /**
+   * Fetches brand guidelines for a site URL from the Brand Governance Agent.
+   * Returns null if the brand is not registered (404), allowing callers to fall back.
+   *
+   * @param {string} siteBaseUrl - The site's base URL to resolve brand by domain
+   * @param {string} imsOrgId - The IMS org ID sent as x-gw-ims-org-id header
+   * @param {object} imsConfig - IMS auth config: { host, clientId, clientCode, clientSecret }
+   * @returns {Promise<object|null>} Brand guidelines or null if not registered
+   */
+  async getBrandGuidelinesForUrl(siteBaseUrl, imsOrgId, imsConfig) {
+    if (!isValidUrl(siteBaseUrl)) {
+      throw this.#createError(`Invalid site base URL: ${siteBaseUrl}`, HTTP_BAD_REQUEST);
+    }
+    if (!isValidIMSOrgId(imsOrgId)) {
+      throw this.#createError(`Invalid IMS Org ID: ${imsOrgId}`, HTTP_BAD_REQUEST);
+    }
+    const {
+      host, clientId, clientCode, clientSecret,
+    } = imsConfig;
+    if (!hasText(host) || !hasText(clientId) || !hasText(clientCode) || !hasText(clientSecret)) {
+      throw this.#createError(`Invalid IMS Config: ${JSON.stringify(imsConfig)}`, HTTP_BAD_REQUEST);
+    }
+
+    const imsAccessToken = await this.#getImsAccessToken(imsConfig);
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${imsAccessToken}`,
+      'x-api-key': this.apiKey,
+      'x-gw-ims-org-id': imsOrgId,
+    };
+
+    const brandResponse = await fetch(
+      `${this.apiBaseUrl}${API_GET_BRAND_FROM_URL(siteBaseUrl)}`,
+      { headers },
+    );
+    if (brandResponse.status === HTTP_NOT_FOUND) {
+      return null;
+    }
+    if (!brandResponse.ok) {
+      throw this.#createError(
+        `Error resolving brand for URL ${siteBaseUrl}: ${brandResponse.status}`,
+        brandResponse.status,
+      );
+    }
+    const brand = await brandResponse.json();
+
+    const checksResponse = await fetch(
+      `${this.apiBaseUrl}${API_GET_BRAND_CHECKS(brand.id)}`,
+      { headers },
+    );
+    if (!checksResponse.ok) {
+      throw this.#createError(
+        `Error fetching brand checks for brand ${brand.id}: ${checksResponse.status}`,
+        checksResponse.status,
+      );
+    }
+    const checksResult = await checksResponse.json();
+    const checks = checksResult.data || [];
+
+    const guidelines = checks
+      .filter((check) => Array.isArray(check.scopes) && check.scopes.includes('COPY'))
+      .map((check) => ({ name: check.name, text: check.rule }));
+
+    return {
+      id: brand.id,
+      name: brand.name,
+      imsOrgId,
+      createdAt: brand.createdAt,
+      updatedAt: brand.updatedAt,
+      guidelines,
+    };
+  }
+}

--- a/packages/spacecat-shared-brand-client/src/brand-governance-client.js
+++ b/packages/spacecat-shared-brand-client/src/brand-governance-client.js
@@ -128,9 +128,6 @@ export class BrandGovernanceClient {
       );
     }
     const brand = await brandResponse.json();
-    // Org scoping is enforced server-side by the Brand Governance Agent via the
-    // x-gw-ims-org-id request header. Unlike BrandClient, the BrandResponse schema
-    // does not include an org_id field, so client-side org verification is not possible.
     if (!hasText(brand.id)) {
       throw this.#createError(`Brand resolved for URL ${siteBaseUrl} has no id`, HTTP_NOT_FOUND);
     }

--- a/packages/spacecat-shared-brand-client/src/brand-governance-client.js
+++ b/packages/spacecat-shared-brand-client/src/brand-governance-client.js
@@ -128,6 +128,12 @@ export class BrandGovernanceClient {
       );
     }
     const brand = await brandResponse.json();
+    // Org scoping is enforced server-side by the Brand Governance Agent via the
+    // x-gw-ims-org-id request header. Unlike BrandClient, the BrandResponse schema
+    // does not include an org_id field, so client-side org verification is not possible.
+    if (!hasText(brand.id)) {
+      throw this.#createError(`Brand resolved for URL ${siteBaseUrl} has no id`, HTTP_NOT_FOUND);
+    }
 
     const allChecks = [];
     let page = 1;

--- a/packages/spacecat-shared-brand-client/src/brand-governance-client.js
+++ b/packages/spacecat-shared-brand-client/src/brand-governance-client.js
@@ -52,7 +52,6 @@ export class BrandGovernanceClient {
     }
     this.apiBaseUrl = apiBaseUrl;
     this.apiKey = apiKey;
-    this.serviceAccessToken = null;
   }
 
   #createError(message, status) {
@@ -62,9 +61,6 @@ export class BrandGovernanceClient {
   }
 
   async #getImsAccessToken(imsConfig) {
-    if (this.serviceAccessToken) {
-      return this.serviceAccessToken;
-    }
     const {
       host, clientId, clientCode, clientSecret,
     } = imsConfig;
@@ -79,8 +75,7 @@ export class BrandGovernanceClient {
     };
     const imsClient = ImsClient.createFrom(imsContext);
     const response = await imsClient.getServiceAccessToken();
-    this.serviceAccessToken = response?.access_token;
-    return this.serviceAccessToken;
+    return response?.access_token;
   }
 
   /**

--- a/packages/spacecat-shared-brand-client/src/brand-governance-client.js
+++ b/packages/spacecat-shared-brand-client/src/brand-governance-client.js
@@ -50,7 +50,7 @@ export class BrandGovernanceClient {
       throw this.#createError(`Invalid Brand Governance API Base URL: ${apiBaseUrl}`, HTTP_BAD_REQUEST);
     }
     if (!hasText(apiKey)) {
-      throw this.#createError(`Invalid Brand Governance API Key: ${apiKey}`, HTTP_BAD_REQUEST);
+      throw this.#createError('Invalid Brand Governance API Key', HTTP_BAD_REQUEST);
     }
     this.apiBaseUrl = apiBaseUrl;
     this.apiKey = apiKey;

--- a/packages/spacecat-shared-brand-client/src/brand-governance-client.js
+++ b/packages/spacecat-shared-brand-client/src/brand-governance-client.js
@@ -98,11 +98,10 @@ export class BrandGovernanceClient {
     if (!isValidIMSOrgId(imsOrgId)) {
       throw this.#createError(`Invalid IMS Org ID: ${imsOrgId}`, HTTP_BAD_REQUEST);
     }
-    const {
-      host, clientId, clientCode, clientSecret,
-    } = imsConfig;
-    if (!hasText(host) || !hasText(clientId) || !hasText(clientCode) || !hasText(clientSecret)) {
-      throw this.#createError(`Invalid IMS Config: ${JSON.stringify(imsConfig)}`, HTTP_BAD_REQUEST);
+    const missingFields = ['host', 'clientId', 'clientCode', 'clientSecret']
+      .filter((k) => !hasText(imsConfig[k]));
+    if (missingFields.length > 0) {
+      throw this.#createError(`Invalid IMS Config: missing fields [${missingFields.join(', ')}]`, HTTP_BAD_REQUEST);
     }
 
     const imsAccessToken = await this.#getImsAccessToken(imsConfig);

--- a/packages/spacecat-shared-brand-client/src/index.d.ts
+++ b/packages/spacecat-shared-brand-client/src/index.d.ts
@@ -36,6 +36,40 @@ export interface BrandGuidelines extends Brand {
   additionalGuidelines?: string[];
 }
 
+export interface BrandGovernanceGuideline {
+  name: string;
+  text: string;
+}
+
+export interface BrandGovernanceGuidelines {
+  id: string;
+  name: string;
+  imsOrgId: string;
+  createdAt: string;
+  updatedAt: string;
+  guidelines: BrandGovernanceGuideline[];
+}
+
+export class BrandGovernanceClient {
+  constructor(config: { apiBaseUrl: string; apiKey: string }, log?: Console);
+
+  static createFrom(context: UniversalContext): BrandGovernanceClient;
+
+  /**
+   * Fetches brand guidelines for a site URL from the Brand Governance Agent.
+   * Returns null if the brand is not registered (404) — caller falls back to Brand Publish.
+   *
+   * @param siteBaseUrl - The site's base URL to resolve brand by domain
+   * @param imsOrgId - The IMS org ID sent as x-gw-ims-org-id header
+   * @param imsConfig - IMS auth config
+   */
+  getBrandGuidelinesForUrl(
+    siteBaseUrl: string,
+    imsOrgId: string,
+    imsConfig: ImsConfig,
+  ): Promise<BrandGovernanceGuidelines | null>;
+}
+
 export default class BrandClient {
   constructor(config: BrandClientConfig, log?: Console);
 

--- a/packages/spacecat-shared-brand-client/src/index.js
+++ b/packages/spacecat-shared-brand-client/src/index.js
@@ -14,6 +14,8 @@ import {
 } from '@adobe/spacecat-shared-utils';
 import { ImsClient } from '@adobe/spacecat-shared-ims-client';
 
+export { BrandGovernanceClient } from './brand-governance-client.js';
+
 const HTTP_BAD_REQUEST = 400;
 const HTTP_NOT_FOUND = 404;
 const HTTP_INTERNAL_SERVER_ERROR = 500;

--- a/packages/spacecat-shared-brand-client/test/index.test.js
+++ b/packages/spacecat-shared-brand-client/test/index.test.js
@@ -309,10 +309,12 @@ describe('BrandGovernanceClient', () => {
     return status === 200 ? scope.reply(200, brand) : scope.reply(status);
   };
 
-  const mockBrandChecks = (brandId, checks, status = 200) => {
+  const mockBrandChecks = (brandId, checks, status = 200, page = 1) => {
     const scope = nock(validGovApiBaseUrl)
       .get(`/api/v1/brands/${brandId}/checks`)
-      .query({ status: 'ACTIVE', type: 'BRAND', pageSize: '100' });
+      .query({
+        status: 'ACTIVE', type: 'BRAND', scope: 'COPY', pageSize: '100', page: String(page),
+      });
     return status === 200 ? scope.reply(200, { data: checks }) : scope.reply(status);
   };
 
@@ -356,12 +358,11 @@ describe('BrandGovernanceClient', () => {
   });
 
   describe('getBrandGuidelinesForUrl', () => {
-    it('fetches guidelines and returns only COPY-scoped checks', async () => {
+    it('fetches COPY-scoped guidelines via server-side scope filter and maps to name/text', async () => {
       const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
       const checks = [
-        { name: 'Sophisticated Voice', rule: 'Use sensory language', scopes: ['COPY'] },
-        { name: 'Color Palette', rule: 'Use brand colors', scopes: ['IMAGES'] },
-        { name: 'Mixed Rule', rule: 'Applies broadly', scopes: ['COPY', 'IMAGES'] },
+        { name: 'Sophisticated Voice', rule: 'Use sensory language' },
+        { name: 'Mixed Rule', rule: 'Applies broadly' },
       ];
 
       mockImsToken();
@@ -400,39 +401,29 @@ describe('BrandGovernanceClient', () => {
       mockBrandFromUrl(mockBrand);
       nock(validGovApiBaseUrl)
         .get(`/api/v1/brands/${mockBrand.id}/checks`)
-        .query({ status: 'ACTIVE', type: 'BRAND', pageSize: '100' })
+        .query({
+          status: 'ACTIVE', type: 'BRAND', scope: 'COPY', pageSize: '100', page: '1',
+        })
         .reply(200, {});
 
       const result = await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
       expect(result.guidelines).to.deep.equal([]);
     });
 
-    it('excludes checks with null scopes', async () => {
+    it('paginates through all pages until the last page has fewer than pageSize results', async () => {
       const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+      const page1Checks = Array.from({ length: 100 }, (_, i) => ({ name: `Rule ${i + 1}`, rule: `Text ${i + 1}` }));
+      const page2Checks = [{ name: 'Rule 101', rule: 'Text 101' }];
 
       mockImsToken();
       mockBrandFromUrl(mockBrand);
-      mockBrandChecks(mockBrand.id, [
-        { name: 'No Scope Rule', rule: 'Has no scope', scopes: null },
-      ]);
+      mockBrandChecks(mockBrand.id, page1Checks, 200, 1);
+      mockBrandChecks(mockBrand.id, page2Checks, 200, 2);
 
       const result = await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
-      expect(result.guidelines).to.deep.equal([]);
-    });
-
-    it('excludes checks with empty scopes array', async () => {
-      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
-
-      mockImsToken();
-      mockBrandFromUrl(mockBrand);
-      mockBrandChecks(mockBrand.id, [
-        { name: 'Empty Scope', rule: 'No scope assigned', scopes: [] },
-        { name: 'Images Only', rule: 'Visual rule', scopes: ['IMAGES'] },
-        { name: 'Copy Rule', rule: 'Text rule', scopes: ['COPY'] },
-      ]);
-
-      const result = await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
-      expect(result.guidelines).to.deep.equal([{ name: 'Copy Rule', text: 'Text rule' }]);
+      expect(result.guidelines).to.have.length(101);
+      expect(result.guidelines[0]).to.deep.equal({ name: 'Rule 1', text: 'Text 1' });
+      expect(result.guidelines[100]).to.deep.equal({ name: 'Rule 101', text: 'Text 101' });
     });
 
     it('throws error for invalid site base URL', async () => {
@@ -531,7 +522,9 @@ describe('BrandGovernanceClient', () => {
 
       nock(validGovApiBaseUrl)
         .get(`/api/v1/brands/${mockBrand.id}/checks`)
-        .query({ status: 'ACTIVE', type: 'BRAND', pageSize: '100' })
+        .query({
+          status: 'ACTIVE', type: 'BRAND', scope: 'COPY', pageSize: '100', page: '1',
+        })
         .twice()
         .reply(200, { data: [] });
 

--- a/packages/spacecat-shared-brand-client/test/index.test.js
+++ b/packages/spacecat-shared-brand-client/test/index.test.js
@@ -394,6 +394,16 @@ describe('BrandGovernanceClient', () => {
       expect(result).to.be.null;
     });
 
+    it('throws when brand resolved by URL has no id (guards against /brands/undefined/checks)', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+
+      mockImsToken();
+      mockBrandFromUrl({ name: 'No ID Brand' });
+
+      await expect(client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig))
+        .to.be.rejectedWith(`Brand resolved for URL ${validSiteBaseUrl} has no id`);
+    });
+
     it('returns empty guidelines when checks response has no data property', async () => {
       const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
 

--- a/packages/spacecat-shared-brand-client/test/index.test.js
+++ b/packages/spacecat-shared-brand-client/test/index.test.js
@@ -483,6 +483,17 @@ describe('BrandGovernanceClient', () => {
       )).to.be.rejectedWith('Invalid IMS Config');
     });
 
+    it('throws error when IMS token response is empty', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+
+      nock('https://ims-gov-host')
+        .post('/ims/token/v4')
+        .reply(200, {});
+
+      await expect(client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig))
+        .to.be.rejectedWith('Failed to obtain IMS access token');
+    });
+
     it('throws error when brand URL lookup returns non-404 error', async () => {
       const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
 

--- a/packages/spacecat-shared-brand-client/test/index.test.js
+++ b/packages/spacecat-shared-brand-client/test/index.test.js
@@ -10,10 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
+/* eslint-disable max-len */
+
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';
-import BrandClient from '../src/index.js';
+import BrandClient, { BrandGovernanceClient } from '../src/index.js';
 
 use(chaiAsPromised);
 
@@ -268,6 +270,262 @@ describe('BrandClient', () => {
       await client.getBrandGuidelines(brandConfig, validImsOrgId, validImsConfig);
 
       // Verify IMS token was only requested once
+      expect(imsMock.isDone()).to.equal(true);
+    });
+  });
+});
+
+describe('BrandGovernanceClient', () => {
+  const validGovApiBaseUrl = 'https://brand-governance-agent.adobe.io';
+  const validGovApiKey = 'gov-api-key';
+  const validSiteBaseUrl = 'https://example.com';
+  const validImsOrgId = '36031A57899DEACD0A49402F@AdobeOrg';
+  const validGovImsConfig = {
+    host: 'https://ims-gov-host',
+    clientId: 'gov-client-id',
+    clientCode: 'gov-client-code',
+    clientSecret: 'gov-client-secret',
+  };
+  const mockLog = {
+    debug: () => {},
+    info: () => {},
+    error: () => {},
+  };
+  const mockBrand = {
+    id: 'brand-gov-123',
+    name: 'Test Brand',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-02T00:00:00.000Z',
+  };
+
+  const mockImsToken = () => nock('https://ims-gov-host')
+    .post('/ims/token/v4')
+    .reply(200, { access_token: 'gov-service-token' });
+
+  const mockBrandFromUrl = (brand, status = 200) => {
+    const scope = nock(validGovApiBaseUrl)
+      .get('/api/v1/brands/from-url')
+      .query({ url: validSiteBaseUrl });
+    return status === 200 ? scope.reply(200, brand) : scope.reply(status);
+  };
+
+  const mockBrandChecks = (brandId, checks, status = 200) => {
+    const scope = nock(validGovApiBaseUrl)
+      .get(`/api/v1/brands/${brandId}/checks`)
+      .query({ status: 'ACTIVE', type: 'BRAND', pageSize: '100' });
+    return status === 200 ? scope.reply(200, { data: checks }) : scope.reply(status);
+  };
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  describe('constructor', () => {
+    it('creates instance with valid config', () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+      expect(client).to.be.instanceOf(BrandGovernanceClient);
+    });
+
+    it('throws error for invalid API base URL', () => {
+      expect(() => new BrandGovernanceClient({ apiBaseUrl: 'not-a-url', apiKey: validGovApiKey }, mockLog))
+        .to.throw('Invalid Brand Governance API Base URL');
+    });
+
+    it('throws error for missing API key', () => {
+      expect(() => new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: '' }, mockLog))
+        .to.throw('Invalid Brand Governance API Key');
+    });
+  });
+
+  describe('createFrom', () => {
+    it('creates new instance from context env and caches it', () => {
+      const ctx = {
+        env: { BRAND_GOV_API_BASE_URL: validGovApiBaseUrl, BRAND_GOV_API_KEY: validGovApiKey },
+        log: mockLog,
+      };
+      const client = BrandGovernanceClient.createFrom(ctx);
+      expect(client).to.be.instanceOf(BrandGovernanceClient);
+      expect(ctx.brandGovernanceClient).to.equal(client);
+    });
+
+    it('returns cached instance from context without re-constructing', () => {
+      const existingClient = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+      const ctx = { env: {}, log: mockLog, brandGovernanceClient: existingClient };
+      expect(BrandGovernanceClient.createFrom(ctx)).to.equal(existingClient);
+    });
+  });
+
+  describe('getBrandGuidelinesForUrl', () => {
+    it('fetches guidelines and returns only COPY-scoped checks', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+      const checks = [
+        { name: 'Sophisticated Voice', rule: 'Use sensory language', scopes: ['COPY'] },
+        { name: 'Color Palette', rule: 'Use brand colors', scopes: ['IMAGES'] },
+        { name: 'Mixed Rule', rule: 'Applies broadly', scopes: ['COPY', 'IMAGES'] },
+      ];
+
+      mockImsToken();
+      mockBrandFromUrl(mockBrand);
+      mockBrandChecks(mockBrand.id, checks);
+
+      const result = await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
+
+      expect(result).to.deep.equal({
+        id: mockBrand.id,
+        name: mockBrand.name,
+        imsOrgId: validImsOrgId,
+        createdAt: mockBrand.createdAt,
+        updatedAt: mockBrand.updatedAt,
+        guidelines: [
+          { name: 'Sophisticated Voice', text: 'Use sensory language' },
+          { name: 'Mixed Rule', text: 'Applies broadly' },
+        ],
+      });
+    });
+
+    it('returns null when brand is not registered (404 from from-url)', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+
+      mockImsToken();
+      mockBrandFromUrl(null, 404);
+
+      const result = await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
+      expect(result).to.be.null;
+    });
+
+    it('returns empty guidelines when checks response has no data property', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+
+      mockImsToken();
+      mockBrandFromUrl(mockBrand);
+      nock(validGovApiBaseUrl)
+        .get(`/api/v1/brands/${mockBrand.id}/checks`)
+        .query({ status: 'ACTIVE', type: 'BRAND', pageSize: '100' })
+        .reply(200, {});
+
+      const result = await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
+      expect(result.guidelines).to.deep.equal([]);
+    });
+
+    it('excludes checks with null scopes', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+
+      mockImsToken();
+      mockBrandFromUrl(mockBrand);
+      mockBrandChecks(mockBrand.id, [
+        { name: 'No Scope Rule', rule: 'Has no scope', scopes: null },
+      ]);
+
+      const result = await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
+      expect(result.guidelines).to.deep.equal([]);
+    });
+
+    it('excludes checks with empty scopes array', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+
+      mockImsToken();
+      mockBrandFromUrl(mockBrand);
+      mockBrandChecks(mockBrand.id, [
+        { name: 'Empty Scope', rule: 'No scope assigned', scopes: [] },
+        { name: 'Images Only', rule: 'Visual rule', scopes: ['IMAGES'] },
+        { name: 'Copy Rule', rule: 'Text rule', scopes: ['COPY'] },
+      ]);
+
+      const result = await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
+      expect(result.guidelines).to.deep.equal([{ name: 'Copy Rule', text: 'Text rule' }]);
+    });
+
+    it('throws error for invalid site base URL', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+      await expect(client.getBrandGuidelinesForUrl('not-a-url', validImsOrgId, validGovImsConfig))
+        .to.be.rejectedWith('Invalid site base URL');
+    });
+
+    it('throws error for invalid IMS org ID', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+      await expect(client.getBrandGuidelinesForUrl(validSiteBaseUrl, 'invalid-org', validGovImsConfig))
+        .to.be.rejectedWith('Invalid IMS Org ID');
+    });
+
+    it('throws error when IMS config host is missing', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+      await expect(client.getBrandGuidelinesForUrl(
+        validSiteBaseUrl,
+        validImsOrgId,
+        { clientId: 'id', clientCode: 'code', clientSecret: 'secret' },
+      )).to.be.rejectedWith('Invalid IMS Config');
+    });
+
+    it('throws error when IMS config clientId is missing', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+      await expect(client.getBrandGuidelinesForUrl(
+        validSiteBaseUrl,
+        validImsOrgId,
+        { host: 'https://ims-gov-host', clientCode: 'code', clientSecret: 'secret' },
+      )).to.be.rejectedWith('Invalid IMS Config');
+    });
+
+    it('throws error when IMS config clientCode is missing', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+      await expect(client.getBrandGuidelinesForUrl(
+        validSiteBaseUrl,
+        validImsOrgId,
+        { host: 'https://ims-gov-host', clientId: 'id', clientSecret: 'secret' },
+      )).to.be.rejectedWith('Invalid IMS Config');
+    });
+
+    it('throws error when IMS config clientSecret is missing', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+      await expect(client.getBrandGuidelinesForUrl(
+        validSiteBaseUrl,
+        validImsOrgId,
+        { host: 'https://ims-gov-host', clientId: 'id', clientCode: 'code' },
+      )).to.be.rejectedWith('Invalid IMS Config');
+    });
+
+    it('throws error when brand URL lookup returns non-404 error', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+
+      mockImsToken();
+      mockBrandFromUrl(null, 500);
+
+      await expect(client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig))
+        .to.be.rejectedWith(`Error resolving brand for URL ${validSiteBaseUrl}: 500`);
+    });
+
+    it('throws error when brand checks fetch fails', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+
+      mockImsToken();
+      mockBrandFromUrl(mockBrand);
+      mockBrandChecks(mockBrand.id, null, 503);
+
+      await expect(client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig))
+        .to.be.rejectedWith(`Error fetching brand checks for brand ${mockBrand.id}: 503`);
+    });
+
+    it('reuses cached IMS access token on subsequent calls', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+
+      const imsMock = nock('https://ims-gov-host')
+        .post('/ims/token/v4')
+        .reply(200, { access_token: 'gov-service-token' });
+
+      nock(validGovApiBaseUrl)
+        .get('/api/v1/brands/from-url')
+        .query({ url: validSiteBaseUrl })
+        .twice()
+        .reply(200, mockBrand);
+
+      nock(validGovApiBaseUrl)
+        .get(`/api/v1/brands/${mockBrand.id}/checks`)
+        .query({ status: 'ACTIVE', type: 'BRAND', pageSize: '100' })
+        .twice()
+        .reply(200, { data: [] });
+
+      await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
+      await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
+
       expect(imsMock.isDone()).to.equal(true);
     });
   });

--- a/packages/spacecat-shared-brand-client/test/index.test.js
+++ b/packages/spacecat-shared-brand-client/test/index.test.js
@@ -420,6 +420,49 @@ describe('BrandGovernanceClient', () => {
       expect(result.guidelines).to.deep.equal([]);
     });
 
+    it('throws when pagination exceeds the maximum page limit (prevents runaway loop)', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+      const fullPage = Array.from({ length: 100 }, (_, i) => ({ name: `Rule ${i + 1}`, rule: `Text ${i + 1}` }));
+
+      mockImsToken();
+      mockBrandFromUrl(mockBrand);
+      // MAX_PAGES is 20 — mock all 20 full pages; the loop must bail before requesting page 21
+      for (let i = 1; i <= 20; i += 1) {
+        mockBrandChecks(mockBrand.id, fullPage, 200, i);
+      }
+
+      await expect(client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig))
+        .to.be.rejectedWith('Brand checks pagination exceeded 20 pages for brand');
+    });
+
+    it('sends x-gw-ims-org-id, x-api-key, and Authorization headers on all requests', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+
+      nock('https://ims-gov-host')
+        .post('/ims/token/v4')
+        .reply(200, { access_token: 'gov-service-token' });
+
+      nock(validGovApiBaseUrl)
+        .get('/api/v1/brands/from-url')
+        .query({ url: validSiteBaseUrl })
+        .matchHeader('x-gw-ims-org-id', validImsOrgId)
+        .matchHeader('x-api-key', validGovApiKey)
+        .matchHeader('Authorization', 'Bearer gov-service-token')
+        .reply(200, mockBrand);
+
+      nock(validGovApiBaseUrl)
+        .get(`/api/v1/brands/${mockBrand.id}/checks`)
+        .query({
+          status: 'ACTIVE', type: 'BRAND', scope: 'COPY', pageSize: '100', page: '1',
+        })
+        .matchHeader('x-gw-ims-org-id', validImsOrgId)
+        .reply(200, { data: [] });
+
+      const result = await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
+      expect(result).to.not.be.null;
+      expect(nock.isDone()).to.equal(true);
+    });
+
     it('paginates through all pages until the last page has fewer than pageSize results', async () => {
       const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
       const page1Checks = Array.from({ length: 100 }, (_, i) => ({ name: `Rule ${i + 1}`, rule: `Text ${i + 1}` }));

--- a/packages/spacecat-shared-brand-client/test/index.test.js
+++ b/packages/spacecat-shared-brand-client/test/index.test.js
@@ -504,11 +504,12 @@ describe('BrandGovernanceClient', () => {
         .to.be.rejectedWith(`Error fetching brand checks for brand ${mockBrand.id}: 503`);
     });
 
-    it('reuses cached IMS access token on subsequent calls', async () => {
+    it('fetches a fresh IMS token on every call to avoid stale token errors on warm Lambdas', async () => {
       const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
 
-      const imsMock = nock('https://ims-gov-host')
+      nock('https://ims-gov-host')
         .post('/ims/token/v4')
+        .twice()
         .reply(200, { access_token: 'gov-service-token' });
 
       nock(validGovApiBaseUrl)
@@ -526,7 +527,7 @@ describe('BrandGovernanceClient', () => {
       await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
       await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
 
-      expect(imsMock.isDone()).to.equal(true);
+      expect(nock.isDone()).to.equal(true);
     });
   });
 });

--- a/packages/spacecat-shared-brand-client/test/index.test.js
+++ b/packages/spacecat-shared-brand-client/test/index.test.js
@@ -453,7 +453,7 @@ describe('BrandGovernanceClient', () => {
         validSiteBaseUrl,
         validImsOrgId,
         { clientId: 'id', clientCode: 'code', clientSecret: 'secret' },
-      )).to.be.rejectedWith('Invalid IMS Config');
+      )).to.be.rejectedWith('Invalid IMS Config: missing fields [host]');
     });
 
     it('throws error when IMS config clientId is missing', async () => {
@@ -462,7 +462,7 @@ describe('BrandGovernanceClient', () => {
         validSiteBaseUrl,
         validImsOrgId,
         { host: 'https://ims-gov-host', clientCode: 'code', clientSecret: 'secret' },
-      )).to.be.rejectedWith('Invalid IMS Config');
+      )).to.be.rejectedWith('Invalid IMS Config: missing fields [clientId]');
     });
 
     it('throws error when IMS config clientCode is missing', async () => {
@@ -471,7 +471,7 @@ describe('BrandGovernanceClient', () => {
         validSiteBaseUrl,
         validImsOrgId,
         { host: 'https://ims-gov-host', clientId: 'id', clientSecret: 'secret' },
-      )).to.be.rejectedWith('Invalid IMS Config');
+      )).to.be.rejectedWith('Invalid IMS Config: missing fields [clientCode]');
     });
 
     it('throws error when IMS config clientSecret is missing', async () => {
@@ -480,7 +480,7 @@ describe('BrandGovernanceClient', () => {
         validSiteBaseUrl,
         validImsOrgId,
         { host: 'https://ims-gov-host', clientId: 'id', clientCode: 'code' },
-      )).to.be.rejectedWith('Invalid IMS Config');
+      )).to.be.rejectedWith('Invalid IMS Config: missing fields [clientSecret]');
     });
 
     it('throws error when IMS token response is empty', async () => {


### PR DESCRIPTION
## Summary

- Add `BrandGovernanceClient` as a named export in `spacecat-shared-brand-client` alongside the existing `BrandClient`
- New client resolves brand guidelines by site URL via two sequential Brand Governance Agent API calls:
  1. `GET /api/v1/brands/from-url?url={siteBaseUrl}` — resolves brand by domain; returns `null` on 404 so callers fall back gracefully
  2. `GET /api/v1/brands/{id}/checks?status=ACTIVE&type=BRAND&pageSize=100` — fetches checks, filters to `COPY`-scoped only, maps to `{ name, text }`
- Adds TypeScript declarations for the new class in `index.d.ts`
- `BrandClient` (Brand Publish) is unchanged — fully backwards compatible

## New env vars required (in consuming services)
- `BRAND_GOV_API_BASE_URL` — Brand Governance Agent base URL
- `BRAND_GOV_API_KEY` — `x-api-key` header value
- `BRAND_GOV_IMS_CLIENT_ID`, `BRAND_GOV_IMS_CLIENT_CODE`, `BRAND_GOV_IMS_CLIENT_SECRET` — service account IMS credentials
- `IMS_HOST` — reuses the existing standard IMS host env var

## Jira
[LLMO-4920](https://jira.corp.adobe.com/browse/LLMO-4920) — prerequisite for [LLMO-4918](https://jira.corp.adobe.com/browse/LLMO-4918)

## Test plan
- [ ] Unit tests to be added after team review of the approach (per team agreement)
- [ ] Manually verify with `scripts/test-brand-governance-api.js` against stage: brand lookup by URL returns COPY-scoped checks mapped to `{ name, text }`
- [ ] Verify `null` is returned for a domain not registered in Brand Governance (404 path)
- [ ] Verify `BrandClient` (existing Brand Publish) behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)