### PR TITLE
feat(tokowaka-client): mark path-level suggestions as coveredByDomainWide on domain-wide deploy

### DIFF
--- a/packages/spacecat-shared-tokowaka-client/src/index.js
+++ b/packages/spacecat-shared-tokowaka-client/src/index.js
@@ -1532,11 +1532,13 @@ class TokowakaClient {
       if (!isEdgeDeployableSuggestionStatus(s.getStatus())) {
         return false;
       }
-      if (isPatternSuggestion(s)) {
-        return false;
-      }
       if (s.getData()?.edgeDeployed) {
         return false;
+      }
+      // Path-level pattern suggestions (not domain-wide) are fully covered by a
+      // domain-wide deployment. Other pattern suggestions (including other DW ones) are not.
+      if (isPatternSuggestion(s)) {
+        return coverageField === 'coveredByDomainWide' && !s.getData()?.isDomainWide;
       }
       const url = s.getData()?.url;
       return url && matchers.some((match) => match(url));

--- a/packages/spacecat-shared-tokowaka-client/test/index.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/index.test.js
@@ -3117,6 +3117,50 @@ describe('TokowakaClient', () => {
       expect(coveredData).to.not.have.property('coveredByDomainWide');
     });
 
+    it('cleans up coveredByDomainWide on path-level suggestions when rolling back domain-wide', async () => {
+      const prerenderOpportunity = { getId: () => 'opp-dw', getType: () => 'prerender' };
+      const dwSuggestion = {
+        getId: () => 'dw-1',
+        getData: () => ({
+          isDomainWide: true,
+          allowedRegexPatterns: ['/*'],
+          edgeDeployed: Date.now(),
+        }),
+        setData: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      const pathSuggestion = {
+        getId: () => 'path-1',
+        getData: () => ({
+          allowedRegexPatterns: ['/products/*'],
+          coveredByDomainWide: 'dw-1',
+        }),
+        setData: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      sinon.stub(client, 'fetchMetaconfig').resolves({
+        siteId: 'site-123',
+        prerender: { allowList: ['/*'] },
+      });
+      sinon.stub(client, 'uploadMetaconfig').resolves();
+
+      const result = await client.rollbackSuggestions(
+        mockSite,
+        prerenderOpportunity,
+        [dwSuggestion],
+        { allSuggestions: [dwSuggestion, pathSuggestion], updatedBy: 'test@example.com' },
+      );
+
+      expect(result.succeededSuggestions).to.include(dwSuggestion);
+      expect(pathSuggestion.setData.calledOnce).to.be.true;
+      const pathData = pathSuggestion.setData.firstCall.args[0];
+      expect(pathData).to.not.have.property('coveredByDomainWide');
+      expect(pathData).to.have.property('allowedRegexPatterns');
+    });
+
     it('cleans up covered suggestions (coveredByPattern) when rolling back a path-level pattern', async () => {
       const prerenderOpportunity = { getId: () => 'opp-p', getType: () => 'prerender' };
       const pathSuggestion = {
@@ -5907,6 +5951,51 @@ describe('TokowakaClient', () => {
 
       // dw2 is domain-wide so should not appear in coveredSuggestions
       expect(result.coveredSuggestions).to.not.include(dw2);
+    });
+
+    it('should mark path-level pattern suggestions as coveredByDomainWide when domain-wide is deployed', async () => {
+      const dw = makeSuggestion('dw1', {
+        isDomainWide: true,
+        allowedRegexPatterns: ['^https://example\\.com/.*'],
+      });
+      const pathLevel = makeSuggestion('path1', {
+        allowedRegexPatterns: ['/products/*'],
+      });
+
+      fetchMetaconfigStub.resolves({ siteId: 'site-123' });
+
+      const result = await client.deployToEdge({
+        site: mockSite,
+        opportunity: mockOpportunity,
+        targetSuggestions: [dw],
+        allSuggestions: [dw, pathLevel],
+      });
+
+      expect(result.coveredSuggestions).to.include(pathLevel);
+      expect(pathLevel.getData()).to.have.property('coveredByDomainWide', 'dw1');
+    });
+
+    it('should not mark already-deployed path-level suggestions as coveredByDomainWide', async () => {
+      const dw = makeSuggestion('dw1', {
+        isDomainWide: true,
+        allowedRegexPatterns: ['^https://example\\.com/.*'],
+      });
+      const pathLevel = makeSuggestion('path1', {
+        allowedRegexPatterns: ['/products/*'],
+        edgeDeployed: Date.now(),
+      });
+
+      fetchMetaconfigStub.resolves({ siteId: 'site-123' });
+
+      const result = await client.deployToEdge({
+        site: mockSite,
+        opportunity: mockOpportunity,
+        targetSuggestions: [dw],
+        allSuggestions: [dw, pathLevel],
+      });
+
+      expect(result.coveredSuggestions).to.not.include(pathLevel);
+      expect(pathLevel.getData()).to.not.have.property('coveredByDomainWide');
     });
 
     it('should not mark non-NEW suggestions as covered', async () => {

--- a/packages/spacecat-shared-tokowaka-client/test/index.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/index.test.js
@@ -3159,6 +3159,11 @@ describe('TokowakaClient', () => {
       const pathData = pathSuggestion.setData.firstCall.args[0];
       expect(pathData).to.not.have.property('coveredByDomainWide');
       expect(pathData).to.have.property('allowedRegexPatterns');
+      // Verify the cleaned-up path suggestion was actually persisted via saveMany
+      expect(client.dataAccess.Suggestion.saveMany).to.have.been.calledWith(
+        sinon.match((arr) => arr.includes(pathSuggestion)),
+        sinon.match.any,
+      );
     });
 
     it('cleans up covered suggestions (coveredByPattern) when rolling back a path-level pattern', async () => {


### PR DESCRIPTION
## Summary

- When a domain-wide pattern suggestion is deployed, path-level pattern suggestions (those with `allowedRegexPatterns` but not `isDomainWide`) are now marked with `coveredByDomainWide: <suggestionId>`, since a domain-wide deployment covers all path-level patterns
- When the domain-wide suggestion is rolled back, `coveredByDomainWide` is stripped from those path-level suggestions (the existing rollback cleanup logic already handles this correctly)
- Already-deployed (`edgeDeployed`) path-level suggestions and other domain-wide suggestions are not marked

## Changes

**`src/index.js`** — `#deployPatternSuggestion`: reordered the `edgeDeployed` guard before `isPatternSuggestion`, and changed the pattern suggestion exclusion to allow path-level suggestions through when deploying domain-wide

**`test/index.test.js`** — two new deploy tests (path-level gets marked, already-deployed path-level is skipped) and one new rollback test (path-level `coveredByDomainWide` is cleaned up on DW rollback)

## Test plan

- [x] All 776 tests passing
- [x] 100% line/branch/function/statement coverage maintained