### PR TITLE
fix(data-access): mint UUID v7 ids to match DB schema default

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/base/schema.builder.js
+++ b/packages/spacecat-shared-data-access/src/models/base/schema.builder.js
@@ -15,6 +15,7 @@ import {
 } from '@adobe/spacecat-shared-utils';
 
 import { SchemaBuilderError } from '../../errors/index.js';
+import { uuidv7 } from '../../util/uuid.js';
 import {
   decapitalize,
   entityNameToAllPKValue,
@@ -29,17 +30,15 @@ import Schema from './schema.js';
 
 const DEFAULT_SERVICE_NAME = 'SpaceCat';
 
-/**
- * ID attribute configuration object.
- * Ensures a UUID-based "primary key".
- * @type {object}
- */
+// The DB column default is `uuid_generate_v7()` (mysticat-data-service migration
+// 20250130000001_initial_setup.sql). We mint v7 client-side so the in-memory
+// record matches what the DB would have minted — sortable, locality-friendly.
 const ID_ATTRIBUTE_DATA = {
   type: 'string',
   postgrestField: 'id',
   required: true,
   readOnly: true,
-  default: () => crypto.randomUUID(),
+  default: () => uuidv7(),
   validate: (value) => isValidUUID(value),
 };
 

--- a/packages/spacecat-shared-data-access/src/util/uuid.js
+++ b/packages/spacecat-shared-data-access/src/util/uuid.js
@@ -18,7 +18,9 @@ import { randomBytes } from 'crypto';
 // schema has been v7-by-design since Jan 2025; this keeps the ORM aligned.
 /* eslint-disable no-bitwise */
 function uuidv7() {
-  const bytes = Buffer.alloc(16);
+  // Every byte is overwritten below (0-5 from the timestamp, 6-15 from
+  // randomBytes), so allocUnsafe avoids the zero-fill that alloc would do.
+  const bytes = Buffer.allocUnsafe(16);
   const ms = BigInt(Date.now());
 
   bytes[0] = Number((ms >> 40n) & 0xffn);

--- a/packages/spacecat-shared-data-access/src/util/uuid.js
+++ b/packages/spacecat-shared-data-access/src/util/uuid.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { randomBytes } from 'crypto';
+
+// Mirrors the database's `uuid_generate_v7()` plpgsql function defined in
+// mysticat-data-service migration 20250130000001_initial_setup.sql so client-
+// minted ids share the same time-sortable layout as DB-defaulted rows. The
+// schema has been v7-by-design since Jan 2025; this keeps the ORM aligned.
+/* eslint-disable no-bitwise */
+function uuidv7() {
+  const bytes = Buffer.alloc(16);
+  const ms = BigInt(Date.now());
+
+  bytes[0] = Number((ms >> 40n) & 0xffn);
+  bytes[1] = Number((ms >> 32n) & 0xffn);
+  bytes[2] = Number((ms >> 24n) & 0xffn);
+  bytes[3] = Number((ms >> 16n) & 0xffn);
+  bytes[4] = Number((ms >> 8n) & 0xffn);
+  bytes[5] = Number(ms & 0xffn);
+
+  randomBytes(10).copy(bytes, 6);
+
+  bytes[6] = (bytes[6] & 0x0f) | 0x70;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = bytes.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+/* eslint-enable no-bitwise */
+
+export { uuidv7 };

--- a/packages/spacecat-shared-data-access/test/it/contact-sales-lead/contact-sales-lead.test.js
+++ b/packages/spacecat-shared-data-access/test/it/contact-sales-lead/contact-sales-lead.test.js
@@ -123,6 +123,7 @@ describe('ContactSalesLead IT', async () => {
     checkContactSalesLead(lead);
 
     expect(isValidUUID(lead.getId())).to.be.true;
+    expect(lead.getId().charAt(14)).to.equal('7');
     expect(lead.getOrganizationId()).to.equal(data.organizationId);
     expect(lead.getSiteId()).to.equal(data.siteId);
     expect(lead.getName()).to.equal(data.name);
@@ -144,6 +145,7 @@ describe('ContactSalesLead IT', async () => {
     checkContactSalesLead(lead);
 
     expect(isValidUUID(lead.getId())).to.be.true;
+    expect(lead.getId().charAt(14)).to.equal('7');
     expect(lead.getOrganizationId()).to.equal(data.organizationId);
     expect(lead.getName()).to.equal(data.name);
     expect(lead.getEmail()).to.equal(data.email);

--- a/packages/spacecat-shared-data-access/test/it/opportunity/opportunity.test.js
+++ b/packages/spacecat-shared-data-access/test/it/opportunity/opportunity.test.js
@@ -177,6 +177,7 @@ describe('Opportunity IT', async () => {
     expect(opportunity).to.be.an('object');
 
     expect(isValidUUID(opportunity.getId())).to.be.true;
+    expect(opportunity.getId().charAt(14)).to.equal('7');
     expect(isIsoDate(opportunity.getCreatedAt())).to.be.true;
     expect(isIsoDate(opportunity.getUpdatedAt())).to.be.true;
 
@@ -206,6 +207,7 @@ describe('Opportunity IT', async () => {
     expect(opportunity).to.be.an('object');
 
     expect(isValidUUID(opportunity.getId())).to.be.true;
+    expect(opportunity.getId().charAt(14)).to.equal('7');
     expect(isIsoDate(opportunity.getCreatedAt())).to.be.true;
     expect(isIsoDate(opportunity.getUpdatedAt())).to.be.true;
 
@@ -303,6 +305,7 @@ describe('Opportunity IT', async () => {
       expect(opportunity).to.be.an('object');
 
       expect(isValidUUID(opportunity.getId())).to.be.true;
+      expect(opportunity.getId().charAt(14)).to.equal('7');
       expect(isIsoDate(opportunity.getCreatedAt())).to.be.true;
       expect(isIsoDate(opportunity.getUpdatedAt())).to.be.true;
 
@@ -488,7 +491,9 @@ describe('Opportunity IT', async () => {
       const fixEntity2 = result.createdItems[1];
 
       expect(isValidUUID(fixEntity1.getId())).to.be.true;
+      expect(fixEntity1.getId().charAt(14)).to.equal('7');
       expect(isValidUUID(fixEntity2.getId())).to.be.true;
+      expect(fixEntity2.getId().charAt(14)).to.equal('7');
       expect(fixEntity1.getType()).to.equal('CODE_CHANGE');
       expect(fixEntity2.getType()).to.equal('CONTENT_UPDATE');
       expect(fixEntity1.getStatus()).to.equal('PENDING');

--- a/packages/spacecat-shared-data-access/test/it/report/report.test.js
+++ b/packages/spacecat-shared-data-access/test/it/report/report.test.js
@@ -141,6 +141,7 @@ describe('Report IT', async () => {
     checkReport(report);
 
     expect(isValidUUID(report.getId())).to.be.true;
+    expect(report.getId().charAt(14)).to.equal('7');
     expect(report.getSiteId()).to.equal(data.siteId);
     expect(report.getReportType()).to.equal(data.reportType);
     expect(report.getReportPeriod()).to.deep.equal(data.reportPeriod);
@@ -182,6 +183,7 @@ describe('Report IT', async () => {
     checkReport(report);
 
     expect(isValidUUID(report.getId())).to.be.true;
+    expect(report.getId().charAt(14)).to.equal('7');
     expect(report.getSiteId()).to.equal(data.siteId);
     expect(report.getReportType()).to.equal(data.reportType);
     expect(report.getReportPeriod()).to.deep.equal(data.reportPeriod);
@@ -219,6 +221,7 @@ describe('Report IT', async () => {
     checkReport(report);
 
     expect(isValidUUID(report.getId())).to.be.true;
+    expect(report.getId().charAt(14)).to.equal('7');
     expect(report.getSiteId()).to.equal(data.siteId);
     expect(report.getReportType()).to.equal(data.reportType);
     expect(report.getReportPeriod()).to.deep.equal(data.reportPeriod);

--- a/packages/spacecat-shared-data-access/test/it/site/site.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site/site.test.js
@@ -445,6 +445,7 @@ describe('Site IT', async () => {
 
     expect(newSite.getBaseURL()).to.equal(newSiteData.baseURL);
     expect(newSite.getName()).to.equal(newSiteData.name);
+    expect(newSite.getId().charAt(14)).to.equal('7');
   });
 
   it('updates a site', async () => {

--- a/packages/spacecat-shared-data-access/test/it/suggestion/suggestion.test.js
+++ b/packages/spacecat-shared-data-access/test/it/suggestion/suggestion.test.js
@@ -211,6 +211,7 @@ describe('Suggestion IT', async () => {
 
       expect(suggestion.getOpportunityId()).to.equal(opportunity.getId());
       expect(isValidUUID(suggestion.getId())).to.be.true;
+      expect(suggestion.getId().charAt(14)).to.equal('7');
       expect(isIsoDate(suggestion.getCreatedAt())).to.be.true;
       expect(isIsoDate(suggestion.getUpdatedAt())).to.be.true;
 

--- a/packages/spacecat-shared-data-access/test/unit/models/base/schema.builder.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/base/schema.builder.test.js
@@ -394,8 +394,11 @@ describe('SchemaBuilder', () => {
       expect(isIsoDate(instance.attributes.updatedAt.set())).to.be.true;
     });
 
-    it('sets default for id attribute', () => {
-      expect(isValidUUID(instance.attributes.mockModelId.default())).to.be.true;
+    it('sets default for id attribute as a UUID v7', () => {
+      const id = instance.attributes.mockModelId.default();
+      expect(isValidUUID(id)).to.be.true;
+      // Version nibble pinned to 7 — see schema.builder.js for context.
+      expect(id.charAt(14)).to.equal('7');
     });
 
     it('validates id attribute', () => {

--- a/packages/spacecat-shared-data-access/test/unit/util/uuid.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/util/uuid.test.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { isValidUUID } from '@adobe/spacecat-shared-utils';
+import { uuidv7 } from '../../../src/util/uuid.js';
+
+const UUID_FORMAT = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+describe('uuidv7', () => {
+  it('produces a string in canonical UUID format', () => {
+    const id = uuidv7();
+    expect(id).to.be.a('string');
+    expect(id).to.match(UUID_FORMAT);
+    expect(isValidUUID(id)).to.be.true;
+  });
+
+  it('pins the version nibble to 7', () => {
+    for (let i = 0; i < 64; i += 1) {
+      const id = uuidv7();
+      // Position 14 is the high nibble of byte 6 — the version field per RFC 9562.
+      expect(id.charAt(14)).to.equal('7', `expected version nibble 7 in ${id}`);
+    }
+  });
+
+  it('pins the variant bits to RFC 4122 (8/9/a/b)', () => {
+    for (let i = 0; i < 64; i += 1) {
+      const id = uuidv7();
+      // Position 19 is the high nibble of byte 8 — the variant field.
+      expect('89ab').to.include(id.charAt(19), `expected variant 8/9/a/b in ${id}`);
+    }
+  });
+
+  it('encodes the current unix-ms in the first 48 bits', () => {
+    const before = Date.now();
+    const id = uuidv7();
+    const after = Date.now();
+
+    const tsHex = id.slice(0, 8) + id.slice(9, 13);
+    const ts = parseInt(tsHex, 16);
+
+    expect(ts).to.be.at.least(before);
+    expect(ts).to.be.at.most(after);
+  });
+
+  it('emits time-sortable ids across distinct millisecond ticks', async () => {
+    const a = uuidv7();
+    await new Promise((resolve) => {
+      setTimeout(resolve, 2);
+    });
+    const b = uuidv7();
+    expect(a < b).to.be.true;
+  });
+
+  it('produces unique ids across many calls', () => {
+    const ids = new Set();
+    for (let i = 0; i < 1000; i += 1) {
+      ids.add(uuidv7());
+    }
+    expect(ids.size).to.equal(1000);
+  });
+});

--- a/packages/spacecat-shared-utils/src/core.d.ts
+++ b/packages/spacecat-shared-utils/src/core.d.ts
@@ -15,5 +15,5 @@ export {
   isArray, isBoolean, isInteger, isIsoDate, isIsoTimeOffsetsDate,
   isNonEmptyArray, isNonEmptyObject, isNumber, isObject, isString,
   isValidDate, isValidHelixPreviewUrl, isValidIMSOrgId, isValidUrl,
-  isValidUUID, toBoolean,
+  isValidUUID, toBoolean, UUID_REGEX, UUID_V4_REGEX,
 } from './index.js';

--- a/packages/spacecat-shared-utils/src/core.js
+++ b/packages/spacecat-shared-utils/src/core.js
@@ -31,4 +31,6 @@ export {
   isValidUrl,
   isValidUUID,
   toBoolean,
+  UUID_REGEX,
+  UUID_V4_REGEX,
 } from './functions.js';

--- a/packages/spacecat-shared-utils/src/functions.js
+++ b/packages/spacecat-shared-utils/src/functions.js
@@ -14,7 +14,12 @@
 const REGEX_ISO_DATE = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/;
 const REGEX_TIME_OFFSET_DATE = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}(Z|[+-]\d{2}:\d{2})/;
 const IMS_ORG_ID_REGEX = /[a-z0-9]{24}@AdobeOrg/i;
-const UUID_V4_REGEX = /^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/;
+// Matches any RFC 4122 / 9562 UUID variant (v1 through v8). Named `UUID_REGEX`
+// rather than `UUID_V4_REGEX` because the pattern was never v4-specific — the
+// database mints v7 ids since mysticat-data-service migration #1 (Jan 2025).
+const UUID_REGEX = /^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/;
+// Deprecated alias retained so older callers don't break. Prefer `UUID_REGEX`.
+const UUID_V4_REGEX = UUID_REGEX;
 
 /**
  * Determines if the given parameter is an array.
@@ -220,7 +225,7 @@ function isValidUrl(urlString) {
  * @return {boolean} True if the given string is a valid UUID.
  */
 function isValidUUID(uuid) {
-  return UUID_V4_REGEX.test(uuid);
+  return UUID_REGEX.test(uuid);
 }
 
 /**
@@ -345,4 +350,6 @@ export {
   isValidIMSOrgId,
   isValidHelixPreviewUrl,
   toBoolean,
+  UUID_REGEX,
+  UUID_V4_REGEX,
 };

--- a/packages/spacecat-shared-utils/src/index.d.ts
+++ b/packages/spacecat-shared-utils/src/index.d.ts
@@ -56,6 +56,18 @@ export function isValidHelixPreviewUrl(urlString: string): boolean;
 
 export function isValidUUID(uuid: string): boolean;
 
+/**
+ * Matches any RFC 4122 / 9562 UUID variant (v1 through v8).
+ * The database mints v7 ids; the API also encounters v4 ids minted by the
+ * legacy ORM path or by Mystique direct INSERTs that use `gen_random_uuid()`.
+ */
+export const UUID_REGEX: RegExp;
+
+/**
+ * @deprecated Use `UUID_REGEX`. This pattern was never v4-specific.
+ */
+export const UUID_V4_REGEX: RegExp;
+
 export function isValidIMSOrgId(imsOrgId: string): boolean;
 
 export function dateAfterDays(days: number, dateString: string): Date;

--- a/packages/spacecat-shared-utils/src/index.js
+++ b/packages/spacecat-shared-utils/src/index.js
@@ -31,6 +31,8 @@ export {
   isValidIMSOrgId,
   isValidHelixPreviewUrl,
   toBoolean,
+  UUID_REGEX,
+  UUID_V4_REGEX,
 } from './functions.js';
 
 export { isValidEmail } from './email.js';

--- a/packages/spacecat-shared-utils/test/functions.test.js
+++ b/packages/spacecat-shared-utils/test/functions.test.js
@@ -36,6 +36,8 @@ import {
   isValidIMSOrgId,
   isValidHelixPreviewUrl,
   toBoolean,
+  UUID_REGEX,
+  UUID_V4_REGEX,
 } from '../src/index.js';
 
 describe('Shared functions', () => {
@@ -348,6 +350,19 @@ describe('Shared functions', () => {
 
     it('returns true for valid UUID', async () => {
       expect(isValidUUID('123e4567-e89b-12d3-a456-426614174000')).to.be.true;
+    });
+
+    it('accepts both v4 and v7 ids (RFC 4122 / 9562 variants)', () => {
+      expect(isValidUUID('78fec9c7-2141-4600-b7b1-ea5c78752b91')).to.be.true;
+      expect(isValidUUID('019cde0c-fe79-76b2-bc50-a40e1b1b1c36')).to.be.true;
+    });
+
+    it('exposes UUID_REGEX and the deprecated UUID_V4_REGEX alias', () => {
+      expect(UUID_REGEX).to.be.an.instanceOf(RegExp);
+      expect(UUID_V4_REGEX).to.equal(UUID_REGEX);
+      expect(UUID_REGEX.test('78fec9c7-2141-4600-b7b1-ea5c78752b91')).to.be.true;
+      expect(UUID_REGEX.test('019cde0c-fe79-76b2-bc50-a40e1b1b1c36')).to.be.true;
+      expect(UUID_REGEX.test('not-a-uuid')).to.be.false;
     });
   });
 

--- a/packages/spacecat-shared-utils/test/index.test.js
+++ b/packages/spacecat-shared-utils/test/index.test.js
@@ -133,6 +133,8 @@ describe('Index Exports', () => {
     'toggleWWWHostname',
     'tracingFetch',
     'urlMatchesFilter',
+    'UUID_REGEX',
+    'UUID_V4_REGEX',
     'wwwUrlResolver',
   ];
 

--- a/packages/spacecat-shared-utils/test/subpaths.test.js
+++ b/packages/spacecat-shared-utils/test/subpaths.test.js
@@ -28,7 +28,7 @@ const EXPECTED_CORE_EXPORTS = [
   'isArray', 'isBoolean', 'isInteger', 'isIsoDate', 'isIsoTimeOffsetsDate',
   'isNonEmptyArray', 'isNonEmptyObject', 'isNumber', 'isObject', 'isString',
   'isValidDate', 'isValidHelixPreviewUrl', 'isValidIMSOrgId', 'isValidUrl',
-  'isValidUUID', 'toBoolean',
+  'isValidUUID', 'toBoolean', 'UUID_REGEX', 'UUID_V4_REGEX',
 ];
 
 const EXPECTED_AWS_EXPORTS = [


### PR DESCRIPTION
## Summary

Aligns the SpaceCat ORM with the v7-by-design DB schema. The DB column default for every PK has been `uuid_generate_v7()` since [mysticat-data-service migration #1](https://github.com/adobe/mysticat-data-service/blob/main/db/migrations/20250130000001_initial_setup.sql) (Jan 2025), but `schema.builder.js` was stamping `crypto.randomUUID()` (v4) in `#applyDefaults` *before* the INSERT, defeating the DB default. This created a v4/v7 asymmetry on the same tables (sites, opportunities, suggestions) between ORM-written rows and Mystique-direct-INSERT rows, and the v4-strict gateway regex in `spacecat-api-service` rejected the v7 rows at the API boundary (SITES-45292).

Two changes, each independently shippable:

- `fix(data-access)`: replace the client-side v4 default with `uuidv7()`, an inline implementation that mirrors the DB's plpgsql function bit-for-bit (no new npm dep). Strengthens unit and IT-test assertions so a regression to v4 fails fast.
- `feat(utils)`: rename the misleadingly-named `UUID_V4_REGEX` constant to `UUID_REGEX` (the pattern was always version-agnostic), export both names with the v4 name marked deprecated, and add explicit v4/v7 coverage to the `isValidUUID` test suite.

## Why roll forward, not migrate

`sites.id` alone is referenced by 100+ partitioned analytics tables. In-place UUID swaps require coordinated cross-table UPDATEs that aren't worth the risk. Both v4 and v7 are valid RFC 4122/9562 UUIDs, so they coexist forever — new writes converge on v7 (sortable, locality-friendly B-tree indexes); old v4 rows live out their natural life.

## Where the v4 came from

`packages/spacecat-shared-data-access/src/models/base/schema.builder.js:42` (pre-fix):

\`\`\`js
const ID_ATTRIBUTE_DATA = {
  ...
  default: () => crypto.randomUUID(),   // Node's randomUUID → UUID v4
  validate: (value) => isValidUUID(value),
};
\`\`\`

`BaseCollection.create()` → `#prepareItem` → `#applyDefaults` runs *before* the PostgREST insert, so the row arrived at PG with \`id\` already populated and the DB v7 default never fired.

## What the new `uuidv7()` does

`packages/spacecat-shared-data-access/src/util/uuid.js` (new) implements the same byte layout as the DB's `uuid_generate_v7()` plpgsql function:

- Bytes 0-5: unix timestamp in milliseconds (big-endian)
- Bytes 6-15: 10 random bytes via `crypto.randomBytes`
- Byte 6 high nibble pinned to `7` (version field)
- Byte 8 high two bits pinned to `10` (variant field)

## Test changes

- **Unit (data-access)**: new `test/unit/util/uuid.test.js` proves version nibble = 7, variant bits 8/9/a/b, ms-encoded timestamp, time-sortable, unique across 1000 calls. `test/unit/models/base/schema.builder.test.js` now asserts the generated id's version nibble explicitly.
- **IT (data-access)**: added `expect(getId().charAt(14)).to.equal('7')` to create-path assertions in `site.test.js`, `opportunity.test.js`, `suggestion.test.js`, `report.test.js`, `contact-sales-lead.test.js`. These run against a real PostgREST + Postgres, so if anyone ever regresses the ORM to v4 the IT suite catches it.
- **Unit (utils)**: extended the `isValidUUID` test suite to cover v4 and v7 explicitly; added a test asserting `UUID_REGEX` and `UUID_V4_REGEX` are both exported and identity-equal.
- **Subpath barrel checks (utils)**: `test/index.test.js` and `test/subpaths.test.js` expected-exports lists were updated to include the two new public symbols.

## Verification

- ✅ `npm test -w packages/spacecat-shared-data-access` — 2231 passing, 100% coverage on the new `uuid.js`
- ✅ `npm test -w packages/spacecat-shared-utils` — 1154 passing
- ✅ `npm run lint` clean for both packages

## Compatibility

- **Validators stay agnostic.** `isValidUUID` and `z.uuid()` (Zod 4.1.13) both accept v4 *and* v7 — verified empirically. No callsite in `packages/spacecat-shared-utils/src/schemas.js` uses the strict `z.uuidv4()`, so they keep accepting both.
- **No DB migration.** Schema stays v7-by-design as it has been since Jan 2025.
- **No breaking change for existing consumers.** New rows minted by the ORM will be v7 going forward; the API contract is version-agnostic for any caller using `isValidUUID` or `z.uuid()`.

## Related

- SITES-45292 — the direct-apply e2e where this asymmetry was uncovered
- [adobe/spacecat-api-service#2496](https://github.com/adobe/spacecat-api-service/pull/2496) — companion gate-widening PR (already open, deployed via branch-deploy)
- Ticket Edit 3 (UI-side gate in `experience-success-studio-ui`) and Edit 5 (api-service test assertions) live in other repos and are out of scope for this PR

## Out of scope (worth flagging as follow-ups)

`sentiment-guideline.schema.js:45` and `sentiment-topic.schema.js:43` still use `crypto.randomUUID()` for *secondary* `text` columns (`guideline_id`, `topic_id`) that have no DB default. They're minting v4 for new rows. Not the bug from the ticket — these aren't `id` PK columns — but worth a follow-up if you want fleet-wide v7 alignment.

## Test plan

- [ ] CI green on lint + unit tests for both packages
- [ ] (optional) Run data-access IT tests locally — `npm run test:it -w packages/spacecat-shared-data-access` — to confirm v7 minting works against a real PostgREST + Postgres
- [ ] After release, verify in dev that newly-created sites/opportunities/suggestions have v7 ids (version nibble 7 at position 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)