### PR TITLE
feat(data-access): rename BrandSemrushProject accessors (LLMO-5190)

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/brand-semrush-project/brand-semrush-project.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/brand-semrush-project/brand-semrush-project.collection.js
@@ -22,17 +22,17 @@ class BrandSemrushProjectCollection extends BaseCollection {
   static COLLECTION_NAME = 'BrandSemrushProjectCollection';
 
   /**
-   * Find the single row for a (brand, semrushLocationId, language) slice, or
-   * null. Used by spacecat-api-service POST /v2/orgs/.../semrush/projects to
-   * 409 on a duplicate slice before calling Semrush.
+   * Find the single row for a (brand, geoTargetId, languageCode) slice, or
+   * null. Used by spacecat-api-service POST /v2/orgs/.../serenity/markets to
+   * 409 on a duplicate slice before calling the upstream.
    *
    * @param {string} brandId
-   * @param {number} semrushLocationId
-   * @param {string} language
+   * @param {number} geoTargetId Google Ads Geo Target ID.
+   * @param {string} languageCode BCP-47 primary subtag.
    * @returns {Promise<BrandSemrushProject|null>}
    */
-  async findBySlice(brandId, semrushLocationId, language) {
-    return this.findByIndexKeys({ brandId, semrushLocationId, language });
+  async findBySlice(brandId, geoTargetId, languageCode) {
+    return this.findByIndexKeys({ brandId, geoTargetId, languageCode });
   }
 }
 

--- a/packages/spacecat-shared-data-access/src/models/brand-semrush-project/brand-semrush-project.model.js
+++ b/packages/spacecat-shared-data-access/src/models/brand-semrush-project/brand-semrush-project.model.js
@@ -13,10 +13,12 @@
 import BaseModel from '../base/base.model.js';
 
 /**
- * BrandSemrushProject - mapping between an Adobe brand and a Semrush AIO
- * project. One row per (brand, semrushLocationId, language) slice. The Semrush
- * workspace is reachable via brand -> organization.getSemrushWorkspaceId() and
- * is not duplicated on this entity.
+ * BrandSemrushProject - mapping between an Adobe brand and an upstream
+ * Semrush AIO project. One row per (brand, geoTargetId, languageCode) slice.
+ * The Semrush workspace is reachable via
+ * brand -> organization.getSemrushWorkspaceId() and is not duplicated on this
+ * entity. Entity + table names retain the `Semrush` prefix as internal
+ * storage identifiers; the public JS accessors do not.
  *
  * @class BrandSemrushProject
  * @extends BaseModel

--- a/packages/spacecat-shared-data-access/src/models/brand-semrush-project/brand-semrush-project.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/brand-semrush-project/brand-semrush-project.schema.js
@@ -20,7 +20,7 @@ import BrandSemrushProjectCollection from './brand-semrush-project.collection.js
 // (db/migrations/20260528000000_brand_to_semrush_projects.sql). The slice
 // uniqueness gate is an exact DB string match, so inconsistent casing or
 // format between callers would silently bypass the 409 and bill a duplicate
-// Semrush project. Accepts BCP-47-shaped tags: 2/3-letter primary subtag
+// upstream project. Accepts BCP-47-shaped tags: 2/3-letter primary subtag
 // (`en`, `de`, `zho`) optionally followed by a 2-4-letter region/script
 // subtag (`de-ch`, `pt-br`, `zh-hant`). All lowercase by contract.
 const LANGUAGE_TAG_REGEX = /^[a-z]{2,3}(-[a-z]{2,4})?$/;
@@ -45,15 +45,23 @@ const schema = new SchemaBuilder(BrandSemrushProject, BrandSemrushProjectCollect
     required: true,
     validate: (value) => hasText(value),
   })
-  .addAttribute('semrushLocationId', {
+  // Google Ads Geo Target ID (criterion_id for the country). Semrush re-uses
+  // it as their location identifier; the value is owned by Google Ads, not
+  // Semrush. DB column stays `semrush_location_id` — the table layout is
+  // subject to change independently (see LLMO-5190 plan §Context).
+  .addAttribute('geoTargetId', {
     type: 'number',
     required: true,
     validate: (value) => Number.isInteger(value) && value > 0,
+    postgrestField: 'semrush_location_id',
   })
-  .addAttribute('language', {
+  // BCP-47 primary subtag (`en`, `de`, `fr`), optionally with a region/script
+  // subtag (`de-ch`, `pt-br`, `zh-hant`). DB column stays `language`.
+  .addAttribute('languageCode', {
     type: 'string',
     required: true,
     validate: (value) => hasText(value) && LANGUAGE_TAG_REGEX.test(value),
+    postgrestField: 'language',
   })
   .addAllIndex(['semrushProjectId']);
 

--- a/packages/spacecat-shared-data-access/src/models/brand-semrush-project/brand-semrush-project.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/brand-semrush-project/brand-semrush-project.schema.js
@@ -16,6 +16,11 @@ import SchemaBuilder from '../base/schema.builder.js';
 import BrandSemrushProject from './brand-semrush-project.model.js';
 import BrandSemrushProjectCollection from './brand-semrush-project.collection.js';
 
+// "upstream" in the comments below refers to Semrush AIO — the entity name,
+// table name, and `semrushProjectId` accessor stay because the value IS the
+// upstream identifier. The public API surface decouples via the LLMO-5190
+// rename plan (see the schema attributes' `postgrestField` overrides).
+
 // Mirrors the CHECK constraint on brand_to_semrush_projects.language
 // (db/migrations/20260528000000_brand_to_semrush_projects.sql). The slice
 // uniqueness gate is an exact DB string match, so inconsistent casing or

--- a/packages/spacecat-shared-data-access/src/models/brand-semrush-project/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/brand-semrush-project/index.d.ts
@@ -22,11 +22,11 @@ import type {
 export interface BrandSemrushProject extends BaseModel {
   getBrandId(): string;
   getSemrushProjectId(): string;
-  getSemrushLocationId(): number;
-  getLanguage(): string;
+  getGeoTargetId(): number;
+  getLanguageCode(): string;
   setSemrushProjectId(value: string): BrandSemrushProject;
-  setSemrushLocationId(value: number): BrandSemrushProject;
-  setLanguage(value: string): BrandSemrushProject;
+  setGeoTargetId(value: number): BrandSemrushProject;
+  setLanguageCode(value: string): BrandSemrushProject;
 }
 
 export interface BrandSemrushProjectCollection extends
@@ -37,7 +37,7 @@ export interface BrandSemrushProjectCollection extends
   findBySemrushProjectId(semrushProjectId: string): Promise<BrandSemrushProject | null>;
   findBySlice(
     brandId: string,
-    semrushLocationId: number,
-    language: string,
+    geoTargetId: number,
+    languageCode: string,
   ): Promise<BrandSemrushProject | null>;
 }

--- a/packages/spacecat-shared-data-access/test/fixtures/brand-semrush-projects.fixture.js
+++ b/packages/spacecat-shared-data-access/test/fixtures/brand-semrush-projects.fixture.js
@@ -15,15 +15,15 @@ const brandSemrushProjects = [
     brandSemrushProjectId: '5b1e2d6a-7c5f-4a91-9b32-8e34ad11d201',
     brandId: 'c3e1a4b6-2a8e-4d61-8b03-7d0a1d6b3201',
     semrushProjectId: 'proj-fixture-us-en',
-    semrushLocationId: 2840,
-    language: 'en',
+    geoTargetId: 2840,
+    languageCode: 'en',
   },
   {
     brandSemrushProjectId: '6c2f3e7b-8d6a-4b02-aa43-9f45be22e312',
     brandId: 'c3e1a4b6-2a8e-4d61-8b03-7d0a1d6b3201',
     semrushProjectId: 'proj-fixture-de-de',
-    semrushLocationId: 2276,
-    language: 'de',
+    geoTargetId: 2276,
+    languageCode: 'de',
   },
 ];
 

--- a/packages/spacecat-shared-data-access/test/unit/models/brand-semrush-project/brand-semrush-project.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/brand-semrush-project/brand-semrush-project.collection.test.js
@@ -34,8 +34,8 @@ describe('BrandSemrushProjectCollection', () => {
   const mockRecord = {
     brandId: 'c3e1a4b6-2a8e-4d61-8b03-7d0a1d6b3201',
     semrushProjectId: 'proj-collection-test',
-    semrushLocationId: 2840,
-    language: 'en',
+    geoTargetId: 2840,
+    languageCode: 'en',
     updatedBy: 'system',
   };
 
@@ -73,15 +73,15 @@ describe('BrandSemrushProjectCollection', () => {
 
       const result = await instance.findBySlice(
         mockRecord.brandId,
-        mockRecord.semrushLocationId,
-        mockRecord.language,
+        mockRecord.geoTargetId,
+        mockRecord.languageCode,
       );
 
       expect(result).to.equal(expected);
       expect(findStub).to.have.been.calledOnceWithExactly({
         brandId: mockRecord.brandId,
-        semrushLocationId: mockRecord.semrushLocationId,
-        language: mockRecord.language,
+        geoTargetId: mockRecord.geoTargetId,
+        languageCode: mockRecord.languageCode,
       });
     });
 
@@ -90,8 +90,8 @@ describe('BrandSemrushProjectCollection', () => {
 
       const result = await instance.findBySlice(
         mockRecord.brandId,
-        mockRecord.semrushLocationId,
-        mockRecord.language,
+        mockRecord.geoTargetId,
+        mockRecord.languageCode,
       );
 
       expect(result).to.equal(null);

--- a/packages/spacecat-shared-data-access/test/unit/models/brand-semrush-project/brand-semrush-project.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/brand-semrush-project/brand-semrush-project.model.test.js
@@ -77,25 +77,25 @@ describe('BrandSemrushProjectModel', () => {
     });
   });
 
-  describe('semrushLocationId', () => {
-    it('gets semrushLocationId', () => {
-      expect(instance.getSemrushLocationId()).to.equal(2840);
+  describe('geoTargetId', () => {
+    it('gets geoTargetId', () => {
+      expect(instance.getGeoTargetId()).to.equal(2840);
     });
 
-    it('sets semrushLocationId', () => {
-      instance.setSemrushLocationId(2826);
-      expect(instance.getSemrushLocationId()).to.equal(2826);
+    it('sets geoTargetId', () => {
+      instance.setGeoTargetId(2826);
+      expect(instance.getGeoTargetId()).to.equal(2826);
     });
   });
 
-  describe('language', () => {
-    it('gets language', () => {
-      expect(instance.getLanguage()).to.equal('en');
+  describe('languageCode', () => {
+    it('gets languageCode', () => {
+      expect(instance.getLanguageCode()).to.equal('en');
     });
 
-    it('sets language', () => {
-      instance.setLanguage('de');
-      expect(instance.getLanguage()).to.equal('de');
+    it('sets languageCode', () => {
+      instance.setLanguageCode('de');
+      expect(instance.getLanguageCode()).to.equal('de');
     });
   });
 });

--- a/packages/spacecat-shared-data-access/test/unit/models/brand-semrush-project/brand-semrush-project.schema.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/brand-semrush-project/brand-semrush-project.schema.test.js
@@ -44,86 +44,98 @@ describe('BrandSemrushProject Schema', () => {
     });
   });
 
-  describe('semrushLocationId attribute', () => {
+  describe('geoTargetId attribute', () => {
     it('is required with a positive-integer validator', () => {
-      const attr = attributes.semrushLocationId;
+      const attr = attributes.geoTargetId;
       expect(attr).to.exist;
       expect(attr.required).to.be.true;
       expect(attr.validate).to.be.a('function');
+    });
+
+    // postgrestField override preserves the DB column name (`semrush_location_id`)
+    // even though the JS attribute is now `geoTargetId`. Asserted here so a
+    // future accidental column rename in the model layer would fail the test
+    // before silently breaking the projector / data-service readers.
+    it('maps to the semrush_location_id DB column via postgrestField', () => {
+      expect(attributes.geoTargetId.postgrestField).to.equal('semrush_location_id');
     });
 
     it('accepts positive integers', () => {
-      expect(attributes.semrushLocationId.validate(2840)).to.be.true;
-      expect(attributes.semrushLocationId.validate(1)).to.be.true;
+      expect(attributes.geoTargetId.validate(2840)).to.be.true;
+      expect(attributes.geoTargetId.validate(1)).to.be.true;
     });
 
     it('rejects zero and negative integers', () => {
-      expect(attributes.semrushLocationId.validate(0)).to.be.false;
-      expect(attributes.semrushLocationId.validate(-1)).to.be.false;
+      expect(attributes.geoTargetId.validate(0)).to.be.false;
+      expect(attributes.geoTargetId.validate(-1)).to.be.false;
     });
 
     it('rejects non-integer numbers', () => {
-      expect(attributes.semrushLocationId.validate(1.5)).to.be.false;
-      expect(attributes.semrushLocationId.validate(Number.NaN)).to.be.false;
-      expect(attributes.semrushLocationId.validate(Infinity)).to.be.false;
+      expect(attributes.geoTargetId.validate(1.5)).to.be.false;
+      expect(attributes.geoTargetId.validate(Number.NaN)).to.be.false;
+      expect(attributes.geoTargetId.validate(Infinity)).to.be.false;
     });
 
     it('rejects numeric strings (no coercion)', () => {
-      expect(attributes.semrushLocationId.validate('2840')).to.be.false;
+      expect(attributes.geoTargetId.validate('2840')).to.be.false;
     });
   });
 
-  describe('language attribute', () => {
+  describe('languageCode attribute', () => {
     it('is required with a BCP-47-shaped validator', () => {
-      const attr = attributes.language;
+      const attr = attributes.languageCode;
       expect(attr).to.exist;
       expect(attr.required).to.be.true;
       expect(attr.validate).to.be.a('function');
     });
 
+    it('maps to the language DB column via postgrestField', () => {
+      expect(attributes.languageCode.postgrestField).to.equal('language');
+    });
+
     it('accepts 2-letter lowercase ISO 639-1 tags', () => {
-      expect(attributes.language.validate('en')).to.be.true;
-      expect(attributes.language.validate('de')).to.be.true;
-      expect(attributes.language.validate('it')).to.be.true;
+      expect(attributes.languageCode.validate('en')).to.be.true;
+      expect(attributes.languageCode.validate('de')).to.be.true;
+      expect(attributes.languageCode.validate('it')).to.be.true;
     });
 
     it('accepts 3-letter lowercase ISO 639-3 tags', () => {
-      expect(attributes.language.validate('zho')).to.be.true;
-      expect(attributes.language.validate('cmn')).to.be.true;
+      expect(attributes.languageCode.validate('zho')).to.be.true;
+      expect(attributes.languageCode.validate('cmn')).to.be.true;
     });
 
     it('accepts primary subtag with a 2-4 letter region/script subtag', () => {
-      expect(attributes.language.validate('de-ch')).to.be.true;
-      expect(attributes.language.validate('pt-br')).to.be.true;
-      expect(attributes.language.validate('zh-hant')).to.be.true;
+      expect(attributes.languageCode.validate('de-ch')).to.be.true;
+      expect(attributes.languageCode.validate('pt-br')).to.be.true;
+      expect(attributes.languageCode.validate('zh-hant')).to.be.true;
     });
 
     it('rejects uppercase and mixed case', () => {
-      expect(attributes.language.validate('EN')).to.be.false;
-      expect(attributes.language.validate('En')).to.be.false;
-      expect(attributes.language.validate('en-US')).to.be.false;
-      expect(attributes.language.validate('zh-Hant')).to.be.false;
+      expect(attributes.languageCode.validate('EN')).to.be.false;
+      expect(attributes.languageCode.validate('En')).to.be.false;
+      expect(attributes.languageCode.validate('en-US')).to.be.false;
+      expect(attributes.languageCode.validate('zh-Hant')).to.be.false;
     });
 
     it('rejects values that do not match the BCP-47 shape', () => {
-      expect(attributes.language.validate('english')).to.be.false;
-      expect(attributes.language.validate('e')).to.be.false;
-      expect(attributes.language.validate('en-')).to.be.false;
-      expect(attributes.language.validate('en-u')).to.be.false;
-      expect(attributes.language.validate('en-toolong')).to.be.false;
-      expect(attributes.language.validate('en_us')).to.be.false;
-      expect(attributes.language.validate(' en')).to.be.false;
-      expect(attributes.language.validate('en ')).to.be.false;
+      expect(attributes.languageCode.validate('english')).to.be.false;
+      expect(attributes.languageCode.validate('e')).to.be.false;
+      expect(attributes.languageCode.validate('en-')).to.be.false;
+      expect(attributes.languageCode.validate('en-u')).to.be.false;
+      expect(attributes.languageCode.validate('en-toolong')).to.be.false;
+      expect(attributes.languageCode.validate('en_us')).to.be.false;
+      expect(attributes.languageCode.validate(' en')).to.be.false;
+      expect(attributes.languageCode.validate('en ')).to.be.false;
     });
 
     it('rejects empty string and whitespace-only strings', () => {
-      expect(attributes.language.validate('')).to.be.false;
-      expect(attributes.language.validate('   ')).to.be.false;
+      expect(attributes.languageCode.validate('')).to.be.false;
+      expect(attributes.languageCode.validate('   ')).to.be.false;
     });
 
     it('rejects nullish values', () => {
-      expect(attributes.language.validate(null)).to.be.false;
-      expect(attributes.language.validate(undefined)).to.be.false;
+      expect(attributes.languageCode.validate(null)).to.be.false;
+      expect(attributes.languageCode.validate(undefined)).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Summary

Rename the `BrandSemrushProject` JS accessor surface to honest, non-leaky names ahead of the Serenity API refactor (LLMO-5190). This is the **Phase 0** of the three-phase coordinated cut-over described in [spacecat-api-service/docs/specs/2026-05-28-prompts-api-abstraction.md](https://github.com/adobe/spacecat-api-service/blob/feat/llmo-5190/docs/specs/2026-05-28-prompts-api-abstraction.md) — a new minor of `@adobe/spacecat-shared-data-access` published from this PR is the precondition for the api-service rewrite.

### What changed

| Old JS attribute | New JS attribute | DB column (unchanged) |
|---|---|---|
| `semrushLocationId` (number) | `geoTargetId` (number) | `semrush_location_id` |
| `language` (string) | `languageCode` (string) | `language` |
| `semrushProjectId` (string) | `semrushProjectId` (kept) | `semrush_project_id` |

Why these specific changes:

- **`semrushLocationId` → `geoTargetId`**: the value is literally the Google Ads Geo Target ID (`criterion_id = 2000 + ISO numeric` for countries). Semrush re-uses it; the "semrush" prefix on this field was wrong, not just leaky.
- **`language` → `languageCode`**: the value is a BCP-47 primary subtag (`en`, `de`, `de-ch`), not a display name. `languageCode` is unambiguous.
- **`semrushProjectId` kept**: the value genuinely IS Semrush's project UUID. The honest-naming rule prefers a truthful name over a fake-abstract one. The entity name `BrandSemrushProject` and the table `brand_to_semrush_projects` are internal storage identifiers and also stay.

### DB columns intentionally preserved

The `postgrestField` override on the renamed attributes keeps the DB columns as `semrush_location_id` and `language`. The mysticat-projector pipeline and the data-service PostgREST views read those columns directly and are unaffected.

Note: the table + columns may be restructured for unrelated reasons later (e.g., if the slice key gains a sub-national geo dimension, or if the mapping is generalized beyond Semrush). Renaming columns in this PR would either be wasted work or would conflict with that pending change. If the storage layout stabilizes as-is, we can align column names with the JS accessors in a follow-up migration.

### Why `feat:` (minor bump) and no `BREAKING CHANGE:` footer

A workspace-wide grep confirms `spacecat-api-service` is the only consumer of `BrandSemrushProject`, and it bumps in the same release window (Phase 1 PR coming after this merges). The major-version ceremony would only serve external consumers that don't exist.

## Related Issues

- LLMO-5190 — Refactor Serenity API: hide Semrush as an implementation detail
- Epic: LLMO-5005

## Test plan

- [x] `npx mocha "test/unit/models/brand-semrush-project/**/*.test.js"` — 42 passing
- [x] `npm run lint` — clean
- [x] Banned-name grep in the package — empty:
  ```bash
  git grep -E 'getSemrushLocationId|setSemrushLocationId|\bgetLanguage\b|\bsetLanguage\b' \
    -- packages/spacecat-shared-data-access/src packages/spacecat-shared-data-access/test
  ```
- [x] `postgrestField` mapping asserted in schema tests so an accidental column-name regression fails the suite (`packages/spacecat-shared-data-access/test/unit/models/brand-semrush-project/brand-semrush-project.schema.test.js`)
- [ ] CI green (semantic-release minor on merge)
- [ ] `npm view @adobe/spacecat-shared-data-access version` returns the new minor before the api-service Phase 1 PR opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)