### PR TITLE
feat(data-access): add brand pendingSemrushProvisioning attribute

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/brand/brand.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/brand/brand.schema.js
@@ -53,11 +53,11 @@ const schema = new SchemaBuilder(Brand, BrandCollection)
   // `brandDomain`, then removes each market it provisions (nulling the column
   // once none remain; failed markets stay for retry). Nullable: NULL = not a
   // deferred draft (a non-pending brand, or
-  // a draft with no provisioning data yet). Maps to brands.pending_provisioning
+  // a draft with no provisioning data yet). Maps to brands.pending_semrush_provisioning
   // (migration 20260618120000). Validated only loosely here — the DB CHECK
-  // (brands_pending_provisioning_is_object) enforces the object shape; field
+  // (brands_pending_semrush_provisioning_is_object) enforces the object shape; field
   // validation lives in the controller.
-  .addAttribute('pendingProvisioning', {
+  .addAttribute('pendingSemrushProvisioning', {
     type: 'any',
     validate: (value) => value == null || (typeof value === 'object' && !Array.isArray(value)),
   })

--- a/packages/spacecat-shared-data-access/src/models/brand/brand.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/brand/brand.schema.js
@@ -46,6 +46,21 @@ const schema = new SchemaBuilder(Brand, BrandCollection)
     type: 'string',
     validate: (value) => value == null || hasText(value),
   })
+  // Deferred Semrush provisioning data for a pending (draft) brand: a JSONB
+  // object { primaryUrl?, markets: [{ market, languageCode }] } the add-brand
+  // wizard collected before the brand's sub-workspace + project exist. The
+  // activate flow reads it as the fallback when the request omits `markets` /
+  // `brandDomain`, then removes each market it provisions (nulling the column
+  // once none remain; failed markets stay for retry). Nullable: NULL = not a
+  // deferred draft (a non-pending brand, or
+  // a draft with no provisioning data yet). Maps to brands.pending_provisioning
+  // (migration 20260618120000). Validated only loosely here — the DB CHECK
+  // (brands_pending_provisioning_is_object) enforces the object shape; field
+  // validation lives in the controller.
+  .addAttribute('pendingProvisioning', {
+    type: 'any',
+    validate: (value) => value == null || (typeof value === 'object' && !Array.isArray(value)),
+  })
   // Uniqueness is enforced at the DB level via the UNIQUE constraint on
   // brands.semrush_workspace_id (mysticat-data-service migration
   // 20260615102123), so findBySemrushWorkspaceId returns at most one row.

--- a/packages/spacecat-shared-data-access/src/models/brand/brand.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/brand/brand.schema.js
@@ -46,17 +46,11 @@ const schema = new SchemaBuilder(Brand, BrandCollection)
     type: 'string',
     validate: (value) => value == null || hasText(value),
   })
-  // Deferred Semrush provisioning data for a pending (draft) brand: a JSONB
-  // object { primaryUrl?, markets: [{ market, languageCode }] } the add-brand
-  // wizard collected before the brand's sub-workspace + project exist. The
-  // activate flow reads it as the fallback when the request omits `markets` /
-  // `brandDomain`, then removes each market it provisions (nulling the column
-  // once none remain; failed markets stay for retry). Nullable: NULL = not a
-  // deferred draft (a non-pending brand, or
-  // a draft with no provisioning data yet). Maps to brands.pending_semrush_provisioning
-  // (migration 20260618120000). Validated only loosely here — the DB CHECK
-  // (brands_pending_semrush_provisioning_is_object) enforces the object shape; field
-  // validation lives in the controller.
+  // Nullable JSONB blob holding deferred Semrush provisioning data for a
+  // pending (draft) brand. Maps to brands.pending_semrush_provisioning
+  // (migration 20260618120000). Validated loosely here (object-or-null); the
+  // DB CHECK enforces the object shape and the controller owns field-level
+  // validation and the activate-flow consumption semantics.
   .addAttribute('pendingSemrushProvisioning', {
     type: 'any',
     validate: (value) => value == null || (typeof value === 'object' && !Array.isArray(value)),

--- a/packages/spacecat-shared-data-access/test/unit/models/brand/brand.schema.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/brand/brand.schema.test.js
@@ -106,6 +106,10 @@ describe('Brand Schema', () => {
       expect(attributes.pendingSemrushProvisioning.validate(undefined)).to.be.true;
     });
 
+    it('accepts an empty object (loose by design — field validation lives in the controller)', () => {
+      expect(attributes.pendingSemrushProvisioning.validate({})).to.be.true;
+    });
+
     it('rejects an array (must be an object)', () => {
       expect(attributes.pendingSemrushProvisioning.validate([{ market: 'US' }])).to.be.false;
     });

--- a/packages/spacecat-shared-data-access/test/unit/models/brand/brand.schema.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/brand/brand.schema.test.js
@@ -85,4 +85,39 @@ describe('Brand Schema', () => {
       expect(attributes.semrushWorkspaceId.postgrestField).to.be.undefined;
     });
   });
+
+  describe('pendingProvisioning attribute', () => {
+    it('exists with a nullable object validator', () => {
+      const attr = attributes.pendingProvisioning;
+      expect(attr).to.exist;
+      expect(attr.type).to.equal('any');
+      expect(attr.validate).to.be.a('function');
+    });
+
+    it('accepts an object (the draft provisioning blob)', () => {
+      expect(attributes.pendingProvisioning.validate({
+        primaryUrl: 'https://acme.com',
+        markets: [{ market: 'US', languageCode: 'en' }],
+      })).to.be.true;
+    });
+
+    it('accepts nullish (not a deferred draft, or cleared on activation)', () => {
+      expect(attributes.pendingProvisioning.validate(null)).to.be.true;
+      expect(attributes.pendingProvisioning.validate(undefined)).to.be.true;
+    });
+
+    it('rejects an array (must be an object)', () => {
+      expect(attributes.pendingProvisioning.validate([{ market: 'US' }])).to.be.false;
+    });
+
+    it('rejects a non-object scalar', () => {
+      expect(attributes.pendingProvisioning.validate('nope')).to.be.false;
+    });
+
+    // No postgrestField override: camelToSnake('pendingProvisioning') already
+    // produces the DB column name `pending_provisioning`.
+    it('uses the default camelToSnake column mapping (no override)', () => {
+      expect(attributes.pendingProvisioning.postgrestField).to.be.undefined;
+    });
+  });
 });

--- a/packages/spacecat-shared-data-access/test/unit/models/brand/brand.schema.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/brand/brand.schema.test.js
@@ -86,38 +86,38 @@ describe('Brand Schema', () => {
     });
   });
 
-  describe('pendingProvisioning attribute', () => {
+  describe('pendingSemrushProvisioning attribute', () => {
     it('exists with a nullable object validator', () => {
-      const attr = attributes.pendingProvisioning;
+      const attr = attributes.pendingSemrushProvisioning;
       expect(attr).to.exist;
       expect(attr.type).to.equal('any');
       expect(attr.validate).to.be.a('function');
     });
 
     it('accepts an object (the draft provisioning blob)', () => {
-      expect(attributes.pendingProvisioning.validate({
+      expect(attributes.pendingSemrushProvisioning.validate({
         primaryUrl: 'https://acme.com',
         markets: [{ market: 'US', languageCode: 'en' }],
       })).to.be.true;
     });
 
     it('accepts nullish (not a deferred draft, or cleared on activation)', () => {
-      expect(attributes.pendingProvisioning.validate(null)).to.be.true;
-      expect(attributes.pendingProvisioning.validate(undefined)).to.be.true;
+      expect(attributes.pendingSemrushProvisioning.validate(null)).to.be.true;
+      expect(attributes.pendingSemrushProvisioning.validate(undefined)).to.be.true;
     });
 
     it('rejects an array (must be an object)', () => {
-      expect(attributes.pendingProvisioning.validate([{ market: 'US' }])).to.be.false;
+      expect(attributes.pendingSemrushProvisioning.validate([{ market: 'US' }])).to.be.false;
     });
 
     it('rejects a non-object scalar', () => {
-      expect(attributes.pendingProvisioning.validate('nope')).to.be.false;
+      expect(attributes.pendingSemrushProvisioning.validate('nope')).to.be.false;
     });
 
-    // No postgrestField override: camelToSnake('pendingProvisioning') already
-    // produces the DB column name `pending_provisioning`.
+    // No postgrestField override: camelToSnake('pendingSemrushProvisioning') already
+    // produces the DB column name `pending_semrush_provisioning`.
     it('uses the default camelToSnake column mapping (no override)', () => {
-      expect(attributes.pendingProvisioning.postgrestField).to.be.undefined;
+      expect(attributes.pendingSemrushProvisioning.postgrestField).to.be.undefined;
     });
   });
 });


### PR DESCRIPTION
## What

Adds a nullable `pendingSemrushProvisioning` attribute to the minimal Brand entity (`brand.schema.js`):

- type `any` (JSONB), validated as object-or-null
- auto-maps to the `brands.pending_semrush_provisioning` column

## Why

The serenity activate flow loads the brand via this entity. The new attribute lets it read a pending (draft) brand's deferred Semrush provisioning data — `{ primaryUrl, markets:[{market, languageCode}] }` — and clear/shrink it as markets are provisioned. Without the attribute the column is invisible to the model.

The DB CHECK (`brands_pending_semrush_provisioning_is_object`) enforces the object shape; this validator only guards against a non-object value reaching `save()`.

## Related

- mysticat-data-service: `brands.pending_semrush_provisioning` column migration (branch feat/pending-brands-deferred-provisioning) — must ship before this attribute is exercised against a deployed DB.
- spacecat-api-service: consumes `getPendingSemrushProvisioning()` / `setPendingSemrushProvisioning()` (branch feat/pending-brands-deferred-provisioning); bump the dependency once this is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
