### PR TITLE
feat(utils): accept optional headers in detectBotBlocker

### DIFF
--- a/packages/spacecat-shared-utils/src/bot-blocker-detect/bot-blocker-detect.js
+++ b/packages/spacecat-shared-utils/src/bot-blocker-detect/bot-blocker-detect.js
@@ -326,6 +326,9 @@ function analyzeError(error) {
  *
  * @param {Object} config - Configuration object
  * @param {string} config.baseUrl - The base URL to check
+ * @param {Object} [config.headers={}] - Extra request headers to send alongside the
+ *   probe (e.g. per-site `scraperConfig.headers` so the probe mirrors what the
+ *   real scraper sends). `User-Agent` is always overridden with SPACECAT_USER_AGENT.
  * @param {number} [config.timeout=5000] - Request timeout in milliseconds
  * @param {Object} [config.log=console] - Logger with warn/debug methods
  * @returns {Promise<Object>} Detection result with:
@@ -337,7 +340,12 @@ function analyzeError(error) {
  *   - confidence {number}: Confidence level (0.0-1.0, see confidence level constants)
  * @throws {Error} If baseUrl is not a valid URL
  */
-export async function detectBotBlocker({ baseUrl, timeout = DEFAULT_TIMEOUT, log = console }) {
+export async function detectBotBlocker({
+  baseUrl,
+  headers = {},
+  timeout = DEFAULT_TIMEOUT,
+  log = console,
+}) {
   if (!baseUrl || !isValidUrl(baseUrl)) {
     throw new Error('Invalid baseUrl');
   }
@@ -362,7 +370,11 @@ export async function detectBotBlocker({ baseUrl, timeout = DEFAULT_TIMEOUT, log
     for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
       response = await tracingFetch(currentUrl, { // eslint-disable-line no-await-in-loop
         method: 'GET',
-        headers: { 'User-Agent': SPACECAT_USER_AGENT },
+        // Caller headers first, scraper-owned UA last so it always wins on conflict.
+        // The schema in @adobe/spacecat-shared-data-access already blocks User-Agent
+        // and other reserved names from `scraperConfig.headers`; this ordering is a
+        // belt-and-braces defense for any older callers.
+        headers: { ...headers, 'User-Agent': SPACECAT_USER_AGENT },
         redirect: 'manual',
         timeout,
       });

--- a/packages/spacecat-shared-utils/src/bot-blocker-detect/index.d.ts
+++ b/packages/spacecat-shared-utils/src/bot-blocker-detect/index.d.ts
@@ -12,6 +12,7 @@
 
 export interface BotBlockerConfig {
   baseUrl: string;
+  headers?: Record<string, string>;
   timeout?: number;
 }
 

--- a/packages/spacecat-shared-utils/test/bot-blocker-detect/bot-blocker-detect.test.js
+++ b/packages/spacecat-shared-utils/test/bot-blocker-detect/bot-blocker-detect.test.js
@@ -233,6 +233,41 @@ describe('Bot Blocker Detection', () => {
       expect(result.confidence).to.equal(0.5);
     });
 
+    it('forwards caller-supplied headers on the probe request', async () => {
+      // Mirrors the scraper allowlist case (e.g. Akamai Bot Manager requiring
+      // `Accept-Language`): the probe must send the same custom headers the
+      // real scraper sends, otherwise it reports a false-positive block.
+      nock(baseUrl)
+        .matchHeader('Accept-Language', 'en-US')
+        .matchHeader('X-Foo', 'bar')
+        .get('/')
+        .reply(200, '<html></html>');
+
+      const result = await detectBotBlocker({
+        baseUrl,
+        headers: { 'Accept-Language': 'en-US', 'X-Foo': 'bar' },
+      });
+
+      expect(result.crawlable).to.be.true;
+    });
+
+    it('overrides caller-supplied User-Agent with SPACECAT_USER_AGENT', async () => {
+      // The schema in @adobe/spacecat-shared-data-access blocks User-Agent at
+      // write time, but defend in depth: if a caller somehow passes one, the
+      // probe must still identify as the scraper UA.
+      nock(baseUrl)
+        .matchHeader('User-Agent', (v) => v && v !== 'attacker-ua')
+        .get('/')
+        .reply(200, '<html></html>');
+
+      const result = await detectBotBlocker({
+        baseUrl,
+        headers: { 'User-Agent': 'attacker-ua' },
+      });
+
+      expect(result.crawlable).to.be.true;
+    });
+
     it('detects Cloudflare blocking with 403 and cf-ray header', async () => {
       nock(baseUrl)
         .get('/')


### PR DESCRIPTION
## Related Issues
- LLMO-4975 — careinsurance.com bot-blocker probe reports false-positive block even though scraping succeeds via `scraperConfig.headers`

## Summary
Plumb an optional `headers` map into `detectBotBlocker` so callers can mirror the headers the real scraper sends. Today the probe hits the origin with only a hardcoded `User-Agent`, so any site whose WAF allowlists scraper traffic via a required header (e.g. Akamai Bot Manager checking `Accept-Language`) probes as `crawlable: false` even though the scraper itself gets through fine.

`headers` defaults to `{}`, so existing callers are unaffected. `User-Agent` is spread last in the fetch headers and always overridden with `SPACECAT_USER_AGENT` — the `scraperConfig` schema in `@adobe/spacecat-shared-data-access` already blocks reserved header names at write time; the ordering is belt-and-braces.

## Test plan
- [x] 2 new unit tests: headers passthrough + UA override defense
- [x] Full `spacecat-shared-utils` suite passes (1154 tests)
- [x] ESLint clean 