### PR TITLE
fix: downgrade expected RUM domainkey 404s from error to debug

### DIFF
--- a/packages/spacecat-shared-rum-api-client/src/client.js
+++ b/packages/spacecat-shared-rum-api-client/src/client.js
@@ -92,7 +92,9 @@ export default class RUMAPIClient {
     });
 
     if (!resp.ok) {
-      throw new Error(`Error during fetching domainkey for domain '${domain} using admin key. Status: ${resp.status}`);
+      const error = new Error(`Error during fetching domainkey for domain '${domain} using admin key. Status: ${resp.status}`);
+      error.status = resp.status;
+      throw error;
     }
 
     try {
@@ -143,7 +145,9 @@ export default class RUMAPIClient {
       this.log.debug(`Query "${query}" fetched ${bundles.length} bundles`); // maybe even remove?
       return handler(bundles, opts);
     } catch (e) {
-      throw new Error(`Query '${query}' failed. Opts: ${JSON.stringify(sanitize(opts))}. Reason: ${e.message}`);
+      const error = new Error(`Query '${query}' failed. Opts: ${JSON.stringify(sanitize(opts))}. Reason: ${e.message}`);
+      error.status = e.status;
+      throw error;
     }
   }
 
@@ -184,7 +188,9 @@ export default class RUMAPIClient {
 
       return results;
     } catch (e) {
-      throw new Error(`Multi query failed. Queries: ${JSON.stringify(queries)}, Opts: ${JSON.stringify(sanitize(opts))}. Reason: ${e.message}`);
+      const error = new Error(`Multi query failed. Queries: ${JSON.stringify(queries)}, Opts: ${JSON.stringify(sanitize(opts))}. Reason: ${e.message}`);
+      error.status = e.status;
+      throw error;
     }
   }
 
@@ -203,7 +209,9 @@ export default class RUMAPIClient {
         handler,
       }, this.log);
     } catch (e) {
-      throw new Error(`Query stream '${query}' failed. Opts: ${JSON.stringify(sanitize(opts))}. Reason: ${e.message}`);
+      const error = new Error(`Query stream '${query}' failed. Opts: ${JSON.stringify(sanitize(opts))}. Reason: ${e.message}`);
+      error.status = e.status;
+      throw error;
     }
   }
 }

--- a/packages/spacecat-shared-rum-api-client/src/client.js
+++ b/packages/spacecat-shared-rum-api-client/src/client.js
@@ -145,7 +145,7 @@ export default class RUMAPIClient {
       this.log.debug(`Query "${query}" fetched ${bundles.length} bundles`); // maybe even remove?
       return handler(bundles, opts);
     } catch (e) {
-      const error = new Error(`Query '${query}' failed. Opts: ${JSON.stringify(sanitize(opts))}. Reason: ${e.message}`);
+      const error = new Error(`Query '${query}' failed. Opts: ${JSON.stringify(sanitize(opts))}. Reason: ${e.message}`, { cause: e });
       error.status = e.status;
       throw error;
     }
@@ -188,7 +188,7 @@ export default class RUMAPIClient {
 
       return results;
     } catch (e) {
-      const error = new Error(`Multi query failed. Queries: ${JSON.stringify(queries)}, Opts: ${JSON.stringify(sanitize(opts))}. Reason: ${e.message}`);
+      const error = new Error(`Multi query failed. Queries: ${JSON.stringify(queries)}, Opts: ${JSON.stringify(sanitize(opts))}. Reason: ${e.message}`, { cause: e });
       error.status = e.status;
       throw error;
     }
@@ -209,7 +209,7 @@ export default class RUMAPIClient {
         handler,
       }, this.log);
     } catch (e) {
-      const error = new Error(`Query stream '${query}' failed. Opts: ${JSON.stringify(sanitize(opts))}. Reason: ${e.message}`);
+      const error = new Error(`Query stream '${query}' failed. Opts: ${JSON.stringify(sanitize(opts))}. Reason: ${e.message}`, { cause: e });
       error.status = e.status;
       throw error;
     }

--- a/packages/spacecat-shared-rum-api-client/test/index.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/index.test.js
@@ -115,6 +115,23 @@ describe('RUMAPIClient#queryStream', () => {
     await expect(rumApiClient.queryStream('404', opts)).to.be.rejectedWith('You need to provide a \'domainkey\' or set RUM_ADMIN_KEY env variable');
   });
 
+  it('propagates the HTTP status through the queryStream re-wrap on a 404 domainkey miss', async () => {
+    const adminContext = { env: { RUM_ADMIN_KEY: 'admin-key' } };
+    const adminClient = RUMAPIClient.createFrom(adminContext);
+    nock(RUM_BUNDLER_API_HOST)
+      .get('/domainkey/example.com')
+      .matchHeader('Authorization', 'Bearer admin-key')
+      .reply(404);
+
+    const opts = { domain: 'example.com', interval: 0 };
+    const error = await adminClient.queryStream('404', opts).then(
+      () => expect.fail('expected queryStream to reject'),
+      (e) => e,
+    );
+    expect(error.message).to.include("Query stream '404' failed.");
+    expect(error.status).to.equal(404);
+  });
+
   it('creates a readable stream of processed bundles', async () => {
     const rumBundles = [
       {

--- a/packages/spacecat-shared-rum-api-client/test/index.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/index.test.js
@@ -299,6 +299,26 @@ describe('RUMAPIClient with admin key for external domainkey fetch', () => {
       .to.be.rejectedWith("Error during fetching domainkey for domain 'example.com using admin key. Status: 500");
   });
 
+  it('propagates the HTTP status through the query re-wrap on a 404 domainkey miss', async () => {
+    nock(RUM_BUNDLER_API_HOST)
+      .get('/domainkey/example.com')
+      .matchHeader('Authorization', 'Bearer admin-key')
+      .reply(404);
+
+    const opts = {
+      domain: 'example.com',
+      interval: 0,
+    };
+
+    const error = await client.query('404', opts).then(
+      () => expect.fail('expected query to reject'),
+      (e) => e,
+    );
+    expect(error.message).to.include("Query '404' failed.");
+    expect(error.message).to.include('Status: 404');
+    expect(error.status).to.equal(404);
+  });
+
   it('throws error when external domainkey fetch returns unexpected response', async () => {
     nock(RUM_BUNDLER_API_HOST)
       .get('/domainkey/example.com')
@@ -359,5 +379,21 @@ describe('RUMAPIClient retrieveDomainkey method', () => {
     // second call should return the cached value (no new HTTP request)
     const dk2 = await client.retrieveDomainkey(domain);
     expect(dk2).to.equal('cached-domain-key');
+  });
+
+  it('attaches the HTTP status to the thrown error on a 404 (domain not onboarded to RUM)', async () => {
+    const domain = 'not-onboarded.example.com';
+
+    nock(RUM_BUNDLER_API_HOST)
+      .get(`/domainkey/${domain}`)
+      .matchHeader('Authorization', 'Bearer admin-key')
+      .reply(404);
+
+    const error = await client.retrieveDomainkey(domain).then(
+      () => expect.fail('expected retrieveDomainkey to reject'),
+      (e) => e,
+    );
+    expect(error.message).to.include('Status: 404');
+    expect(error.status).to.equal(404);
   });
 });

--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -396,7 +396,7 @@ async function wwwUrlResolver(site, rumApiClient, log) {
     if (e.status === 404) {
       log.debug(`[wwwUrlResolver] No RUM domainkey for ${hostname} (site not onboarded to RUM): ${e.message}`);
     } else {
-      log.error(`Could not retrieved RUM domainkey for ${hostname}: ${e.message}`);
+      log.error(`Could not retrieve RUM domainkey for ${hostname}: ${e.message}`);
     }
   }
 
@@ -408,7 +408,7 @@ async function wwwUrlResolver(site, rumApiClient, log) {
     if (e.status === 404) {
       log.debug(`[wwwUrlResolver] No RUM domainkey for ${hostname} (site not onboarded to RUM): ${e.message}`);
     } else {
-      log.error(`Could not retrieved RUM domainkey for ${hostname}: ${e.message}`);
+      log.error(`Could not retrieve RUM domainkey for ${hostname}: ${e.message}`);
     }
   }
 

--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -393,7 +393,11 @@ async function wwwUrlResolver(site, rumApiClient, log) {
     }
     log.debug(`[wwwUrlResolver] ${wwwToggledHostname} has key but no bundle data, trying ${hostname}`);
   } catch (e) {
-    log.error(`Could not retrieved RUM domainkey for ${hostname}: ${e.message}`);
+    if (e.status === 404) {
+      log.debug(`[wwwUrlResolver] No RUM domainkey for ${hostname} (site not onboarded to RUM): ${e.message}`);
+    } else {
+      log.error(`Could not retrieved RUM domainkey for ${hostname}: ${e.message}`);
+    }
   }
 
   try {
@@ -401,7 +405,11 @@ async function wwwUrlResolver(site, rumApiClient, log) {
     log.debug(`Resolved URL ${hostname} for ${baseURL} using RUM API Client`);
     return hostname;
   } catch (e) {
-    log.error(`Could not retrieved RUM domainkey for ${hostname}: ${e.message}`);
+    if (e.status === 404) {
+      log.debug(`[wwwUrlResolver] No RUM domainkey for ${hostname} (site not onboarded to RUM): ${e.message}`);
+    } else {
+      log.error(`Could not retrieved RUM domainkey for ${hostname}: ${e.message}`);
+    }
   }
 
   const fallback = hostname.startsWith('www.') ? hostname : `www.${hostname}`;

--- a/packages/spacecat-shared-utils/test/url-helpers.test.js
+++ b/packages/spacecat-shared-utils/test/url-helpers.test.js
@@ -985,6 +985,39 @@ describe('URL Utility Functions', () => {
       expect(result).to.equal('www.example.com');
     });
 
+    it('should log a 404 domainkey miss at debug, not error (site not onboarded to RUM)', async () => {
+      site.getBaseURL.returns('https://example.com');
+      const notFound = new Error("Query '404' failed. Reason: ... Status: 404");
+      notFound.status = 404;
+      rumApiClient.retrieveDomainkey.rejects(notFound);
+
+      const result = await wwwUrlResolver(site, rumApiClient, log);
+
+      expect(result).to.equal('www.example.com');
+      expect(log.debug).to.have.been.calledWith(
+        `[wwwUrlResolver] No RUM domainkey for example.com (site not onboarded to RUM): ${notFound.message}`,
+      );
+      expect(log.error).to.not.have.been.called;
+    });
+
+    it('should log debug for a 404 first attempt and error for a non-404 second attempt', async () => {
+      site.getBaseURL.returns('https://example.com');
+      const notFound = new Error('No domainkey. Status: 404');
+      notFound.status = 404;
+      const serverError = new Error('upstream 500');
+      serverError.status = 500;
+      rumApiClient.retrieveDomainkey.withArgs('www.example.com').rejects(notFound);
+      rumApiClient.retrieveDomainkey.withArgs('example.com').rejects(serverError);
+
+      const result = await wwwUrlResolver(site, rumApiClient, log);
+
+      expect(result).to.equal('www.example.com');
+      expect(log.debug).to.have.been.calledWith(
+        `[wwwUrlResolver] No RUM domainkey for example.com (site not onboarded to RUM): ${notFound.message}`,
+      );
+      expect(log.error).to.have.been.calledWith('Could not retrieved RUM domainkey for example.com: upstream 500');
+    });
+
     it('should fallback to non-www when hostname already has www and both RUM checks fail', async () => {
       site.getBaseURL.returns('https://www.example.org');
       rumApiClient.retrieveDomainkey.rejects(new Error('No domain key'));

--- a/packages/spacecat-shared-utils/test/url-helpers.test.js
+++ b/packages/spacecat-shared-utils/test/url-helpers.test.js
@@ -969,7 +969,7 @@ describe('URL Utility Functions', () => {
 
       await wwwUrlResolver(site, rumApiClient, log);
 
-      expect(log.error).to.have.been.calledWith('Could not retrieved RUM domainkey for example.com: API error');
+      expect(log.error).to.have.been.calledWith('Could not retrieve RUM domainkey for example.com: API error');
       expect(log.error).to.have.been.calledTwice;
     });
 
@@ -980,8 +980,8 @@ describe('URL Utility Functions', () => {
 
       const result = await wwwUrlResolver(site, rumApiClient, log);
 
-      expect(log.error).to.have.been.calledWith('Could not retrieved RUM domainkey for example.com: First error');
-      expect(log.error).to.have.been.calledWith('Could not retrieved RUM domainkey for example.com: Second error');
+      expect(log.error).to.have.been.calledWith('Could not retrieve RUM domainkey for example.com: First error');
+      expect(log.error).to.have.been.calledWith('Could not retrieve RUM domainkey for example.com: Second error');
       expect(result).to.equal('www.example.com');
     });
 
@@ -1015,7 +1015,7 @@ describe('URL Utility Functions', () => {
       expect(log.debug).to.have.been.calledWith(
         `[wwwUrlResolver] No RUM domainkey for example.com (site not onboarded to RUM): ${notFound.message}`,
       );
-      expect(log.error).to.have.been.calledWith('Could not retrieved RUM domainkey for example.com: upstream 500');
+      expect(log.error).to.have.been.calledWith('Could not retrieve RUM domainkey for example.com: upstream 500');
     });
 
     it('should fallback to non-www when hostname already has www and both RUM checks fail', async () => {


### PR DESCRIPTION
## What

A `404` from `GET bundles.aem.page/domainkey/{domain}` means the domain was never onboarded to RUM. For SEO/LLMO-only sites this is the expected steady state, not a failure - yet it was being logged at `error` level on every audit/import run.

This was the single largest source of prod `ERROR`-severity log lines (~45%) across `spacecat-audit-worker` and `spacecat-import-worker`, spread over hundreds of distinct real customer domains.

## Changes

**`spacecat-shared-rum-api-client` (`src/client.js`)**
- `_exchangeDomainkey` now attaches `error.status = resp.status` when the admin-key fetch returns a non-ok response.
- `query`, `queryMulti`, and `queryStream` catch-blocks propagate `error.status = e.status` through the re-wrap. Previously these created a fresh `Error` and dropped all custom properties, so callers could never see the underlying HTTP status.

**`spacecat-shared-utils` (`src/url-helpers.js`)**
- `wwwUrlResolver` (the URL resolver used by 15+ audits) now checks `e.status === 404` in both catch-blocks and logs at `debug` ("site not onboarded to RUM") instead of `error`. Non-404 failures still log at `error`.
- `wwwUrlResolver` takes `rumApiClient` as an injected parameter, so this does not add a `utils -> rum-api-client` dependency.

## Tests
- rum-api-client: status attached on a 404 from `retrieveDomainkey`, and propagated through the `query` re-wrap.
- utils: 404 domainkey miss -> `debug` (not `error`) in both catch-blocks; mixed 404-then-500 case still logs `error` for the non-404.
- Both packages: 100% lines/statements, branch thresholds met. Lint clean.

## Rollout
This is Phase A of a 3-phase cascade. Once `rum-api-client` and `utils` publish, the consumers re-pin (exact, no caret):
- `spacecat-import-worker` - consume + branch the per-importer catch on `e.status === 404`.
- `spacecat-audit-worker` - re-pin both packages (no code change; the fix lives in the shared packages).