### PR TITLE
feat(drs-client): forward imsOrgId/brand as parameters.metadata on sc…

### DIFF
--- a/packages/spacecat-shared-drs-client/src/index.js
+++ b/packages/spacecat-shared-drs-client/src/index.js
@@ -232,6 +232,11 @@ export default class DrsClient {
    * @param {string[]} params.urls - URLs to scrape
    * @param {string} [params.priority='HIGH'] - Job priority (HIGH or LOW)
    * @param {string} [params.spacecatOrgId] - SpaceCat organization ID
+   * @param {string} [params.imsOrgId] - IMS organization ID. When provided, it is attached as
+   *   `parameters.metadata.imsOrgId` so DRS can scope the job's S2S token without relying on
+   *   resolving the org from `site_id`. When omitted, DRS falls back to `site_id` auto-resolution.
+   * @param {string} [params.brand] - Brand name; attached as `parameters.metadata.brand` only
+   *   when `imsOrgId` is also provided.
    * @param {number} [params.daysBack] - Time-window filter in days (reddit_comments only)
    * @param {number} [params.commentLimit=150] - Max comments per thread (reddit_comments only)
    * @param {('Best'|'Top'|'New'|'Controversial'|'Old'|'Q&A')} [params.sortBy='Best']
@@ -247,6 +252,8 @@ export default class DrsClient {
     priority = 'HIGH',
     daysBack,
     spacecatOrgId,
+    imsOrgId,
+    brand,
     commentLimit,
     sortBy,
     loadAllReplies,
@@ -293,6 +300,13 @@ export default class DrsClient {
       site_id: siteId,
       urls,
     };
+
+    if (imsOrgId) {
+      parameters.metadata = {
+        imsOrgId,
+        ...(brand ? { brand } : {}),
+      };
+    }
 
     if (isRedditComments) {
       parameters.comment_limit = commentLimit ?? REDDIT_COMMENTS_DEFAULT_COMMENT_LIMIT;

--- a/packages/spacecat-shared-drs-client/test/index.test.js
+++ b/packages/spacecat-shared-drs-client/test/index.test.js
@@ -458,6 +458,67 @@ describe('DrsClient', () => {
       scope.done();
     });
 
+    it('includes parameters.metadata.imsOrgId when imsOrgId is provided', async () => {
+      const scope = nock(DRS_API_URL)
+        .post('/jobs', (body) => {
+          expect(body.parameters.metadata).to.deep.equal({ imsOrgId: 'ABC123DEF456@AdobeOrg' });
+          return true;
+        })
+        .reply(200, { job_id: 'scrape-ims' });
+
+      const result = await client.submitScrapeJob({
+        datasetId: SCRAPE_DATASET_IDS.YOUTUBE_VIDEOS,
+        siteId: 'site-1',
+        urls: ['https://youtube.com/watch?v=abc'],
+        imsOrgId: 'ABC123DEF456@AdobeOrg',
+      });
+
+      expect(result.job_id).to.equal('scrape-ims');
+      scope.done();
+    });
+
+    it('includes brand alongside imsOrgId in metadata when both are provided', async () => {
+      const scope = nock(DRS_API_URL)
+        .post('/jobs', (body) => {
+          expect(body.parameters.metadata).to.deep.equal({
+            imsOrgId: 'ABC123DEF456@AdobeOrg',
+            brand: 'Hermes',
+          });
+          return true;
+        })
+        .reply(200, { job_id: 'scrape-brand' });
+
+      const result = await client.submitScrapeJob({
+        datasetId: SCRAPE_DATASET_IDS.YOUTUBE_VIDEOS,
+        siteId: 'site-1',
+        urls: ['https://youtube.com/watch?v=abc'],
+        imsOrgId: 'ABC123DEF456@AdobeOrg',
+        brand: 'Hermes',
+      });
+
+      expect(result.job_id).to.equal('scrape-brand');
+      scope.done();
+    });
+
+    it('omits metadata when imsOrgId is not provided (even if brand is)', async () => {
+      const scope = nock(DRS_API_URL)
+        .post('/jobs', (body) => {
+          expect(body.parameters).to.not.have.property('metadata');
+          return true;
+        })
+        .reply(200, { job_id: 'scrape-no-ims' });
+
+      const result = await client.submitScrapeJob({
+        datasetId: SCRAPE_DATASET_IDS.YOUTUBE_VIDEOS,
+        siteId: 'site-1',
+        urls: ['https://youtube.com/watch?v=abc'],
+        brand: 'Hermes',
+      });
+
+      expect(result.job_id).to.equal('scrape-no-ims');
+      scope.done();
+    });
+
     it('applies reddit_comments defaults (comment_limit=150, sort_by=Best) when omitted', async () => {
       const scope = nock(DRS_API_URL)
         .post('/jobs', (body) => {


### PR DESCRIPTION
## What

`submitScrapeJob` now accepts optional `imsOrgId` (and `brand`) and attaches them as `parameters.metadata.imsOrgId` on the DRS `POST /jobs` body (only when `imsOrgId` is provided).

## Why

DRS moved to S2S auth and now needs `imsOrgId` to scope job tokens. It can auto-resolve `imsOrgId` from `parameters.site_id`, but that path **400s** when the SpaceCat org behind a site can't find  `imsOrgId` (observed on adobe.com and hermes.com offsite-brand-presence runs). The DRS team asked producers to send `metadata.imsOrgId` explicitly; `submitScrapeJob` previously had no way to do this.

## Notes

- **Additive / backward-compatible**: when `imsOrgId` is omitted, no `metadata` is sent and DRS falls back to `site_id` auto-resolution (existing behavior).
- Mirrors the existing `submitPromptGenerationJob` payload shape.
- Consumed by spacecat-audit-worker offsite-brand-presence (companion PR). Requires a release so audit-worker can bump the dep.

## Test

- New `submitScrapeJob` tests: imsOrgId in metadata, brand alongside imsOrgId, metadata omitted when imsOrgId absent.