### PR TITLE
feat(drs-client): export REDDIT_COMMENTS_SORT_BY_VALUES allowlist

### DIFF
--- a/packages/spacecat-shared-drs-client/src/index.d.ts
+++ b/packages/spacecat-shared-drs-client/src/index.d.ts
@@ -160,4 +160,10 @@ export declare const SCRAPE_DATASET_IDS: Readonly<{
   WIKIPEDIA: 'wikipedia';
 }>;
 
+/**
+ * Allowlist of valid `sortBy` values for the `reddit_comments` dataset.
+ * Exported so callers can validate input at their own boundary.
+ */
+export declare const REDDIT_COMMENTS_SORT_BY_VALUES: ReadonlySet<RedditSortBy>;
+
 export default DrsClient;

--- a/packages/spacecat-shared-drs-client/src/index.js
+++ b/packages/spacecat-shared-drs-client/src/index.js
@@ -41,7 +41,14 @@ const VALID_SCRAPE_DATASET_IDS = new Set(Object.values(SCRAPE_DATASET_IDS));
 const URL_LOOKUP_BATCH_SIZE = 100;
 
 // Reddit-comments specific scrape parameters.
-export const REDDIT_COMMENTS_SORT_BY_VALUES = new Set(['Best', 'Top', 'New', 'Controversial', 'Old', 'Q&A']);
+// Exported so callers can validate `sortBy` at their own boundary without
+// duplicating the allowlist. Frozen for consistency with the sibling
+// EXPERIMENT_PHASES / SCRAPE_DATASET_IDS exports (note: Object.freeze does
+// not actually prevent Set mutation methods — the ReadonlySet<> type in the
+// .d.ts is what guards TypeScript consumers).
+export const REDDIT_COMMENTS_SORT_BY_VALUES = Object.freeze(
+  new Set(['Best', 'Top', 'New', 'Controversial', 'Old', 'Q&A']),
+);
 const REDDIT_COMMENTS_DEFAULT_COMMENT_LIMIT = 150;
 const REDDIT_COMMENTS_DEFAULT_SORT_BY = 'Best';
 const REDDIT_COMMENTS_ONLY_PARAMS = ['daysBack', 'commentLimit', 'sortBy', 'loadAllReplies'];

--- a/packages/spacecat-shared-drs-client/src/index.js
+++ b/packages/spacecat-shared-drs-client/src/index.js
@@ -40,8 +40,8 @@ const VALID_SCRAPE_DATASET_IDS = new Set(Object.values(SCRAPE_DATASET_IDS));
 
 const URL_LOOKUP_BATCH_SIZE = 100;
 
-// Reddit-comments specific scrape parameters
-const VALID_REDDIT_SORT_BY = new Set(['Best', 'Top', 'New', 'Controversial', 'Old', 'Q&A']);
+// Reddit-comments specific scrape parameters.
+export const REDDIT_COMMENTS_SORT_BY_VALUES = new Set(['Best', 'Top', 'New', 'Controversial', 'Old', 'Q&A']);
 const REDDIT_COMMENTS_DEFAULT_COMMENT_LIMIT = 150;
 const REDDIT_COMMENTS_DEFAULT_SORT_BY = 'Best';
 const REDDIT_COMMENTS_ONLY_PARAMS = ['daysBack', 'commentLimit', 'sortBy', 'loadAllReplies'];
@@ -268,8 +268,8 @@ export default class DrsClient {
     if (commentLimit !== undefined && !isPositiveInteger(commentLimit)) {
       throw new Error('commentLimit must be a positive integer');
     }
-    if (sortBy !== undefined && !VALID_REDDIT_SORT_BY.has(sortBy)) {
-      throw new Error(`Invalid sortBy "${sortBy}". Must be one of: ${[...VALID_REDDIT_SORT_BY].join(', ')}`);
+    if (sortBy !== undefined && !REDDIT_COMMENTS_SORT_BY_VALUES.has(sortBy)) {
+      throw new Error(`Invalid sortBy "${sortBy}". Must be one of: ${[...REDDIT_COMMENTS_SORT_BY_VALUES].join(', ')}`);
     }
     if (loadAllReplies !== undefined && typeof loadAllReplies !== 'boolean') {
       throw new Error('loadAllReplies must be a boolean');

--- a/packages/spacecat-shared-drs-client/test/index.test.js
+++ b/packages/spacecat-shared-drs-client/test/index.test.js
@@ -15,7 +15,11 @@ import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import nock from 'nock';
-import DrsClient, { SCRAPE_DATASET_IDS, EXPERIMENT_PHASES } from '../src/index.js';
+import DrsClient, {
+  SCRAPE_DATASET_IDS,
+  EXPERIMENT_PHASES,
+  REDDIT_COMMENTS_SORT_BY_VALUES,
+} from '../src/index.js';
 
 use(chaiAsPromised);
 use(sinonChai);
@@ -245,6 +249,14 @@ describe('DrsClient', () => {
 
     it('is frozen', () => {
       expect(Object.isFrozen(SCRAPE_DATASET_IDS)).to.be.true;
+    });
+  });
+
+  describe('REDDIT_COMMENTS_SORT_BY_VALUES', () => {
+    it('exports the allowlist of reddit_comments sortBy values', () => {
+      expect([...REDDIT_COMMENTS_SORT_BY_VALUES]).to.have.members([
+        'Best', 'Top', 'New', 'Controversial', 'Old', 'Q&A',
+      ]);
     });
   });
 

--- a/packages/spacecat-shared-drs-client/test/index.test.js
+++ b/packages/spacecat-shared-drs-client/test/index.test.js
@@ -258,6 +258,10 @@ describe('DrsClient', () => {
         'Best', 'Top', 'New', 'Controversial', 'Old', 'Q&A',
       ]);
     });
+
+    it('is frozen', () => {
+      expect(Object.isFrozen(REDDIT_COMMENTS_SORT_BY_VALUES)).to.be.true;
+    });
   });
 
   describe('submitScrapeJob', () => {


### PR DESCRIPTION
## Summary
- Export `REDDIT_COMMENTS_SORT_BY_VALUES` (formerly file-local `VALID_REDDIT_SORT_BY`) so downstream callers can validate `sortBy` at their own boundary without duplicating the allowlist.
- Adds runtime export, `.d.ts` declaration, and a unit test asserting the membership.
- Renamed on export to match the sibling `REDDIT_COMMENTS_DEFAULT_SORT_BY` and to make the `reddit_comments`-only scope explicit. Safe rename — the previous name was never exported (introduced in 1.9.0 / #1628).

## Motivation
`spacecat-audit-worker` currently duplicates this Set in `offsite-brand-presence/handler.js` with a TODO to import from this package once exported. Follow-up PR there will drop the duplicate.

## Test plan
- [x] `npm run lint -w packages/spacecat-shared-drs-client`
- [x] `npm test -w packages/spacecat-shared-drs-client` — 89 passing, 100% coverage

Made with [Cursor](https://cursor.com)