### PR TITLE
fix(data-access): batch suggestion-grant lookups to avoid 414 URI Too Long

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/suggestion-grant/suggestion-grant.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/suggestion-grant/suggestion-grant.collection.js
@@ -28,7 +28,17 @@ class SuggestionGrantCollection extends BaseCollection {
   static COLLECTION_NAME = 'SuggestionGrantCollection';
 
   /**
+   * Max suggestion IDs per PostgREST request. PostgREST serializes `.in()` into the request
+   * URL (`suggestion_id=in.(<uuid>,<uuid>,...)`); each UUID costs ~39 chars, so 100 IDs keeps
+   * the query string near ~4KB — comfortably under the ~8KB limit that otherwise triggers a
+   * `414 URI Too Long` and fails the whole lookup.
+   */
+  static FIND_BY_SUGGESTION_IDS_CHUNK_SIZE = 100;
+
+  /**
    * Finds all grant rows for the given suggestion IDs (suggestion_id, grant_id only).
+   * Lookups are chunked to avoid `414 URI Too Long` from PostgREST GET URLs when many
+   * suggestion IDs are supplied.
    *
    * @async
    * @param {string[]} suggestionIds - Suggestion IDs to look up.
@@ -39,16 +49,28 @@ class SuggestionGrantCollection extends BaseCollection {
     if (!Array.isArray(suggestionIds) || suggestionIds.length === 0) {
       return [];
     }
-    const { data, error } = await this.postgrestService
-      .from(this.tableName)
-      .select('suggestion_id,grant_id')
-      .in('suggestion_id', suggestionIds);
 
-    if (error) {
-      throw new DataAccessError('Failed to find grants by suggestion IDs', this, error);
+    const chunkSize = SuggestionGrantCollection.FIND_BY_SUGGESTION_IDS_CHUNK_SIZE;
+    const rows = [];
+
+    for (let i = 0; i < suggestionIds.length; i += chunkSize) {
+      const chunk = suggestionIds.slice(i, i + chunkSize);
+      // eslint-disable-next-line no-await-in-loop
+      const { data, error } = await this.postgrestService
+        .from(this.tableName)
+        .select('suggestion_id,grant_id')
+        .in('suggestion_id', chunk);
+
+      if (error) {
+        throw new DataAccessError('Failed to find grants by suggestion IDs', this, error);
+      }
+
+      if (data) {
+        rows.push(...data);
+      }
     }
 
-    return data ?? [];
+    return rows;
   }
 
   /**

--- a/packages/spacecat-shared-data-access/test/unit/models/suggestion-grant/suggestion-grant.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/suggestion-grant/suggestion-grant.collection.test.js
@@ -124,6 +124,49 @@ describe('SuggestionGrantCollection', () => {
       await expect(instance.findBySuggestionIds(['sugg-1']))
         .to.be.rejectedWith(DataAccessError, 'Failed to find grants by suggestion IDs');
     });
+
+    it('chunks the lookup and aggregates rows when given more than the chunk size', async () => {
+      const chunkSize = SuggestionGrantCollection.FIND_BY_SUGGESTION_IDS_CHUNK_SIZE;
+      const total = chunkSize * 2 + 50; // 250 -> 3 chunks: 100, 100, 50
+      const suggestionIds = Array.from({ length: total }, (_, i) => `sugg-${i}`);
+
+      // Resolve one grant row per id in the requested chunk so aggregation is verifiable.
+      const inStub = stub().callsFake((_field, chunk) => Promise.resolve({
+        data: chunk.map((id) => ({ suggestion_id: id, grant_id: `g-${id}` })),
+        error: null,
+      }));
+      instance.postgrestService = {
+        from: stub().returns({ select: stub().returns({ in: inStub }) }),
+      };
+
+      const result = await instance.findBySuggestionIds(suggestionIds);
+
+      expect(result).to.have.length(total);
+      expect(inStub.callCount).to.equal(3);
+      expect(inStub.getCall(0).args[1]).to.have.length(chunkSize);
+      expect(inStub.getCall(1).args[1]).to.have.length(chunkSize);
+      expect(inStub.getCall(2).args[1]).to.have.length(50);
+      // No chunk exceeds the limit.
+      inStub.getCalls().forEach((call) => {
+        expect(call.args[1].length).to.be.at.most(chunkSize);
+      });
+    });
+
+    it('throws DataAccessError and stops when a later chunk fails', async () => {
+      const chunkSize = SuggestionGrantCollection.FIND_BY_SUGGESTION_IDS_CHUNK_SIZE;
+      const suggestionIds = Array.from({ length: chunkSize + 10 }, (_, i) => `sugg-${i}`);
+
+      const inStub = stub();
+      inStub.onFirstCall().resolves({ data: [], error: null });
+      inStub.onSecondCall().resolves({ data: null, error: { message: 'db error' } });
+      instance.postgrestService = {
+        from: stub().returns({ select: stub().returns({ in: inStub }) }),
+      };
+
+      await expect(instance.findBySuggestionIds(suggestionIds))
+        .to.be.rejectedWith(DataAccessError, 'Failed to find grants by suggestion IDs');
+      expect(inStub.callCount).to.equal(2);
+    });
   });
 
   describe('splitSuggestionsByGrantStatus', () => {


### PR DESCRIPTION
## Problem

`SuggestionGrantCollection.findBySuggestionIds` serialized **every** suggestion ID into a single PostgREST `.in('suggestion_id', [...])` filter. PostgREST encodes `.in()` into the request URL, so for large opportunities the query string exceeds the ~8KB URL limit (e.g. 643 suggestions ≈ 25KB) and returns **414 URI Too Long**.

The error is wrapped as `DataAccessError('Failed to find grants by suggestion IDs')` and surfaces in prod (api-service) as:

```
[traceId=...] Grant suggestions handler failed Failed to find grants by suggestion IDs
[traceId=...] Failed to filter suggestions by grant status Failed to find grants by suggestion IDs
```

It was chronic in prod — ~8 failures/hour (~191/24h). The grant-status filter throws on every affected request; the suggestions endpoint fails open (200 with unfiltered results), so grant-status was silently incorrect for large opportunities.

## Fix

Chunk the lookup into batches of **100** IDs (~4KB per request — well under the limit) and aggregate the rows, mirroring the existing chunking pattern in `base.collection.js`.

## Testing

- `npm test -w packages/spacecat-shared-data-access` → 2324 passing, 100% coverage on the changed file.
- Added unit tests: multi-chunk aggregation (250 IDs → 3 calls of 100/100/50) and error propagation when a later chunk fails.
- Lint clean.

## Verification

Reproduced on site `f81e7bad-c8b2-451c-b2af-e0954f26255e` / opportunity `79c80b1a-3b27-4100-98f8-f5af4a133a92` (643 suggestions): temporarily reducing the NEW suggestion count stopped the error, confirming the failure scales with the number of IDs in the `.in()` call.

## Follow-up (separate)

The underlying PostgREST error (`code`/`details`/`hint`) is swallowed by the `DataAccessError` wrapper — only the message is logged. Worth logging the cause fields to make data-layer failures debuggable in prod.

Jira: SITES-46550

🤖 Generated with [Claude Code](https://claude.com/claude-code)