### PR TITLE
feat(data-access): register money-pages as a supported audit type

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
+++ b/packages/spacecat-shared-data-access/src/models/audit/audit.model.js
@@ -96,6 +96,7 @@ class Audit extends BaseModel {
     CWV_TRENDS_AUDIT: 'cwv-trends-audit',
     OFFSITE_BRAND_PRESENCE: 'offsite-brand-presence',
     SEMANTIC_VALUE_VISIBILITY: 'semantic-value-visibility',
+    MONEY_PAGES: 'money-pages',
   };
 
   static AUDIT_TYPE_PROPERTIES = {

--- a/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/audit/audit.model.test.js
@@ -221,6 +221,7 @@ describe('AuditModel', () => {
       CWV_TRENDS_AUDIT: 'cwv-trends-audit',
       OFFSITE_BRAND_PRESENCE: 'offsite-brand-presence',
       SEMANTIC_VALUE_VISIBILITY: 'semantic-value-visibility',
+      MONEY_PAGES: 'money-pages',
     };
 
     it('should have all audit types present in AUDIT_TYPES', () => {


### PR DESCRIPTION
## Summary
- Adds `MONEY_PAGES: 'money-pages'` to `Audit.AUDIT_TYPES` in `audit.model.js`
- This registers `money-pages` as a valid audit type in the master registry, enabling it to be used in global audit configuration via `POST /configurations/audits`

## Testing
No behavior change — this is a constant addition. Existing unit tests pass unchanged.