### PR TITLE
fix(data-access): add getAllFixesWithSuggestionsByOpportunityId to FixEntityCollection

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/fix-entity/fix-entity.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/fix-entity/fix-entity.collection.js
@@ -171,6 +171,73 @@ class FixEntityCollection extends BaseCollection {
    * @throws {ValidationError} - Throws an error if opportunityId or
    *   fixEntityCreatedDate is not provided.
    */
+  /**
+   * Gets all fixes with their suggestions for a specific opportunity.
+   *
+   * @async
+   * @param {string} opportunityId - The ID of the opportunity.
+   * @returns {Promise<Array>} - A promise that resolves to an array of objects containing:
+   *   - fixEntity: The FixEntity model
+   *   - suggestions: Array of associated Suggestion models
+   * @throws {DataAccessError} - Throws an error if the query fails.
+   * @throws {ValidationError} - Throws an error if opportunityId is not provided.
+   */
+  async getAllFixesWithSuggestionsByOpportunityId(opportunityId) {
+    guardId('opportunityId', opportunityId, 'FixEntityCollection');
+
+    try {
+      const fixEntitySuggestionCollection = this.entityRegistry.getCollection('FixEntitySuggestionCollection');
+      const suggestionCollection = this.entityRegistry.getCollection('SuggestionCollection');
+
+      const fixEntitySuggestions = await fixEntitySuggestionCollection
+        .allByIndexKeys({ opportunityId });
+
+      if (fixEntitySuggestions.length === 0) {
+        return [];
+      }
+
+      const suggestionsByFixEntityId = {};
+      const fixEntityIds = new Set();
+
+      for (const fixEntitySuggestion of fixEntitySuggestions) {
+        const fixEntityId = fixEntitySuggestion.getFixEntityId();
+        const suggestionId = fixEntitySuggestion.getSuggestionId();
+
+        fixEntityIds.add(fixEntityId);
+
+        if (!suggestionsByFixEntityId[fixEntityId]) {
+          suggestionsByFixEntityId[fixEntityId] = [];
+        }
+        suggestionsByFixEntityId[fixEntityId].push(suggestionId);
+      }
+
+      const fixEntities = await this.batchGetByKeys(
+        Array.from(fixEntityIds).map((id) => ({ [this.idName]: id })),
+      );
+
+      const allSuggestionIds = Object.values(suggestionsByFixEntityId).flat();
+      const suggestions = await suggestionCollection.batchGetByKeys(
+        allSuggestionIds.map((id) => ({ [suggestionCollection.idName]: id })),
+      );
+
+      const suggestionsById = {};
+      for (const suggestion of suggestions.data) {
+        suggestionsById[suggestion.getId()] = suggestion;
+      }
+
+      return fixEntities.data.map((fixEntity) => {
+        const suggestionIds = suggestionsByFixEntityId[fixEntity.getId()] || [];
+        return {
+          fixEntity,
+          suggestions: suggestionIds.map((id) => suggestionsById[id]).filter(Boolean),
+        };
+      });
+    } catch (error) {
+      this.log.error('Failed to get all fixes with suggestions by opportunity ID', error);
+      throw new DataAccessError('Failed to get all fixes with suggestions by opportunity ID', this, error);
+    }
+  }
+
   async getAllFixesWithSuggestionByCreatedAt(opportunityId, fixEntityCreatedDate) {
     guardId('opportunityId', opportunityId, 'FixEntityCollection');
     guardString('fixEntityCreatedDate', fixEntityCreatedDate, 'FixEntityCollection');

--- a/packages/spacecat-shared-data-access/src/models/fix-entity/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/fix-entity/index.d.ts
@@ -40,4 +40,6 @@ export interface FixEntityCollection extends BaseCollection<FixEntity> {
   findByOpportunityIdAndStatus(opportunityId: string, status: string): Promise<FixEntity | null>;
   getSuggestionsByFixEntityId(fixEntityId: string): Promise<{data: Array<Suggestion>, unprocessed: Array<string>}>;
   setSuggestionsForFixEntity(opportunityId: string, fixEntity: FixEntity, suggestions: Array<Suggestion>): Promise<{createdItems: Array<FixEntitySuggestion>, errorItems: Array<FixEntitySuggestion>, removedCount: number}>;
+  getAllFixesWithSuggestionsByOpportunityId(opportunityId: string): Promise<Array<{fixEntity: FixEntity, suggestions: Array<Suggestion>}>>;
+  getAllFixesWithSuggestionByCreatedAt(opportunityId: string, fixEntityCreatedDate: string): Promise<Array<{fixEntity: FixEntity, suggestions: Array<Suggestion>}>>;
 }


### PR DESCRIPTION

The deployed spacecat-api-service calls this method but it was missing from FixEntityCollection, causing:
  'this[#FixEntity].getAllFixesWithSuggestionsByOpportunityId is not a function'

on stage/CI/RV environments where the new api-service was deployed but spacecat-shared had not yet been updated with the matching method.

The method retrieves all FixEntities with their associated Suggestions for a given opportunity, without filtering by date — same logic as getAllFixesWithSuggestionByCreatedAt but queries by opportunityId only.

Also added TypeScript declaration in index.d.ts.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
