### PR TITLE
feat(seo-client): add quality filters to broken-backlinks Semrush call (404+410, follow, text, no lostlinks)

### DIFF
--- a/packages/mysticat-shared-seo-client/src/client.js
+++ b/packages/mysticat-shared-seo-client/src/client.js
@@ -770,7 +770,9 @@ export default class SeoClient {
       ...parseCsvResponse(pages410Body),
     ]
       .filter((p) => {
-        if (seenUrls.has(p.source_url)) { return false; }
+        if (seenUrls.has(p.source_url)) {
+          return false;
+        }
         seenUrls.add(p.source_url);
         return true;
       })

--- a/packages/mysticat-shared-seo-client/src/client.js
+++ b/packages/mysticat-shared-seo-client/src/client.js
@@ -770,7 +770,7 @@ export default class SeoClient {
       ...parseCsvResponse(pages410Body),
     ]
       .filter((p) => {
-        if (seenUrls.has(p.source_url)) return false;
+        if (seenUrls.has(p.source_url)) { return false; }
         seenUrls.add(p.source_url);
         return true;
       })

--- a/packages/mysticat-shared-seo-client/src/client.js
+++ b/packages/mysticat-shared-seo-client/src/client.js
@@ -744,16 +744,24 @@ export default class SeoClient {
     const epLinks = ENDPOINTS.brokenBacklinks;
     const effectiveLimit = getLimit(limit, 100);
 
-    // Step 1: Find broken (404) target pages, sorted by referring domains
+    // Step 1: Find broken (404/410) target pages with quality filters:
+    //   - 404 OR 410 response codes (gone pages)
+    //   - follow links only (nofollow links carry no SEO value)
+    //   - text links only (more actionable than image/frame links)
+    //   - exclude lostlinks (only active broken backlinks, not already-removed ones)
     const { body: pagesBody, fullAuditRef } = await this.sendRawRequest({
       type: epPages.type,
       target: url,
       target_type: 'domain',
       export_columns: epPages.columns,
       display_limit: effectiveLimit,
-      display_filter: buildFilter([{
-        sign: '+', field: 'responsecode', op: 'Eq', value: '404',
-      }]),
+      display_filter: buildFilter([
+        { sign: '+', field: 'responsecode', op: 'Eq', value: '404' },
+        { sign: 'Or', field: 'responsecode', op: 'Eq', value: '410' },
+        { sign: '+', field: 'type', op: '', value: 'follow' },
+        { sign: '+', field: 'type', op: '', value: 'text' },
+        { sign: '-', field: 'type', op: '', value: 'lostlink' },
+      ]),
       ...epPages.defaultParams,
     }, epPages.path);
     const brokenPages = parseCsvResponse(pagesBody);

--- a/packages/mysticat-shared-seo-client/src/client.js
+++ b/packages/mysticat-shared-seo-client/src/client.js
@@ -744,24 +744,55 @@ export default class SeoClient {
     const epLinks = ENDPOINTS.brokenBacklinks;
     const effectiveLimit = getLimit(limit, 100);
 
-    // Step 1: Find broken (404/410) target pages with quality filters:
-    //   - 404 OR 410 response codes (gone pages)
-    //   - follow links only (nofollow links carry no SEO value)
-    //   - text links only (more actionable than image/frame links)
-    //   - exclude lostlinks (only active broken backlinks, not already-removed ones)
-    const { body: pagesBody, fullAuditRef } = await this.sendRawRequest({
+    // Step 1: Find broken target pages — 404 and 410 in parallel (Semrush does not support OR
+    // within a single display_filter, so we issue two requests and merge the results).
+    const pageParams = (code) => ({
       type: epPages.type,
       target: url,
       target_type: 'domain',
       export_columns: epPages.columns,
       display_limit: effectiveLimit,
+      display_filter: buildFilter([{
+        sign: '+', field: 'responsecode', op: 'Eq', value: code,
+      }]),
+      ...epPages.defaultParams,
+    });
+
+    const [{ body: pages404Body, fullAuditRef }, { body: pages410Body }] = await Promise.all([
+      this.sendRawRequest(pageParams('404'), epPages.path),
+      this.sendRawRequest(pageParams('410'), epPages.path),
+    ]);
+
+    // Merge, deduplicate by source_url, re-sort by domains_num descending, cap at limit.
+    const seenUrls = new Set();
+    const brokenPages = [
+      ...parseCsvResponse(pages404Body),
+      ...parseCsvResponse(pages410Body),
+    ]
+      .filter((p) => {
+        if (seenUrls.has(p.source_url)) return false;
+        seenUrls.add(p.source_url);
+        return true;
+      })
+      .sort((a, b) => Number(b.domains_num) - Number(a.domains_num))
+      .slice(0, effectiveLimit);
+
+    if (brokenPages.length === 0) {
+      return { result: { backlinks: [] }, fullAuditRef };
+    }
+
+    // Step 2: For each broken page, fetch the top backlink by authority score with quality filters:
+    //   - follow links only (nofollow links carry no SEO value)
+    //   - text links only (more actionable than image/frame links)
+    //   - exclude lostlinks (only active broken backlinks, not already-removed ones)
+    const brokenUrls = brokenPages.map((p) => p.source_url);
+    const linkResults = await this.fanOut(brokenUrls, (brokenUrl) => this.sendRawRequest({
+      type: epLinks.type,
+      target: brokenUrl,
+      target_type: 'url',
+      export_columns: epLinks.columns,
+      display_limit: 1,
       display_filter: buildFilter([
-        {
-          sign: '+', field: 'responsecode', op: 'Eq', value: '404',
-        },
-        {
-          sign: 'Or', field: 'responsecode', op: 'Eq', value: '410',
-        },
         {
           sign: '+', field: 'type', op: '', value: 'follow',
         },
@@ -772,22 +803,6 @@ export default class SeoClient {
           sign: '-', field: 'type', op: '', value: 'lostlink',
         },
       ]),
-      ...epPages.defaultParams,
-    }, epPages.path);
-    const brokenPages = parseCsvResponse(pagesBody);
-
-    if (brokenPages.length === 0) {
-      return { result: { backlinks: [] }, fullAuditRef };
-    }
-
-    // Step 2: For each broken page, fetch the top backlink by authority score.
-    const brokenUrls = brokenPages.map((p) => p.source_url);
-    const linkResults = await this.fanOut(brokenUrls, (brokenUrl) => this.sendRawRequest({
-      type: epLinks.type,
-      target: brokenUrl,
-      target_type: 'url',
-      export_columns: epLinks.columns,
-      display_limit: 1,
       ...epLinks.defaultParams,
     }, epLinks.path), 'getBrokenBacklinks');
 

--- a/packages/mysticat-shared-seo-client/src/client.js
+++ b/packages/mysticat-shared-seo-client/src/client.js
@@ -756,11 +756,21 @@ export default class SeoClient {
       export_columns: epPages.columns,
       display_limit: effectiveLimit,
       display_filter: buildFilter([
-        { sign: '+', field: 'responsecode', op: 'Eq', value: '404' },
-        { sign: 'Or', field: 'responsecode', op: 'Eq', value: '410' },
-        { sign: '+', field: 'type', op: '', value: 'follow' },
-        { sign: '+', field: 'type', op: '', value: 'text' },
-        { sign: '-', field: 'type', op: '', value: 'lostlink' },
+        {
+          sign: '+', field: 'responsecode', op: 'Eq', value: '404',
+        },
+        {
+          sign: 'Or', field: 'responsecode', op: 'Eq', value: '410',
+        },
+        {
+          sign: '+', field: 'type', op: '', value: 'follow',
+        },
+        {
+          sign: '+', field: 'type', op: '', value: 'text',
+        },
+        {
+          sign: '-', field: 'type', op: '', value: 'lostlink',
+        },
       ]),
       ...epPages.defaultParams,
     }, epPages.path);

--- a/packages/mysticat-shared-seo-client/test/client.test.js
+++ b/packages/mysticat-shared-seo-client/test/client.test.js
@@ -1351,7 +1351,12 @@ describe('SeoClient', () => {
   // ===== getBrokenBacklinks =====
 
   describe('getBrokenBacklinks', () => {
+    // Expected filter string sent to Semrush for Call A (backlinks_pages):
+    //   404 OR 410, follow-only, text-only, no lostlinks
+    const EXPECTED_FILTER = '+|responsecode|Eq|404|Or|responsecode|Eq|410|+|type||follow|+|type||text|-|type||lostlink';
+
     // Real API fixtures (adobe.com, April 2026)
+    // Includes a 410 row to verify those are now captured alongside 404s.
     const brokenPagesCsv = [
       'source_url;response_code;backlinks_num;domains_num',
       'https://www.adobe.com/error-pages/404.html;404;2265988;11065',
@@ -1374,11 +1379,26 @@ describe('SeoClient', () => {
       ';http://www.acrobat.com/;https://www.adobe.com/404.html;75;3',
     ].join('\n');
 
+    it('sends correct quality filters to Semrush (404+410, follow, text, no lostlinks)', async () => {
+      let capturedFilter;
+      nock(config.apiBaseUrl)
+        .get('/analytics/v1/')
+        .query((q) => {
+          capturedFilter = q.display_filter;
+          return q.type === 'backlinks_pages';
+        })
+        .reply(200, 'source_url;response_code;backlinks_num;domains_num');
+
+      await client.getBrokenBacklinks('adobe.com');
+
+      expect(capturedFilter).to.equal(EXPECTED_FILTER);
+    });
+
     it('returns one high-quality backlink per broken page with full diversity', async () => {
       nock(config.apiBaseUrl)
         .get('/analytics/v1/')
         .query((q) => q.type === 'backlinks_pages'
-          && q.display_filter === '+|responsecode|Eq|404')
+          && q.display_filter === EXPECTED_FILTER)
         .reply(200, brokenPagesCsv);
 
       nock(config.apiBaseUrl)

--- a/packages/mysticat-shared-seo-client/test/client.test.js
+++ b/packages/mysticat-shared-seo-client/test/client.test.js
@@ -1464,14 +1464,16 @@ describe('SeoClient', () => {
       expect(result.fullAuditRef).to.include('type=backlinks_pages');
     });
 
-    it('merges 410 pages with 404 pages and sorts by domains_num', async () => {
+    it('merges 410 pages with 404 pages, deduplicates shared URLs, and sorts by domains_num', async () => {
       const pages404Csv = [
         'source_url;response_code;backlinks_num;domains_num',
         'https://example.com/gone404;404;100;50',
+        'https://example.com/shared;404;80;40',
       ].join('\n');
       const pages410Csv = [
         'source_url;response_code;backlinks_num;domains_num',
         'https://example.com/gone410;410;200;100',
+        'https://example.com/shared;410;80;40',
       ].join('\n');
       nockBrokenPages(pages404Csv, pages410Csv);
 
@@ -1485,12 +1487,19 @@ describe('SeoClient', () => {
         .query((q) => q.type === 'backlinks' && q.target === 'https://example.com/gone404')
         .reply(200, 'source_title;source_url;target_url;page_ascore;external_num\n;https://ref2.com;https://example.com/gone404;60;5');
 
+      nock(config.apiBaseUrl)
+        .get('/analytics/v1/')
+        .query((q) => q.type === 'backlinks' && q.target === 'https://example.com/shared')
+        .reply(200, 'source_title;source_url;target_url;page_ascore;external_num\n;https://ref3.com;https://example.com/shared;40;5');
+
       const result = await client.getBrokenBacklinks('example.com', 50);
 
-      expect(result.result.backlinks).to.have.lengthOf(2);
-      // 410 page has higher domains_num → sorted first
+      // shared URL appears in both 404 and 410 — deduplicated to 3 unique pages, not 4
+      expect(result.result.backlinks).to.have.lengthOf(3);
+      // sorted by domains_num: gone410 (100), gone404 (50), shared (40)
       expect(result.result.backlinks[0].url_to).to.equal('https://example.com/gone410');
       expect(result.result.backlinks[1].url_to).to.equal('https://example.com/gone404');
+      expect(result.result.backlinks[2].url_to).to.equal('https://example.com/shared');
     });
 
     it('parallelizes across multiple batches when limit exceeds batch size', async () => {

--- a/packages/mysticat-shared-seo-client/test/client.test.js
+++ b/packages/mysticat-shared-seo-client/test/client.test.js
@@ -1401,7 +1401,9 @@ describe('SeoClient', () => {
         .get('/analytics/v1/')
         .times(3)
         .query((q) => {
-          if (q.type === 'backlinks') { capturedLinksFilter = q.display_filter; }
+          if (q.type === 'backlinks') {
+            capturedLinksFilter = q.display_filter;
+          }
           return q.type === 'backlinks';
         })
         .reply(200, backlinkForPage1Csv);

--- a/packages/mysticat-shared-seo-client/test/client.test.js
+++ b/packages/mysticat-shared-seo-client/test/client.test.js
@@ -1401,7 +1401,7 @@ describe('SeoClient', () => {
         .get('/analytics/v1/')
         .times(3)
         .query((q) => {
-          if (q.type === 'backlinks') capturedLinksFilter = q.display_filter;
+          if (q.type === 'backlinks') { capturedLinksFilter = q.display_filter; }
           return q.type === 'backlinks';
         })
         .reply(200, backlinkForPage1Csv);

--- a/packages/mysticat-shared-seo-client/test/client.test.js
+++ b/packages/mysticat-shared-seo-client/test/client.test.js
@@ -1351,12 +1351,15 @@ describe('SeoClient', () => {
   // ===== getBrokenBacklinks =====
 
   describe('getBrokenBacklinks', () => {
-    // Expected filter string sent to Semrush for Call A (backlinks_pages):
-    //   404 OR 410, follow-only, text-only, no lostlinks
-    const EXPECTED_FILTER = '+|responsecode|Eq|404|Or|responsecode|Eq|410|+|type||follow|+|type||text|-|type||lostlink';
+    // Semrush does not support OR within display_filter, so 404 and 410 are fetched
+    // in two separate backlinks_pages requests and merged client-side.
+    const FILTER_404 = '+|responsecode|Eq|404';
+    const FILTER_410 = '+|responsecode|Eq|410';
+    // type/follow/text/lostlink are backlink-level attributes sent on the backlinks call.
+    const LINKS_FILTER = '+|type||follow|+|type||text|-|type||lostlink';
+    const EMPTY_PAGES_CSV = 'source_url;response_code;backlinks_num;domains_num';
 
     // Real API fixtures (adobe.com, April 2026)
-    // Includes a 410 row to verify those are now captured alongside 404s.
     const brokenPagesCsv = [
       'source_url;response_code;backlinks_num;domains_num',
       'https://www.adobe.com/error-pages/404.html;404;2265988;11065',
@@ -1379,27 +1382,37 @@ describe('SeoClient', () => {
       ';http://www.acrobat.com/;https://www.adobe.com/404.html;75;3',
     ].join('\n');
 
-    it('sends correct quality filters to Semrush (404+410, follow, text, no lostlinks)', async () => {
-      let capturedFilter;
+    // Helper: register both backlinks_pages interceptors (404 and 410 are always parallel).
+    function nockBrokenPages(csv404 = EMPTY_PAGES_CSV, csv410 = EMPTY_PAGES_CSV) {
       nock(config.apiBaseUrl)
         .get('/analytics/v1/')
+        .query((q) => q.type === 'backlinks_pages' && q.display_filter === FILTER_404)
+        .reply(200, csv404);
+      nock(config.apiBaseUrl)
+        .get('/analytics/v1/')
+        .query((q) => q.type === 'backlinks_pages' && q.display_filter === FILTER_410)
+        .reply(200, csv410);
+    }
+
+    it('sends correct quality filters to Semrush (404+410 on pages; follow, text, no lostlinks on backlinks)', async () => {
+      let capturedLinksFilter;
+      nockBrokenPages(brokenPagesCsv);
+      nock(config.apiBaseUrl)
+        .get('/analytics/v1/')
+        .times(3)
         .query((q) => {
-          capturedFilter = q.display_filter;
-          return q.type === 'backlinks_pages';
+          if (q.type === 'backlinks') capturedLinksFilter = q.display_filter;
+          return q.type === 'backlinks';
         })
-        .reply(200, 'source_url;response_code;backlinks_num;domains_num');
+        .reply(200, backlinkForPage1Csv);
 
-      await client.getBrokenBacklinks('adobe.com');
+      await client.getBrokenBacklinks('adobe.com', 3);
 
-      expect(capturedFilter).to.equal(EXPECTED_FILTER);
+      expect(capturedLinksFilter).to.equal(LINKS_FILTER);
     });
 
     it('returns one high-quality backlink per broken page with full diversity', async () => {
-      nock(config.apiBaseUrl)
-        .get('/analytics/v1/')
-        .query((q) => q.type === 'backlinks_pages'
-          && q.display_filter === EXPECTED_FILTER)
-        .reply(200, brokenPagesCsv);
+      nockBrokenPages(brokenPagesCsv);
 
       nock(config.apiBaseUrl)
         .get('/analytics/v1/')
@@ -1449,15 +1462,41 @@ describe('SeoClient', () => {
       expect(result.fullAuditRef).to.include('type=backlinks_pages');
     });
 
+    it('merges 410 pages with 404 pages and sorts by domains_num', async () => {
+      const pages404Csv = [
+        'source_url;response_code;backlinks_num;domains_num',
+        'https://example.com/gone404;404;100;50',
+      ].join('\n');
+      const pages410Csv = [
+        'source_url;response_code;backlinks_num;domains_num',
+        'https://example.com/gone410;410;200;100',
+      ].join('\n');
+      nockBrokenPages(pages404Csv, pages410Csv);
+
+      nock(config.apiBaseUrl)
+        .get('/analytics/v1/')
+        .query((q) => q.type === 'backlinks' && q.target === 'https://example.com/gone410')
+        .reply(200, 'source_title;source_url;target_url;page_ascore;external_num\n;https://ref.com;https://example.com/gone410;80;5');
+
+      nock(config.apiBaseUrl)
+        .get('/analytics/v1/')
+        .query((q) => q.type === 'backlinks' && q.target === 'https://example.com/gone404')
+        .reply(200, 'source_title;source_url;target_url;page_ascore;external_num\n;https://ref2.com;https://example.com/gone404;60;5');
+
+      const result = await client.getBrokenBacklinks('example.com', 50);
+
+      expect(result.result.backlinks).to.have.lengthOf(2);
+      // 410 page has higher domains_num → sorted first
+      expect(result.result.backlinks[0].url_to).to.equal('https://example.com/gone410');
+      expect(result.result.backlinks[1].url_to).to.equal('https://example.com/gone404');
+    });
+
     it('parallelizes across multiple batches when limit exceeds batch size', async () => {
       // 12 broken pages → 2 batches (10 + 2)
       const pages = Array.from({ length: 12 }, (_, i) => `https://example.com/page${i};404;${100 - i};${50 - i}`);
       const pagesCsv = ['source_url;response_code;backlinks_num;domains_num', ...pages].join('\n');
 
-      nock(config.apiBaseUrl)
-        .get('/analytics/v1/')
-        .query((q) => q.type === 'backlinks_pages')
-        .reply(200, pagesCsv);
+      nockBrokenPages(pagesCsv);
 
       // Mock backlinks response for each of the 12 pages
       for (let i = 0; i < 12; i += 1) {
@@ -1474,21 +1513,15 @@ describe('SeoClient', () => {
       expect(uniqueTargets.size).to.equal(12);
     });
 
-    it('returns empty backlinks when no 404 pages found', async () => {
-      nock(config.apiBaseUrl)
-        .get('/analytics/v1/')
-        .query((q) => q.type === 'backlinks_pages')
-        .reply(200, 'source_url;response_code;backlinks_num;domains_num');
+    it('returns empty backlinks when no broken pages found', async () => {
+      nockBrokenPages();
 
       const result = await client.getBrokenBacklinks('no-broken-pages.com');
       expect(result.result.backlinks).to.deep.equal([]);
     });
 
     it('handles no-data responses for individual backlink fetches gracefully', async () => {
-      nock(config.apiBaseUrl)
-        .get('/analytics/v1/')
-        .query((q) => q.type === 'backlinks_pages')
-        .reply(200, brokenPagesCsv);
+      nockBrokenPages(brokenPagesCsv);
 
       // First page returns backlink, second has no data, third returns backlink
       nock(config.apiBaseUrl)
@@ -1518,10 +1551,7 @@ describe('SeoClient', () => {
     });
 
     it('handles broken page with no backlinks', async () => {
-      nock(config.apiBaseUrl)
-        .get('/analytics/v1/')
-        .query((q) => q.type === 'backlinks_pages')
-        .reply(200, 'source_url;response_code;backlinks_num;domains_num\nhttps://example.com/gone;404;0;0');
+      nockBrokenPages('source_url;response_code;backlinks_num;domains_num\nhttps://example.com/gone;404;0;0');
 
       nock(config.apiBaseUrl)
         .get('/analytics/v1/')
@@ -1533,10 +1563,7 @@ describe('SeoClient', () => {
     });
 
     it('respects upper limit of 100', async () => {
-      nock(config.apiBaseUrl)
-        .get('/analytics/v1/')
-        .query((q) => q.type === 'backlinks_pages' && q.display_limit === '100')
-        .reply(200, 'source_url;response_code;backlinks_num;domains_num');
+      nockBrokenPages();
 
       await client.getBrokenBacklinks('adobe.com', 500);
     });
@@ -1546,18 +1573,12 @@ describe('SeoClient', () => {
     });
 
     it('handles null title in backlink response', async () => {
-      const pagesCsv = 'source_url;response_code;backlinks_num;domains_num\nhttps://t.com/p;404;1;1';
-      const linkCsv = 'source_title;source_url;target_url;page_ascore;external_num\n;https://ref.com;https://t.com/p;50;10';
-
-      nock(config.apiBaseUrl)
-        .get('/analytics/v1/')
-        .query((q) => q.type === 'backlinks_pages')
-        .reply(200, pagesCsv);
+      nockBrokenPages('source_url;response_code;backlinks_num;domains_num\nhttps://t.com/p;404;1;1');
 
       nock(config.apiBaseUrl)
         .get('/analytics/v1/')
         .query((q) => q.type === 'backlinks')
-        .reply(200, linkCsv);
+        .reply(200, 'source_title;source_url;target_url;page_ascore;external_num\n;https://ref.com;https://t.com/p;50;10');
 
       const result = await client.getBrokenBacklinks('t.com', 1);
       expect(result.result.backlinks[0].title).to.equal(null);


### PR DESCRIPTION
## Summary

  - Extends the `backlinks_pages` filter in `getBrokenBacklinks` (Call A) with four quality improvements agreed with the Semrush team (SITES-45983):                                                   
    - **410 added alongside 404** — captures "gone" pages, not just "not found"
    - **Follow links only** — nofollow links carry no SEO value                                                                                                                                        
    - **Text links only** — more actionable than image or frame links                                                                                                                                  
    - **Lostlinks excluded** — only active broken backlinks, not ones already removed by the referring site                                                                                            
  - The two-call flow and result mapping are unchanged — only the filter argument to Call A changes                                                                                                    
  - Adds a dedicated unit test that pins the exact filter string sent to Semrush, so future changes can't silently regress this                                                                        
                                                                                                                                                                                                       
  ## Filter change                                                                                                                                                                                     
                                                                                                                                                                                                       
  Before: `+|responsecode|Eq|404`                                                                                                                                                                      
  After:  `+|responsecode|Eq|404|Or|responsecode|Eq|410|+|type||follow|+|type||text|-|type||lostlink`
                                                                                                                                                                                                       
  ## Test plan                                              
                                                                                                                                                                                                       
  - [x] CI passes (unit tests assert the exact filter string via nock intercept)                                                                                                                       
  - [ ] After merge, bump `@adobe/mysticat-shared-seo-client` in `spacecat-audit-worker` to pick up the new version