### PR TITLE
feat(data-access): export resetDataAccessConnections for test teardown

### DIFF
--- a/packages/spacecat-shared-data-access/src/service/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/service/index.d.ts
@@ -103,3 +103,5 @@ export function createDataAccess(
   logger: object,
   client?: object,
 ): DataAccess;
+
+export function resetDataAccessConnections(): Promise<void>;

--- a/packages/spacecat-shared-data-access/src/service/index.js
+++ b/packages/spacecat-shared-data-access/src/service/index.js
@@ -28,6 +28,10 @@ const fetchContext = process.env.HELIX_FETCH_FORCE_HTTP1
   ? h1NoCache() : keepAliveNoCache();
 const { fetch: postgrestFetch } = fetchContext;
 
+// Releases the keep-alive fetch context. For test/script teardown only —
+// Lambda runtimes intentionally keep the context alive between invocations.
+export const resetDataAccessConnections = () => fetchContext.reset();
+
 /**
  * Creates a fetch wrapper that converts native (WHATWG) Headers instances to plain objects.
  * @adobe/fetch's Headers class doesn't recognize native Headers instances (instanceof check

--- a/packages/spacecat-shared-data-access/test/unit/service/index.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/service/index.test.js
@@ -13,7 +13,11 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { createDataAccess, createFetchCompat } from '../../../src/service/index.js';
+import {
+  createDataAccess,
+  createFetchCompat,
+  resetDataAccessConnections,
+} from '../../../src/service/index.js';
 
 describe('service/index', () => {
   it('uses provided PostgREST client and does not require postgrestUrl', () => {
@@ -113,6 +117,13 @@ describe('service/index', () => {
       await wrappedFetch('http://example.com');
 
       expect(mockFetch).to.have.been.calledOnceWith('http://example.com', undefined);
+    });
+  });
+
+  describe('resetDataAccessConnections', () => {
+    it('resolves and is idempotent', async () => {
+      await resetDataAccessConnections();
+      await resetDataAccessConnections();
     });
   });
 });


### PR DESCRIPTION
## Why

The module-scope \`@adobe/fetch\` context in \`service/index.js\` opens a keep-alive Agent pool (sockets, h2 sessions, pending body-stream pipelines). In Lambda that's intentional — it gives us connection reuse across warm invocations. In test/script contexts it prevents Node from exiting because the Agent's pooled handles keep the event loop alive.

This was confirmed by \`why-is-node-running\` dumps from the \`spacecat-api-service\` integration suite, which showed **270 active handles** rooted in \`@adobe/fetch\`:

\`\`\`
node_modules/@adobe/fetch/src/core/request.js:91   - socket = tls.connect(...)
node_modules/@adobe/fetch/src/core/h1.js:192       - req = request(url, opts)
node_modules/@adobe/fetch/src/core/h2.js:178       - session = connect(...)
node_modules/@adobe/fetch/src/fetch/body.js:60     - return streamToBuffer(stream)
... (many more)
\`\`\`

This causes intermittent 15-minute timeouts on \`ci/it-postgres\` in \`spacecat-api-service\` ([runs 26282298612](https://github.com/adobe/spacecat-api-service/actions/runs/26282298612), [26229325483](https://github.com/adobe/spacecat-api-service/actions/runs/26229325483), [26216823004](https://github.com/adobe/spacecat-api-service/actions/runs/26216823004)).

## What

Adds \`resetDataAccessConnections()\` — a one-line wrapper around \`fetchContext.reset()\` (a documented public method of \`@adobe/fetch\`) that destroys pooled keep-alive sockets and closes h2 sessions. The context remains reusable: subsequent fetches just establish fresh connections.

## Safety

- Pure addition — new export, no existing code path changes.
- No current consumer invokes it; production Lambdas behave identically.
- Idempotent and safe to call multiple times.
- Will be consumed by [spacecat-api-service IT harness](https://github.com/adobe/spacecat-api-service/pull/2472) (separate PR after release).

## Verification

- \`npm test -w packages/spacecat-shared-data-access\` — 2200 passing, 100% line coverage on \`service/index.js\`.
- \`npm run lint -w packages/spacecat-shared-data-access\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)