### PR TITLE
feat(brand-governance): replace /checks with /profile endpoint in BrandGovernanceClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29832,7 +29832,7 @@
     },
     "packages/spacecat-shared-http-utils": {
       "name": "@adobe/spacecat-shared-http-utils",
-      "version": "1.30.0",
+      "version": "1.31.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",

--- a/packages/spacecat-shared-brand-client/src/brand-governance-client.js
+++ b/packages/spacecat-shared-brand-client/src/brand-governance-client.js
@@ -17,16 +17,14 @@ import { ImsClient } from '@adobe/spacecat-shared-ims-client';
 const HTTP_BAD_REQUEST = 400;
 const HTTP_NOT_FOUND = 404;
 
-const CHECKS_PAGE_SIZE = 100;
-const MAX_PAGES = 20;
-
 const API_GET_BRAND_FROM_URL = (url) => `/api/v1/brands/from-url?url=${encodeURIComponent(url)}`;
-const API_GET_BRAND_CHECKS = (brandId, page) => `/api/v1/brands/${brandId}/checks?status=ACTIVE&type=BRAND&scope=COPY&pageSize=${CHECKS_PAGE_SIZE}&page=${page}`;
+const API_GET_BRAND_PROFILE = (brandId) => `/api/v1/brands/${brandId}/profile`;
 
 /**
  * Client for the Adobe Brand Governance Agent API.
- * Resolves brand guidelines by site URL using COPY-scoped checks.
- * Returns null when the brand is not registered — caller falls back to Brand Publish.
+ * Resolves brand profile by site URL using the /profile endpoint.
+ * Returns null when the brand is not registered or has no profile — caller falls back to
+ * Brand Publish.
  */
 export class BrandGovernanceClient {
   static createFrom(context) {
@@ -139,45 +137,19 @@ export class BrandGovernanceClient {
       throw this.#createError(`Brand resolved for URL ${siteBaseUrl} has no id`, HTTP_NOT_FOUND);
     }
 
-    const allChecks = [];
-    let page = 1;
-    do {
-      // eslint-disable-next-line no-await-in-loop
-      const checksResponse = await fetch(
-        `${this.apiBaseUrl}${API_GET_BRAND_CHECKS(brand.id, page)}`,
-        { headers },
+    const profileResponse = await fetch(
+      `${this.apiBaseUrl}${API_GET_BRAND_PROFILE(brand.id)}`,
+      { headers },
+    );
+    if (profileResponse.status === HTTP_NOT_FOUND) {
+      return null;
+    }
+    if (!profileResponse.ok) {
+      throw this.#createError(
+        `Error fetching brand profile for brand ${brand.id}: ${profileResponse.status}`,
+        profileResponse.status,
       );
-      if (!checksResponse.ok) {
-        throw this.#createError(
-          `Error fetching brand checks for brand ${brand.id}: ${checksResponse.status}`,
-          checksResponse.status,
-        );
-      }
-      // eslint-disable-next-line no-await-in-loop
-      const { data = [] } = await checksResponse.json();
-      allChecks.push(...data);
-      if (data.length < CHECKS_PAGE_SIZE) {
-        break;
-      }
-      page += 1;
-      if (page > MAX_PAGES) {
-        throw this.#createError(
-          `Brand checks pagination exceeded ${MAX_PAGES} pages for brand ${brand.id}`,
-          HTTP_BAD_REQUEST,
-        );
-      }
-    // eslint-disable-next-line no-constant-condition
-    } while (true);
-
-    const guidelines = allChecks.map((check) => ({ name: check.name, text: check.rule }));
-
-    return {
-      id: brand.id,
-      name: brand.name,
-      imsOrgId,
-      createdAt: brand.createdAt,
-      updatedAt: brand.updatedAt,
-      guidelines,
-    };
+    }
+    return profileResponse.json();
   }
 }

--- a/packages/spacecat-shared-brand-client/src/index.d.ts
+++ b/packages/spacecat-shared-brand-client/src/index.d.ts
@@ -36,18 +36,9 @@ export interface BrandGuidelines extends Brand {
   additionalGuidelines?: string[];
 }
 
-export interface BrandGovernanceGuideline {
-  name: string;
-  text: string;
-}
-
-export interface BrandGovernanceGuidelines {
-  id: string;
-  name: string;
-  imsOrgId: string;
-  createdAt: string;
-  updatedAt: string;
-  guidelines: BrandGovernanceGuideline[];
+export interface BrandGovernanceProfile {
+  data: Record<string, unknown>;
+  meta?: Record<string, unknown>;
 }
 
 export class BrandGovernanceClient {
@@ -58,6 +49,7 @@ export class BrandGovernanceClient {
   /**
    * Fetches brand guidelines for a site URL from the Brand Governance Agent.
    * Returns null if the brand is not registered (404) — caller falls back to Brand Publish.
+   * The returned object is the raw /profile response from the Brand Governance Agent.
    *
    * @param siteBaseUrl - The site's base URL to resolve brand by domain
    * @param imsOrgId - The IMS org ID sent as x-gw-ims-org-id header
@@ -67,7 +59,7 @@ export class BrandGovernanceClient {
     siteBaseUrl: string,
     imsOrgId: string,
     imsConfig: ImsConfig,
-  ): Promise<BrandGovernanceGuidelines | null>;
+  ): Promise<BrandGovernanceProfile | null>;
 }
 
 export default class BrandClient {

--- a/packages/spacecat-shared-brand-client/test/index.test.js
+++ b/packages/spacecat-shared-brand-client/test/index.test.js
@@ -309,13 +309,9 @@ describe('BrandGovernanceClient', () => {
     return status === 200 ? scope.reply(200, brand) : scope.reply(status);
   };
 
-  const mockBrandChecks = (brandId, checks, status = 200, page = 1) => {
-    const scope = nock(validGovApiBaseUrl)
-      .get(`/api/v1/brands/${brandId}/checks`)
-      .query({
-        status: 'ACTIVE', type: 'BRAND', scope: 'COPY', pageSize: '100', page: String(page),
-      });
-    return status === 200 ? scope.reply(200, { data: checks }) : scope.reply(status);
+  const mockBrandProfile = (brandId, profile, status = 200) => {
+    const scope = nock(validGovApiBaseUrl).get(`/api/v1/brands/${brandId}/profile`);
+    return status === 200 ? scope.reply(200, profile) : scope.reply(status);
   };
 
   beforeEach(() => {
@@ -358,30 +354,28 @@ describe('BrandGovernanceClient', () => {
   });
 
   describe('getBrandGuidelinesForUrl', () => {
-    it('fetches COPY-scoped guidelines via server-side scope filter and maps to name/text', async () => {
+    const mockProfile = {
+      data: {
+        id: 'brand-gov-123',
+        brand_name: 'Test Brand',
+        identity: { traits: ['Premium', 'Modern'], core_values: ['Quality'] },
+        voice_and_tone: { guardrails: ['Be concise'], formality_label: 'professional' },
+        language: { preferred_patterns: ['Active voice'], avoid_patterns: ['Jargon'] },
+        editorial: { dos: ['Use facts'], donts: ['Exaggerate'] },
+      },
+      meta: { version: 1 },
+    };
+
+    it('fetches raw brand profile data from /profile endpoint', async () => {
       const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
-      const checks = [
-        { name: 'Sophisticated Voice', rule: 'Use sensory language' },
-        { name: 'Mixed Rule', rule: 'Applies broadly' },
-      ];
 
       mockImsToken();
       mockBrandFromUrl(mockBrand);
-      mockBrandChecks(mockBrand.id, checks);
+      mockBrandProfile(mockBrand.id, mockProfile);
 
       const result = await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
 
-      expect(result).to.deep.equal({
-        id: mockBrand.id,
-        name: mockBrand.name,
-        imsOrgId: validImsOrgId,
-        createdAt: mockBrand.createdAt,
-        updatedAt: mockBrand.updatedAt,
-        guidelines: [
-          { name: 'Sophisticated Voice', text: 'Use sensory language' },
-          { name: 'Mixed Rule', text: 'Applies broadly' },
-        ],
-      });
+      expect(result).to.deep.equal(mockProfile);
     });
 
     it('returns null when brand is not registered (404 from from-url)', async () => {
@@ -394,7 +388,18 @@ describe('BrandGovernanceClient', () => {
       expect(result).to.be.null;
     });
 
-    it('throws when brand resolved by URL has no id (guards against /brands/undefined/checks)', async () => {
+    it('returns null when brand has no profile (404 from profile endpoint)', async () => {
+      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
+
+      mockImsToken();
+      mockBrandFromUrl(mockBrand);
+      mockBrandProfile(mockBrand.id, null, 404);
+
+      const result = await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
+      expect(result).to.be.null;
+    });
+
+    it('throws when brand resolved by URL has no id (guards against /brands/undefined/profile)', async () => {
       const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
 
       mockImsToken();
@@ -402,37 +407,6 @@ describe('BrandGovernanceClient', () => {
 
       await expect(client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig))
         .to.be.rejectedWith(`Brand resolved for URL ${validSiteBaseUrl} has no id`);
-    });
-
-    it('returns empty guidelines when checks response has no data property', async () => {
-      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
-
-      mockImsToken();
-      mockBrandFromUrl(mockBrand);
-      nock(validGovApiBaseUrl)
-        .get(`/api/v1/brands/${mockBrand.id}/checks`)
-        .query({
-          status: 'ACTIVE', type: 'BRAND', scope: 'COPY', pageSize: '100', page: '1',
-        })
-        .reply(200, {});
-
-      const result = await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
-      expect(result.guidelines).to.deep.equal([]);
-    });
-
-    it('throws when pagination exceeds the maximum page limit (prevents runaway loop)', async () => {
-      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
-      const fullPage = Array.from({ length: 100 }, (_, i) => ({ name: `Rule ${i + 1}`, rule: `Text ${i + 1}` }));
-
-      mockImsToken();
-      mockBrandFromUrl(mockBrand);
-      // MAX_PAGES is 20 — mock all 20 full pages; the loop must bail before requesting page 21
-      for (let i = 1; i <= 20; i += 1) {
-        mockBrandChecks(mockBrand.id, fullPage, 200, i);
-      }
-
-      await expect(client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig))
-        .to.be.rejectedWith('Brand checks pagination exceeded 20 pages for brand');
     });
 
     it('sends x-gw-ims-org-id, x-api-key, and Authorization headers on all requests', async () => {
@@ -451,32 +425,15 @@ describe('BrandGovernanceClient', () => {
         .reply(200, mockBrand);
 
       nock(validGovApiBaseUrl)
-        .get(`/api/v1/brands/${mockBrand.id}/checks`)
-        .query({
-          status: 'ACTIVE', type: 'BRAND', scope: 'COPY', pageSize: '100', page: '1',
-        })
+        .get(`/api/v1/brands/${mockBrand.id}/profile`)
         .matchHeader('x-gw-ims-org-id', validImsOrgId)
-        .reply(200, { data: [] });
+        .matchHeader('x-api-key', validGovApiKey)
+        .matchHeader('Authorization', 'Bearer gov-service-token')
+        .reply(200, mockProfile);
 
       const result = await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
       expect(result).to.not.be.null;
       expect(nock.isDone()).to.equal(true);
-    });
-
-    it('paginates through all pages until the last page has fewer than pageSize results', async () => {
-      const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
-      const page1Checks = Array.from({ length: 100 }, (_, i) => ({ name: `Rule ${i + 1}`, rule: `Text ${i + 1}` }));
-      const page2Checks = [{ name: 'Rule 101', rule: 'Text 101' }];
-
-      mockImsToken();
-      mockBrandFromUrl(mockBrand);
-      mockBrandChecks(mockBrand.id, page1Checks, 200, 1);
-      mockBrandChecks(mockBrand.id, page2Checks, 200, 2);
-
-      const result = await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
-      expect(result.guidelines).to.have.length(101);
-      expect(result.guidelines[0]).to.deep.equal({ name: 'Rule 1', text: 'Text 1' });
-      expect(result.guidelines[100]).to.deep.equal({ name: 'Rule 101', text: 'Text 101' });
     });
 
     it('throws error for invalid site base URL', async () => {
@@ -548,15 +505,15 @@ describe('BrandGovernanceClient', () => {
         .to.be.rejectedWith(`Error resolving brand for URL ${validSiteBaseUrl}: 500`);
     });
 
-    it('throws error when brand checks fetch fails', async () => {
+    it('throws error when brand profile fetch fails', async () => {
       const client = new BrandGovernanceClient({ apiBaseUrl: validGovApiBaseUrl, apiKey: validGovApiKey }, mockLog);
 
       mockImsToken();
       mockBrandFromUrl(mockBrand);
-      mockBrandChecks(mockBrand.id, null, 503);
+      mockBrandProfile(mockBrand.id, null, 503);
 
       await expect(client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig))
-        .to.be.rejectedWith(`Error fetching brand checks for brand ${mockBrand.id}: 503`);
+        .to.be.rejectedWith(`Error fetching brand profile for brand ${mockBrand.id}: 503`);
     });
 
     it('fetches a fresh IMS token on every call to avoid stale token errors on warm Lambdas', async () => {
@@ -574,12 +531,9 @@ describe('BrandGovernanceClient', () => {
         .reply(200, mockBrand);
 
       nock(validGovApiBaseUrl)
-        .get(`/api/v1/brands/${mockBrand.id}/checks`)
-        .query({
-          status: 'ACTIVE', type: 'BRAND', scope: 'COPY', pageSize: '100', page: '1',
-        })
+        .get(`/api/v1/brands/${mockBrand.id}/profile`)
         .twice()
-        .reply(200, { data: [] });
+        .reply(200, mockProfile);
 
       await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);
       await client.getBrandGuidelinesForUrl(validSiteBaseUrl, validImsOrgId, validGovImsConfig);


### PR DESCRIPTION
## Summary

- Replaces the paginated `/checks?scope=COPY` endpoint with the single `/profile` endpoint in `BrandGovernanceClient.getBrandGuidelinesForUrl()`
- Returns the raw Brand Governance Agent profile response (`{ data: { identity, voice_and_tone, language, messaging, editorial } }`) directly to callers — no mapping needed server-side
- Returns `null` on 404 from either `/from-url` or `/profile`, preserving the existing fallback contract for callers

## Test plan

- [x] Replaced `mockBrandChecks` helper with `mockBrandProfile` in test suite
- [x] Updated success test to verify raw profile data is returned as-is
- [x] Added test for 404 from `/profile` endpoint (returns null)
- [x] Updated header verification test to assert against `/profile` endpoint
- [x] Updated fresh-token test to use `/profile` mock
- [x] All 37 tests passing, 100% line/branch/function coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)