### PR TITLE
fix(http-utils): pin launchdarkly-client to 1.3.0 (ship Lambda log-noise fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29840,7 +29840,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
-        "@adobe/spacecat-shared-launchdarkly-client": "1.0.4",
+        "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
         "@adobe/spacecat-shared-utils": "1.81.1",
         "jose": "6.2.3"
       },
@@ -29850,45 +29850,6 @@
         "chai-as-promised": "8.0.2",
         "esmock": "2.7.6",
         "sinon": "22.0.0"
-      },
-      "engines": {
-        "node": ">=22.0.0 <25.0.0",
-        "npm": ">=10.9.0 <12.0.0"
-      }
-    },
-    "packages/spacecat-shared-http-utils/node_modules/@adobe/helix-universal": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.4.0.tgz",
-      "integrity": "sha512-3ZfFdjYtpv7RCgul9yyOBsRVsxLNapwt0YjASBhyzJGNjnPxrWDlqDtbpBdwAgA1Nuh9nmjzFDFu8CJWv6BMKw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@adobe/fetch": "4.2.3",
-        "aws4": "1.13.2"
-      }
-    },
-    "packages/spacecat-shared-http-utils/node_modules/@adobe/helix-universal/node_modules/@adobe/fetch": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
-      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "4.4.3",
-        "http-cache-semantics": "4.2.0",
-        "lru-cache": "7.18.3"
-      },
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
-    "packages/spacecat-shared-http-utils/node_modules/@adobe/spacecat-shared-launchdarkly-client": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-launchdarkly-client/-/spacecat-shared-launchdarkly-client-1.0.4.tgz",
-      "integrity": "sha512-5mw6zDJ1iBPcjv4FuXPhVtP6bQbYX8u8/RTfGo8JLv9+rRsEcnZMzGfX7SuzrOd8KDjwNCBhc0Dllk4tDiqqgg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@adobe/helix-universal": "5.4.0",
-        "@adobe/spacecat-shared-utils": "1.81.1",
-        "@launchdarkly/node-server-sdk": "^9.9.7"
       },
       "engines": {
         "node": ">=22.0.0 <25.0.0",
@@ -31483,7 +31444,7 @@
     },
     "packages/spacecat-shared-launchdarkly-client": {
       "name": "@adobe/spacecat-shared-launchdarkly-client",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-universal": "5.4.2",

--- a/packages/spacecat-shared-http-utils/package.json
+++ b/packages/spacecat-shared-http-utils/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@adobe/fetch": "4.3.0",
-    "@adobe/spacecat-shared-launchdarkly-client": "1.0.4",
+    "@adobe/spacecat-shared-launchdarkly-client": "1.3.0",
     "@adobe/spacecat-shared-utils": "1.81.1",
     "jose": "6.2.3"
   },


### PR DESCRIPTION
## What

Bumps `spacecat-shared-http-utils`'s dependency on `@adobe/spacecat-shared-launchdarkly-client` from `1.0.4` to `1.3.0` (exact pin, no caret).

## Why

This is **Phase 2** of the LaunchDarkly Lambda log-noise cascade (Phase 1 = #1674, published `launchdarkly-client@1.3.0`).

`http-utils` hard-pinned `launchdarkly-client@1.0.4`, which shipped a **nested** copy on the IMS auth path (`auth/handlers/ims.js`, `auth/read-only-admin-wrapper.js`). That `1.0.4` passed no `logger` to `ld.init()` and created a new streaming client per request - the root cause of ~71% of SpaceCat prod `error` logs being LaunchDarkly noise. The nested pin also shadowed the earlier logger fix, so it never reached prod.

Pinning to `1.3.0` removes that shadowing copy so consumers (next: `spacecat-api-service`, Phase 3) resolve a single client with the cache + polling (`stream:false`) + bounded init-timeout fix.

## Verification

- `npm install` reconciles to a single `launchdarkly-client@1.3.0`; the stale nested `1.0.4` lockfile entry is removed (no `1.0.4` launchdarkly reference remains).
- `npm test -w packages/spacecat-shared-http-utils` and `npm run lint -w packages/spacecat-shared-http-utils` pass.

## Next

Phase 3: bump `spacecat-api-service` to the new `http-utils` + `launchdarkly-client@1.3.0`, dedupe to a single hoisted copy, redeploy, then validate in Coralogix (dev → prod).