### PR TITLE
fix(utils): correct AMS detection for AEM 6.5 sites with Core Components

### DIFF
--- a/packages/spacecat-shared-utils/src/aem.js
+++ b/packages/spacecat-shared-utils/src/aem.js
@@ -145,6 +145,13 @@ export function detectAEMVersion(htmlSource, headers = {}) {
     }
   }
 
+  // x-dispatcher is a server infrastructure header only present on AMS dispatcher nodes —
+  // give it higher weight than the MD5 fingerprint pattern to overcome accumulated
+  // CS-looking signals (cmp- classes, lc- format, experience-fragments) on AMS 6.5 sites
+  if (/^dispatcher[0-9]/i.test(headers['x-dispatcher'])) {
+    amsMatches += 6;
+  }
+
   for (const pattern of aemHeadlessPatterns) {
     if (pattern.test(normalizedHtml)) {
       aemHeadlessMatches += 1;
@@ -172,14 +179,17 @@ export function detectAEMVersion(htmlSource, headers = {}) {
     amsMatches += 5; // Increased weight since this is a very reliable AMS indicator
   }
 
-  // Give extra weight to CS clientlib format pattern as it's very distinctive
+  // lc-[timestamp]-lc format exists on AEM 6.5 (AMS) too — not CS-exclusive
   if (/\/etc\.clientlibs\/[^"']+\.lc-[a-f0-9]+-lc\.min\.(js|css)/i.test(normalizedHtml)) {
-    csMatches += 3;
+    csMatches += 1;
   }
 
   // Give significant weight to explicit RUM data-routing indicators
+  // ams= gets higher weight (+8 total) because AMS 6.5 sites running Core Components
+  // accumulate many CS-looking patterns (lc- format, cmp- classes, experience-fragments)
+  // that can overtake a lower-weighted explicit AMS declaration
   if (/data-routing="[^"]*ams=([^,"]*)/i.test(normalizedHtml)) {
-    amsMatches += 5;
+    amsMatches += 7;
   }
 
   if (/data-routing="[^"]*eds=([^,"]*)/i.test(normalizedHtml)) {

--- a/packages/spacecat-shared-utils/src/aem.js
+++ b/packages/spacecat-shared-utils/src/aem.js
@@ -102,8 +102,10 @@ export function detectAEMVersion(htmlSource, headers = {}) {
     /data-routing="[^"]*ams=([^,"]*)/i,
   ];
 
+  // Case-insensitive: HTTP header values may arrive with unexpected casing.
+  // Must stay aligned with the extra-weight check below.
   const amsHeaderPatterns = [
-    /^dispatcher[0-9].*$/,
+    /^dispatcher[0-9]/i,
   ];
 
   const aemHeadlessPatterns = [

--- a/packages/spacecat-shared-utils/test/aem.test.js
+++ b/packages/spacecat-shared-utils/test/aem.test.js
@@ -241,6 +241,26 @@ describe('AEM Detection', () => {
         expect(result).to.equal(DELIVERY_TYPES.AEM_AMS);
       });
 
+      it('should detect AMS with mixed-case x-dispatcher header value', () => {
+        // HTTP header values may arrive with unexpected casing — the pattern and the
+        // extra-weight check must both match case-insensitively to score consistently.
+        const headers = { 'x-dispatcher': 'Dispatcher3eusouth2' };
+        const htmlSource = `
+          <html>
+            <head>
+              <link rel="stylesheet" href="/etc.clientlibs/mysite/clientlibs/base.lc-1781626636100-lc.min.css">
+            </head>
+            <body>
+              <div class="cmp-container">
+                <div data-cmp-is="image" class="cmp-image"></div>
+              </div>
+            </body>
+          </html>
+        `;
+        const result = detectAEMVersion(htmlSource, headers);
+        expect(result).to.equal(DELIVERY_TYPES.AEM_AMS);
+      });
+
       it('should detect AMS via foundation- pattern', () => {
         const htmlSource = `
           <html>

--- a/packages/spacecat-shared-utils/test/aem.test.js
+++ b/packages/spacecat-shared-utils/test/aem.test.js
@@ -197,6 +197,50 @@ describe('AEM Detection', () => {
         expect(result).to.equal(DELIVERY_TYPES.AEM_AMS);
       });
 
+      it('should detect AMS 6.5 with Core Components despite CS-looking patterns', () => {
+        // AEM 6.5 (AMS) can use Core Components (cmp- classes, data-cmp-),
+        // experience fragments, and lc-[timestamp]-lc clientlib format — all of which
+        // also appear on CS. The explicit ams= data-routing must win.
+        const htmlSource = `
+          <html>
+            <head>
+              <script defer src="https://rum.hlx.page/.rum/@adobe/helix-rum-js@%5E2/dist/rum-standalone.js"
+                data-routing="env=prod,tier=publish,ams=My Org Name"></script>
+              <link rel="stylesheet" href="/etc.clientlibs/mysite/clientlibs/base.lc-1781626636100-lc.min.css">
+            </head>
+            <body data-cmp-link-accessibility-enabled data-cmp-data-layer-name="adobeDataLayer">
+              <div id="container-abc" class="cmp-container">
+                <div class="cmp-experiencefragment">
+                  <div data-cmp-is="image" class="cmp-image">
+                    <img src="/content/experience-fragments/mysite/header.svg">
+                  </div>
+                </div>
+              </div>
+            </body>
+          </html>
+        `;
+        const result = detectAEMVersion(htmlSource);
+        expect(result).to.equal(DELIVERY_TYPES.AEM_AMS);
+      });
+
+      it('should detect AMS 6.5 with Core Components and x-dispatcher header', () => {
+        const headers = { 'x-dispatcher': 'dispatcher3eusouth2' };
+        const htmlSource = `
+          <html>
+            <head>
+              <link rel="stylesheet" href="/etc.clientlibs/mysite/clientlibs/base.lc-1781626636100-lc.min.css">
+            </head>
+            <body>
+              <div class="cmp-container">
+                <div data-cmp-is="image" class="cmp-image"></div>
+              </div>
+            </body>
+          </html>
+        `;
+        const result = detectAEMVersion(htmlSource, headers);
+        expect(result).to.equal(DELIVERY_TYPES.AEM_AMS);
+      });
+
       it('should detect AMS via foundation- pattern', () => {
         const htmlSource = `
           <html>


### PR DESCRIPTION
## Summary

`detectAEMVersion` was misclassifying AEM 6.5 (AMS) sites as `aem_cs`. The root cause: several patterns the scorer treated as CS indicators are **not CS-exclusive** — Core Components (`cmp-` classes, `data-cmp-`), the `lc-[timestamp]-lc` clientlib format, and `/content/experience-fragments/` all ship on AEM 6.5 (AMS) too. An AMS page accumulates enough of these "CS-looking" points to overtake its own explicit AMS signals.

Discovered via `publish-prod-sgad-secretary-general-of-administration-digital.adobecqms.net` (AMS domain — `x-dispatcher: dispatcher3eusouth2`, `data-routing="ams=..."`) being returned as `aem_cs`.

## Changes — three weight recalibrations

1. **`lc-[timestamp]-lc` CS extra weight: +3 → +1** — this clientlib caching format was backported to AEM 6.5, so it's a weak CS signal, not a decisive one.
2. **`data-routing ams=` extra weight: +5 → +7** — `data-routing` is an explicit, site-authored declaration; the AMS variant must outweigh the CS-looking points an AMS page legitimately accumulates.
3. **`x-dispatcher` header extra weight: 0 → +6** — infrastructure header only emitted by AMS dispatcher nodes; now decisive, matching the MD5-clientlib signal.

## Why only `ams=` gets the boost (not `cs=`/`eds=`)

The contamination is **one-directional**. CS markup appears on AMS 6.5, but legacy AMS markup (`/etc/designs/`, `foundation-`, MD5-fingerprinted clientlibs) never appears on modern CS. So an AMS page competes against CS noise, while a CS page faces no equivalent AMS noise. Measured opposite-type points on live sites:

| AMS site | CS points it picks up | | CS site | AMS points it picks up |
|---|---|---|---|---|
| mptmd.gob.es | **7** | | eplan.com | 0 |
| honeywell.com | **5** | | deloitte.com | 0 |
| stryker.com | 1 | | aramark.com | 0 |
| | | | audemarspiguet.com | 2 (low-weight only) |

A CS site's `cs=` (+6 total) is never at risk; an AMS site's old `ams=` (+6) *was* losing to a 7–8 point CS pile. Hence `cs=`/`eds=` need no boost.

## Test plan

- [x] All 1177 tests pass locally
- [x] New regression tests added:
  - AMS 6.5 + Core Components + `lc-` + experience-fragments + explicit `ams=` → `aem_ams`
  - AMS 6.5 + Core Components + `lc-` + `x-dispatcher` header → `aem_ams`
  - Mixed-case `x-dispatcher` value (`Dispatcher3eusouth2`) → `aem_ams`
- [x] `mptmd.gob.es` now correctly classified as `aem_ams`
- [x] Spot-checked 20 live sites across all delivery types — no regressions

Jira: SITES-46675

🤖 Generated with [Claude Code](https://claude.com/claude-code)
