### PR TITLE
fix: quiet recoverable ERROR-severity log noise (config-validation fallback + missing metrics)

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -558,7 +558,9 @@ export const Config = (data = {}) => {
   } catch (error) {
     const logger = getLogger();
     if (logger && logger !== console) {
-      logger.error('Site configuration validation failed, using provided data', {
+      // Recoverable: validation failed but we fall back to the provided data,
+      // so this is a warning, not an error (avoids prod ERROR-severity noise).
+      logger.warn('Site configuration validation failed, using provided data', {
         error: error.message,
         invalidConfig: data,
       });

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -174,16 +174,20 @@ describe('Config Tests', () => {
       expect(config.getHandlers()).to.be.undefined;
     });
 
-    it('logs error when validation fails and logger is available', () => {
+    it('logs a warning when validation fails and logger is available', () => {
       // Create a mock logger
       const mockLogger = {};
 
-      // Spy on the logger error method
-      let loggedError = null;
+      // Spy on the logger warn method (recoverable fallback -> warn, not error)
+      let loggedWarning = null;
       let loggedData = null;
-      mockLogger.error = (message, data) => {
-        loggedError = message;
+      let errorCalled = false;
+      mockLogger.warn = (message, data) => {
+        loggedWarning = message;
         loggedData = data;
+      };
+      mockLogger.error = () => {
+        errorCalled = true;
       };
 
       // Register the mock logger
@@ -214,8 +218,9 @@ describe('Config Tests', () => {
         },
       });
 
-      // Should have logged the error
-      expect(loggedError).to.equal('Site configuration validation failed, using provided data');
+      // Should have logged a warning (recoverable fallback), not an error
+      expect(errorCalled).to.equal(false);
+      expect(loggedWarning).to.equal('Site configuration validation failed, using provided data');
       expect(loggedData).to.have.property('error');
       expect(loggedData).to.have.property('invalidConfig');
       expect(loggedData.invalidConfig).to.deep.equal(invalidData);

--- a/packages/spacecat-shared-utils/src/metrics-store.js
+++ b/packages/spacecat-shared-utils/src/metrics-store.js
@@ -51,7 +51,15 @@ export async function getStoredMetrics(config, context) {
 
     return metrics;
   } catch (e) {
-    log.warn(`Failed to retrieve metrics from ${filePath}, error: ${e.message}`);
+    const isMissingKey = e.name === 'NoSuchKey'
+      || e.message?.toLowerCase().includes('the specified key does not exist');
+    if (isMissingKey) {
+      // Expected/recoverable: no metrics stored yet for this site/source/metric.
+      log.warn(`No stored metrics found at ${filePath}, error: ${e.message}`);
+    } else {
+      // Genuine infra error (e.g. EBUSY/EMFILE/DNS/timeout) - keep visible at error.
+      log.error(`Failed to retrieve metrics from ${filePath}, error: ${e.message}`);
+    }
     return [];
   }
 }

--- a/packages/spacecat-shared-utils/test/metrics-store.test.js
+++ b/packages/spacecat-shared-utils/test/metrics-store.test.js
@@ -114,13 +114,37 @@ describe('Metrics Store', () => {
       expect(context.log.debug).to.have.been.calledWith('Successfully retrieved 2 metrics from metrics/testSite/testSource/testMetric.json');
     });
 
-    it('should return empty array when retrieval fails', async () => {
-      context.s3.s3Client.send.rejects(new Error('Test error'));
+    it('should warn (not error) and return empty array when the object is missing (NoSuchKey)', async () => {
+      const error = new Error('The specified key does not exist.');
+      error.name = 'NoSuchKey';
+      context.s3.s3Client.send.rejects(error);
 
       const metrics = await getStoredMetrics(config, context);
 
       expect(metrics).to.deep.equal([]);
-      expect(context.log.warn).to.have.been.calledWith('Failed to retrieve metrics from metrics/testSite/testSource/testMetric.json, error: Test error');
+      expect(context.log.warn).to.have.been.calledWith('No stored metrics found at metrics/testSite/testSource/testMetric.json, error: The specified key does not exist.');
+      expect(context.log.error).to.not.have.been.called;
+    });
+
+    it('should warn (not error) when the error message indicates a missing key', async () => {
+      // some S3 paths surface the missing-key condition only via the message
+      context.s3.s3Client.send.rejects(new Error('The specified key does not exist.'));
+
+      const metrics = await getStoredMetrics(config, context);
+
+      expect(metrics).to.deep.equal([]);
+      expect(context.log.warn).to.have.been.calledWith('No stored metrics found at metrics/testSite/testSource/testMetric.json, error: The specified key does not exist.');
+      expect(context.log.error).to.not.have.been.called;
+    });
+
+    it('should error (not warn) and return empty array on a genuine infra error', async () => {
+      context.s3.s3Client.send.rejects(new Error('getaddrinfo EBUSY s3.us-east-1.amazonaws.com'));
+
+      const metrics = await getStoredMetrics(config, context);
+
+      expect(metrics).to.deep.equal([]);
+      expect(context.log.error).to.have.been.calledWith('Failed to retrieve metrics from metrics/testSite/testSource/testMetric.json, error: getaddrinfo EBUSY s3.us-east-1.amazonaws.com');
+      expect(context.log.warn).to.not.have.been.called;
     });
   });
 


### PR DESCRIPTION
## What

Two recoverable conditions are currently logged at `error`, inflating prod ERROR-severity volume in the `spacecat-services-prod` app. Both are downgraded to the correct level.

### `fix(data-access)` - config-validation fallback (~38 ERROR lines / 3h in prod)
`Config()` (`src/models/site/config.js`) catches a Joi validation failure, logs it, and **falls back to the provided data** - a recoverable path that fires on every read/save of an affected site. Downgraded `logger.error` -> `logger.warn`; the message and `{ error, invalidConfig }` context are unchanged. Validation behavior and the fallback itself are untouched.

### `fix(utils)` - metrics-store granularity (~30 ERROR lines / 3h in prod)
`getStoredMetrics()` (`src/metrics-store.js`) was recently changed to a blanket `log.warn` to silence expected missing-file reads. That also downgraded **genuine** infra errors (the live prod lines are mostly `getaddrinfo EBUSY` / `EMFILE` - real transient S3 DNS/FD-exhaustion errors that must stay visible). Now granular:
- missing object (`NoSuchKey` / "the specified key does not exist") -> `log.warn`
- everything else (EBUSY/EMFILE/DNS/timeout/...) -> `log.error`

The `NoSuchKey` name check matches existing idioms in the repo (configuration.collection.js, llmo-config.js).

## Why
Part of the prod ERROR-noise cleanup (sibling to the recent domainkey-404 cascade). These are expected/recoverable outcomes, not server errors, and were drowning genuine errors in the Error severity stream.

## Testing
- data-access: 2322 passing; coverage 100 stmts / 97.76 branches / 100 lines (gates met); both `config.js` branches covered.
- utils: 1172 passing; coverage 100 stmts / 99.22 branches / 100 lines; both new metrics-store branches (missing-key warn, genuine-error error) covered. TDD: utils tests went red against the blanket-warn impl, green after the fix.

## Follow-up (separate PRs)
- Consumer re-pin of `@adobe/spacecat-shared-data-access` + `@adobe/spacecat-shared-utils` (api-service) once this releases.
- api-service `detectedCdn` PATCH validation - prevents the malformed value that *triggers* the data-access validation fallback for one site.

## Release note
Two scoped commits (`fix(data-access)`, `fix(utils)`) so semantic-release versions each package independently. Preserve both lines in the squash commit body on merge.