### PR TITLE
feat(tokowaka-client): subpath-aware metaconfig S3 key

### DIFF
--- a/packages/spacecat-shared-tokowaka-client/src/index.js
+++ b/packages/spacecat-shared-tokowaka-client/src/index.js
@@ -729,9 +729,8 @@ class TokowakaClient {
     // Group suggestions by URL
     const suggestionsByUrl = groupSuggestionsByUrlPath(eligibleSuggestions, baseURL, this.log);
 
-    // Check if domain-level metaconfig exists
-    const firstUrl = new URL(Object.keys(suggestionsByUrl)[0], baseURL).toString();
-    const metaconfig = await this.fetchMetaconfig(firstUrl);
+    // Check if site-level metaconfig exists — use baseURL so subpath sites get their own key
+    const metaconfig = await this.fetchMetaconfig(baseURL);
 
     if (!metaconfig) {
       throw this.#createError(
@@ -987,9 +986,10 @@ class TokowakaClient {
       throw this.#createError('Preview URL not found in suggestion data', HTTP_BAD_REQUEST);
     }
 
-    // Fetch metaconfig and existing config in parallel
+    // Fetch metaconfig and existing config in parallel — use site baseURL for metaconfig
+    // so subpath sites (e.g. nba.com/timberwolves) get their own metaconfig key
     const [metaconfig, existingConfig] = await Promise.all([
-      this.fetchMetaconfig(previewUrl).catch(() => null),
+      this.fetchMetaconfig(getEffectiveBaseURL(site)).catch(() => null),
       this.fetchConfig(previewUrl, false),
     ]);
 

--- a/packages/spacecat-shared-tokowaka-client/src/utils/s3-utils.js
+++ b/packages/spacecat-shared-tokowaka-client/src/utils/s3-utils.js
@@ -115,8 +115,11 @@ export function getTokowakaMetaconfigS3Path(url, logger, isPreview = false) {
     const urlObj = new URL(url);
     const normalizedHostName = getHostName(urlObj, logger);
     const prefix = isPreview ? 'preview/opportunities' : 'opportunities';
+    const subpath = urlObj.pathname === '/' ? '' : urlObj.pathname.replace(/\/+$/, '');
 
-    return `${prefix}/${normalizedHostName}/config`;
+    return subpath
+      ? `${prefix}/${normalizedHostName}${subpath}/config`
+      : `${prefix}/${normalizedHostName}/config`;
   } catch (error) {
     logger.error(`Error generating metaconfig S3 path for URL ${url}: ${error.message}`);
     throw new Error(`Failed to generate metaconfig S3 path: ${error.message}`);

--- a/packages/spacecat-shared-tokowaka-client/test/utils/s3-utils.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/utils/s3-utils.test.js
@@ -96,18 +96,46 @@ describe('S3 Utils', () => {
   });
 
   describe('getTokowakaMetaconfigS3Path', () => {
-    it('should generate correct metaconfig S3 path for deploy', () => {
-      const url = 'https://example.com/page1';
+    it('should generate correct metaconfig S3 path for root site', () => {
+      const url = 'https://example.com';
       const logger = { error: () => {} };
       const result = getTokowakaMetaconfigS3Path(url, logger, false);
       expect(result).to.equal('opportunities/example.com/config');
     });
 
-    it('should generate correct metaconfig S3 path for preview', () => {
-      const url = 'https://example.com/page1';
+    it('should generate correct metaconfig S3 path for root site with trailing slash', () => {
+      const url = 'https://example.com/';
+      const logger = { error: () => {} };
+      const result = getTokowakaMetaconfigS3Path(url, logger, false);
+      expect(result).to.equal('opportunities/example.com/config');
+    });
+
+    it('should generate subpath-scoped metaconfig S3 path for subpath site', () => {
+      const url = 'https://example.com/subsite';
+      const logger = { error: () => {} };
+      const result = getTokowakaMetaconfigS3Path(url, logger, false);
+      expect(result).to.equal('opportunities/example.com/subsite/config');
+    });
+
+    it('should strip trailing slash from subpath site URL', () => {
+      const url = 'https://example.com/subsite/';
+      const logger = { error: () => {} };
+      const result = getTokowakaMetaconfigS3Path(url, logger, false);
+      expect(result).to.equal('opportunities/example.com/subsite/config');
+    });
+
+    it('should generate correct preview metaconfig S3 path for root site', () => {
+      const url = 'https://example.com';
       const logger = { error: () => {} };
       const result = getTokowakaMetaconfigS3Path(url, logger, true);
       expect(result).to.equal('preview/opportunities/example.com/config');
+    });
+
+    it('should generate correct preview metaconfig S3 path for subpath site', () => {
+      const url = 'https://example.com/subsite';
+      const logger = { error: () => {} };
+      const result = getTokowakaMetaconfigS3Path(url, logger, true);
+      expect(result).to.equal('preview/opportunities/example.com/subsite/config');
     });
 
     it('should throw error on invalid URL', () => {


### PR DESCRIPTION
## Summary

- `getTokowakaMetaconfigS3Path` now includes the URL subpath in the S3 key, so two sites sharing a domain but with different base URL paths (e.g. `nba.com` and `nba.com/timberwolves`) get separate metaconfig objects: `opportunities/nba.com/config.json` and `opportunities/nba.com/timberwolves/config.json`
- Fixed `deploySuggestions` passing a page URL to `fetchMetaconfig` instead of the site `baseURL`
- Fixed `previewSuggestions` passing `previewUrl` (a page URL) to `fetchMetaconfig` instead of `getEffectiveBaseURL(site)`
- Tests updated to use root base URLs for existing cases; 4 new subpath test cases added

## Context

Part of LLMO-4580 — supporting two sites with the same domain but different subpath base URLs as independent SpaceCat entities with separate `siteId`s and IMS orgs.

## Dependencies

This PR should merge before:
- `tokowaka-worker` — edge worker config lookup (reads from S3 at the key this PR writes)
- `spacecat-api-service` — already uses `getEffectiveBaseURL(site)` for metaconfig, no change needed there

## Test plan

- [ ] `npm test -w packages/spacecat-shared-tokowaka-client` passes
- [ ] Verify `getTokowakaMetaconfigS3Path('https://nba.com')` → `opportunities/nba.com/config`
- [ ] Verify `getTokowakaMetaconfigS3Path('https://nba.com/timberwolves')` → `opportunities/nba.com/timberwolves/config`
- [ ] Integration: onboard two sites with same domain, different paths; confirm separate `config.json` objects in S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)