### PR TITLE
fix: pageCitability url-upsert + metrics-store $metadata 404 detection

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/base/base.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/base/base.collection.js
@@ -731,7 +731,7 @@ class BaseCollection {
     return this.#queryByIndexKeys(keys, { ...options, limit: 1 });
   }
 
-  async create(item, { upsert = false } = {}) {
+  async create(item, { upsert = false, onConflict } = {}) {
     if (!isNonEmptyObject(item)) {
       const message = `Failed to create [${this.entityName}]: data is required`;
       this.log.error(message);
@@ -751,7 +751,7 @@ class BaseCollection {
 
       const prepared = this.#prepareItem(item);
       const payload = this.#toDbRecord(prepared);
-      const conflictKey = this.#toDbField(this.idName);
+      const conflictKey = this.#toDbField(onConflict ?? this.idName);
 
       let query = this.postgrestService.from(this.tableName);
       query = upsert ? query.upsert(payload, { onConflict: conflictKey }) : query.insert(payload);

--- a/packages/spacecat-shared-data-access/src/models/page-citability/page-citability.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/page-citability/page-citability.collection.js
@@ -21,7 +21,19 @@ import BaseCollection from '../base/base.collection.js';
 class PageCitabilityCollection extends BaseCollection {
   static COLLECTION_NAME = 'PageCitabilityCollection';
 
-  // add custom collection-level methods here, if needed
+  /**
+   * Creates a PageCitability record, upserting on the globally-unique `url` column.
+   *
+   * The `url` column carries a global unique index (idx_page_citabilities_url_unique),
+   * so upserting on `url` makes create idempotent and eliminates the concurrent
+   * read-then-insert duplicate-key (Postgres 23505) race observed in production.
+   *
+   * @param {object} item - the PageCitability data to persist.
+   * @returns {Promise<PageCitability>} the created (or updated) PageCitability instance.
+   */
+  async create(item) {
+    return super.create(item, { upsert: true, onConflict: 'url' });
+  }
 }
 
 export default PageCitabilityCollection;

--- a/packages/spacecat-shared-data-access/test/unit/models/base/base.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/base/base.collection.test.js
@@ -2322,6 +2322,34 @@ describe('BaseCollection', () => {
       );
       expect(upserted.record.someKey).to.equal('b');
       expect(upsert).to.have.been.calledOnce;
+      // default conflict target is the primary id, mapped to snake_case
+      expect(upsert.firstCall.args[1]).to.deep.equal({ onConflict: 'mock_entity_model_id' });
+    });
+
+    it('upserts on a custom onConflict target mapped through #toDbField in PostgREST mode', async () => {
+      const maybeSingle = stub()
+        .resolves({ data: { some_key: 'c', some_other_key: 11 }, error: null });
+      const select = stub().returns({ maybeSingle });
+      const upsert = stub().returns({ select });
+      const insert = stub().returns({ select });
+      const fromStub = stub().returns({ insert, upsert });
+      const instance = createInstance(
+        { from: fromStub },
+        mockEntityRegistry,
+        richIndexes,
+        mockLogger,
+        richAttributes,
+      );
+
+      const upserted = await instance.create(
+        { someKey: 'c', someOtherKey: 11 },
+        { upsert: true, onConflict: 'someOtherKey' },
+      );
+
+      expect(upserted.record.someKey).to.equal('c');
+      expect(upsert).to.have.been.calledOnce;
+      // onConflict must be mapped from camelCase to snake_case via #toDbField
+      expect(upsert.firstCall.args[1]).to.deep.equal({ onConflict: 'some_other_key' });
     });
 
     it('validates create payload errors for PostgREST mode', async () => {

--- a/packages/spacecat-shared-data-access/test/unit/models/page-citability/page-citability.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/page-citability/page-citability.collection.test.js
@@ -13,6 +13,7 @@
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
 
 import PageCitability from '../../../../src/models/page-citability/page-citability.model.js';
 
@@ -61,6 +62,29 @@ describe('PageCitabilityCollection', () => {
       expect(instance.log).to.equal(mockLogger);
 
       expect(model).to.be.an('object');
+    });
+  });
+
+  describe('create', () => {
+    it('delegates to super.create upserting on the unique url column', async () => {
+      // Stub BaseCollection.prototype.create (the super) to capture the delegation args.
+      const prototype = Object.getPrototypeOf(Object.getPrototypeOf(instance));
+      const superCreateStub = prototype.create;
+      const created = { record: mockRecord };
+      const createSpy = sinon.stub().resolves(created);
+      prototype.create = createSpy;
+
+      try {
+        const result = await instance.create(mockRecord);
+
+        expect(result).to.equal(created);
+        expect(createSpy).to.have.been.calledOnceWithExactly(
+          mockRecord,
+          { upsert: true, onConflict: 'url' },
+        );
+      } finally {
+        prototype.create = superCreateStub;
+      }
     });
   });
 

--- a/packages/spacecat-shared-utils/src/metrics-store.js
+++ b/packages/spacecat-shared-utils/src/metrics-store.js
@@ -52,7 +52,7 @@ export async function getStoredMetrics(config, context) {
     return metrics;
   } catch (e) {
     const isMissingKey = e.name === 'NoSuchKey'
-      || e.message?.toLowerCase().includes('the specified key does not exist');
+      || e.$metadata?.httpStatusCode === 404;
     if (isMissingKey) {
       // Expected/recoverable: no metrics stored yet for this site/source/metric.
       log.warn(`No stored metrics found at ${filePath}, error: ${e.message}`);

--- a/packages/spacecat-shared-utils/test/metrics-store.test.js
+++ b/packages/spacecat-shared-utils/test/metrics-store.test.js
@@ -126,9 +126,11 @@ describe('Metrics Store', () => {
       expect(context.log.error).to.not.have.been.called;
     });
 
-    it('should warn (not error) when the error message indicates a missing key', async () => {
-      // some S3 paths surface the missing-key condition only via the message
-      context.s3.s3Client.send.rejects(new Error('The specified key does not exist.'));
+    it('should warn (not error) when the S3 error carries a 404 in $metadata', async () => {
+      // AWS SDK v3 attaches $metadata.httpStatusCode (404 for a missing key)
+      const error = new Error('The specified key does not exist.');
+      error.$metadata = { httpStatusCode: 404 };
+      context.s3.s3Client.send.rejects(error);
 
       const metrics = await getStoredMetrics(config, context);
 


### PR DESCRIPTION
Two recoverable-log / data-integrity fixes surfaced by the prod ERROR-noise review.

## Change A - metrics-store missing-key detection (spacecat-shared-utils)
`getStoredMetrics` distinguished a missing S3 object (expected, warn) from a genuine infra error (error) via a message-substring check. Switched to the structured AWS SDK v3 signal: `e.name === 'NoSuchKey' || e.$metadata?.httpStatusCode === 404`. More robust than substring matching; no behavior change for real S3 NoSuchKey errors.

## Change B - PageCitability url-upsert (spacecat-shared-data-access)
Prod emits ~100/hour of `[23505] duplicate key value violates unique constraint "idx_page_citabilities_url_unique"`. Root cause: a read-then-insert race - concurrent audit / prerender invocations build the existing-records map before either write lands, both see no row for a URL, both INSERT. `url` carries a global unique index, so the loser throws.

Fix: make PageCitability create idempotent via an upsert on `url`.
- `BaseCollection.create` gains an optional `onConflict` field (defaults to the PK `idName`, fully backward-compatible): `create(item, { upsert = false, onConflict } = {})`.
- `PageCitabilityCollection.create` overrides to `super.create(item, { upsert: true, onConflict: 'url' })` (mirrors ReportCollection's upsert pattern). Consumers (audit-worker) need no call-site change - the existing `PageCitability.create(...)` becomes a race-safe `ON CONFLICT (url) DO UPDATE`.

## Testing
- spacecat-shared-utils: 1172 passing; metrics-store.js 100% coverage; lint clean.
- spacecat-shared-data-access: 2324 passing; 100% lines / 97.76% branches (gate >= 97%); base.collection.js + page-citability.collection.js covered on both onConflict paths; lint clean.