### PR TITLE
fix: add Cookiebot (CybotCookiebotDialog) cookie banner detection

### DIFF
--- a/packages/spacecat-shared-html-analyzer/src/html-filter.js
+++ b/packages/spacecat-shared-html-analyzer/src/html-filter.js
@@ -69,6 +69,7 @@ const COOKIE_BANNER_ID_SELECTORS = [
   '#cookie-popup', '#privacy-popup', '#consent-popup', '#gdpr-popup',
   '#onetrust-consent-sdk', '#onetrust-banner-sdk',
   '#tc-privacy-wrapper',
+  '#CybotCookiebotDialog',
 ];
 
 const COOKIE_BANNER_ARIA_SELECTORS = [


### PR DESCRIPTION
## Summary
- Adds `#CybotCookiebotDialog` to `COOKIE_BANNER_ID_SELECTORS` in `html-filter.js`
- Cookiebot/Usercentrics banners were not being removed — the existing selectors only cover class-based patterns, OneTrust, and ARIA `aria-label` attributes, but Cookiebot uses a unique element ID and `aria-labelledby` instead

## Root cause
The `CybotCookiebotDialog` element:
- Has `id="CybotCookiebotDialog"` — not in any existing ID selector
- Has classes `CybotEdge`, `CybotCookiebotDialogActive` — not in class selectors
- Uses `aria-labelledby` (not `aria-label`) — misses all ARIA selectors

**Opportunity:** https://llmo.now/org/d9aae1ba-2443-4a30-a8c9-5b1a58390966/opportunities/prerender/5e2aa3ae-fb35-42a7-8d64-3f103cc0dad3
**Sample page:** https://www.mccain.fr/produits-par-type-de-cuisson/airfryer/


## Test plan
- [ ] Verify the `#CybotCookiebotDialog` element is removed when `filterHtmlContent` / `removeCookieBanners` is called with a page containing a Cookiebot banner
- [ ] Confirm text validation still passes (banner text contains "cookie"/"consent")
- [ ] Run existing unit tests: `npm test -w packages/spacecat-shared-html-analyzer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)