### PR TITLE
feat(athena-client): surface structured AthenaError on query failure

### DIFF
--- a/packages/spacecat-shared-athena-client/src/index.d.ts
+++ b/packages/spacecat-shared-athena-client/src/index.d.ts
@@ -10,7 +10,17 @@
  * governing permissions and limitations under the License.
  */
 
-import { AthenaClient } from '@aws-sdk/client-athena';
+import { AthenaClient, AthenaError } from '@aws-sdk/client-athena';
+
+/**
+ * Error thrown when an Athena query reaches a FAILED/CANCELLED state. Extends Error
+ * with Athena's structured error when available, so callers can branch on the
+ * authoritative `retryable` flag rather than matching the message string.
+ */
+export interface AthenaQueryError extends Error {
+  athenaError?: AthenaError;
+  retryable?: boolean;
+}
 
 export interface AthenaClientOptions {
   backoffMs?: number;

--- a/packages/spacecat-shared-athena-client/src/index.js
+++ b/packages/spacecat-shared-athena-client/src/index.js
@@ -136,7 +136,16 @@ export class AWSAthenaClient {
         return;
       }
       if (State === QueryExecutionState.FAILED || State === QueryExecutionState.CANCELLED) {
-        throw new Error(StateChangeReason || `Query ${State}`);
+        const error = new Error(StateChangeReason || `Query ${State}`);
+        // Surface Athena's structured error so callers can branch on its authoritative
+        // Retryable flag instead of matching the message string. Additive: message is
+        // unchanged, properties are only present when Athena returns AthenaError.
+        const { AthenaError: athenaError } = status;
+        if (athenaError) {
+          error.athenaError = athenaError;
+          error.retryable = athenaError.Retryable === true;
+        }
+        throw error;
       }
     }
     throw new Error('[Athena Client] Polling timed out');

--- a/packages/spacecat-shared-athena-client/test/index.test.js
+++ b/packages/spacecat-shared-athena-client/test/index.test.js
@@ -170,6 +170,69 @@ describe('AWSAthenaClient', () => {
         .to.be.rejectedWith('Invalid query syntax');
     });
 
+    it('attaches the structured AthenaError (retryable=true) to the thrown error', async () => {
+      sinon.stub(athenaClient.client, 'send').resolves({
+        QueryExecutionId: 'test-execution-id',
+        QueryExecution: {
+          Status: {
+            State: QueryExecutionState.FAILED,
+            StateChangeReason: 'Query exhausted resources at this scale factor',
+            AthenaError: { ErrorCategory: 1, ErrorType: 200, Retryable: true },
+          },
+        },
+      });
+
+      const error = await athenaClient.query('SELECT 1', 'database').then(
+        () => null,
+        (e) => e,
+      );
+      expect(error).to.be.an('error');
+      expect(error.message).to.equal('Query exhausted resources at this scale factor');
+      expect(error.retryable).to.equal(true);
+      expect(error.athenaError).to.deep.equal({
+        ErrorCategory: 1, ErrorType: 200, Retryable: true,
+      });
+    });
+
+    it('sets retryable=false when AthenaError.Retryable is not true', async () => {
+      sinon.stub(athenaClient.client, 'send').resolves({
+        QueryExecutionId: 'test-execution-id',
+        QueryExecution: {
+          Status: {
+            State: QueryExecutionState.FAILED,
+            StateChangeReason: 'SYNTAX_ERROR',
+            AthenaError: { ErrorCategory: 2, Retryable: false },
+          },
+        },
+      });
+
+      const error = await athenaClient.query('SELECT 1', 'database').then(
+        () => null,
+        (e) => e,
+      );
+      expect(error.retryable).to.equal(false);
+    });
+
+    it('leaves retryable/athenaError unset when no AthenaError is returned', async () => {
+      sinon.stub(athenaClient.client, 'send').resolves({
+        QueryExecutionId: 'test-execution-id',
+        QueryExecution: {
+          Status: {
+            State: QueryExecutionState.FAILED,
+            StateChangeReason: 'Invalid query syntax',
+          },
+        },
+      });
+
+      const error = await athenaClient.query('SELECT 1', 'database').then(
+        () => null,
+        (e) => e,
+      );
+      expect(error.message).to.equal('Invalid query syntax');
+      expect(error.retryable).to.equal(undefined);
+      expect(error.athenaError).to.equal(undefined);
+    });
+
     it('handles query cancelled state', async () => {
       const queryExecutionId = 'test-execution-id';
       sinon.stub(athenaClient.client, 'send').resolves({


### PR DESCRIPTION
## What

When an Athena query reaches `FAILED`/`CANCELLED`, `#pollToCompletion` now attaches Athena's **structured error** to the thrown `Error`:

- `error.athenaError` — the full `AthenaError` object (`ErrorCategory`, `ErrorType`, `Retryable`)
- `error.retryable` — its `Retryable` boolean

…when Athena returns an `AthenaError`. Adds an exported `AthenaQueryError` type.

## Why

Callers (e.g. the `cdn-logs-analysis` audit retry logic) currently classify transient-vs-permanent Athena failures by **matching the `StateChangeReason` string**. Athena already exposes an authoritative `Retryable` boolean on `QueryExecution.Status.AthenaError` — keying off it is more robust than substring matching.

## Non-breaking

Additive only: the error **message is unchanged**, and the new properties are present **only** when Athena returns an `AthenaError`. Existing consumers that read `e.message` are unaffected.

```js
// FAILED/CANCELLED branch
const error = new Error(StateChangeReason || `Query ${State}`);
const { AthenaError: athenaError } = status;
if (athenaError) {
  error.athenaError = athenaError;
  error.retryable = athenaError.Retryable === true;
}
throw error;
```

## Tests

3 new cases (retryable=true attached, retryable=false, and no AthenaError → properties unset). Package remains at **100%** coverage.

## Rollout

Consumer side (`spacecat-audit-worker` `cdn-logs-analysis`) already prefers `error.retryable` when present and falls back to string matching otherwise — so it self-upgrades once this releases and the dependency is bumped, with no regression in the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)