### PR TITLE
fix(cloud-manager-client): bump ims-client 1.11.6 -> 1.13.3 to drop electrodb/jsonschema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -840,7 +840,9 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.940.0.tgz",
       "integrity": "sha512-u2sXsNJazJbuHeWICvsj6RvNyJh3isedEfPvB21jK/kxcriK+dE/izlKC2cyxUjERCmku0zTFNzY9FhrLbYHjQ==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -892,7 +894,9 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.940.0.tgz",
       "integrity": "sha512-KsGD2FLaX5ngJao1mHxodIVU9VYd1E8810fcYiGwO1PFHDzf5BEkp6D9IdMeQwT8Q6JLYtiiT1Y/o3UCScnGoA==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.936.0",
         "@aws-sdk/xml-builder": "3.930.0",
@@ -916,7 +920,9 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.940.0.tgz",
       "integrity": "sha512-/G3l5/wbZYP2XEQiOoIkRJmlv15f1P3MSd1a0gz27lHEMrOJOGq66rF1Ca4OJLzapWt3Fy9BPrZAepoAX11kMw==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.940.0",
         "@aws-sdk/types": "3.936.0",
@@ -932,7 +938,9 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.940.0.tgz",
       "integrity": "sha512-dOrc03DHElNBD6N9Okt4U0zhrG4Wix5QUBSZPr5VN8SvmjD9dkrrxOkkJaMCl/bzrW7kbQEp7LuBdbxArMmOZQ==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.940.0",
         "@aws-sdk/types": "3.936.0",
@@ -953,7 +961,9 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.940.0.tgz",
       "integrity": "sha512-gn7PJQEzb/cnInNFTOaDoCN/hOKqMejNmLof1W5VW95Qk0TPO52lH8R4RmJPnRrwFMswOWswTOpR1roKNLIrcw==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.940.0",
         "@aws-sdk/credential-provider-env": "3.940.0",
@@ -978,7 +988,9 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.940.0.tgz",
       "integrity": "sha512-fOKC3VZkwa9T2l2VFKWRtfHQPQuISqqNl35ZhcXjWKVwRwl/o7THPMkqI4XwgT2noGa7LLYVbWMwnsgSsBqglg==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.940.0",
         "@aws-sdk/nested-clients": "3.940.0",
@@ -997,7 +1009,9 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.940.0.tgz",
       "integrity": "sha512-M8NFAvgvO6xZjiti5kztFiAYmSmSlG3eUfr4ZHSfXYZUA/KUdZU/D6xJyaLnU8cYRWBludb6K9XPKKVwKfqm4g==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.940.0",
         "@aws-sdk/credential-provider-http": "3.940.0",
@@ -1020,7 +1034,9 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.940.0.tgz",
       "integrity": "sha512-pILBzt5/TYCqRsJb7vZlxmRIe0/T+FZPeml417EK75060ajDGnVJjHcuVdLVIeKoTKm9gmJc9l45gon6PbHyUQ==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.940.0",
         "@aws-sdk/types": "3.936.0",
@@ -1037,7 +1053,9 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.940.0.tgz",
       "integrity": "sha512-q6JMHIkBlDCOMnA3RAzf8cGfup+8ukhhb50fNpghMs1SNBGhanmaMbZSgLigBRsPQW7fOk2l8jnzdVLS+BB9Uw==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.940.0",
         "@aws-sdk/core": "3.940.0",
@@ -1056,7 +1074,9 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.940.0.tgz",
       "integrity": "sha512-9QLTIkDJHHaYL0nyymO41H8g3ui1yz6Y3GmAN1gYQa6plXisuFBnGAbmKVj7zNvjWaOKdF0dV3dd3AFKEDoJ/w==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.940.0",
         "@aws-sdk/nested-clients": "3.940.0",
@@ -1074,7 +1094,9 @@
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
       "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.936.0",
         "@smithy/protocol-http": "^5.3.5",
@@ -1089,7 +1111,9 @@
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
       "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.936.0",
         "@smithy/types": "^4.9.0",
@@ -1103,7 +1127,9 @@
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.936.0.tgz",
       "integrity": "sha512-l4aGbHpXM45YNgXggIux1HgsCVAvvBoqHPkqLnqMl9QVapfuSTjJHfDYDsx1Xxct6/m7qSMUzanBALhiaGO2fA==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.936.0",
         "@aws/lambda-invoke-store": "^0.2.0",
@@ -1119,7 +1145,9 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.940.0.tgz",
       "integrity": "sha512-nJbLrUj6fY+l2W2rIB9P4Qvpiy0tnTdg/dmixRxrU1z3e8wBdspJlyE+AZN4fuVbeL6rrRrO/zxQC1bB3cw5IA==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.940.0",
         "@aws-sdk/types": "3.936.0",
@@ -1137,7 +1165,9 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.940.0.tgz",
       "integrity": "sha512-x0mdv6DkjXqXEcQj3URbCltEzW6hoy/1uIL+i8gExP6YKrnhiZ7SzuB4gPls2UOpK5UqLiqXjhRLfBb1C9i4Dw==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1186,7 +1216,9 @@
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
       "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.936.0",
         "@smithy/config-resolver": "^4.4.3",
@@ -1202,7 +1234,9 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.940.0.tgz",
       "integrity": "sha512-k5qbRe/ZFjW9oWEdzLIa2twRVIEx7p/9rutofyrRysrtEnYh3HAWCngAnwbgKMoiwa806UzcTRx0TjyEpnKcCg==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/core": "3.940.0",
         "@aws-sdk/nested-clients": "3.940.0",
@@ -1220,7 +1254,9 @@
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
       "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
@@ -1233,7 +1269,9 @@
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
       "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.936.0",
         "@smithy/types": "^4.9.0",
@@ -1249,7 +1287,9 @@
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
       "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.936.0",
         "@smithy/types": "^4.9.0",
@@ -1261,7 +1301,9 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.940.0.tgz",
       "integrity": "sha512-dlD/F+L/jN26I8Zg5x0oDGJiA+/WEQmnSE27fi5ydvYnpfQLwThtQo9SsNS47XSR/SOULaaoC9qx929rZuo74A==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-user-agent": "3.940.0",
         "@aws-sdk/types": "3.936.0",
@@ -1285,7 +1327,9 @@
       "version": "3.930.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
       "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.9.0",
         "fast-xml-parser": "5.2.5",
@@ -1299,6 +1343,7 @@
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
       "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1306,6 +1351,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "strnum": "^2.1.0"
       },
@@ -1868,7 +1914,9 @@
       "version": "3.893.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.893.0.tgz",
       "integrity": "sha512-KSwTfyLZyNLszz5f/yoLC+LC+CRKpeJii/+zVAy7JUOQsKhSykiRUPYUx7o2Sdc4oJfqqUl26A/jSttKYnYtAA==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "mnemonist": "0.38.3",
         "tslib": "^2.6.2"
@@ -1881,6 +1929,7 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.940.0.tgz",
       "integrity": "sha512-5ApYAix2wvJuMszj1lrpg8lm4ipoZMFO8crxtzsdAvxM8TV5bKSRQQ2GA3CMIODrBuSzpXvWueHHrfkx05ZAQw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "3.940.0",
@@ -1901,6 +1950,7 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.940.0.tgz",
       "integrity": "sha512-KsGD2FLaX5ngJao1mHxodIVU9VYd1E8810fcYiGwO1PFHDzf5BEkp6D9IdMeQwT8Q6JLYtiiT1Y/o3UCScnGoA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.936.0",
@@ -1925,6 +1975,7 @@
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
       "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
@@ -1938,6 +1989,7 @@
       "version": "3.930.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
       "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
@@ -1952,6 +2004,7 @@
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
       "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1986,7 +2039,9 @@
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.936.0.tgz",
       "integrity": "sha512-wNJZ8PDw0eQK2x4z1q8JqiDvw9l9xd36EoklVT2CIBt8FnqGdrMGjAx93RRbH3G6Fmvwoe+D3VJXbWHBlhD0Bw==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/endpoint-cache": "3.893.0",
         "@aws-sdk/types": "3.936.0",
@@ -2003,7 +2058,9 @@
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
       "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
@@ -2257,6 +2314,7 @@
       "version": "3.940.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.940.0.tgz",
       "integrity": "sha512-T8UTYtCYSPxktnk68fKBdWztnqdTQItJwi/8N9lsvp20alJ15wCQsvQR+GKB5p4TCKxOPyNEirkcrNlf5TKppA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -15227,7 +15285,9 @@
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "obliterator": "^1.6.1"
       }
@@ -17820,7 +17880,9 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -25884,7 +25946,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
-        "@adobe/spacecat-shared-ims-client": "1.11.6",
+        "@adobe/spacecat-shared-ims-client": "1.13.3",
         "@adobe/spacecat-shared-utils": "1.81.1",
         "@aws-sdk/client-s3": "3.1057.0",
         "zip-lib": "1.3.4"
@@ -25902,82 +25964,6 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
-      }
-    },
-    "packages/spacecat-shared-cloud-manager-client/node_modules/@adobe/helix-universal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-5.3.0.tgz",
-      "integrity": "sha512-1eKFpKZMNamJHhq6eFm9gMLhgQunsf34mEFbaqg9ChEXZYk18SYgUu5GeNTvzk5Rzo0h9AuSwLtnI2Up2OSiSA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@adobe/fetch": "4.2.3",
-        "aws4": "1.13.2"
-      }
-    },
-    "packages/spacecat-shared-cloud-manager-client/node_modules/@adobe/helix-universal/node_modules/@adobe/fetch": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
-      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "4.4.3",
-        "http-cache-semantics": "4.2.0",
-        "lru-cache": "7.18.3"
-      },
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
-    "packages/spacecat-shared-cloud-manager-client/node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "2.88.5",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-2.88.5.tgz",
-      "integrity": "sha512-wwkCpZkzyFZuP340RC4ywfEOpj59nHA+XonaUSE/ybqe0yiam6uz8mC2KEnhFxD+pToUbR2e/0j+XCo5vmyJ6A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@adobe/spacecat-shared-utils": "1.81.1",
-        "@aws-sdk/client-dynamodb": "3.940.0",
-        "@aws-sdk/lib-dynamodb": "3.940.0",
-        "@types/joi": "17.2.3",
-        "aws-xray-sdk": "3.12.0",
-        "electrodb": "3.5.0",
-        "joi": "18.0.2",
-        "pluralize": "8.0.0"
-      },
-      "engines": {
-        "node": ">=22.0.0 <25.0.0",
-        "npm": ">=10.9.0 <12.0.0"
-      }
-    },
-    "packages/spacecat-shared-cloud-manager-client/node_modules/@adobe/spacecat-shared-ims-client": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-ims-client/-/spacecat-shared-ims-client-1.11.6.tgz",
-      "integrity": "sha512-tmCpHVDUHyTjHowm+c6Mrsclyoa86hXDkUqClvnTSrRHWINJHZl2wyEQcsmpugKjTyzu8u94lEDlKs50d4AVZg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@adobe/fetch": "4.2.3",
-        "@adobe/helix-universal": "5.3.0",
-        "@adobe/spacecat-shared-data-access": "2.88.5",
-        "@adobe/spacecat-shared-utils": "1.81.1",
-        "@aws-sdk/client-secrets-manager": "3.940.0",
-        "aws-xray-sdk": "3.12.0"
-      },
-      "engines": {
-        "node": ">=22.0.0 <25.0.0",
-        "npm": ">=10.9.0 <12.0.0"
-      }
-    },
-    "packages/spacecat-shared-cloud-manager-client/node_modules/@adobe/spacecat-shared-ims-client/node_modules/@adobe/fetch": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
-      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "4.4.3",
-        "http-cache-semantics": "4.2.0",
-        "lru-cache": "7.18.3"
-      },
-      "engines": {
-        "node": ">=14.16"
       }
     },
     "packages/spacecat-shared-cloud-manager-client/node_modules/@adobe/spacecat-shared-utils": {
@@ -26078,56 +26064,6 @@
         "@smithy/util-stream": "^4.5.6",
         "@smithy/util-utf8": "^4.2.0",
         "@smithy/util-waiter": "^4.2.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-cloud-manager-client/node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.940.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.940.0.tgz",
-      "integrity": "sha512-fpxSRsGyuXmyNqEwdGJUDWVgN0v8xR7tr32Quls3K+HnYlnBGFmISu5Pcc+BfwmrZHnPaVpPc+S3PUzTnFpOJg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.940.0",
-        "@aws-sdk/credential-provider-node": "3.940.0",
-        "@aws-sdk/middleware-host-header": "3.936.0",
-        "@aws-sdk/middleware-logger": "3.936.0",
-        "@aws-sdk/middleware-recursion-detection": "3.936.0",
-        "@aws-sdk/middleware-user-agent": "3.940.0",
-        "@aws-sdk/region-config-resolver": "3.936.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@aws-sdk/util-user-agent-browser": "3.936.0",
-        "@aws-sdk/util-user-agent-node": "3.940.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.5",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.12",
-        "@smithy/middleware-retry": "^4.4.12",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.8",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.11",
-        "@smithy/util-defaults-mode-node": "^4.2.14",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -26784,17 +26720,6 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
-    "packages/spacecat-shared-cloud-manager-client/node_modules/electrodb": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/electrodb/-/electrodb-3.5.0.tgz",
-      "integrity": "sha512-msJyMTQmx6AC/otRKSre0rktE3E0RUw7ez9u2F25ZU4iXEqzxeu/OyRJcR53hh+jv4Fefi/3F9R+JopgIUZJHQ==",
-      "license": "ISC",
-      "dependencies": {
-        "@aws-sdk/lib-dynamodb": "^3.654.0",
-        "@aws-sdk/util-dynamodb": "^3.654.0",
-        "jsonschema": "1.2.7"
-      }
-    },
     "packages/spacecat-shared-cloud-manager-client/node_modules/fast-xml-parser": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
@@ -26811,33 +26736,6 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      }
-    },
-    "packages/spacecat-shared-cloud-manager-client/node_modules/joi": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
-      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/address": "^5.1.1",
-        "@hapi/formula": "^3.0.2",
-        "@hapi/hoek": "^11.0.7",
-        "@hapi/pinpoint": "^2.0.1",
-        "@hapi/tlds": "^1.1.1",
-        "@hapi/topo": "^6.0.2",
-        "@standard-schema/spec": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "packages/spacecat-shared-cloud-manager-client/node_modules/jsonschema": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.7.tgz",
-      "integrity": "sha512-3dFMg9hmI9LdHag/BRIhMefCfbq1hicvYMy8YhZQorAdzOzWz7NjniSpn39yjpzUAMIWtGyyZuH2KNBloH7ZLw==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "packages/spacecat-shared-cloud-manager-client/node_modules/undici": {
@@ -27658,18 +27556,18 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "3.74.3",
+      "version": "3.75.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",
         "@adobe/spacecat-shared-utils": "1.105.0",
         "@aws-sdk/client-s3": "^3.940.0",
+        "@smithy/util-retry": "^4.0.0",
         "@supabase/postgrest-js": "2.106.2",
         "@types/joi": "17.2.3",
         "aws-xray-sdk": "3.12.0",
         "joi": "18.2.1",
-        "pluralize": "8.0.0",
-        "@smithy/util-retry": "^4.0.0"
+        "pluralize": "8.0.0"
       },
       "devDependencies": {
         "chai": "6.2.2",
@@ -29837,7 +29735,7 @@
     },
     "packages/spacecat-shared-http-utils": {
       "name": "@adobe/spacecat-shared-http-utils",
-      "version": "1.29.0",
+      "version": "1.29.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -32316,7 +32214,7 @@
     },
     "packages/spacecat-shared-rum-api-client": {
       "name": "@adobe/spacecat-shared-rum-api-client",
-      "version": "2.42.0",
+      "version": "2.43.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -37147,7 +37045,7 @@
     },
     "packages/spacecat-shared-utils": {
       "name": "@adobe/spacecat-shared-utils",
-      "version": "1.119.0",
+      "version": "1.119.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",

--- a/packages/spacecat-shared-cloud-manager-client/package.json
+++ b/packages/spacecat-shared-cloud-manager-client/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@adobe/fetch": "4.3.0",
-    "@adobe/spacecat-shared-ims-client": "1.11.6",
+    "@adobe/spacecat-shared-ims-client": "1.13.3",
     "@adobe/spacecat-shared-utils": "1.81.1",
     "@aws-sdk/client-s3": "3.1057.0",
     "zip-lib": "1.3.4"


### PR DESCRIPTION
## What

Bumps `@adobe/spacecat-shared-cloud-manager-client`'s pin on `@adobe/spacecat-shared-ims-client` from `1.11.6` to `1.13.3` (the monorepo's current ims-client). One-line dependency change + lockfile regeneration.

## Why

`cloud-manager-client@1.4.3` hard-pinned `ims-client@1.11.6` - the last ims-client line whose transitive `@adobe/spacecat-shared-data-access@2.88.5` drags in `electrodb@3.5.0 -> jsonschema@1.2.7`. `jsonschema@1.2.7` calls the legacy `url.parse()` at module-init, which is the source of the org-wide **DEP0169** deprecation warning (~thousands/day across services).

`ims-client` dropped its `data-access` dependency entirely at **1.11.10** - it was a type-only JSDoc `@import {type Site}`, never a runtime dependency. So the electrodb/jsonschema subtree was always dead weight pulled in purely to resolve a type annotation.

Because the old pin was exact (`1.11.6`), npm could not dedupe against the monorepo's local `ims-client@1.13.3` and instead nested a real `1.11.6` (with its electrodb/jsonschema subtree). Bumping to `1.13.3` lets npm link the local workspace copy and prunes the subtree.

## Impact

- `electrodb@3.5.0` / `jsonschema@1.2.7` removed from the cloud-manager-client dependency tree (lockfile: -173 lines). The only `electrodb` left in the monorepo is data-access's `3.9.0` devDep, which ships `jsonschema@1.5.0` (no DEP0169).
- Behavioral no-op: cloud-manager-client only uses `ImsClient.createFrom(...)` and `imsClient.getServiceAccessToken()`, both present and unchanged in 1.13.3 (the 1.11.6 -> 1.13.3 delta is dependency bumps plus an additive `getServiceAccessTokenV3`).
- Once released, consumers (`spacecat-import-worker`, `spacecat-autofix-worker`) bump to the new cloud-manager-client to eliminate DEP0169 - they still carry electrodb only via this path.

## Verification

- `npm ls @adobe/spacecat-shared-ims-client -w packages/spacecat-shared-cloud-manager-client` -> `1.13.3 -> ./packages/spacecat-shared-ims-client` (local link, no nested 1.11.6)
- `npm ls electrodb -w packages/spacecat-shared-cloud-manager-client` -> not found
- tests: 84 passing, 100% coverage; lint clean