### PR TITLE
feat: fix ghost RUM key false positive in wwwUrlResolver by verifying bundle data before accepting toggled hostname

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25179,7 +25179,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "3.74.0",
+      "version": "3.74.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",
@@ -27322,7 +27322,7 @@
     },
     "packages/spacecat-shared-html-analyzer": {
       "name": "@adobe/spacecat-shared-html-analyzer",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "cheerio": "^1.0.0-rc.12",

--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -330,22 +330,33 @@ const RUM_BUNDLER_BASE_URL = 'https://bundles.aem.page';
 
 async function hasBundleData(hostname, domainkey, log) {
   const now = new Date();
-  const year = now.getUTCFullYear();
-  const month = (now.getUTCMonth() + 1).toString().padStart(2, '0');
-  const day = now.getUTCDate().toString().padStart(2, '0');
-  const url = `${RUM_BUNDLER_BASE_URL}/bundles/${hostname}/${year}/${month}/${day}?domainkey=${domainkey}`;
-  try {
-    const resp = await fetch(url);
-    if (!resp.ok) {
-      return false;
+  const datesToCheck = [0, 1].map((daysAgo) => {
+    const d = new Date(now);
+    d.setUTCDate(now.getUTCDate() - daysAgo);
+    return `${d.getUTCFullYear()}/${(d.getUTCMonth() + 1).toString().padStart(2, '0')}/${d.getUTCDate().toString().padStart(2, '0')}`;
+  });
+
+  for (const dateStr of datesToCheck) {
+    const url = `${RUM_BUNDLER_BASE_URL}/bundles/${hostname}/${dateStr}?domainkey=${domainkey}`;
+    const safeUrl = `${RUM_BUNDLER_BASE_URL}/bundles/${hostname}/${dateStr}?domainkey=REDACTED`;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const resp = await fetch(url, {
+        headers: { 'User-Agent': SPACECAT_USER_AGENT },
+        signal: AbortSignal.timeout(5000),
+      });
+      if (resp.ok) {
+        // eslint-disable-next-line no-await-in-loop
+        const { rumBundles } = await resp.json();
+        if (Array.isArray(rumBundles) && rumBundles.length > 0) {
+          return true;
+        }
+      }
+    } catch (e) {
+      log.warn(`[wwwUrlResolver] bundle probe failed for ${hostname} (${safeUrl}): ${e.message.replace(domainkey, 'REDACTED')}`);
     }
-    const { rumBundles } = await resp.json();
-    return Array.isArray(rumBundles) && rumBundles.length > 0;
-    /* c8 ignore next 3 */
-  } catch (e) {
-    log.warn(`[wwwUrlResolver] bundle probe failed for ${hostname}: ${e.message}`);
-    return false;
   }
+  return false;
 }
 
 /**
@@ -380,7 +391,6 @@ async function wwwUrlResolver(site, rumApiClient, log) {
       log.debug(`Resolved URL ${wwwToggledHostname} for ${baseURL} using RUM API Client`);
       return wwwToggledHostname;
     }
-    /* c8 ignore next */
     log.debug(`[wwwUrlResolver] ${wwwToggledHostname} has key but no bundle data, trying ${hostname}`);
   } catch (e) {
     log.error(`Could not retrieved RUM domainkey for ${hostname}: ${e.message}`);

--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -326,12 +326,35 @@ function toggleWWWHostname(hostname) {
   return hostname.startsWith('www.') ? hostname.replace('www.', '') : `www.${hostname}`;
 }
 
+const RUM_BUNDLER_BASE_URL = 'https://bundles.aem.page';
+
+async function hasBundleData(hostname, domainkey, log) {
+  const now = new Date();
+  const year = now.getUTCFullYear();
+  const month = (now.getUTCMonth() + 1).toString().padStart(2, '0');
+  const day = now.getUTCDate().toString().padStart(2, '0');
+  const url = `${RUM_BUNDLER_BASE_URL}/bundles/${hostname}/${year}/${month}/${day}?domainkey=${domainkey}`;
+  try {
+    const resp = await fetch(url);
+    if (!resp.ok) {
+      return false;
+    }
+    const { rumBundles } = await resp.json();
+    return Array.isArray(rumBundles) && rumBundles.length > 0;
+    /* c8 ignore next 3 */
+  } catch (e) {
+    log.warn(`[wwwUrlResolver] bundle probe failed for ${hostname}: ${e.message}`);
+    return false;
+  }
+}
+
 /**
  * Resolves the correct URL for a site by checking RUM data availability.
- * Tries www-toggled version first, then falls back to original.
+ * Tries www-toggled version first (only if actual bundle data exists there),
+ * then falls back to original hostname.
  * @param {object} site - The site object with getBaseURL() and getConfig() methods.
  * @param {object} rumApiClient - The RUM API client instance with retrieveDomainkey method.
- * @param {object} log - Logger instance with debug() and error() methods.
+ * @param {object} log - Logger instance with debug(), warn(), and error() methods.
  * @returns {Promise<string>} - The resolved hostname without protocol.
  */
 async function wwwUrlResolver(site, rumApiClient, log) {
@@ -352,9 +375,13 @@ async function wwwUrlResolver(site, rumApiClient, log) {
 
   try {
     const wwwToggledHostname = toggleWWWHostname(hostname);
-    await rumApiClient.retrieveDomainkey(wwwToggledHostname);
-    log.debug(`Resolved URL ${wwwToggledHostname} for ${baseURL} using RUM API Client`);
-    return wwwToggledHostname;
+    const domainkey = await rumApiClient.retrieveDomainkey(wwwToggledHostname);
+    if (await hasBundleData(wwwToggledHostname, domainkey, log)) {
+      log.debug(`Resolved URL ${wwwToggledHostname} for ${baseURL} using RUM API Client`);
+      return wwwToggledHostname;
+    }
+    /* c8 ignore next */
+    log.debug(`[wwwUrlResolver] ${wwwToggledHostname} has key but no bundle data, trying ${hostname}`);
   } catch (e) {
     log.error(`Could not retrieved RUM domainkey for ${hostname}: ${e.message}`);
   }

--- a/packages/spacecat-shared-utils/test/url-helpers.test.js
+++ b/packages/spacecat-shared-utils/test/url-helpers.test.js
@@ -1029,6 +1029,8 @@ describe('URL Utility Functions', () => {
       rumApiClient.retrieveDomainkey.withArgs('example.com').resolves('real-key');
       nock('https://bundles.aem.page')
         .get(/\/bundles\/www\.example\.com\//)
+        .query({ domainkey: 'ghost-key' })
+        .times(2)
         .reply(200, { rumBundles: [] });
 
       const result = await wwwUrlResolver(site, rumApiClient, log);
@@ -1039,17 +1041,36 @@ describe('URL Utility Functions', () => {
       expect(log.debug).to.have.been.calledWith('Resolved URL example.com for https://example.com using RUM API Client');
     });
 
+    it('should accept www-toggled hostname when today is empty but yesterday has bundle data', async () => {
+      site.getBaseURL.returns('https://example.com');
+      rumApiClient.retrieveDomainkey.withArgs('www.example.com').resolves('domain-key');
+      nock('https://bundles.aem.page')
+        .get(/\/bundles\/www\.example\.com\//)
+        .query({ domainkey: 'domain-key' })
+        .reply(200, { rumBundles: [] })
+        .get(/\/bundles\/www\.example\.com\//)
+        .query({ domainkey: 'domain-key' })
+        .reply(200, { rumBundles: [{ weight: 1 }] });
+
+      const result = await wwwUrlResolver(site, rumApiClient, log);
+
+      expect(result).to.equal('www.example.com');
+    });
+
     it('should fall back to original hostname when bundle probe returns non-200', async () => {
       site.getBaseURL.returns('https://example.com');
       rumApiClient.retrieveDomainkey.withArgs('www.example.com').resolves('some-key');
       rumApiClient.retrieveDomainkey.withArgs('example.com').resolves('real-key');
       nock('https://bundles.aem.page')
         .get(/\/bundles\/www\.example\.com\//)
+        .query({ domainkey: 'some-key' })
+        .times(2)
         .reply(500);
 
       const result = await wwwUrlResolver(site, rumApiClient, log);
 
       expect(result).to.equal('example.com');
+      expect(log.debug).to.have.been.calledWith('[wwwUrlResolver] www.example.com has key but no bundle data, trying example.com');
     });
 
     it('should fall back to original hostname when bundle probe throws a network error', async () => {
@@ -1058,11 +1079,14 @@ describe('URL Utility Functions', () => {
       rumApiClient.retrieveDomainkey.withArgs('example.com').resolves('real-key');
       nock('https://bundles.aem.page')
         .get(/\/bundles\/www\.example\.com\//)
+        .query({ domainkey: 'some-key' })
+        .times(2)
         .replyWithError('network failure');
 
       const result = await wwwUrlResolver(site, rumApiClient, log);
 
       expect(result).to.equal('example.com');
+      expect(log.debug).to.have.been.calledWith('[wwwUrlResolver] www.example.com has key but no bundle data, trying example.com');
     });
   });
 

--- a/packages/spacecat-shared-utils/test/url-helpers.test.js
+++ b/packages/spacecat-shared-utils/test/url-helpers.test.js
@@ -804,6 +804,7 @@ describe('URL Utility Functions', () => {
 
       log = {
         debug: sandbox.stub(),
+        warn: sandbox.stub(),
         error: sandbox.stub(),
       };
 
@@ -817,6 +818,7 @@ describe('URL Utility Functions', () => {
 
     afterEach(() => {
       sandbox.restore();
+      nock.cleanAll();
     });
 
     it('should return overrideBaseURL when configured with https', async () => {
@@ -853,6 +855,9 @@ describe('URL Utility Functions', () => {
       });
       site.getBaseURL.returns('https://example.com');
       rumApiClient.retrieveDomainkey.withArgs('www.example.com').resolves('domain-key');
+      nock('https://bundles.aem.page')
+        .get(/\/bundles\/www\.example\.com\//)
+        .reply(200, { rumBundles: [{ weight: 1 }] });
 
       const result = await wwwUrlResolver(site, rumApiClient, log);
 
@@ -873,6 +878,9 @@ describe('URL Utility Functions', () => {
     it('should check RUM for www subdomain (not return early)', async () => {
       site.getBaseURL.returns('https://www.example.com');
       rumApiClient.retrieveDomainkey.withArgs('example.com').resolves('domain-key');
+      nock('https://bundles.aem.page')
+        .get(/\/bundles\/example\.com\//)
+        .reply(200, { rumBundles: [{ weight: 1 }] });
 
       const result = await wwwUrlResolver(site, rumApiClient, log);
 
@@ -883,6 +891,9 @@ describe('URL Utility Functions', () => {
     it('should check RUM for no subdomain (not return early)', async () => {
       site.getBaseURL.returns('https://example.com');
       rumApiClient.retrieveDomainkey.withArgs('www.example.com').resolves('domain-key');
+      nock('https://bundles.aem.page')
+        .get(/\/bundles\/www\.example\.com\//)
+        .reply(200, { rumBundles: [{ weight: 1 }] });
 
       const result = await wwwUrlResolver(site, rumApiClient, log);
 
@@ -893,6 +904,9 @@ describe('URL Utility Functions', () => {
     it('should prioritize www-toggled version (www added) when it has RUM data', async () => {
       site.getBaseURL.returns('https://example.com');
       rumApiClient.retrieveDomainkey.withArgs('www.example.com').resolves('domain-key');
+      nock('https://bundles.aem.page')
+        .get(/\/bundles\/www\.example\.com\//)
+        .reply(200, { rumBundles: [{ weight: 1 }] });
 
       const result = await wwwUrlResolver(site, rumApiClient, log);
 
@@ -904,6 +918,9 @@ describe('URL Utility Functions', () => {
     it('should prioritize www-toggled version (www removed) when it has RUM data', async () => {
       site.getBaseURL.returns('https://www.example.com');
       rumApiClient.retrieveDomainkey.withArgs('example.com').resolves('domain-key');
+      nock('https://bundles.aem.page')
+        .get(/\/bundles\/example\.com\//)
+        .reply(200, { rumBundles: [{ weight: 1 }] });
 
       const result = await wwwUrlResolver(site, rumApiClient, log);
 
@@ -984,6 +1001,9 @@ describe('URL Utility Functions', () => {
       });
       site.getBaseURL.returns('https://example.com');
       rumApiClient.retrieveDomainkey.withArgs('www.example.com').resolves('domain-key');
+      nock('https://bundles.aem.page')
+        .get(/\/bundles\/www\.example\.com\//)
+        .reply(200, { rumBundles: [{ weight: 1 }] });
 
       const result = await wwwUrlResolver(site, rumApiClient, log);
 
@@ -994,10 +1014,55 @@ describe('URL Utility Functions', () => {
       site.getConfig.returns(null);
       site.getBaseURL.returns('https://example.com');
       rumApiClient.retrieveDomainkey.withArgs('www.example.com').resolves('domain-key');
+      nock('https://bundles.aem.page')
+        .get(/\/bundles\/www\.example\.com\//)
+        .reply(200, { rumBundles: [{ weight: 1 }] });
 
       const result = await wwwUrlResolver(site, rumApiClient, log);
 
       expect(result).to.equal('www.example.com');
+    });
+
+    it('should fall back to original hostname when www-toggled has a key but no bundle data (ghost key)', async () => {
+      site.getBaseURL.returns('https://example.com');
+      rumApiClient.retrieveDomainkey.withArgs('www.example.com').resolves('ghost-key');
+      rumApiClient.retrieveDomainkey.withArgs('example.com').resolves('real-key');
+      nock('https://bundles.aem.page')
+        .get(/\/bundles\/www\.example\.com\//)
+        .reply(200, { rumBundles: [] });
+
+      const result = await wwwUrlResolver(site, rumApiClient, log);
+
+      expect(result).to.equal('example.com');
+      expect(rumApiClient.retrieveDomainkey).to.have.been.calledWith('www.example.com');
+      expect(rumApiClient.retrieveDomainkey).to.have.been.calledWith('example.com');
+      expect(log.debug).to.have.been.calledWith('Resolved URL example.com for https://example.com using RUM API Client');
+    });
+
+    it('should fall back to original hostname when bundle probe returns non-200', async () => {
+      site.getBaseURL.returns('https://example.com');
+      rumApiClient.retrieveDomainkey.withArgs('www.example.com').resolves('some-key');
+      rumApiClient.retrieveDomainkey.withArgs('example.com').resolves('real-key');
+      nock('https://bundles.aem.page')
+        .get(/\/bundles\/www\.example\.com\//)
+        .reply(500);
+
+      const result = await wwwUrlResolver(site, rumApiClient, log);
+
+      expect(result).to.equal('example.com');
+    });
+
+    it('should fall back to original hostname when bundle probe throws a network error', async () => {
+      site.getBaseURL.returns('https://example.com');
+      rumApiClient.retrieveDomainkey.withArgs('www.example.com').resolves('some-key');
+      rumApiClient.retrieveDomainkey.withArgs('example.com').resolves('real-key');
+      nock('https://bundles.aem.page')
+        .get(/\/bundles\/www\.example\.com\//)
+        .replyWithError('network failure');
+
+      const result = await wwwUrlResolver(site, rumApiClient, log);
+
+      expect(result).to.equal('example.com');
     });
   });
 


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/SITES-46095

Problem                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                    
The RUM system can have "ghost keys" — domain keys that exist in the registry but have no actual data behind them. The old wwwUrlResolver treated key existence as proof that a domain was correct. So for a site like aashirvaad.com, it would   
find a ghost key for www.aashirvaad.com, assume that was the right domain, and all audits would query the wrong domain and return empty results.                                                                                                  
                                                                                                                                                                                                                                                    
Fix                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                    
After finding a domain key, the resolver now makes a second check: it calls the RUM bundler API to confirm there is real bundle data behind that key. Only if actual data is found does it accept the www-toggled domain. If the bundle probe    returns empty, fails with a non-200 status, or throws a network error, it treats the key as a ghost and falls through to try the original hostname instead.
                                                                                                                                                                                                                                                    
Changes                                                

  - url-helpers.js: Added hasBundleData helper that probes bundles.aem.page to verify real data exists behind a domain key. Updated wwwUrlResolver to call this check before accepting the www-toggled hostname.                                    
  - url-helpers.test.js: Added bundle probe nock interceptors to existing resolution tests. Added 3 new tests covering ghost key, non-200, and network error paths.
