### PR TITLE
fix(utils): normalize $LATEST function version in resolveSecretsName

### DIFF
--- a/packages/spacecat-shared-utils/src/helpers.js
+++ b/packages/spacecat-shared-utils/src/helpers.js
@@ -33,6 +33,12 @@ export function resolveSecretsName(opts, ctx, defaultPath) {
 
   // if funcVersion is something like ci123, then use ci directly
   funcVersion = /^ci\d+$/i.test(funcVersion) ? 'ci' : funcVersion;
+  // when a Lambda is invoked via an unqualified ARN (e.g. SQS event source
+  // mappings without an alias), helix-universal sets ctx.func.version to
+  // '$LATEST'. '$' is not a valid character in AWS Secrets Manager secret
+  // names, which causes ValidationException downstream. Normalize to
+  // 'latest' so the resolved secret path matches the :latest alias path.
+  funcVersion = funcVersion === '$LATEST' ? 'latest' : funcVersion;
 
   return `${defaultPath}/${funcVersion}`;
 }

--- a/packages/spacecat-shared-utils/test/helpers.test.js
+++ b/packages/spacecat-shared-utils/test/helpers.test.js
@@ -41,6 +41,12 @@ describe('resolveSecretsName', () => {
     expect(resolveSecretsName({}, ctx, defaultPath)).to.equal('secretPath/ci');
   });
 
+  it('normalizes $LATEST to latest (unqualified ARN invocations)', () => {
+    const ctx = { func: { version: '$LATEST' } };
+    const defaultPath = 'secretPath';
+    expect(resolveSecretsName({}, ctx, defaultPath)).to.equal('secretPath/latest');
+  });
+
   it('throws error when ctx is undefined', () => {
     expect(() => resolveSecretsName({}, undefined, 'defaultPath')).to.throw('Invalid context: func.version is required and must be a string');
   });


### PR DESCRIPTION
## Summary

`resolveSecretsName` builds a secret path of the form `<defaultPath>/<funcVersion>`, where `funcVersion = ctx.func.version`. When a Lambda is invoked via an **unqualified ARN** (e.g. SQS Event Source Mappings configured without a `:latest` alias qualifier), helix-universal defaults `ctx.func.version` to `'$LATEST'`. The `$` character is not allowed in AWS Secrets Manager secret names — Secrets Manager responds with:

```
ValidationException: Invalid name. Must be a valid name containing alphanumeric
characters, or any of the following: -/_+=.@!
```

This normalizes `'$LATEST'` → `'latest'`, mirroring the existing ci-build normalization (`ci123` → `ci`). The resolved secret path now matches what the `:latest` alias would produce.

## Why this surfaces now

Discovered while landing **SITES-40597** — first feature wiring `enableAuthentication: true` through SQS to `spacecat-content-scraper`. Content-scraper's 3 SQS Event Source Mappings target the unqualified Lambda ARN (no `:latest` qualifier), so the self-service auth path in `run-sqs.js` hit `$LATEST` immediately. Audit-worker's existing auth flow does not hit this bug — it resolves the token in its own Lambda context (alias-qualified ESMs) and passes the resulting header to content-scraper.

The fix is in shared utils because the same bug can affect **any** Lambda invoked without an alias qualifier — not just content-scraper.

## Backwards compatibility

| Input | Before | After |
|---|---|---|
| `"1.0.0"` | `.../1.0.0` | `.../1.0.0` (unchanged) |
| `"latest"` (qualified ARN) | `.../latest` | `.../latest` (unchanged) |
| `"ci"` / `"ci123"` | `.../ci` | `.../ci` (unchanged) |
| `"\$LATEST"` (unqualified ARN) | throws downstream | `.../latest` (now works, same path as qualified) |

No secret-path collisions: the alias-qualified path always produced `.../latest`; the new normalization routes unqualified invocations to the same path. No existing secrets were stored under `.../\$LATEST` (Secrets Manager rejected the name), so there's no migration.

No API surface change. Same signature, same throws.

## Test plan

- [x] `npm test -w packages/spacecat-shared-utils` — 1152 passing, 100% lines/statements coverage maintained
- [x] New test: `normalizes \$LATEST to latest (unqualified ARN invocations)`
- [ ] After release: pick up new `@adobe/spacecat-shared-utils` in `spacecat-content-scraper`, re-run SITES-40597 E2E (DRS → SpaceCat CI → content-scraper) and confirm `retrievePageAuthentication` succeeds

## Related

- SITES-40597 — Enable ASO for BrightData-blocked customers (Okta)
- Companion PRs already merged: adobe/spacecat-scrape-job-manager#177, adobe/spacecat-content-scraper#886