### PR TITLE
feat(launchdarkly-client): eliminate Lambda log noise (cache + polling + init timeout)

### DIFF
--- a/docs/plans/2026-06-15-launchdarkly-lambda-noise-design.md
+++ b/docs/plans/2026-06-15-launchdarkly-lambda-noise-design.md
@@ -54,6 +54,16 @@ Three compounding factors:
    level. It is shadowed by the nested `1.0.4` pin in `http-utils`, so the auth path never
    loads it. The version cascade - not just the code - is what kept this broken.
 
+### Not a cause: the LD SDK version
+
+The upstream SDK is not implicated. Both the prod-deployed `launchdarkly-client@1.0.4` and
+the current HEAD pin `@launchdarkly/node-server-sdk@^9.9.7` (same v9 line; latest is
+`9.11.2`). The SDK default is unchanged across v9: with no `logger` supplied it uses
+`basicLogger` at `info`, which writes to stderr. So bumping the SDK alone would **not** fix
+the noise - the wrapper-passes-logger fix is required regardless of SDK version and is
+deterministic, not version-dependent. An SDK bump (9.9.7 -> 9.11.2) is optional, orthogonal
+hygiene and is intentionally kept out of this change.
+
 ## Goal
 
 Eliminate the LD log noise **at the source** (not merely relabel it), and stop the
@@ -91,6 +101,10 @@ SDK in use: `@launchdarkly/node-server-sdk@9.10.10`.
      "on the advice of LaunchDarkly support." Disabling streaming in serverless is a
      well-established pattern, but we will validate flag-evaluation correctness explicitly
      (see Validation gates) and note this deviation.
+   - API choice: use the **stable** top-level `stream` / `pollInterval` options. The newer
+     `dataSystem` polling config (which the SDK docs label "Recommended") is marked
+     `@experimental` in 9.10/9.11, so it is deliberately avoided for this prod hot-path fix.
+     Do not "modernize" to `dataSystem` until it is stable.
 
 3. **Bounded init with timeout.** Replace `await client.waitForInitialization()` with
    `await client.waitForInitialization({ timeoutSeconds: 5 })`. Removes the "without a

--- a/docs/plans/2026-06-15-launchdarkly-lambda-noise-design.md
+++ b/docs/plans/2026-06-15-launchdarkly-lambda-noise-design.md
@@ -1,0 +1,156 @@
+# LaunchDarkly Lambda Log-Noise Elimination - Design
+
+- Date: 2026-06-15
+- Status: proposed
+- Owner: Dominique Jäggi
+- Affected packages: `spacecat-shared-launchdarkly-client`, `spacecat-shared-http-utils`
+- Downstream consumer: `spacecat-api-service` (version bump + redeploy)
+
+## Problem
+
+In SpaceCat prod, LaunchDarkly (LD) SDK log lines dominate the `error`-level logs. Over a
+representative window (Coralogix prod, `spacecat-services-prod`, `level=error`,
+2026-06-15 00:00:00Z - 05:45:00Z, ~5.75h):
+
+- Total `error` events: 148,521
+- LaunchDarkly SDK lines (all `level=error`):
+  - `info: [launchdarkly] will retry stream connection in N ms` - 55,323
+  - `warn: [launchdarkly] waitForInitialization called without a timeout` - 44,165
+  - `warn: [launchdarkly] received I/O error ... will retry` - 5,737
+  - Subtotal: 105,225 (~71% of all prod errors)
+- `api-service` alone accounts for 105,912 of the 148,521 errors - i.e. api-service's
+  error volume is almost entirely LD noise.
+
+These are not real errors. They drown the genuine operational errors (import-worker RUM
+domainkey 404s, audit-worker enrollment + DB constraint issues) and inflate error-rate
+signals.
+
+## Root cause
+
+Three compounding factors:
+
+1. **Wrong SDK logger in the deployed client.** The auth-path LD client running in prod is
+   `@adobe/spacecat-shared-launchdarkly-client@1.0.4`, resolved as a **nested** copy under
+   `spacecat-shared-http-utils` (which hard-pins `launchdarkly-client@1.0.4`). That version
+   passes **no `logger`** to `ld.init()`, so the SDK falls back to `basicLogger`, which
+   writes every level (info/warn/error) to `console.error` / stderr. AWS Lambda captures
+   all stderr as `error`-level, so every LD line is tagged `error`. The `info:` / `warn:`
+   prefixes in the messages are the `basicLogger` format - the tell that our wrapper logger
+   is not in play.
+
+2. **Per-request streaming client churn.** The IMS auth handler creates a brand-new
+   streaming LD client on every authenticated request, with no caching:
+   - `spacecat-shared-http-utils/src/auth/handlers/ims.js:169` - `LaunchDarklyClient.createFrom(context)`
+   - `spacecat-shared-http-utils/src/auth/read-only-admin-wrapper.js:169` - same
+
+   Each client opens a streaming connection and calls `waitForInitialization()` with **no
+   timeout**. Under Lambda freeze/thaw, streaming connections cannot stay alive, so each
+   invocation re-connects and retries - producing the "will retry stream connection" and
+   "received I/O error ... will retry" storms. The missing timeout produces the
+   "waitForInitialization called without a timeout" warning.
+
+3. **The existing logger fix never reached prod.** PR #1511 (`launchdarkly-client@1.2.x`,
+   2026-04-06) already routes LD `info`/`warn`/`debug` through the Lambda logger at `debug`
+   level. It is shadowed by the nested `1.0.4` pin in `http-utils`, so the auth path never
+   loads it. The version cascade - not just the code - is what kept this broken.
+
+## Goal
+
+Eliminate the LD log noise **at the source** (not merely relabel it), and stop the
+underlying Lambda anti-pattern (per-request streaming client creation, untimed init).
+
+### Non-goals / out of scope
+
+- The `url.parse` `DEP0169` DeprecationWarning (1,098 events) - explicitly out of scope.
+- LD daemon mode (DynamoDB feature store + LD Relay) - more robust at scale but requires new
+  infra; not warranted for the current single kill-switch flag. Recorded as a future option.
+
+## Design
+
+The behavior change lives entirely in `spacecat-shared-launchdarkly-client`. The release
+cascade carries it to prod.
+
+### Part 1 - `spacecat-shared-launchdarkly-client` changes
+
+SDK in use: `@launchdarkly/node-server-sdk@9.10.10`.
+
+1. **Singleton cache (per `sdkKey`).** Cache the initialized underlying SDK client and its
+   init promise at module scope, keyed by `sdkKey`. The lightweight `LaunchDarklyClient`
+   wrapper stays per-call so each request keeps its own `log` (correct requestId), but
+   `init()` reuses the cached SDK client / init promise. Effect: **one init per warm Lambda
+   container instead of one per request.**
+   - On init failure, clear the cached promise so the next request retries (no poisoned
+     cache that permanently fails a warm container).
+
+2. **Polling instead of streaming.** Pass `{ stream: false, pollInterval: 30 }` to
+   `ld.init()`. Removes the persistent streaming connection (the source of the "will retry
+   stream connection" / "received I/O error" storms) and drops `launchdarkly-eventsource`
+   from the hot path. `pollInterval` is in seconds; 30s staleness is acceptable for a
+   kill-switch flag.
+   - Caveat to validate: the SDK `LDOptions.stream` doc says streaming should be disabled
+     "on the advice of LaunchDarkly support." Disabling streaming in serverless is a
+     well-established pattern, but we will validate flag-evaluation correctness explicitly
+     (see Validation gates) and note this deviation.
+
+3. **Bounded init with timeout.** Replace `await client.waitForInitialization()` with
+   `await client.waitForInitialization({ timeoutSeconds: 5 })`. Removes the "without a
+   timeout" warning and bounds cold-start latency. On timeout/throw, fail-open: the auth
+   call sites already catch and return `false`.
+
+4. **Keep the logger mapping.** Retain the existing wrapper mapping (`error -> log.error`;
+   `warn`/`info`/`debug -> log.debug`) as defense-in-depth for any residual SDK chatter.
+
+### Part 2 - Release cascade (this is what lands it in prod)
+
+1. Release `spacecat-shared-launchdarkly-client` (minor) with Part 1.
+2. **Bump `spacecat-shared-http-utils`'s pin from `launchdarkly-client@1.0.4` to the new
+   version**, then release `http-utils`. Without this the nested `1.0.4` keeps shadowing the
+   fix - this is the step the prior fix missed.
+3. Bump `spacecat-api-service` to the new `http-utils` (and dedupe to a single hoisted
+   `launchdarkly-client`), then redeploy.
+
+### Part 3 - Rollout and validation gates
+
+Deploy dev first, validate in Coralogix, then prod.
+
+## Test plan
+
+`spacecat-shared` enforces 100% lines/statements, 97% branches per package. New/updated unit
+tests in `spacecat-shared-launchdarkly-client`:
+
+- Cache reuse: two `createFrom` / `init()` calls with the same `sdkKey` call `ld.init` once.
+- Polling options: `ld.init` receives `{ stream: false, pollInterval: 30 }`.
+- Timeout: `waitForInitialization` is called with `{ timeoutSeconds: 5 }`.
+- Fail-open / cache-clear: when init rejects, the cached promise is cleared and a subsequent
+  call retries `ld.init`.
+- Logger mapping unchanged: `info`/`warn`/`debug -> log.debug`, `error -> log.error`.
+
+## Validation gates
+
+- **Dev (after deploy):** Coralogix `spacecat-services-dev`, `level=error` -
+  LD templates (`will retry stream connection`, `waitForInitialization ... timeout`,
+  `received I/O error`) drop to ~0; api-service error volume drops sharply over a comparable
+  window. Confirm `FF_READ_ONLY_ORG` still gates a known org (flag evaluation correct) and
+  cold-start latency is acceptable.
+- **Prod (after deploy):** same Coralogix verification on `spacecat-services-prod`.
+
+## Expected outcome
+
+- api-service prod error volume falls from ~106k to near-zero LD lines over a comparable
+  window; the genuine import-worker / audit-worker errors become the visible top-N.
+- Residual LD lines (a handful per cold start) are `debug` level and suppressed at prod's
+  default `info` level.
+- Secondary benefits: lower auth-path latency (no per-request streaming connect / untimed
+  init) and no wasted outbound streaming connections.
+
+## Tunables (defaults)
+
+- `pollInterval`: 30 seconds.
+- init `timeoutSeconds`: 5 seconds.
+
+## References
+
+- Coralogix prod analysis 2026-06-15 (window above).
+- Prior logger fix: PR #1511 (`launchdarkly-client@1.2.x`), commit `9efd5a95`.
+- Call sites: `spacecat-shared-http-utils/src/auth/handlers/ims.js:169`,
+  `spacecat-shared-http-utils/src/auth/read-only-admin-wrapper.js:169`.

--- a/docs/plans/2026-06-15-launchdarkly-lambda-noise-design.md
+++ b/docs/plans/2026-06-15-launchdarkly-lambda-noise-design.md
@@ -61,8 +61,12 @@ the current HEAD pin `@launchdarkly/node-server-sdk@^9.9.7` (same v9 line; lates
 `9.11.2`). The SDK default is unchanged across v9: with no `logger` supplied it uses
 `basicLogger` at `info`, which writes to stderr. So bumping the SDK alone would **not** fix
 the noise - the wrapper-passes-logger fix is required regardless of SDK version and is
-deterministic, not version-dependent. An SDK bump (9.9.7 -> 9.11.2) is optional, orthogonal
-hygiene and is intentionally kept out of this change.
+deterministic, not version-dependent.
+
+The SDK is nonetheless bumped to `^9.11.2` as part of this change (routine hygiene, bundled
+because we are already touching this package - not the fix itself). On bump, re-verify the
+two API facts this design relies on still hold in 9.11.2: top-level `stream` / `pollInterval`
+are stable (not `@deprecated`), and the `dataSystem` config is still `@experimental`.
 
 ## Goal
 
@@ -113,6 +117,10 @@ SDK in use: `@launchdarkly/node-server-sdk@9.10.10`.
 
 4. **Keep the logger mapping.** Retain the existing wrapper mapping (`error -> log.error`;
    `warn`/`info`/`debug -> log.debug`) as defense-in-depth for any residual SDK chatter.
+
+5. **Bump the SDK** `@launchdarkly/node-server-sdk` `^9.9.7 -> ^9.11.2` (hygiene, bundled
+   because we are already in this package; behavior-neutral for the fix). Re-verify the
+   stable-`stream`/`pollInterval` and experimental-`dataSystem` facts on the bumped version.
 
 ### Part 2 - Release cascade (this is what lands it in prod)
 

--- a/docs/plans/2026-06-15-launchdarkly-lambda-noise-plan.md
+++ b/docs/plans/2026-06-15-launchdarkly-lambda-noise-plan.md
@@ -1,0 +1,488 @@
+# LaunchDarkly Lambda Log-Noise Elimination - Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop LaunchDarkly SDK lines from flooding SpaceCat prod logs as `error`-level noise (~71% of all prod errors) by fixing the LD client lifecycle and logging in the shared client, then cascading the new version to prod.
+
+**Architecture:** The behavior change is confined to `spacecat-shared-launchdarkly-client`: a module-scope SDK-client cache (one client per warm Lambda container instead of one per request), polling instead of streaming, a bounded init timeout, and the existing logger mapping. A two-step release cascade (`launchdarkly-client` -> `http-utils` pin bump -> `api-service` consumption bump + redeploy) is what actually lands it in prod - the prior logger fix never deployed because `http-utils` hard-pins the old `launchdarkly-client@1.0.4`.
+
+**Tech Stack:** Node 22 ESM, `@launchdarkly/node-server-sdk@^9.11.2`, Mocha + Chai + Sinon + esmock, c8 coverage (100% lines/statements, 97% branches), semantic-release monorepo (OIDC publish).
+
+**Spec:** `docs/plans/2026-06-15-launchdarkly-lambda-noise-design.md`
+
+---
+
+## File Structure
+
+Phase 1 (repo: `spacecat-shared`, branch `fix/launchdarkly-lambda-noise`):
+- Modify: `packages/spacecat-shared-launchdarkly-client/src/launchdarkly-client.js` - cache, polling, timeout, `clearClientCache` export.
+- Modify: `packages/spacecat-shared-launchdarkly-client/src/index.js` - re-export `clearClientCache`.
+- Modify: `packages/spacecat-shared-launchdarkly-client/test/index.test.js` - reset cache in `afterEach`, new assertions, cross-instance + cache-clear tests.
+- Modify: `packages/spacecat-shared-launchdarkly-client/package.json` - SDK bump to `^9.11.2`.
+
+Phase 2 (repo: `spacecat-shared`, NEW branch, after Phase 1 publishes):
+- Modify: `packages/spacecat-shared-http-utils/package.json` - bump `@adobe/spacecat-shared-launchdarkly-client` pin `1.0.4` -> `^1.3.0`.
+
+Phase 3 (repo: `spacecat-api-service`, NEW branch, after Phase 2 publishes):
+- Modify: `package.json` + `package-lock.json` - bump `@adobe/spacecat-shared-http-utils` and `@adobe/spacecat-shared-launchdarkly-client`, dedupe to a single hoisted copy.
+
+Phase 4: validation gates (Coralogix), no code.
+
+---
+
+## Phase 1 - `spacecat-shared-launchdarkly-client`
+
+Work on the existing branch `fix/launchdarkly-lambda-noise` in `spacecat-shared`. All commands run from the repo root `/Users/dj/work/github/adobe/spacecat-shared`.
+
+### Task 1: Bump the LaunchDarkly SDK to 9.11.2 (hygiene, behavior-neutral)
+
+**Files:**
+- Modify: `packages/spacecat-shared-launchdarkly-client/package.json`
+
+- [ ] **Step 1: Edit the dependency**
+
+In `packages/spacecat-shared-launchdarkly-client/package.json`, change:
+```json
+"@launchdarkly/node-server-sdk": "^9.9.7"
+```
+to:
+```json
+"@launchdarkly/node-server-sdk": "^9.11.2"
+```
+
+- [ ] **Step 2: Install**
+
+Run: `npm install`
+Expected: lockfile updates `@launchdarkly/node-server-sdk` to `9.11.2`.
+
+- [ ] **Step 3: Verify the two API facts the design relies on still hold in 9.11.2**
+
+Run:
+```bash
+DT=node_modules/@launchdarkly/js-server-sdk-common/dist/api/options
+grep -n -B1 "stream?: boolean" $DT/LDOptions.d.ts | grep -i deprecat || echo "stream: NOT deprecated (OK)"
+grep -n "@experimental" $DT/LDDataSystemOptions.d.ts | head -1 && echo "dataSystem: still experimental (OK - keep using stream/pollInterval)"
+```
+Expected: `stream` is NOT deprecated; `dataSystem` is still `@experimental`. If either changed, stop and revisit the design.
+
+- [ ] **Step 4: Run the existing suite (must stay green)**
+
+Run: `npm test -w packages/spacecat-shared-launchdarkly-client`
+Expected: PASS, coverage thresholds met.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/spacecat-shared-launchdarkly-client/package.json package-lock.json
+git commit -m "fix(launchdarkly-client): bump node-server-sdk to ^9.11.2"
+```
+
+### Task 2: Module-scope SDK-client cache (reuse across warm invocations)
+
+**Files:**
+- Modify: `packages/spacecat-shared-launchdarkly-client/src/launchdarkly-client.js`
+- Modify: `packages/spacecat-shared-launchdarkly-client/src/index.js`
+- Test: `packages/spacecat-shared-launchdarkly-client/test/index.test.js`
+
+- [ ] **Step 1: Capture the cache-reset hook in the test setup**
+
+In `test/index.test.js`, the suite esmocks once in `before()`. Add a `clearClientCache` capture and reset it after each test so the new module-scope cache does not leak between tests.
+
+In the `before(async () => { ... })` block, after `LaunchDarklyClient = module.default;`, add:
+```js
+    clearClientCache = module.clearClientCache;
+```
+Add the declaration near the other `let` declarations at the top of the `describe`:
+```js
+  let clearClientCache;
+```
+Change the existing `afterEach`:
+```js
+  afterEach(() => {
+    sinon.resetHistory();
+  });
+```
+to:
+```js
+  afterEach(() => {
+    sinon.resetHistory();
+    clearClientCache();
+  });
+```
+
+- [ ] **Step 2: Write the failing cross-instance reuse test**
+
+Add this test inside the `describe('init', ...)` block (next to the existing reuse tests):
+```js
+    it('reuses one SDK client across separate instances with the same sdkKey', async () => {
+      const log = {
+        info: sinon.stub(), error: sinon.stub(), debug: sinon.stub(), warn: sinon.stub(),
+      };
+      const a = new LaunchDarklyClient({ sdkKey: testSdkKey }, log);
+      const b = new LaunchDarklyClient({ sdkKey: testSdkKey }, log);
+
+      await a.init();
+      await b.init();
+
+      // Without a module-scope cache, each instance calls ld.init separately.
+      expect(mockInit).to.have.been.calledOnce;
+    });
+```
+
+- [ ] **Step 3: Run it to confirm it fails**
+
+Run: `npm test -w packages/spacecat-shared-launchdarkly-client -- --grep "reuses one SDK client"`
+Expected: FAIL - `mockInit` called twice.
+
+- [ ] **Step 4: Add the cache + reset export to the client**
+
+In `src/launchdarkly-client.js`, add module-scope constants and cache near the top (after the existing `DEFAULT_API_BASE_URL`):
+```js
+const DEFAULT_POLL_INTERVAL_SECONDS = 30;
+const DEFAULT_INIT_TIMEOUT_SECONDS = 5;
+
+// Cache of initialized SDK clients, keyed by sdkKey. A warm Lambda container
+// reuses one client across invocations instead of opening a new connection per
+// request. Each entry holds the in-flight/resolved init promise.
+const sdkClientCache = new Map();
+
+/**
+ * Resets the module-scope SDK-client cache. Exported for tests; not part of the
+ * normal runtime flow.
+ */
+export function clearClientCache() {
+  sdkClientCache.clear();
+}
+```
+
+Replace the body of `async init()` with:
+```js
+  async init() {
+    if (!this.sdkKey) {
+      throw new Error('LaunchDarkly SDK key is required for flag evaluation');
+    }
+
+    if (this.client) {
+      return undefined;
+    }
+
+    const cached = sdkClientCache.get(this.sdkKey);
+    if (cached) {
+      // Reuse an already-initialized client or join an in-flight initialization.
+      this.client = await cached.initPromise;
+      return undefined;
+    }
+
+    const initPromise = (async () => {
+      const client = ld.init(this.sdkKey, {
+        stream: false,
+        pollInterval: DEFAULT_POLL_INTERVAL_SECONDS,
+        ...this.options,
+        logger: this.sdkLogger,
+      });
+      await client.waitForInitialization({ timeoutSeconds: DEFAULT_INIT_TIMEOUT_SECONDS });
+      return client;
+    })();
+
+    sdkClientCache.set(this.sdkKey, { initPromise });
+
+    try {
+      this.client = await initPromise;
+      this.log.info('LaunchDarkly client initialized successfully');
+    } catch (error) {
+      // Clear the poisoned entry so the next call retries initialization.
+      sdkClientCache.delete(this.sdkKey);
+      this.log.error('Failed to initialize LaunchDarkly client:', error);
+      throw error;
+    }
+    return undefined;
+  }
+```
+
+- [ ] **Step 5: Re-export `clearClientCache`**
+
+In `src/index.js`, change:
+```js
+import LaunchDarklyClient from './launchdarkly-client.js';
+
+export { LaunchDarklyClient };
+export default LaunchDarklyClient;
+```
+to:
+```js
+import LaunchDarklyClient, { clearClientCache } from './launchdarkly-client.js';
+
+export { LaunchDarklyClient, clearClientCache };
+export default LaunchDarklyClient;
+```
+
+- [ ] **Step 6: Run the new test + full suite**
+
+Run: `npm test -w packages/spacecat-shared-launchdarkly-client`
+Expected: PASS, including the new cross-instance test and all pre-existing reuse tests (the `afterEach` reset keeps them isolated).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/spacecat-shared-launchdarkly-client/src packages/spacecat-shared-launchdarkly-client/test
+git commit -m "feat(launchdarkly-client): cache SDK client per sdkKey across warm invocations"
+```
+
+### Task 3: Polling instead of streaming + bounded init timeout
+
+**Files:**
+- Test: `packages/spacecat-shared-launchdarkly-client/test/index.test.js`
+- Modify: `packages/spacecat-shared-launchdarkly-client/src/launchdarkly-client.js` (already done in Task 2 - this task drives it with tests and updates the existing arg assertion)
+
+- [ ] **Step 1: Write failing assertions for the new init options**
+
+Add this test inside `describe('init', ...)`:
+```js
+    it('initializes in polling mode with a bounded init timeout', async () => {
+      const log = {
+        info: sinon.stub(), error: sinon.stub(), debug: sinon.stub(), warn: sinon.stub(),
+      };
+      const client = new LaunchDarklyClient({ sdkKey: testSdkKey }, log);
+
+      await client.init();
+
+      const options = mockInit.firstCall.args[1];
+      expect(options).to.include({ stream: false, pollInterval: 30 });
+      expect(options).to.have.property('logger');
+      expect(mockClient.waitForInitialization)
+        .to.have.been.calledWith({ timeoutSeconds: 5 });
+    });
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `npm test -w packages/spacecat-shared-launchdarkly-client -- --grep "polling mode"`
+Expected: PASS (the implementation from Task 2 already passes `stream:false`, `pollInterval:30`, and `{ timeoutSeconds: 5 }`). If it fails, fix the `ld.init` options / `waitForInitialization` call in `src/launchdarkly-client.js` to match.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/spacecat-shared-launchdarkly-client/test
+git commit -m "test(launchdarkly-client): assert polling mode and init timeout"
+```
+
+### Task 4: Cache is cleared on init failure (retry, no poisoned warm container)
+
+**Files:**
+- Test: `packages/spacecat-shared-launchdarkly-client/test/index.test.js`
+
+- [ ] **Step 1: Write the failing retry test**
+
+Add inside `describe('init', ...)`:
+```js
+    it('clears the cache on init failure so the next call retries', async () => {
+      const log = {
+        info: sinon.stub(), error: sinon.stub(), debug: sinon.stub(), warn: sinon.stub(),
+      };
+      mockClient.waitForInitialization.onFirstCall().rejects(new Error('init timeout'));
+      mockClient.waitForInitialization.onSecondCall().resolves();
+
+      const first = new LaunchDarklyClient({ sdkKey: testSdkKey }, log);
+      await expect(first.init()).to.be.rejectedWith('init timeout');
+
+      const second = new LaunchDarklyClient({ sdkKey: testSdkKey }, log);
+      await second.init();
+
+      // A failed init must not poison the cache: ld.init runs again on retry.
+      expect(mockInit).to.have.been.calledTwice;
+
+      mockClient.waitForInitialization.reset();
+      mockClient.waitForInitialization.resolves();
+    });
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `npm test -w packages/spacecat-shared-launchdarkly-client -- --grep "clears the cache on init failure"`
+Expected: PASS (the `catch` block in Task 2 deletes the cache entry). If it fails, ensure `sdkClientCache.delete(this.sdkKey)` is in the `catch`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/spacecat-shared-launchdarkly-client/test
+git commit -m "test(launchdarkly-client): retry after init failure clears cache"
+```
+
+### Task 5: Full verification gate + open Phase 1 PR
+
+- [ ] **Step 1: Run lint, full suite, coverage**
+
+Run:
+```bash
+npm run lint -w packages/spacecat-shared-launchdarkly-client
+npm test -w packages/spacecat-shared-launchdarkly-client
+```
+Expected: lint clean; all tests pass; c8 reports 100% lines/statements, >=97% branches. If a new branch (e.g. the `catch` path) is uncovered, the Task 4 test should cover it - confirm.
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git push -u origin fix/launchdarkly-lambda-noise
+```
+Open a PR to `adobe/spacecat-shared` `main` via the `mcp__github__*` tools. Title: `feat(launchdarkly-client): eliminate Lambda log noise (cache + polling + init timeout)`. Body: link the spec, summarize root cause (nested `1.0.4` pin shipped a no-logger streaming client created per request) and the fix. Note this is Phase 1 of a 3-PR cascade.
+
+- [ ] **Step 3: Validation gate - merge + publish**
+
+After review + merge, confirm semantic-release published the new minor:
+```bash
+npm view @adobe/spacecat-shared-launchdarkly-client dist-tags.latest
+```
+Expected: `1.3.0` (or the computed minor). Record the exact version - Phase 2 pins to it.
+
+---
+
+## Phase 2 - `spacecat-shared-http-utils` pin bump (lands the fix on the auth path)
+
+This is what makes prod actually pick up the fix: `http-utils` hard-pins `launchdarkly-client@1.0.4`, which shadows everything. Do this in a NEW branch only AFTER Phase 1's version is on npm (otherwise CI `npm install` fails with a missing version).
+
+### Task 6: Bump the launchdarkly-client pin in http-utils
+
+**Files:**
+- Modify: `packages/spacecat-shared-http-utils/package.json`
+
+- [ ] **Step 1: New branch from latest main**
+
+```bash
+git fetch origin main
+git checkout -b fix/http-utils-ld-client-bump origin/main
+```
+
+- [ ] **Step 2: Edit the pin**
+
+In `packages/spacecat-shared-http-utils/package.json`, change the `@adobe/spacecat-shared-launchdarkly-client` dependency from `1.0.4` to `^1.3.0` (use the exact version published in Phase 1).
+
+- [ ] **Step 3: Install + test**
+
+```bash
+npm install
+npm test -w packages/spacecat-shared-http-utils
+npm run lint -w packages/spacecat-shared-http-utils
+```
+Expected: PASS. The auth handlers call `LaunchDarklyClient.createFrom(...)` unchanged; existing tests stub the client, so behavior is unchanged at the http-utils layer.
+
+- [ ] **Step 4: Verify no nested old copy remains in the workspace**
+
+Run:
+```bash
+find node_modules/@adobe/spacecat-shared-http-utils/node_modules -name package.json -path '*launchdarkly-client*' -exec node -p "require('./{}').version" \; 2>/dev/null || echo "no nested copy (OK)"
+```
+Expected: no nested `launchdarkly-client` under http-utils (hoisted to a single `>=1.3.0`).
+
+- [ ] **Step 5: Commit, push, PR**
+
+```bash
+git add packages/spacecat-shared-http-utils/package.json package-lock.json
+git commit -m "fix(http-utils): bump launchdarkly-client to ^1.3.0 to ship Lambda log-noise fix"
+git push -u origin fix/http-utils-ld-client-bump
+```
+Open PR to `adobe/spacecat-shared` `main`. After merge, confirm publish:
+```bash
+npm view @adobe/spacecat-shared-http-utils dist-tags.latest
+```
+Record the new http-utils version for Phase 3.
+
+---
+
+## Phase 3 - `spacecat-api-service` consumption bump + dedupe + deploy
+
+Repo: `spacecat-api-service` (`/Users/dj/work/github/adobe/spacecat-api-service`). Do this AFTER Phase 2 is on npm.
+
+### Task 7: Bump consumers and remove the nested old client
+
+**Files:**
+- Modify: `package.json`, `package-lock.json`
+
+- [ ] **Step 1: New branch from latest main**
+
+```bash
+cd /Users/dj/work/github/adobe/spacecat-api-service
+git fetch origin main
+git checkout -b fix/ld-lambda-noise-consume origin/main
+```
+
+- [ ] **Step 2: Bump both shared deps**
+
+In `package.json`, set:
+- `@adobe/spacecat-shared-http-utils` to the version published in Phase 2.
+- `@adobe/spacecat-shared-launchdarkly-client` to `^1.3.0` (so the top-level range and the http-utils pin both resolve to one hoisted copy).
+
+- [ ] **Step 3: Install and confirm a single hoisted client**
+
+```bash
+npm install
+node -p "require('./node_modules/@adobe/spacecat-shared-launchdarkly-client/package.json').version"
+find node_modules/@adobe/spacecat-shared-http-utils/node_modules -path '*launchdarkly-client*' 2>/dev/null || echo "no nested copy (OK)"
+```
+Expected: top-level client is `>=1.3.0`; no nested copy under http-utils. This is the dedupe that guarantees the auth path loads the fixed client.
+
+- [ ] **Step 4: Run the api-service test suite**
+
+Run: `npm test`
+Expected: PASS. If auth tests stub the LD client, no behavior change is expected.
+
+- [ ] **Step 5: Commit, push, PR**
+
+```bash
+git add package.json package-lock.json
+git commit -m "fix: consume launchdarkly-client log-noise fix and dedupe nested copy"
+git push -u origin fix/ld-lambda-noise-consume
+```
+Open PR to `adobe/spacecat-api-service` `main` via `mcp__github__*`. Merge per the repo's CD flow (deploys to dev/ci, then prod).
+
+---
+
+## Phase 4 - Validation gates (Coralogix)
+
+LD logs flow to Coralogix during the Splunk cutover. Use the SpaceCat Coralogix label map: dev = `aws-682033462621` / `spacecat-services-dev`; prod = `aws-640168421876` / `spacecat-services-prod`. Keep windows <= 6h.
+
+### Task 8: Verify dev after api-service deploys to ci/dev
+
+- [ ] **Step 1: Confirm LD noise templates are gone in dev**
+
+DataPrime (last 3h, dev):
+```
+source logs | filter $l.applicationname == 'aws-682033462621'
+  && $l.subsystemname == 'spacecat-services-dev'
+  && $d.level == 'error'
+  && $d.message ~ 'launchdarkly'
+  | count
+```
+Expected: ~0 (was a steady stream of `will retry stream connection` / `waitForInitialization ... timeout`).
+
+- [ ] **Step 2: Confirm flag evaluation still works (fail-open + correctness)**
+
+Exercise an IMS-authenticated request for an org gated by `FF_READ_ONLY_ORG` and confirm the gate behaves as before. Check dev logs show no new LD `error` lines and no auth regressions.
+
+- [ ] **Step 3: Sanity-check cold-start latency**
+
+Confirm api-service p50/p99 latency in dev is not worse than before (the single per-cold-start poll with a 5s timeout replaces per-request streaming).
+
+### Task 9: Verify prod after deploy
+
+- [ ] **Step 1: Re-run the top-error analysis in prod**
+
+DataPrime (prod, comparable window):
+```
+source logs | filter $l.applicationname == 'aws-640168421876'
+  && $l.subsystemname == 'spacecat-services-prod'
+  && $d.level == 'error'
+  | groupby $d.inv.functionName aggregate count() as cnt
+```
+Expected: `api-service` error count drops from ~106k to roughly the genuine-error baseline; the LD templates (`will retry stream connection`, `waitForInitialization ... timeout`, `received I/O error`) are absent from the top-N.
+
+- [ ] **Step 2: Confirm the genuine errors are now visible**
+
+Expected top errors are the real ones (import-worker RUM domainkey 404s, audit-worker enrollment + DB unique-constraint), not LD noise. Done.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: cache (Task 2), polling + timeout (Task 3), logger mapping retained (unchanged code, covered by existing logger tests at lines ~130-138), cache-clear-on-failure (Task 4), SDK bump (Task 1), release cascade (Tasks 5-7), validation gates (Tasks 8-9). The url.parse DEP0169 is explicitly out of scope per the spec.
+- Type/name consistency: `clearClientCache` exported from `launchdarkly-client.js` and re-exported from `index.js`; `sdkClientCache`, `DEFAULT_POLL_INTERVAL_SECONDS` (30), `DEFAULT_INIT_TIMEOUT_SECONDS` (5) used consistently; tests assert the same literals (`stream:false`, `pollInterval:30`, `timeoutSeconds:5`).
+- Cross-repo gates: Phase 2 waits on Phase 1's npm publish; Phase 3 waits on Phase 2's. Each is a separate branch/PR.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3807,18 +3807,18 @@
       }
     },
     "node_modules/@launchdarkly/js-sdk-common": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@launchdarkly/js-sdk-common/-/js-sdk-common-2.24.0.tgz",
-      "integrity": "sha512-f/xRD8gl/bSOVljat79nAzX0V0QjJ76R54aAbB6PJDWL+7BWBSFMxduaeokzbX53cs3oOVajL8ej/ps7+ojMeQ==",
+      "version": "2.25.1",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-sdk-common/-/js-sdk-common-2.25.1.tgz",
+      "integrity": "sha512-erG2RbA8QQMKW+D9Y7Uahez1dU+TzmyTzv9qlB7b0Pr/DS2SmUg5H8pJbkLcRrSxoshczZdB1UqsuE3RAk7UYQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@launchdarkly/js-server-sdk-common": {
-      "version": "2.18.3",
-      "resolved": "https://registry.npmjs.org/@launchdarkly/js-server-sdk-common/-/js-server-sdk-common-2.18.3.tgz",
-      "integrity": "sha512-9lf1IRLJSghtDZlUT04KmmJOwRnAUuqXUcn7C2S9jNPDvrsmFJeD9Dpn7PoCUOR5rZgqAEveWdlBw9qjWeY6jw==",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/js-server-sdk-common/-/js-server-sdk-common-2.19.1.tgz",
+      "integrity": "sha512-3N1R62FF5qeBJdZbZk62ixGFG73kbwwqoHD00e0OygMB3hIRuV+spYbB3S8BXZ8VpnzKBame0OChC8lYrb/Zow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@launchdarkly/js-sdk-common": "2.24.0",
+        "@launchdarkly/js-sdk-common": "2.25.1",
         "semver": "7.5.4"
       }
     },
@@ -3856,12 +3856,12 @@
       "license": "ISC"
     },
     "node_modules/@launchdarkly/node-server-sdk": {
-      "version": "9.10.10",
-      "resolved": "https://registry.npmjs.org/@launchdarkly/node-server-sdk/-/node-server-sdk-9.10.10.tgz",
-      "integrity": "sha512-qJNVrHbX+FKUhVUl7FWK9ICsL4lJmHBE7vOCkvERFFODRxYrrf8HdiyYDf79aI8JMSOLCKZgcJJKNXAvRJXThg==",
+      "version": "9.11.2",
+      "resolved": "https://registry.npmjs.org/@launchdarkly/node-server-sdk/-/node-server-sdk-9.11.2.tgz",
+      "integrity": "sha512-+S0V8bkxSvD3THaLTw/AKG6OVFFUqcoKXDrV7JhuCk9xhvI/LsvgpdzHZdzJjlicW/U+DRn3rPvhzGdYPLyasg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@launchdarkly/js-server-sdk-common": "2.18.3",
+        "@launchdarkly/js-server-sdk-common": "2.19.1",
         "https-proxy-agent": "^7.0.6",
         "launchdarkly-eventsource": "2.2.0"
       }
@@ -31488,7 +31488,7 @@
       "dependencies": {
         "@adobe/helix-universal": "5.4.2",
         "@adobe/spacecat-shared-utils": "1.81.1",
-        "@launchdarkly/node-server-sdk": "^9.9.7"
+        "@launchdarkly/node-server-sdk": "^9.11.2"
       },
       "devDependencies": {
         "chai": "6.2.2",

--- a/packages/spacecat-shared-launchdarkly-client/package.json
+++ b/packages/spacecat-shared-launchdarkly-client/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@adobe/helix-universal": "5.4.2",
     "@adobe/spacecat-shared-utils": "1.81.1",
-    "@launchdarkly/node-server-sdk": "^9.9.7"
+    "@launchdarkly/node-server-sdk": "^9.11.2"
   },
   "devDependencies": {
     "chai": "6.2.2",

--- a/packages/spacecat-shared-launchdarkly-client/src/index.d.ts
+++ b/packages/spacecat-shared-launchdarkly-client/src/index.d.ts
@@ -74,4 +74,9 @@ export declare class LaunchDarklyClient {
   ): Promise<Record<string, any>>;
 }
 
+/**
+ * Resets the module-scope SDK-client cache. Intended for use in tests only.
+ */
+export declare function clearClientCache(): void;
+
 export { LaunchDarklyClient as default };

--- a/packages/spacecat-shared-launchdarkly-client/src/index.js
+++ b/packages/spacecat-shared-launchdarkly-client/src/index.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import LaunchDarklyClient from './launchdarkly-client.js';
+import LaunchDarklyClient, { clearClientCache } from './launchdarkly-client.js';
 
-export { LaunchDarklyClient };
+export { LaunchDarklyClient, clearClientCache };
 export default LaunchDarklyClient;

--- a/packages/spacecat-shared-launchdarkly-client/src/launchdarkly-client.js
+++ b/packages/spacecat-shared-launchdarkly-client/src/launchdarkly-client.js
@@ -87,7 +87,6 @@ class LaunchDarklyClient {
       debug: (...args) => log.debug('[LaunchDarkly]', ...args),
     };
     this.client = null;
-    this.initPromise = null;
   }
 
   /**
@@ -113,9 +112,11 @@ class LaunchDarklyClient {
 
     const initPromise = (async () => {
       const client = ld.init(this.sdkKey, {
+        ...this.options,
+        // Forced after the spread: a consumer's options must not be able to
+        // re-enable streaming (the whole point of this change) or swap the logger.
         stream: false,
         pollInterval: DEFAULT_POLL_INTERVAL_SECONDS,
-        ...this.options,
         logger: this.sdkLogger,
       });
       await client.waitForInitialization({ timeoutSeconds: DEFAULT_INIT_TIMEOUT_SECONDS });

--- a/packages/spacecat-shared-launchdarkly-client/src/launchdarkly-client.js
+++ b/packages/spacecat-shared-launchdarkly-client/src/launchdarkly-client.js
@@ -122,6 +122,9 @@ class LaunchDarklyClient {
       return client;
     })();
 
+    // The first caller's sdkLogger is baked into the cached client; later
+    // callers reuse it. Per-instance this.log is still used for flag-evaluation
+    // logging in variation(), so request-scoped logs are unaffected.
     sdkClientCache.set(this.sdkKey, { initPromise });
 
     try {

--- a/packages/spacecat-shared-launchdarkly-client/src/launchdarkly-client.js
+++ b/packages/spacecat-shared-launchdarkly-client/src/launchdarkly-client.js
@@ -13,6 +13,21 @@
 import * as ld from '@launchdarkly/node-server-sdk';
 
 const DEFAULT_API_BASE_URL = 'https://app.launchdarkly.com';
+const DEFAULT_POLL_INTERVAL_SECONDS = 30;
+const DEFAULT_INIT_TIMEOUT_SECONDS = 5;
+
+// Cache of initialized SDK clients, keyed by sdkKey. A warm Lambda container
+// reuses one client across invocations instead of opening a new connection per
+// request. Each entry holds the in-flight/resolved init promise.
+const sdkClientCache = new Map();
+
+/**
+ * Resets the module-scope SDK-client cache. Exported for tests; not part of the
+ * normal runtime flow.
+ */
+export function clearClientCache() {
+  sdkClientCache.clear();
+}
 
 /**
  * LaunchDarkly Client wrapper for SpaceCat services.
@@ -89,23 +104,35 @@ class LaunchDarklyClient {
       return undefined;
     }
 
-    if (this.initPromise) {
-      await this.initPromise;
+    const cached = sdkClientCache.get(this.sdkKey);
+    if (cached) {
+      // Reuse an already-initialized client or join an in-flight initialization.
+      this.client = await cached.initPromise;
       return undefined;
     }
 
-    this.initPromise = (async () => {
-      try {
-        this.client = ld.init(this.sdkKey, { ...this.options, logger: this.sdkLogger });
-        await this.client.waitForInitialization();
-        this.log.info('LaunchDarkly client initialized successfully');
-      } catch (error) {
-        this.log.error('Failed to initialize LaunchDarkly client:', error);
-        throw error;
-      }
+    const initPromise = (async () => {
+      const client = ld.init(this.sdkKey, {
+        stream: false,
+        pollInterval: DEFAULT_POLL_INTERVAL_SECONDS,
+        ...this.options,
+        logger: this.sdkLogger,
+      });
+      await client.waitForInitialization({ timeoutSeconds: DEFAULT_INIT_TIMEOUT_SECONDS });
+      return client;
     })();
 
-    await this.initPromise;
+    sdkClientCache.set(this.sdkKey, { initPromise });
+
+    try {
+      this.client = await initPromise;
+      this.log.info('LaunchDarkly client initialized successfully');
+    } catch (error) {
+      // Clear the poisoned entry so the next call retries initialization.
+      sdkClientCache.delete(this.sdkKey);
+      this.log.error('Failed to initialize LaunchDarkly client:', error);
+      throw error;
+    }
     return undefined;
   }
 

--- a/packages/spacecat-shared-launchdarkly-client/test/exports.test.js
+++ b/packages/spacecat-shared-launchdarkly-client/test/exports.test.js
@@ -11,7 +11,7 @@
  */
 
 import { expect } from 'chai';
-import DefaultExport, { LaunchDarklyClient } from '../src/index.js';
+import DefaultExport, { LaunchDarklyClient, clearClientCache } from '../src/index.js';
 
 describe('Module Exports', () => {
   it('should export LaunchDarklyClient as named export', () => {
@@ -26,5 +26,10 @@ describe('Module Exports', () => {
 
   it('should have both exports reference the same constructor', () => {
     expect(DefaultExport).to.equal(LaunchDarklyClient);
+  });
+
+  it('should export clearClientCache as a named export', () => {
+    expect(clearClientCache).to.be.a('function');
+    expect(clearClientCache.name).to.equal('clearClientCache');
   });
 });

--- a/packages/spacecat-shared-launchdarkly-client/test/index.test.js
+++ b/packages/spacecat-shared-launchdarkly-client/test/index.test.js
@@ -21,6 +21,7 @@ use(sinonChai);
 
 describe('LaunchDarklyClient', () => {
   let LaunchDarklyClient;
+  let clearClientCache;
   let mockClient;
   let mockInit;
   const testSdkKey = 'sdk-test-key-12345';
@@ -45,10 +46,12 @@ describe('LaunchDarklyClient', () => {
     });
 
     LaunchDarklyClient = module.default;
+    clearClientCache = module.clearClientCache;
   });
 
   afterEach(() => {
     sinon.resetHistory();
+    clearClientCache();
   });
 
   describe('constructor', () => {
@@ -267,36 +270,28 @@ describe('LaunchDarklyClient', () => {
       expect(mockInit).to.have.been.calledOnce;
     });
 
-    it('should wait for initPromise when concurrent calls happen', async () => {
-      const client = new LaunchDarklyClient({ sdkKey: testSdkKey });
+    it('joins an in-flight initialization via the shared cache', async () => {
+      // Two separate instances for the same sdkKey: the second one should join
+      // the in-flight init promise stored in sdkClientCache rather than calling
+      // ld.init() a second time.
+      const log = {
+        info: sinon.stub(), error: sinon.stub(), debug: sinon.stub(), warn: sinon.stub(),
+      };
+      const first = new LaunchDarklyClient({ sdkKey: testSdkKey }, log);
+      const second = new LaunchDarklyClient({ sdkKey: testSdkKey }, log);
 
-      // Manually create a scenario where initPromise exists
-      // This simulates the exact moment between two concurrent init() calls
-      let resolvePromise;
-      const testPromise = new Promise((resolve) => {
-        resolvePromise = resolve;
-      });
+      // Start first init but don't await it yet so the cache entry is in-flight
+      const firstInit = first.init();
 
-      // Set initPromise directly to simulate initialization in progress
-      client.initPromise = testPromise;
+      // Second instance joins the in-flight promise from the cache
+      const secondInit = second.init();
 
-      // Temporarily set client to null to force the code path
-      const originalClient = client.client;
-      client.client = null;
+      const [result1, result2] = await Promise.all([firstInit, secondInit]);
 
-      // Now call init() - this should hit lines 66-68
-      const initCall = client.init();
-
-      // Verify we're waiting
-      expect(client.initPromise).to.equal(testPromise);
-
-      // Restore client and resolve
-      client.client = originalClient;
-      resolvePromise();
-
-      // Wait for init to complete
-      const result = await initCall;
-      expect(result).to.be.undefined;
+      expect(result1).to.be.undefined;
+      expect(result2).to.be.undefined;
+      // Only one real SDK init despite two separate instances
+      expect(mockInit).to.have.been.calledOnce;
     });
 
     it('should throw error if initialization fails', async () => {
@@ -315,6 +310,53 @@ describe('LaunchDarklyClient', () => {
       expect(customLog.error).to.have.been.calledWith('Failed to initialize LaunchDarkly client:', initError);
 
       // Reset for other tests
+      mockClient.waitForInitialization.resolves();
+    });
+
+    it('reuses one SDK client across separate instances with the same sdkKey', async () => {
+      const log = {
+        info: sinon.stub(), error: sinon.stub(), debug: sinon.stub(), warn: sinon.stub(),
+      };
+      const a = new LaunchDarklyClient({ sdkKey: testSdkKey }, log);
+      const b = new LaunchDarklyClient({ sdkKey: testSdkKey }, log);
+
+      await a.init();
+      await b.init();
+
+      expect(mockInit).to.have.been.calledOnce;
+    });
+
+    it('initializes in polling mode with a bounded init timeout', async () => {
+      const log = {
+        info: sinon.stub(), error: sinon.stub(), debug: sinon.stub(), warn: sinon.stub(),
+      };
+      const client = new LaunchDarklyClient({ sdkKey: testSdkKey }, log);
+
+      await client.init();
+
+      const options = mockInit.firstCall.args[1];
+      expect(options).to.include({ stream: false, pollInterval: 30 });
+      expect(options).to.have.property('logger');
+      expect(mockClient.waitForInitialization)
+        .to.have.been.calledWith({ timeoutSeconds: 5 });
+    });
+
+    it('clears the cache on init failure so the next call retries', async () => {
+      const log = {
+        info: sinon.stub(), error: sinon.stub(), debug: sinon.stub(), warn: sinon.stub(),
+      };
+      mockClient.waitForInitialization.onFirstCall().rejects(new Error('init timeout'));
+      mockClient.waitForInitialization.onSecondCall().resolves();
+
+      const first = new LaunchDarklyClient({ sdkKey: testSdkKey }, log);
+      await expect(first.init()).to.be.rejectedWith('init timeout');
+
+      const second = new LaunchDarklyClient({ sdkKey: testSdkKey }, log);
+      await second.init();
+
+      expect(mockInit).to.have.been.calledTwice;
+
+      mockClient.waitForInitialization.reset();
       mockClient.waitForInitialization.resolves();
     });
   });

--- a/packages/spacecat-shared-launchdarkly-client/test/index.test.js
+++ b/packages/spacecat-shared-launchdarkly-client/test/index.test.js
@@ -326,6 +326,38 @@ describe('LaunchDarklyClient', () => {
       expect(mockInit).to.have.been.calledOnce;
     });
 
+    it('maintains separate cache entries per sdkKey', async () => {
+      const log = {
+        info: sinon.stub(), error: sinon.stub(), debug: sinon.stub(), warn: sinon.stub(),
+      };
+      const a = new LaunchDarklyClient({ sdkKey: 'sdk-key-a' }, log);
+      const b = new LaunchDarklyClient({ sdkKey: 'sdk-key-b' }, log);
+
+      await a.init();
+      await b.init();
+
+      // Different keys must not share a cache entry: ld.init runs once per key.
+      expect(mockInit).to.have.been.calledTwice;
+      expect(mockInit.firstCall.args[0]).to.equal('sdk-key-a');
+      expect(mockInit.secondCall.args[0]).to.equal('sdk-key-b');
+    });
+
+    it('forces polling and cannot be overridden by consumer options', async () => {
+      const log = {
+        info: sinon.stub(), error: sinon.stub(), debug: sinon.stub(), warn: sinon.stub(),
+      };
+      const client = new LaunchDarklyClient(
+        { sdkKey: testSdkKey, options: { stream: true, pollInterval: 999 } },
+        log,
+      );
+
+      await client.init();
+
+      // The forced settings win over consumer options - streaming stays off.
+      const options = mockInit.firstCall.args[1];
+      expect(options).to.include({ stream: false, pollInterval: 30 });
+    });
+
     it('initializes in polling mode with a bounded init timeout', async () => {
       const log = {
         info: sinon.stub(), error: sinon.stub(), debug: sinon.stub(), warn: sinon.stub(),


### PR DESCRIPTION
## Problem

LaunchDarkly SDK lines dominate SpaceCat prod `error` logs. Over a representative window (Coralogix prod, `spacecat-services-prod`, `level=error`, 2026-06-15 00:00:00Z–05:45:00Z, ~5.75h): **105,225 of 148,521 error events (~71%) are LaunchDarkly noise** (`will retry stream connection`, `waitForInitialization ... without a timeout`, `received I/O error ... will retry`). `api-service` alone accounts for 105,912 of those errors. These are not real errors; they drown genuine operational signal and inflate error-rate metrics.

## Root cause

1. The auth-path LD client running in prod is `launchdarkly-client@1.0.4` (a **nested** copy under `spacecat-shared-http-utils`, which hard-pins `1.0.4`). That version passes **no `logger`** to `ld.init()`, so the SDK uses `basicLogger`, which writes every level to stderr → Lambda tags it all `error` (hence the `info:`/`warn:` prefixes in the messages).
2. The IMS auth handler creates a **new streaming LD client on every authenticated request** (`http-utils` `ims.js` / `read-only-admin-wrapper.js`, no caching), each opening a streaming connection and calling `waitForInitialization()` with no timeout. Streaming can't survive Lambda freeze/thaw, so each invocation reconnects and retries.
3. The prior logger fix (#1511, `1.2.x`) never reached prod because the nested `1.0.4` pin shadows it.

## What this PR does (Phase 1 of 3)

Behavior change is confined to `spacecat-shared-launchdarkly-client`:

- **Singleton cache per `sdkKey`** at module scope — one SDK client per warm Lambda container instead of one per request. Same-instance and cross-instance/in-flight callers reuse it; a failed init clears the cache entry so the next call retries.
- **Polling instead of streaming** (`stream: false`, `pollInterval: 30`) — removes the streaming reconnect storm and drops `launchdarkly-eventsource` from the hot path. Uses the **stable** top-level options; the newer `dataSystem` config is still `@experimental`, so it is deliberately avoided.
- **Bounded init** — `waitForInitialization({ timeoutSeconds: 5 })`, removing the "without a timeout" warning and capping cold-start latency; fail-open is preserved (the auth call sites already catch).
- **Logger mapping retained** (`error → log.error`; `warn`/`info`/`debug → log.debug`) as defense-in-depth.
- **SDK bump** `@launchdarkly/node-server-sdk` `^9.9.7 → ^9.11.2` (routine hygiene, behavior-neutral; verified `stream`/`pollInterval` stable and `dataSystem` still experimental on the bumped version).

## Cascade (this PR is only step 1)

The fix only reaches prod after the version cascade — Phase 1 alone does nothing in prod until consumers pick it up:

1. **This PR** → publishes `launchdarkly-client` (minor, → `1.3.0`).
2. **Next:** bump the `launchdarkly-client` pin in `spacecat-shared-http-utils` (`1.0.4 → ^1.3.0`) — this is what removes the shadowing nested copy on the auth path.
3. **Then:** bump `spacecat-api-service` to consume the new `http-utils` + dedupe to a single hoisted client, redeploy, and verify in Coralogix (dev → prod).

## Testing

- `npm test -w packages/spacecat-shared-launchdarkly-client` → 43 passing, **100% statements/branches/functions/lines**.
- `npm run lint -w packages/spacecat-shared-launchdarkly-client` → clean.
- New tests: cross-instance cache reuse, in-flight init join, polling-mode + init-timeout options, and cache-cleared-on-failure retry.

## Out of scope

The `url.parse` `DEP0169` DeprecationWarning and LD daemon mode (DynamoDB feature store) are explicitly out of scope (see spec).

## Design docs (included in this PR)

- `docs/plans/2026-06-15-launchdarkly-lambda-noise-design.md`
- `docs/plans/2026-06-15-launchdarkly-lambda-noise-plan.md`
