### PR TITLE
fix(data-access): declare Preflight createdBy/error as 'any' so Service construction succeeds

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/preflight/preflight.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/preflight/preflight.schema.js
@@ -30,8 +30,16 @@ const schema = new SchemaBuilder(Preflight, PreflightCollection)
     required: true,
     default: Preflight.Status.IN_PROGRESS,
   })
+  // `createdBy` and `error` use type 'any' (matching neighbor `result`) because
+  // ElectroDB's `map` type requires a `properties` schema for every sub-key,
+  // and the validate function below already enforces the precise shape — a
+  // duplicate `properties` declaration adds nothing. Declaring `type: 'map'`
+  // here without `properties` was the original definition and throws
+  // `InvalidAttributeDefinition` at Service construction, blocking any
+  // downstream consumer that builds a v1 `new Service(EntityRegistry.getEntities())`
+  // (e.g. spacecat-api-service `fixes.test.js`).
   .addAttribute('createdBy', {
-    type: 'map',
+    type: 'any',
     required: true,
     validate: (value) => isObject(value) && typeof value.email === 'string' && value.email.length > 0,
   })
@@ -48,7 +56,7 @@ const schema = new SchemaBuilder(Preflight, PreflightCollection)
     validate: (value) => !value || isObject(value),
   })
   .addAttribute('error', {
-    type: 'map',
+    type: 'any',
     validate: (value) => !value || (isObject(value) && typeof value.code === 'string' && value.code.length > 0 && typeof value.message === 'string' && value.message.length > 0),
   });
 

--- a/packages/spacecat-shared-data-access/test/unit/models/preflight/preflight.schema.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/preflight/preflight.schema.test.js
@@ -20,6 +20,24 @@ describe('Preflight Schema', () => {
     attributes = preflightSchema.getAttributes();
   });
 
+  // ElectroDB's `map` type requires a `properties` schema. Declaring a Map
+  // attribute without `properties` (as the original Preflight schema did for
+  // `createdBy` and `error`) throws `InvalidAttributeDefinition` at
+  // `new Service(...)` time, which silently breaks any downstream test or
+  // runtime path that instantiates the full entity registry via electrodb's
+  // v1 Service constructor (e.g. spacecat-api-service `fixes.test.js`). The
+  // `validate` function already enforces the precise shape, so `any` is the
+  // minimal correct type here — matching the neighbor `result` attribute.
+  describe('attribute types (regression guard for ElectroDB Service construction)', () => {
+    it('declares createdBy as type "any" (not "map") so Service construction succeeds', () => {
+      expect(attributes.createdBy.type).to.equal('any');
+    });
+
+    it('declares error as type "any" (not "map") so Service construction succeeds', () => {
+      expect(attributes.error.type).to.equal('any');
+    });
+  });
+
   describe('createdBy attribute', () => {
     it('accepts a valid object with email and displayName', () => {
       expect(attributes.createdBy.validate({ email: 'user@example.com', displayName: 'User' })).to.be.true;


### PR DESCRIPTION
## Summary

The Preflight entity introduced in 3.72.0 declares `createdBy` and `error` as `type: 'map'` without a `properties` schema. ElectroDB rejects that at `new Service(...)` time with `InvalidAttributeDefinition`, which breaks any downstream consumer that constructs the full v1 Service from the entity registry.

```
ElectroError: Invalid "properties" definition for Map attribute: "undefined".
The "properties" definition must describe the attributes that the Map will accept
  at Attribute.buildChildMapProperties (electrodb/src/schema.js:208:13)
  at new MapAttribute (electrodb/src/schema.js:658:34)
  at Schema.normalizeAttributes (electrodb/src/schema.js:1498:30)
  at new Schema (electrodb/src/schema.js:1221:25)
  at Entity._parseModel (electrodb/src/entity.js:4844:18)
  at new Entity (electrodb/src/entity.js:61:23)
  at Service._inferJoinEntity (electrodb/src/service.js:209:18)
  at Service._inferServiceNameFromEntityMap (electrodb/src/service.js:190:8)
  at Service._v1MapConstructor (electrodb/src/service.js:154:28)
  at new Service (electrodb/src/service.js:168:14)
```

### Why no consumer caught it before today

The shared package's own tests instantiate entities via `createElectroMocks`, which builds collections one at a time and does not exercise `new electrodb.Service(EntityRegistry.getEntities())`. Spacecat-api-service is the only consumer that does that — specifically in `test/controllers/fixes.test.js:48` — but its `package.json` has been pinned at `@adobe/spacecat-shared-data-access@3.71.1` (pre-Preflight) since 3.72.0 shipped. The regression has been latent for ~24 hours; surfacing now in the LLMO-5190 Phase 1 PR ([adobe/spacecat-api-service#2506](https://github.com/adobe/spacecat-api-service/pull/2506)) that bumps the consumer to 3.73.0.

### Why `type: 'any'` and not `properties: {…}`

Two options to make ElectroDB happy:

1. **Declare `properties: {…}`** for both Map attributes, matching the existing `quotas` pattern in `entitlement.schema.js`.
2. **Switch to `type: 'any'`**, matching the neighbor `result` attribute on the same Preflight entity — a `validate` function already enforces the precise shape (`{email: string}` and `{code: string, message: string}`).

Option 2 wins on three grounds:

- **Smaller diff, larger fix.** One word change per attribute, vs. a 3–6 line `properties` block per attribute with risk of drifting out of sync with the `validate` function.
- **Single source of truth.** Today the validate function and a hypothetical `properties` block would both describe the shape, and there's no enforcement that they agree. With `any`, the validate function is the sole authority.
- **Consistent with the same entity.** `result` already uses `type: 'any'` for the same reason (free-form-ish object validated by `validate`); aligning `createdBy` and `error` makes the schema internally coherent.

No DB / PostgREST behavior changes — `any` and `map` are both serialized as JSON columns by the postgrest mapper.

### Regression guard

Added a focused assertion in `test/unit/models/preflight/preflight.schema.test.js` that a future revert to `type: 'map'` without `properties` fails the schema test before it can be merged:

```js
it('declares createdBy as type "any" (not "map") so Service construction succeeds', () => {
  expect(attributes.createdBy.type).to.equal('any');
});
```

A deeper guard — a shared-side test that does `new electrodb.Service(EntityRegistry.getEntities())` — would catch this class of bug for all future entities. That's a follow-up worth filing; out of scope here because (a) shared does not currently depend on `electrodb` directly, and (b) the existing api-service-side test catches the same class once consumers bump.

## Test plan

- [x] `npx mocha "packages/spacecat-shared-data-access/test/unit/models/preflight/preflight.schema.test.js"` — 20 passing (18 existing + 2 new)
- [x] `npm run lint -w packages/spacecat-shared-data-access` — clean
- [ ] CI green (full suite + semantic-release dry-run)
- [ ] Patch release `3.73.1` published, unblocks [adobe/spacecat-api-service#2506](https://github.com/adobe/spacecat-api-service/pull/2506) CI

## Related

- Surfaced by: [adobe/spacecat-api-service#2506](https://github.com/adobe/spacecat-api-service/pull/2506) (LLMO-5190 Phase 1)
- Original Preflight PR: [adobe/spacecat-shared#1601 (SITES-45417)](https://github.com/adobe/spacecat-shared/commit/2b57e6a1af8de07cee588409faab0ec4827a5a7d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)