### PR TITLE
feat(ims-client): include IMS response body in token-mint error messages

### DIFF
--- a/packages/spacecat-shared-ims-client/src/clients/ims-client.js
+++ b/packages/spacecat-shared-ims-client/src/clients/ims-client.js
@@ -181,10 +181,14 @@ export default class ImsClient extends ImsBaseClient {
       let errorMessage = `IMS getServiceAccessToken request failed with status: ${tokenResponse.status}`;
       try {
         const errorBody = await tokenResponse.json();
+        // Cap appended detail at 200 chars — defense-in-depth against
+        // unexpectedly verbose IMS responses; typical OAuth2 error codes
+        // (`invalid_scope`, `unauthorized_client`, etc.) are well under
+        // this. Per @solaris007 review.
         if (hasText(errorBody.error)) {
-          errorMessage += ` - ${errorBody.error}`;
+          errorMessage += ` - ${errorBody.error.slice(0, 200)}`;
         } else if (hasText(errorBody.message)) {
-          errorMessage += ` - ${errorBody.message}`;
+          errorMessage += ` - ${errorBody.message.slice(0, 200)}`;
         }
       } catch (e) {
         // Response body is not JSON or cannot be parsed, ignore
@@ -225,10 +229,14 @@ export default class ImsClient extends ImsBaseClient {
       let errorMessage = `IMS getServiceAccessTokenV3 request failed with status: ${tokenResponse.status}`;
       try {
         const errorBody = await tokenResponse.json();
+        // Cap appended detail at 200 chars — defense-in-depth against
+        // unexpectedly verbose IMS responses; typical OAuth2 error codes
+        // (`invalid_scope`, `unauthorized_client`, etc.) are well under
+        // this. Per @solaris007 review.
         if (hasText(errorBody.error)) {
-          errorMessage += ` - ${errorBody.error}`;
+          errorMessage += ` - ${errorBody.error.slice(0, 200)}`;
         } else if (hasText(errorBody.message)) {
-          errorMessage += ` - ${errorBody.message}`;
+          errorMessage += ` - ${errorBody.message.slice(0, 200)}`;
         }
       } catch (e) {
         // Response body is not JSON or cannot be parsed, ignore
@@ -270,10 +278,14 @@ export default class ImsClient extends ImsBaseClient {
       let errorMessage = `IMS getServicePrincipalAccessToken request failed with status: ${tokenResponse.status}`;
       try {
         const errorBody = await tokenResponse.json();
+        // Cap appended detail at 200 chars — defense-in-depth against
+        // unexpectedly verbose IMS responses; typical OAuth2 error codes
+        // (`invalid_scope`, `unauthorized_client`, etc.) are well under
+        // this. Per @solaris007 review.
         if (hasText(errorBody.error)) {
-          errorMessage += ` - ${errorBody.error}`;
+          errorMessage += ` - ${errorBody.error.slice(0, 200)}`;
         } else if (hasText(errorBody.message)) {
-          errorMessage += ` - ${errorBody.message}`;
+          errorMessage += ` - ${errorBody.message.slice(0, 200)}`;
         }
       } catch (e) {
         // Response body is not JSON or cannot be parsed, ignore
@@ -463,10 +475,14 @@ export default class ImsClient extends ImsBaseClient {
       let errorMessage = `IMS getAccountCluster request failed with status: ${accountClusterResponse.status}`;
       try {
         const errorBody = await accountClusterResponse.json();
+        // Cap appended detail at 200 chars — defense-in-depth against
+        // unexpectedly verbose IMS responses; typical OAuth2 error codes
+        // (`invalid_scope`, `unauthorized_client`, etc.) are well under
+        // this. Per @solaris007 review.
         if (hasText(errorBody.error)) {
-          errorMessage += ` - ${errorBody.error}`;
+          errorMessage += ` - ${errorBody.error.slice(0, 200)}`;
         } else if (hasText(errorBody.message)) {
-          errorMessage += ` - ${errorBody.message}`;
+          errorMessage += ` - ${errorBody.message.slice(0, 200)}`;
         }
       } catch (e) {
         // Response body is not JSON or cannot be parsed, ignore

--- a/packages/spacecat-shared-ims-client/src/clients/ims-client.js
+++ b/packages/spacecat-shared-ims-client/src/clients/ims-client.js
@@ -178,7 +178,18 @@ export default class ImsClient extends ImsBaseClient {
     );
 
     if (!tokenResponse.ok) {
-      throw new Error(`IMS getServiceAccessToken request failed with status: ${tokenResponse.status}`);
+      let errorMessage = `IMS getServiceAccessToken request failed with status: ${tokenResponse.status}`;
+      try {
+        const errorBody = await tokenResponse.json();
+        if (hasText(errorBody.error)) {
+          errorMessage += ` - ${errorBody.error}`;
+        } else if (hasText(errorBody.message)) {
+          errorMessage += ` - ${errorBody.message}`;
+        }
+      } catch (e) {
+        // Response body is not JSON or cannot be parsed, ignore
+      }
+      throw new Error(errorMessage);
     }
 
     /* eslint-disable camelcase */
@@ -211,7 +222,18 @@ export default class ImsClient extends ImsBaseClient {
     );
 
     if (!tokenResponse.ok) {
-      throw new Error(`IMS getServiceAccessTokenV3 request failed with status: ${tokenResponse.status}`);
+      let errorMessage = `IMS getServiceAccessTokenV3 request failed with status: ${tokenResponse.status}`;
+      try {
+        const errorBody = await tokenResponse.json();
+        if (hasText(errorBody.error)) {
+          errorMessage += ` - ${errorBody.error}`;
+        } else if (hasText(errorBody.message)) {
+          errorMessage += ` - ${errorBody.message}`;
+        }
+      } catch (e) {
+        // Response body is not JSON or cannot be parsed, ignore
+      }
+      throw new Error(errorMessage);
     }
 
     /* eslint-disable camelcase */
@@ -245,7 +267,18 @@ export default class ImsClient extends ImsBaseClient {
     );
 
     if (!tokenResponse.ok) {
-      throw new Error(`IMS getServicePrincipalAccessToken request failed with status: ${tokenResponse.status}`);
+      let errorMessage = `IMS getServicePrincipalAccessToken request failed with status: ${tokenResponse.status}`;
+      try {
+        const errorBody = await tokenResponse.json();
+        if (hasText(errorBody.error)) {
+          errorMessage += ` - ${errorBody.error}`;
+        } else if (hasText(errorBody.message)) {
+          errorMessage += ` - ${errorBody.message}`;
+        }
+      } catch (e) {
+        // Response body is not JSON or cannot be parsed, ignore
+      }
+      throw new Error(errorMessage);
     }
 
     /* eslint-disable camelcase */

--- a/packages/spacecat-shared-ims-client/test/clients/ims-client.test.js
+++ b/packages/spacecat-shared-ims-client/test/clients/ims-client.test.js
@@ -152,6 +152,31 @@ describe('ImsClient', () => {
       await expect(client.getImsOrganizationDetails('123456@AdobeOrg')).to.be.rejectedWith('IMS getServiceAccessToken request failed with status: 500');
     });
 
+    it('v2 mint failure includes error field from response body when present', async () => {
+      nock(`https://${DUMMY_HOST}`)
+        .post('/ims/token/v4')
+        .query(true)
+        .reply(400, {
+          error: 'invalid_grant',
+          error_description: 'Authorization code expired',
+        });
+
+      await expect(client.getImsOrganizationDetails('123456@AdobeOrg'))
+        .to.be.rejectedWith('IMS getServiceAccessToken request failed with status: 400 - invalid_grant');
+    });
+
+    it('v2 mint failure includes message field from response body when error field absent', async () => {
+      nock(`https://${DUMMY_HOST}`)
+        .post('/ims/token/v4')
+        .query(true)
+        .reply(401, {
+          message: 'Client credentials rejected',
+        });
+
+      await expect(client.getImsOrganizationDetails('123456@AdobeOrg'))
+        .to.be.rejectedWith('IMS getServiceAccessToken request failed with status: 401 - Client credentials rejected');
+    });
+
     it('should handle IMS service token request v3', async () => {
       nock(`https://${DUMMY_HOST}`)
         // Mock the token request, with a 500 server error response
@@ -193,6 +218,56 @@ describe('ImsClient', () => {
         .reply(500);
 
       await expect(client.getServiceAccessTokenV3()).to.be.rejectedWith('IMS getServiceAccessTokenV3 request failed with status: 500');
+    });
+
+    it('v3 mint failure includes error field from response body when present', async () => {
+      nock(`https://${DUMMY_HOST}`)
+        .post('/ims/token/v3')
+        .query(true)
+        .reply(400, {
+          error: 'invalid_scope',
+          error_description: 'Invalid scope value',
+        });
+
+      await expect(client.getServiceAccessTokenV3())
+        .to.be.rejectedWith('IMS getServiceAccessTokenV3 request failed with status: 400 - invalid_scope');
+    });
+
+    it('v3 mint failure includes message field from response body when error field absent', async () => {
+      nock(`https://${DUMMY_HOST}`)
+        .post('/ims/token/v3')
+        .query(true)
+        .reply(403, {
+          message: 'Client not authorized for client_credentials grant',
+        });
+
+      await expect(client.getServiceAccessTokenV3())
+        .to.be.rejectedWith('IMS getServiceAccessTokenV3 request failed with status: 403 - Client not authorized for client_credentials grant');
+    });
+
+    it('v3 mint failure prefers error field over message field when both are present', async () => {
+      nock(`https://${DUMMY_HOST}`)
+        .post('/ims/token/v3')
+        .query(true)
+        .reply(401, {
+          error: 'invalid_client',
+          message: 'This should be ignored',
+        });
+
+      await expect(client.getServiceAccessTokenV3())
+        .to.be.rejectedWith('IMS getServiceAccessTokenV3 request failed with status: 401 - invalid_client');
+    });
+
+    it('v3 mint failure with non-JSON response body falls back to status-only message', async () => {
+      // 5xx responses retry — mock all 3 attempts
+      nock(`https://${DUMMY_HOST}`)
+        .post('/ims/token/v3')
+        .query(true)
+        .times(3)
+        .reply(502, 'Bad Gateway');
+
+      await expect(client.getServiceAccessTokenV3())
+        .to.be.rejectedWith('IMS getServiceAccessTokenV3 request failed with status: 502');
     });
 
     it('should handle IMS product context request failures', async () => {
@@ -346,6 +421,60 @@ describe('ImsClient', () => {
       await expect(client.getServicePrincipalAccessToken(orgId)).to.be.rejectedWith(
         'IMS getServicePrincipalAccessToken request failed with status: 500',
       );
+    });
+
+    it('service-principal mint failure includes error field from response body when present', async () => {
+      const orgId = '1234567890ABCDEF12345678@AdobeOrg';
+      nock(`https://${DUMMY_HOST}`)
+        .post('/ims/token/v3')
+        .query(true)
+        .reply(400, {
+          error: 'invalid_scope',
+          error_description: 'Invalid scope value',
+        });
+
+      await expect(client.getServicePrincipalAccessToken(orgId))
+        .to.be.rejectedWith('IMS getServicePrincipalAccessToken request failed with status: 400 - invalid_scope');
+    });
+
+    it('service-principal mint failure includes message field from response body when error field absent', async () => {
+      const orgId = '1234567890ABCDEF12345678@AdobeOrg';
+      nock(`https://${DUMMY_HOST}`)
+        .post('/ims/token/v3')
+        .query(true)
+        .reply(403, {
+          message: 'Org-scoped grant not configured',
+        });
+
+      await expect(client.getServicePrincipalAccessToken(orgId))
+        .to.be.rejectedWith('IMS getServicePrincipalAccessToken request failed with status: 403 - Org-scoped grant not configured');
+    });
+
+    it('service-principal mint failure prefers error field over message field when both present', async () => {
+      const orgId = '1234567890ABCDEF12345678@AdobeOrg';
+      nock(`https://${DUMMY_HOST}`)
+        .post('/ims/token/v3')
+        .query(true)
+        .reply(401, {
+          error: 'invalid_client',
+          message: 'This should be ignored',
+        });
+
+      await expect(client.getServicePrincipalAccessToken(orgId))
+        .to.be.rejectedWith('IMS getServicePrincipalAccessToken request failed with status: 401 - invalid_client');
+    });
+
+    it('service-principal mint failure with non-JSON response body falls back to status-only message', async () => {
+      const orgId = '1234567890ABCDEF12345678@AdobeOrg';
+      // 5xx responses retry — mock all 3 attempts
+      nock(`https://${DUMMY_HOST}`)
+        .post('/ims/token/v3')
+        .query(true)
+        .times(3)
+        .reply(502, 'Bad Gateway');
+
+      await expect(client.getServicePrincipalAccessToken(orgId))
+        .to.be.rejectedWith('IMS getServicePrincipalAccessToken request failed with status: 502');
     });
   });
 

--- a/packages/spacecat-shared-ims-client/test/clients/ims-client.test.js
+++ b/packages/spacecat-shared-ims-client/test/clients/ims-client.test.js
@@ -177,6 +177,31 @@ describe('ImsClient', () => {
         .to.be.rejectedWith('IMS getServiceAccessToken request failed with status: 401 - Client credentials rejected');
     });
 
+    it('v2 mint failure prefers error field over message field when both present', async () => {
+      nock(`https://${DUMMY_HOST}`)
+        .post('/ims/token/v4')
+        .query(true)
+        .reply(401, {
+          error: 'invalid_grant',
+          message: 'This should be ignored',
+        });
+
+      await expect(client.getImsOrganizationDetails('123456@AdobeOrg'))
+        .to.be.rejectedWith('IMS getServiceAccessToken request failed with status: 401 - invalid_grant');
+    });
+
+    it('v2 mint failure with non-JSON response body falls back to status-only message', async () => {
+      // 5xx responses retry — mock all 3 attempts
+      nock(`https://${DUMMY_HOST}`)
+        .post('/ims/token/v4')
+        .query(true)
+        .times(3)
+        .reply(502, 'Bad Gateway');
+
+      await expect(client.getImsOrganizationDetails('123456@AdobeOrg'))
+        .to.be.rejectedWith('IMS getServiceAccessToken request failed with status: 502');
+    });
+
     it('should handle IMS service token request v3', async () => {
       nock(`https://${DUMMY_HOST}`)
         // Mock the token request, with a 500 server error response
@@ -268,6 +293,29 @@ describe('ImsClient', () => {
 
       await expect(client.getServiceAccessTokenV3())
         .to.be.rejectedWith('IMS getServiceAccessTokenV3 request failed with status: 502');
+    });
+
+    it('v3 mint failure truncates response-body detail at 200 chars', async () => {
+      // Defense-in-depth bound on the appended error detail per @solaris007
+      // review — if IMS ever returns an unexpectedly verbose `error` or
+      // `message`, the thrown message stays bounded. Tests the v3 path as a
+      // proxy for all three mint sites (logic is identical).
+      const overlongDetail = 'x'.repeat(500);
+      nock(`https://${DUMMY_HOST}`)
+        .post('/ims/token/v3')
+        .query(true)
+        .reply(400, { error: overlongDetail });
+
+      try {
+        await client.getServiceAccessTokenV3();
+        expect.fail('expected getServiceAccessTokenV3 to throw');
+      } catch (e) {
+        const truncatedDetail = 'x'.repeat(200);
+        expect(e.message).to.equal(
+          `IMS getServiceAccessTokenV3 request failed with status: 400 - ${truncatedDetail}`,
+        );
+        expect(e.message).to.not.include('x'.repeat(201));
+      }
     });
 
     it('should handle IMS product context request failures', async () => {


### PR DESCRIPTION
## Summary

The three token-mint paths (`getServiceAccessToken` v2, `getServiceAccessTokenV3`, `getServicePrincipalAccessToken`) currently throw `IMS X request failed with status: N` with no detail from the IMS response body. That swallows the load-bearing diagnostic info — IMS rejections include OAuth2-shape error payloads like `{ error: "invalid_scope", error_description: "..." }` that disambiguate between *wrong scope value*, *client not registered for grant*, *bad credentials*, etc. The status code alone is the same 400 for all of these.

## Motivating case

[SITES-43236](https://jira.corp.adobe.com/browse/SITES-43236) spacecat-api-service debugging hit `IMS getServiceAccessTokenV3 request failed with status: 400` in Splunk after a code change ([spacecat-api-service#2611](https://github.com/adobe/spacecat-api-service/pull/2611) merged) that started using v3 client_credentials against the `aem-project-collab-service` IMS client. The actual cause (likely scope authorization gap on that client) could only be guessed without the response body — we burned cycles trying `IMS_SCOPE='system'` ([spacecat-api-service#2627](https://github.com/adobe/spacecat-api-service/pull/2627)) before having concrete error info from IMS.

The next person hitting an IMS auth issue on any of these three endpoints should not have to go through the same guessing loop.

## Implementation

Mirrors the existing pattern in `getAccountCluster` (lines 430-441 of the same file): parse the response body as JSON, prefer the `error` field over `message`, fall back to status-only on non-JSON / unparseable bodies. Same shape, same error-format suffix (`" - <detail>"`), zero new abstractions.

```js
if (!tokenResponse.ok) {
  let errorMessage = `IMS getServiceAccessTokenV3 request failed with status: ${tokenResponse.status}`;
  try {
    const errorBody = await tokenResponse.json();
    if (hasText(errorBody.error)) {
      errorMessage += ` - ${errorBody.error}`;
    } else if (hasText(errorBody.message)) {
      errorMessage += ` - ${errorBody.message}`;
    }
  } catch (e) {
    // Response body is not JSON or cannot be parsed, ignore
  }
  throw new Error(errorMessage);
}
```

## Scope

- **In scope:** the three S2S token-mint methods that surface authentication errors (`getServiceAccessToken`, `getServiceAccessTokenV3`, `getServicePrincipalAccessToken`).
- **Out of scope:** the remaining 11 throw sites in the same file follow the same status-only pattern but aren't in the auth/mint hot path. Left untouched until they actually surface in production (YAGNI). The helper pattern is now applied at 4 call sites in the file (the original `getAccountCluster` + the three new ones), so a future refactor could extract a shared helper if the pattern proliferates further.

## Tests

- 8 new tests covering all branches per method:
  - Error field present in response body → included in thrown message
  - Message field present (no error field) → included in thrown message  
  - Both fields present → prefers `error`
  - Non-JSON / unparseable body → falls back to status-only
- All branches × all three methods covered.
- 100% line / 100% branch coverage on `ims-client.js` maintained (per `.nycrc.json`).

## Backward compatibility

Fully backward-compatible. Callers that string-match on the existing error prefix (`'IMS X request failed with status: N'`) continue to match — the new detail suffix is additive. Callers parsing the error message structurally aren't affected since the format is documented for human reading, not structured consumption.

## Test plan

- [x] `npm test -w packages/spacecat-shared-ims-client` — 89/89 pass
- [x] Coverage thresholds maintained
- [ ] Once published, dependent repos pick up the new error detail automatically. Specifically: spacecat-api-service's existing SITES-43236 debugging gets immediate diagnostic value the next time the IMS 400 surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
