### PR TITLE
fix: tighten press/click.*hold regex to prevent false positives on normal page content

### DIFF
--- a/packages/spacecat-shared-utils/src/bot-blocker-detect/bot-blocker-detect.js
+++ b/packages/spacecat-shared-utils/src/bot-blocker-detect/bot-blocker-detect.js
@@ -103,8 +103,8 @@ const CHALLENGE_PATTERNS = {
     /hcaptcha/i,
     /datadome/i,
     /dd-request-id/i,
-    /press.*hold/i, // Press and hold challenges (hCaptcha, custom implementations)
-    /click.*hold/i, // Click and hold button challenges
+    /press\s+(and\s+)?hold/i, // Press and hold challenges (hCaptcha, custom implementations)
+    /click\s+(and\s+)?hold/i, // Click and hold button challenges
     /geetest/i, // GeeTest interactive challenges
     /arkose/i, // Arkose Labs bot protection
     /funcaptcha/i, // FunCaptcha interactive challenges

--- a/packages/spacecat-shared-utils/test/bot-blocker-detect/bot-blocker-detect.test.js
+++ b/packages/spacecat-shared-utils/test/bot-blocker-detect/bot-blocker-detect.test.js
@@ -959,6 +959,20 @@ describe('Bot Blocker Detection', () => {
       expect(result.confidence).to.equal(0.7);
     });
 
+    it('does not false-positive on "pressure" and "placeholder" in normal page content', () => {
+      const html = '<html><body><p>Monitor your blood pressure at home.</p><input placeholder="Enter value"></body></html>';
+      const headers = {};
+
+      const result = analyzeBotProtection({
+        status: 200,
+        headers,
+        html,
+      });
+
+      expect(result.crawlable).to.be.true;
+      expect(result.type).to.equal('none');
+    });
+
     it('detects GeeTest interactive challenge', () => {
       const html = '<html><body><div class="geetest_challenge"></div></body></html>';
       const headers = {};


### PR DESCRIPTION
## Summary

- `CHALLENGE_PATTERNS.general` contained `/press.*hold/i` and `/click.*hold/i` with unbounded `.*` wildcards
- On sites with minified HTML, these matched across thousands of characters — e.g. `blood pressure monitor` (index 281,995) to `placeholder graphic` (index 291,537) on athenahealth.com — causing a false-positive `crawlable: false` result despite the site returning HTTP 200 with no challenge page
- Tightened both patterns to require the words to be adjacent (with optional "and"): `/press\s+(and\s+)?hold/i` — matching real challenge copy like "Press and hold the button" while rejecting incidental word proximity

## Changes

- `src/bot-blocker-detect/bot-blocker-detect.js`: narrow `press.*hold` and `click.*hold` patterns
- `test/bot-blocker-detect/bot-blocker-detect.test.js`: add regression test covering `blood pressure` + `placeholder` content

## Test plan

- [ ] All 1155 existing tests continue to pass
- [ ] New regression test `does not false-positive on "pressure" and "placeholder" in normal page content` passes
- [ ] Real "Press and hold" and "Click and hold" challenge strings still detected correctly