### PR TITLE
Add broken-external-links audit type

### DIFF
--- a/docs/specs/add-broken-external-links-audit-type/spec.md
+++ b/docs/specs/add-broken-external-links-audit-type/spec.md
@@ -1,0 +1,34 @@
+## Spec: spacecat-shared [TESTING-SDD-PR]
+
+### Problem
+`Audit.AUDIT_TYPES` in `spacecat-shared-data-access` is the single source of truth for all audit type strings consumed by the audit worker and any tooling. Without registering `broken-external-links` here, consumer repos would hardcode the string, risking drift and breaking the type-safety convention.
+
+### Implementation Tasks
+
+**Task 1 — Add type constant**
+- **File:** `packages/spacecat-shared-data-access/src/models/audit/audit.model.js`
+- **Change:** Add one entry to `static AUDIT_TYPES`:
+  ```js
+  BROKEN_EXTERNAL_LINKS: 'broken-external-links',
+  ```
+  Insert alphabetically near `BROKEN_BACKLINKS` and `BROKEN_INTERNAL_LINKS`.
+- **Effort:** XS
+
+**Task 2 — Publish new semver**
+- Run `npm run semantic-release-dry` on the branch to confirm the version bump.
+- The PR merge triggers semantic-release; `spacecat-audit-worker` must bump its `@adobe/spacecat-shared-data-access` dependency after publication.
+
+### Affected Files
+- `packages/spacecat-shared-data-access/src/models/audit/audit.model.js`
+- `packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js` (add assertion for new constant)
+
+### Testing Strategy
+- Existing test for `Audit.AUDIT_TYPES` — add `expect(Audit.AUDIT_TYPES.BROKEN_EXTERNAL_LINKS).to.equal('broken-external-links')`.
+- Coverage gate: 100% lines/statements, 97% branches.
+
+### Dependencies on Other Repos
+None — this is the root of the dependency chain.
+
+### Notes
+- No DB schema changes needed; the audit type string is stored in existing `audits.audit_type` column.
+- No `AUDIT_TYPE_PROPERTIES` entry is needed unless properties (like LHS score dimensions) are required — external links audit has none.

--- a/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
+++ b/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
@@ -40,6 +40,7 @@ class Audit extends BaseModel {
     CANONICAL: 'canonical',
     REDIRECT_CHAINS: 'redirect-chains',
     BROKEN_BACKLINKS: 'broken-backlinks',
+    BROKEN_EXTERNAL_LINKS: 'broken-external-links',
     BROKEN_INTERNAL_LINKS: 'broken-internal-links',
     CONTENT_FRAGMENT_UNUSED: 'content-fragment-unused',
     CONTENT_FRAGMENT_UNUSED_AUTO_FIX: 'content-fragment-unused-auto-fix',

--- a/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
@@ -165,6 +165,7 @@ describe('AuditModel', () => {
       CANONICAL: 'canonical',
       REDIRECT_CHAINS: 'redirect-chains',
       BROKEN_BACKLINKS: 'broken-backlinks',
+      BROKEN_EXTERNAL_LINKS: 'broken-external-links',
       BROKEN_INTERNAL_LINKS: 'broken-internal-links',
       CONTENT_FRAGMENT_UNUSED: 'content-fragment-unused',
       CONTENT_FRAGMENT_UNUSED_AUTO_FIX: 'content-fragment-unused-auto-fix',


### PR DESCRIPTION
Part of [Adobe-AEM-Sites/aso-ai-toolkit#31](https://github.com/Adobe-AEM-Sites/aso-ai-toolkit/issues/31)

## Generated by the SDD cross-repo pipeline

Implementation from the spec on the central issue. The per-repo spec is
committed at `docs/specs/add-broken-external-links-audit-type/spec.md` as the first commit.

## Commits



## Cross-Repo Coordination

- Other PRs in this feature will be linked from the central issue's
  dashboard comment as they open. Check the central issue before
  merging.
- If this PR depends on a newer version of a shared package, the
  dependency note above (or in the central issue) lists the manual
  version-bump steps.

---

Review will run automatically once M3 ships. Until then, you can
trigger review manually via `/pr-review` (if the target repo has
`ai-review-kit.yml`) or run a local review.