### PR TITLE
feat(utils): enhance AEM Headless detection with SDK and GraphQL signals

### DIFF
--- a/packages/spacecat-shared-utils/src/aem.js
+++ b/packages/spacecat-shared-utils/src/aem.js
@@ -107,8 +107,16 @@ export function detectAEMVersion(htmlSource, headers = {}) {
   ];
 
   const aemHeadlessPatterns = [
+    // Explicit headless string references
     /aem-headless/i,
-    /\/content\/dam\//i,
+    // Official AEM Headless JS SDK package reference (in bundles or inline scripts)
+    /@adobe\/aem-headless-client/i,
+    // Broader SDK reference without scoped package name
+    /aem-headless-client/i,
+    // Persisted GraphQL query URL pattern
+    /graphql\/execute\.json/i,
+    // AEM GraphQL endpoint reference (ad-hoc queries)
+    /content\/_cq_graphql\//i,
   ];
 
   // Count matches for each type
@@ -188,6 +196,27 @@ export function detectAEMVersion(htmlSource, headers = {}) {
 
   if (/data-routing="[^"]*cs=([^,"]*)/i.test(normalizedHtml)) {
     csMatches += 5;
+  }
+
+  // Give extra weight to strong headless indicators
+  // 'aem-headless' alone exceeds threshold (+2 on top of pattern match = 3 total)
+  if (/aem-headless/i.test(normalizedHtml)) {
+    aemHeadlessMatches += 2;
+  }
+
+  // Official SDK reference is very distinctive — highly reliable signal
+  if (/@adobe\/aem-headless-client/i.test(normalizedHtml)) {
+    aemHeadlessMatches += 3;
+  }
+
+  // GraphQL persisted query URL is a definitive AEM Headless signal
+  if (/graphql\/execute\.json/i.test(normalizedHtml)) {
+    aemHeadlessMatches += 2;
+  }
+
+  // AEM GraphQL endpoint reference is a definitive AEM Headless signal
+  if (/content\/_cq_graphql\//i.test(normalizedHtml)) {
+    aemHeadlessMatches += 2;
   }
 
   // Determine the most likely version based on match counts

--- a/packages/spacecat-shared-utils/test/aem.test.js
+++ b/packages/spacecat-shared-utils/test/aem.test.js
@@ -214,15 +214,14 @@ describe('AEM Detection', () => {
     });
 
     describe('AEM Headless detection', () => {
-      it('should detect AEM Headless via aem-headless pattern', () => {
+      it('should detect AEM Headless via aem-headless string alone', () => {
         const htmlSource = `
           <html>
             <head>
               <meta name="generator" content="aem-headless">
             </head>
             <body>
-              <div class="content">Headless content</div>
-              <img src="/content/dam/mysite/images/hero.jpg" alt="Hero Image">
+              <div id="root"></div>
             </body>
           </html>
         `;
@@ -230,18 +229,72 @@ describe('AEM Detection', () => {
         expect(result).to.equal(DELIVERY_TYPES.AEM_HEADLESS);
       });
 
-      it('should detect AEM Headless via /content/dam/ pattern', () => {
+      it('should detect AEM Headless via AEM Headless JS SDK reference', () => {
         const htmlSource = `
           <html>
+            <head>
+              <script src="/static/js/main.chunk.js"></script>
+            </head>
             <body>
-              <img src="/content/dam/mysite/images/hero.jpg" alt="Hero Image">
-              <a href="/content/dam/mysite/documents/brochure.pdf">Download Brochure</a>
-              <div class="aem-headless-component">Headless content</div>
+              <div id="root"></div>
+              <script>
+                // bundle includes @adobe/aem-headless-client-js
+                const client = new AEMHeadless({ serviceURL: 'https://author.example.com' });
+              </script>
             </body>
           </html>
         `;
         const result = detectAEMVersion(htmlSource);
         expect(result).to.equal(DELIVERY_TYPES.AEM_HEADLESS);
+      });
+
+      it('should detect AEM Headless via persisted GraphQL query URL pattern', () => {
+        const htmlSource = `
+          <html>
+            <body>
+              <div id="app"></div>
+              <script>
+                fetch('/graphql/execute.json/my-project/my-query')
+                  .then(res => res.json());
+              </script>
+            </body>
+          </html>
+        `;
+        const result = detectAEMVersion(htmlSource);
+        expect(result).to.equal(DELIVERY_TYPES.AEM_HEADLESS);
+      });
+
+      it('should detect AEM Headless via _cq_graphql endpoint reference', () => {
+        const htmlSource = `
+          <html>
+            <body>
+              <div id="root"></div>
+              <script>
+                const endpoint = '/content/_cq_graphql/global/endpoint.json';
+              </script>
+            </body>
+          </html>
+        `;
+        const result = detectAEMVersion(htmlSource);
+        expect(result).to.equal(DELIVERY_TYPES.AEM_HEADLESS);
+      });
+
+      it('should NOT detect a CS site with /content/dam/ images as headless', () => {
+        const htmlSource = `
+          <html>
+            <head>
+              <link rel="stylesheet" href="/etc.clientlibs/mysite/clientlibs/base.lc-abc123-lc.min.css">
+            </head>
+            <body>
+              <div class="cmp-image" data-cmp-is="image">
+                <img src="/content/dam/mysite/images/hero.jpg" alt="Hero">
+              </div>
+              <div class="cmp-text" data-cmp-is="text">Text</div>
+            </body>
+          </html>
+        `;
+        const result = detectAEMVersion(htmlSource);
+        expect(result).to.equal(DELIVERY_TYPES.AEM_CS);
       });
     });
 


### PR DESCRIPTION
## Summary

Improves \`detectAEMVersion()\` in \`spacecat-shared-utils\` to detect AEM Headless sites more reliably.

### Problem

1. **\`/content/dam/\` is not headless-specific** — CS and AMS sites reference DAM assets all the time; a CS site with images could be misclassified as headless
2. **Single-signal detection was impossible** — with only 2 patterns and \`MIN_THRESHOLD=2\`, both had to match; a site with just an \`aem-headless\` meta tag would fall through to \`OTHER\` and get waitlisted in PLG onboarding as "not an AEM site"

### Changes

**Replaced \`/content/dam/\` with purpose-built headless patterns:**
| Pattern | What it detects |
|---|---|
| \`@adobe/aem-headless-client\` | Official AEM Headless JS SDK (in bundled scripts) |
| \`aem-headless-client\` | Broader SDK reference |
| \`graphql/execute.json\` | Persisted GraphQL query calls |
| \`content/_cq_graphql/\` | AEM GraphQL endpoint references |

**Added weight boosting** so each strong signal alone clears the detection threshold (consistent with how EDS/AMS/CS already use boosting):
- \`aem-headless\` string → +2 boost (3 pts total, clears threshold alone)
- \`@adobe/aem-headless-client\` → +3 boost (4 pts total)
- \`graphql/execute.json\` → +2 boost (3 pts total)
- \`_cq_graphql\` endpoint → +2 boost (3 pts total)

### Tests

Replaced the two previous headless tests (both relied on having \`aem-headless\` AND \`/content/dam/\` together) with 5 targeted tests:

- ✅ \`aem-headless\` string alone → \`AEM_HEADLESS\`
- ✅ \`@adobe/aem-headless-client-js\` SDK reference → \`AEM_HEADLESS\`
- ✅ \`/graphql/execute.json\` persisted query → \`AEM_HEADLESS\`
- ✅ \`/content/_cq_graphql/\` endpoint → \`AEM_HEADLESS\`
- ✅ CS site with \`/content/dam/\` images → still \`AEM_CS\` (regression guard)

**1155 tests passing, 0 failing.**

## Test plan
- [x] Unit tests pass (\`npm test -w packages/spacecat-shared-utils\`)
- [x] Lint passes (\`npm run lint -w packages/spacecat-shared-utils\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)