### PR TITLE
fix(data-access): remove stale stash conflict markers in CHANGELOG

### DIFF
--- a/packages/spacecat-shared-data-access/CHANGELOG.md
+++ b/packages/spacecat-shared-data-access/CHANGELOG.md
@@ -3732,18 +3732,14 @@ Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 
 * github org ([02f86c3](https://github.com/adobe/spacecat-shared/commit/02f86c351b2b1ab99ce5aca7fd5e6af2246c0efd))
 
-<<<<<<< Updated upstream
-# [@adobe/spacecat-shared-data-access-v1.6.0](https://github.com/adobe-rnd/spacecat-shared/compare/@adobe/spacecat-shared-data-access-v1.5.2...@adobe/spacecat-shared-data-access-v1.6.0) (2024-01-12)
+# [@adobe/spacecat-shared-data-access-v1.6.0](https://github.com/adobe/spacecat-shared/compare/@adobe/spacecat-shared-data-access-v1.5.2...@adobe/spacecat-shared-data-access-v1.6.0) (2024-01-12)
 
 
 ### Features
 
-* site delivery type ([#77](https://github.com/adobe-rnd/spacecat-shared/issues/77)) ([005bc38](https://github.com/adobe-rnd/spacecat-shared/commit/005bc388ed6ab0f82c8b0f562d4c1f4c0d1e2894))
+* site delivery type ([#77](https://github.com/adobe/spacecat-shared/issues/77)) ([005bc38](https://github.com/adobe/spacecat-shared/commit/005bc388ed6ab0f82c8b0f562d4c1f4c0d1e2894))
 
-# [@adobe/spacecat-shared-data-access-v1.5.2](https://github.com/adobe-rnd/spacecat-shared/compare/@adobe/spacecat-shared-data-access-v1.5.1...@adobe/spacecat-shared-data-access-v1.5.2) (2023-12-30)
-=======
 # [@adobe/spacecat-shared-data-access-v1.5.2](https://github.com/adobe/spacecat-shared/compare/@adobe/spacecat-shared-data-access-v1.5.1...@adobe/spacecat-shared-data-access-v1.5.2) (2023-12-30)
->>>>>>> Stashed changes
 
 
 ### Bug Fixes


### PR DESCRIPTION
## What

Removes an unresolved `git stash` conflict block that has been sitting in `packages/spacecat-shared-data-access/CHANGELOG.md` (lines ~3735–3746) on `main`.

```
<<<<<<< Updated upstream
...
=======
...
>>>>>>> Stashed changes
```

## Where it came from

Commit `02f86c35` *"fix: github org"* (2024-01-12) — the commit that renamed `adobe-rnd/spacecat-shared` to `adobe/spacecat-shared` across the repo — accidentally committed an unresolved `git stash pop` conflict into this CHANGELOG (the markers are labeled `Updated upstream` / `Stashed changes`, i.e. stash-pop, not a normal merge).

It survived ~2.5 years because `@semantic-release/changelog` only **prepends** new entries to the top of the file, so this old block deep in the history was never re-touched and no later merge re-surfaced it. It is harmless at runtime but it is literally broken markup committed in `main`, and it trips every `grep`/scan for conflict markers.

## Resolution

The two sides differed only in: the `Updated upstream` side carried a **v1.6.0** entry (with stale `adobe-rnd` URLs) that the other side lacked, while the `Stashed changes` side had the v1.5.2 line with the corrected `adobe` URL.

Resolved by **keeping the v1.6.0 entry and normalizing its `adobe-rnd` URLs to `adobe`** — honoring the original commit's intent and losing no changelog history. Net diff: 2 insertions, 6 deletions.

## Validation

- `git grep` for conflict markers across the whole tree is now clean.
- Only the old, append-stable region of one generated CHANGELOG is touched — no source, no behavior, no impact on semantic-release (it only prepends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)