### PR TITLE
feat: add llmo-admin IMS group for admin check

### DIFF
--- a/packages/spacecat-shared-http-utils/src/auth/handlers/ims.js
+++ b/packages/spacecat-shared-http-utils/src/auth/handlers/ims.js
@@ -85,10 +85,14 @@ function mergeAdminGroupIdents(...groupMaps) {
   );
 }
 
-const IMS_ADMIN_GROUP_IDENT = mergeAdminGroupIdents(
-  ASO_ADMIN_GROUP_IDENT,
-  LLMO_ADMIN_GROUP_IDENT,
+const IMS_ADMIN_GROUP_IDENT = Object.freeze(
+  Object.fromEntries(
+    Object.entries(
+      mergeAdminGroupIdents(ASO_ADMIN_GROUP_IDENT, LLMO_ADMIN_GROUP_IDENT),
+    ).map(([orgIdent, groupIdents]) => [orgIdent, Object.freeze(groupIdents)]),
+  ),
 );
+
 const SERVICE_CODE = 'dx_aem_perf';
 const loadConfig = (context) => {
   try {

--- a/packages/spacecat-shared-http-utils/src/auth/handlers/ims.js
+++ b/packages/spacecat-shared-http-utils/src/auth/handlers/ims.js
@@ -64,7 +64,7 @@ const LLMO_ADMIN_GROUP_IDENT = {
   ],
   '908936ED5D35CC220A495CD4': [
     964401320, // LLMO admin group for prod
-    901092291, // on call engineers (shared with ASO)
+    901092291,
   ],
 };
 
@@ -73,16 +73,16 @@ function mergeAdminGroupIdents(...groupMaps) {
   for (const map of groupMaps) {
     for (const [orgIdent, groupIdents] of Object.entries(map)) {
       if (!merged[orgIdent]) {
-        merged[orgIdent] = [];
+        merged[orgIdent] = new Set();
       }
       for (const groupIdent of groupIdents) {
-        if (!merged[orgIdent].includes(groupIdent)) {
-          merged[orgIdent].push(groupIdent);
-        }
+        merged[orgIdent].add(groupIdent);
       }
     }
   }
-  return merged;
+  return Object.fromEntries(
+    Object.entries(merged).map(([orgIdent, groupSet]) => [orgIdent, [...groupSet]]),
+  );
 }
 
 const IMS_ADMIN_GROUP_IDENT = mergeAdminGroupIdents(
@@ -126,10 +126,10 @@ function getTenants(organizations) {
 }
 
 /**
- * True when the user belongs to an ASO or LLMO IMS admin group for any org.
+ * True when the user belongs to a platform IMS admin group (ASO, LLMO, etc.) for any org.
  * Used with @adobe.com email to grant the admin scope (hasAdminReadAccess bypass).
  */
-function isUserASOorLLMOAdmin(organizations) {
+function isUserPlatformAdmin(organizations) {
   if (!organizations) {
     throw new Error('organizations param is required.');
   }
@@ -258,7 +258,7 @@ export default class AdobeImsHandler extends AbstractHandler {
         this.log('User belongs to a read-only org, blocking IMS authentication', 'warn');
         throw new Error('Unauthorized');
       }
-      const isAdmin = isUserASOorLLMOAdmin(organizations);
+      const isAdmin = isUserPlatformAdmin(organizations);
       const scopes = [];
       if (imsProfile.email?.toLowerCase().endsWith('@adobe.com') && isAdmin) {
         scopes.push({ name: 'admin' });

--- a/packages/spacecat-shared-http-utils/src/auth/handlers/ims.js
+++ b/packages/spacecat-shared-http-utils/src/auth/handlers/ims.js
@@ -129,7 +129,7 @@ function getTenants(organizations) {
  * True when the user belongs to an ASO or LLMO IMS admin group for any org.
  * Used with @adobe.com email to grant the admin scope (hasAdminReadAccess bypass).
  */
-function isUserImsAdmin(organizations) {
+function isUserASOorLLMOAdmin(organizations) {
   if (!organizations) {
     throw new Error('organizations param is required.');
   }
@@ -258,7 +258,7 @@ export default class AdobeImsHandler extends AbstractHandler {
         this.log('User belongs to a read-only org, blocking IMS authentication', 'warn');
         throw new Error('Unauthorized');
       }
-      const isAdmin = isUserImsAdmin(organizations);
+      const isAdmin = isUserASOorLLMOAdmin(organizations);
       const scopes = [];
       if (imsProfile.email?.toLowerCase().endsWith('@adobe.com') && isAdmin) {
         scopes.push({ name: 'admin' });

--- a/packages/spacecat-shared-http-utils/src/auth/handlers/ims.js
+++ b/packages/spacecat-shared-http-utils/src/auth/handlers/ims.js
@@ -37,7 +37,11 @@ const IGNORED_PROFILE_PROPS = [
   'aa_id',
 ];
 
-const ADMIN_GROUP_IDENT = {
+/**
+ * ASO (Sites Optimizer) IMS admin groups.
+ * Keep in sync with auth-service ADMIN_GROUP_IDENT_BY_PRODUCT.ASO.
+ */
+const ASO_ADMIN_GROUP_IDENT = {
   '8C6043F15F43B6390A49401A': [ // IMS admin group for stag
     635541219,
   ],
@@ -52,6 +56,39 @@ const ADMIN_GROUP_IDENT = {
     945802231, // IMS admin group for AEM Showcase org users
   ],
 };
+
+/** LLMO IMS admin groups — keep in sync with auth-service ADMIN_GROUP_IDENT_BY_PRODUCT.LLMO */
+const LLMO_ADMIN_GROUP_IDENT = {
+  '8C6043F15F43B6390A49401A': [ // LLMO admin group for stag
+    748308943,
+  ],
+  '908936ED5D35CC220A495CD4': [
+    964401320, // LLMO admin group for prod
+    901092291, // on call engineers (shared with ASO)
+  ],
+};
+
+function mergeAdminGroupIdents(...groupMaps) {
+  const merged = {};
+  for (const map of groupMaps) {
+    for (const [orgIdent, groupIdents] of Object.entries(map)) {
+      if (!merged[orgIdent]) {
+        merged[orgIdent] = [];
+      }
+      for (const groupIdent of groupIdents) {
+        if (!merged[orgIdent].includes(groupIdent)) {
+          merged[orgIdent].push(groupIdent);
+        }
+      }
+    }
+  }
+  return merged;
+}
+
+const IMS_ADMIN_GROUP_IDENT = mergeAdminGroupIdents(
+  ASO_ADMIN_GROUP_IDENT,
+  LLMO_ADMIN_GROUP_IDENT,
+);
 const SERVICE_CODE = 'dx_aem_perf';
 const loadConfig = (context) => {
   try {
@@ -88,13 +125,17 @@ function getTenants(organizations) {
   }));
 }
 
-function isUserASOAdmin(organizations) {
+/**
+ * True when the user belongs to an ASO or LLMO IMS admin group for any org.
+ * Used with @adobe.com email to grant the admin scope (hasAdminReadAccess bypass).
+ */
+function isUserImsAdmin(organizations) {
   if (!organizations) {
     throw new Error('organizations param is required.');
   }
 
   return organizations.some((org) => {
-    const adminGroupsForOrg = ADMIN_GROUP_IDENT[org.orgRef.ident];
+    const adminGroupsForOrg = IMS_ADMIN_GROUP_IDENT[org.orgRef.ident];
     if (!adminGroupsForOrg) {
       return false;
     }
@@ -217,7 +258,7 @@ export default class AdobeImsHandler extends AbstractHandler {
         this.log('User belongs to a read-only org, blocking IMS authentication', 'warn');
         throw new Error('Unauthorized');
       }
-      const isAdmin = isUserASOAdmin(organizations);
+      const isAdmin = isUserImsAdmin(organizations);
       const scopes = [];
       if (imsProfile.email?.toLowerCase().endsWith('@adobe.com') && isAdmin) {
         scopes.push({ name: 'admin' });

--- a/packages/spacecat-shared-http-utils/test/auth/handlers/ims.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/handlers/ims.test.js
@@ -402,6 +402,62 @@ describe('AdobeImsHandler', () => {
       expect(result.authenticated).to.be.true;
       expect(result.scopes).to.deep.equal([{ name: 'admin' }]);
     });
+
+    it('gives admin scope to @adobe.com users in LLMO Admin group without ASO admin group', async () => {
+      const token = await createToken({
+        user_id: 'llmo-admin@adobe.com',
+        as: 'ims-na1-stg1',
+        created_at: Date.now(),
+        expires_in: 3600,
+      });
+      context.pathInfo.headers.authorization = `Bearer ${token}`;
+
+      mockImsClient.getImsUserProfile.resolves({
+        email: 'llmo-admin@adobe.com',
+      });
+      mockImsClient.getImsUserOrganizations.resolves([
+        {
+          orgRef: { ident: '908936ED5D35CC220A495CD4' },
+          groups: [{ ident: 964401320 }],
+        },
+      ]);
+
+      const result = await handler.checkAuth({}, context);
+
+      expect(result).to.be.instanceof(AuthInfo);
+      expect(result.authenticated).to.be.true;
+      expect(result.scopes).to.deep.equal([{ name: 'admin' }]);
+    });
+
+    it('does not give admin scope when user has only LLMO Admin group and non-adobe email', async () => {
+      const token = await createToken({
+        user_id: 'customer@example.com',
+        as: 'ims-na1-stg1',
+        created_at: Date.now(),
+        expires_in: 3600,
+      });
+      context.pathInfo.headers.authorization = `Bearer ${token}`;
+
+      mockImsClient.getImsUserProfile.resolves({
+        email: 'customer@example.com',
+      });
+      mockImsClient.getImsUserOrganizations.resolves([
+        {
+          orgRef: { ident: '908936ED5D35CC220A495CD4' },
+          groups: [{ ident: 964401320 }],
+        },
+      ]);
+
+      const result = await handler.checkAuth({}, context);
+
+      expect(result).to.be.instanceof(AuthInfo);
+      expect(result.authenticated).to.be.true;
+      expect(result.scopes).to.deep.equal([{
+        name: 'user',
+        domains: ['908936ED5D35CC220A495CD4'],
+        subScopes: ['dx_aem_perf_auto_suggest', 'dx_aem_perf_auto_fix'],
+      }]);
+    });
   });
 
   describe('read-only org feature flag gate', () => {


### PR DESCRIPTION
# PR Summary: LLMO Admin IMS group for platform admin scope

**Branch:** `feat/llmo-imsauth`  
**Package:** `@adobe/spacecat-shared-http-utils`  
**Files changed:** 2 (+101 / −4 lines)

## Problem

When clients authenticate to **spacecat-api-service** with a raw **IMS** token (not a JWT from auth-service login), only **ASO** IMS admin groups were recognized for the platform **`admin` scope**. That scope drives `hasAdminReadAccess()` and bypasses per-organization checks in controllers such as Serenity `hasAccess(organization)`.

Internal users who are in the **LLMO Admin** IMS group but not in ASO admin groups could receive **403 Forbidden** on org-scoped APIs even when their email is `@adobe.com` and they are members of Adobe Corp in IMS.

## Solution

Extend the IMS handler admin-group check to include **LLMO** admin groups, aligned with `spacecat-auth-service` `ADMIN_GROUP_IDENT_BY_PRODUCT`.

### `packages/spacecat-shared-http-utils/src/auth/handlers/ims.js`

- **`ASO_ADMIN_GROUP_IDENT`** — renamed from `ADMIN_GROUP_IDENT`; same ASO group idents as before.
- **`LLMO_ADMIN_GROUP_IDENT`** — new; keep in sync with auth-service `ADMIN_GROUP_IDENT_BY_PRODUCT.LLMO`:
  - Stag (`8C6043F15F43B6390A49401A`): `748308943`
  - Prod (`908936ED5D35CC220A495CD4`): `964401320`, `901092291` (on-call, shared with ASO)
- **`mergeAdminGroupIdents()`** — merges ASO and LLMO maps per org (deduped group idents).
- **`IMS_ADMIN_GROUP_IDENT`** — merged lookup used for admin checks.
- **`isUserASOorLLMOAdmin()`** — replaces `isUserASOAdmin`; returns true if the user is in any ASO or LLMO admin group for any IMS org.
- **`checkAuth`** — unchanged rule: `@adobe.com` email **and** `isUserASOorLLMOAdmin()` → `{ name: 'admin' }` scope only (no tenant list). Otherwise, normal `user` scopes from all IMS org memberships.

### `packages/spacecat-shared-http-utils/test/auth/handlers/ims.test.js`

- `@adobe.com` + LLMO Admin only (prod `964401320`, no ASO admin group) → `admin` scope.
- Non-Adobe email + LLMO Admin → `user` scope with tenant domains (no admin bypass).

## Behavior unchanged

- Admin scope still requires **`@adobe.com`** (case-insensitive).
- Read-only org LaunchDarkly gate, JWT validation, and tenant scope shape for non-admins are unchanged.
- **`is_llmo_administrator`** on the profile is still set via auth-service JWT login, not this IMS path.

## Consumer follow-up

After release, bump **`@adobe/spacecat-shared-http-utils`** in **spacecat-api-service** (and any other service using `AdobeImsHandler`) so production picks up the change.

## Test plan

- [ ] From monorepo root: `npm install` then `npm test -w packages/spacecat-shared-http-utils`
- [ ] Confirm new IMS handler tests pass
- [ ] After publish, verify api-service with updated dependency: IMS `@adobe.com` user in LLMO Admin can access org-scoped routes (e.g. Serenity) without 403

