### PR TITLE
fix: reset linked issue status to NEW on FixEntity removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -821,7 +821,6 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.940.0.tgz",
       "integrity": "sha512-u2sXsNJazJbuHeWICvsj6RvNyJh3isedEfPvB21jK/kxcriK+dE/izlKC2cyxUjERCmku0zTFNzY9FhrLbYHjQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -2400,7 +2399,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -3905,7 +3903,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -6003,7 +6000,6 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -6176,7 +6172,6 @@
       "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.0",
         "@typescript-eslint/types": "8.60.0",
@@ -6409,7 +6404,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6824,7 +6818,6 @@
       "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.12.0.tgz",
       "integrity": "sha512-lwalRdxXRy+Sn49/vN7W507qqmBRk5Fy2o0a9U6XTjL9IV+oR5PUiiptoBrOcaYCiVuGld8OEbNqhm6wvV3m6A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -7082,7 +7075,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7294,7 +7286,6 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9230,7 +9221,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -12791,7 +12781,6 @@
       "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -15983,7 +15972,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17601,7 +17589,6 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -17760,7 +17747,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -19481,7 +19467,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19750,7 +19735,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19859,7 +19843,6 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -21716,7 +21699,7 @@
     },
     "packages/spacecat-shared-athena-client": {
       "name": "@adobe/spacecat-shared-athena-client",
-      "version": "1.10.3",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.96.3",
@@ -25373,7 +25356,7 @@
     },
     "packages/spacecat-shared-drs-client": {
       "name": "@adobe/spacecat-shared-drs-client",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.98.1",
@@ -34639,7 +34622,7 @@
     },
     "packages/spacecat-shared-utils": {
       "name": "@adobe/spacecat-shared-utils",
-      "version": "1.117.0",
+      "version": "1.118.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",

--- a/packages/spacecat-shared-data-access/src/models/fix-entity/fix-entity.model.js
+++ b/packages/spacecat-shared-data-access/src/models/fix-entity/fix-entity.model.js
@@ -44,6 +44,50 @@ class FixEntity extends BaseModel {
     return fixEntityCollection
       .getSuggestionsByFixEntityId(this.getId());
   }
+
+  /**
+   * Removes this FixEntity. When the fix is bound to a specific issue (granular CWV
+   * model — `changeDetails.issueId` is set), also rewinds every linked Suggestion so
+   * the issue is reopenable: clears `data.issues[issueId].fixEntityId` and resets
+   * that issue's status to NEW. The fix row and its junction rows are deleted by the
+   * inherited remove flow.
+   *
+   * Skipped when the fix has no issueId (legacy / non-CWV fixes) — same behavior as
+   * before. Also skipped when this method is reached as a dependent cascade (parent
+   * removal goes through `_remove()` directly), since the parent teardown moots the
+   * per-issue rewind.
+   */
+  async remove() {
+    const issueId = this.record?.changeDetails?.issueId;
+    if (issueId) {
+      await this.#resetLinkedIssues(issueId);
+    }
+    return super.remove();
+  }
+
+  async #resetLinkedIssues(issueId) {
+    const suggestions = await this.getSuggestions();
+
+    await Promise.all(suggestions.map(async (suggestion) => {
+      const data = suggestion.getData();
+      if (!data || !Array.isArray(data.issues)) {
+        return;
+      }
+      let mutated = false;
+      const nextIssues = data.issues.map((issue) => {
+        if (issue && issue.id === issueId) {
+          mutated = true;
+          return { ...issue, status: 'NEW', fixEntityId: null };
+        }
+        return issue;
+      });
+      if (!mutated) {
+        return;
+      }
+      suggestion.setData({ ...data, issues: nextIssues });
+      await suggestion.save();
+    }));
+  }
 }
 
 export default FixEntity;

--- a/packages/spacecat-shared-data-access/test/unit/models/fix-entity/fix-entity.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/fix-entity/fix-entity.model.test.js
@@ -15,6 +15,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { stub, restore } from 'sinon';
 import sinonChai from 'sinon-chai';
 
+import BaseModel from '../../../../src/models/base/base.model.js';
 import FixEntity from '../../../../src/models/fix-entity/fix-entity.model.js';
 import { createElectroMocks } from '../../util.js';
 
@@ -171,6 +172,152 @@ describe('FixEntityModel', () => {
 
       expect(mockFixEntityCollection.getSuggestionsByFixEntityId)
         .to.have.been.calledOnceWith(instance.getId());
+    });
+  });
+
+  describe('remove', () => {
+    const ISSUE_A = '8e1d2b8c-2b8e-4e6f-9a3a-1b2c3d4e5f60';
+    const ISSUE_B = '8e1d2b8c-2b8e-4e6f-9a3a-1b2c3d4e5f61';
+    let superRemoveStub;
+
+    beforeEach(() => {
+      // Bypass the inherited delete path; we only verify the override's
+      // pre-cleanup, not BaseModel's PostgREST removal machinery.
+      superRemoveStub = stub(BaseModel.prototype, 'remove').resolves();
+    });
+
+    afterEach(() => {
+      superRemoveStub.restore();
+    });
+
+    it('resets the matching issue on every linked suggestion when changeDetails.issueId is set', async () => {
+      const fix = createElectroMocks(FixEntity, {
+        ...mockRecord,
+        changeDetails: { ...mockRecord.changeDetails, issueId: ISSUE_A },
+      }).model;
+
+      const suggestionSaveSpies = [];
+      const buildSuggestion = (issues) => {
+        const data = { issues };
+        const save = stub().resolves();
+        suggestionSaveSpies.push(save);
+        return {
+          getData: () => data,
+          setData: (next) => { data.issues = next.issues; },
+          save,
+          // surface for assertions
+          peek: () => data,
+        };
+      };
+
+      const linkedSuggestions = [
+        buildSuggestion([
+          { id: ISSUE_A, status: 'FIXED', fixEntityId: fix.getId() },
+          { id: ISSUE_B, status: 'NEW', fixEntityId: null },
+        ]),
+        buildSuggestion([
+          { id: ISSUE_A, status: 'FIXED', fixEntityId: fix.getId() },
+        ]),
+      ];
+
+      const mockFixEntityCollection = {
+        getSuggestionsByFixEntityId: stub().resolves(linkedSuggestions),
+      };
+      fix.entityRegistry.getCollection
+        .withArgs('FixEntityCollection')
+        .returns(mockFixEntityCollection);
+
+      await fix.remove();
+
+      // Both suggestions saved once with the matching issue reset.
+      suggestionSaveSpies.forEach((save) => expect(save).to.have.been.calledOnce);
+
+      expect(linkedSuggestions[0].peek().issues).to.deep.equal([
+        { id: ISSUE_A, status: 'NEW', fixEntityId: null },
+        { id: ISSUE_B, status: 'NEW', fixEntityId: null },
+      ]);
+      expect(linkedSuggestions[1].peek().issues).to.deep.equal([
+        { id: ISSUE_A, status: 'NEW', fixEntityId: null },
+      ]);
+
+      expect(superRemoveStub).to.have.been.calledOnce;
+    });
+
+    it('skips suggestion mutation when no linked issue matches but still calls super.remove()', async () => {
+      const fix = createElectroMocks(FixEntity, {
+        ...mockRecord,
+        changeDetails: { ...mockRecord.changeDetails, issueId: ISSUE_A },
+      }).model;
+
+      const saveSpy = stub().resolves();
+      const orphanSuggestion = {
+        getData: () => ({ issues: [{ id: ISSUE_B, status: 'FIXED', fixEntityId: fix.getId() }] }),
+        setData: stub(),
+        save: saveSpy,
+      };
+
+      fix.entityRegistry.getCollection
+        .withArgs('FixEntityCollection')
+        .returns({ getSuggestionsByFixEntityId: stub().resolves([orphanSuggestion]) });
+
+      await fix.remove();
+
+      expect(saveSpy).to.not.have.been.called;
+      expect(orphanSuggestion.setData).to.not.have.been.called;
+      expect(superRemoveStub).to.have.been.calledOnce;
+    });
+
+    it('tolerates suggestions whose data has no issues array', async () => {
+      const fix = createElectroMocks(FixEntity, {
+        ...mockRecord,
+        changeDetails: { ...mockRecord.changeDetails, issueId: ISSUE_A },
+      }).model;
+
+      const noisySuggestions = [
+        { getData: () => null, setData: stub(), save: stub().resolves() },
+        { getData: () => ({ /* no issues */ }), setData: stub(), save: stub().resolves() },
+      ];
+
+      fix.entityRegistry.getCollection
+        .withArgs('FixEntityCollection')
+        .returns({ getSuggestionsByFixEntityId: stub().resolves(noisySuggestions) });
+
+      await fix.remove();
+
+      noisySuggestions.forEach((s) => {
+        expect(s.setData).to.not.have.been.called;
+        expect(s.save).to.not.have.been.called;
+      });
+      expect(superRemoveStub).to.have.been.calledOnce;
+    });
+
+    it('skips cleanup entirely when changeDetails.issueId is not set (legacy / non-CWV fix)', async () => {
+      // mockRecord's changeDetails has no issueId, so this is the legacy path.
+      const fix = createElectroMocks(FixEntity, mockRecord).model;
+      const getSuggestions = stub();
+      fix.entityRegistry.getCollection
+        .withArgs('FixEntityCollection')
+        .returns({ getSuggestionsByFixEntityId: getSuggestions });
+
+      await fix.remove();
+
+      expect(getSuggestions).to.not.have.been.called;
+      expect(superRemoveStub).to.have.been.calledOnce;
+    });
+
+    it('propagates errors from getSuggestions and does not call super.remove()', async () => {
+      const fix = createElectroMocks(FixEntity, {
+        ...mockRecord,
+        changeDetails: { ...mockRecord.changeDetails, issueId: ISSUE_A },
+      }).model;
+
+      const dbError = new Error('PostgREST exploded');
+      fix.entityRegistry.getCollection
+        .withArgs('FixEntityCollection')
+        .returns({ getSuggestionsByFixEntityId: stub().rejects(dbError) });
+
+      await expect(fix.remove()).to.be.rejectedWith('PostgREST exploded');
+      expect(superRemoveStub).to.not.have.been.called;
     });
   });
 });


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/SITES-46317

 ## Summary

Granular CWV suggestions (one issue per LCP / CLS / INP) associate a `changeDetails.issueId` with each FixEntity. Before this change, deleting a FixEntity via `DELETE /sites/:siteId/opportunities/:opportunityId/fixes/:fixId` left the parent suggestion in an inconsistent state — `data.issues[i].status` stayed `FIXED` and `fixEntityId` pointed at a now-deleted row, so the issue couldn't be reopened for further remediation.                          

This change overrides `FixEntity.remove()` so that before the row is deleted, every linked suggestion has its matching issue reset to `status = NEW` with `fixEntityId = null`. The existing delete endpoint inherits the new behavior because the controller already calls `fix.remove()` — no API surface change, no client changes.                                                                     
                                                             
## Changes

  - **`fix-entity.model.js`** — `remove()` override: reads `changeDetails.issueId`, walks linked suggestions, resets the matching issue, then calls `super.remove()`.
  - **`fix-entity.model.test.js`** — 5 new test cases: match-and-reset, no-match skip, malformed-data tolerance, no-issueId skip, error propagation.                                                                                                                        
  
Non-CWV / legacy fixes (no `changeDetails.issueId`) behave exactly as before. Dependent-cascade removal (e.g. opportunity teardown)  goes through `_remove()` directly and intentionally skips the per-issue rewind.
                                                                                                                                       
## Why not a new API parameter                             

The ticket proposed an optional `issueId` query parameter on the DELETE endpoint. Implementing it server-side instead because:       
  1. The UI already has the exact `fixEntityId` from `Suggestion.data.issues[i].fixEntityId` — an extra parameter would be redundant.
  2. The actual gap was server-side state cleanup, which belongs in the data model, not in caller-supplied metadata.                   
  3. Public API surface stays unchanged → backward compatible, no UI changes required.  