### PR TITLE
feat(http-utils): allow s2sAuthWrapper routes to accept multiple capabilities

### DIFF
--- a/packages/spacecat-shared-http-utils/src/auth/route-utils.js
+++ b/packages/spacecat-shared-http-utils/src/auth/route-utils.js
@@ -42,9 +42,14 @@ function matchRoute(method, requestSegments, routeKey) {
  * using the method and path from context.pathInfo. Supports both exact
  * matches and parameterized route patterns (e.g. 'GET /sites/:siteId').
  *
+ * The mapped value is returned verbatim — it may be a single capability string
+ * or an array of acceptable capabilities. Callers must handle both shapes (the
+ * s2sAuthWrapper normalizes to an array). Note an empty array `[]` is truthy and
+ * is passed through; the wrapper treats it as "no usable capability" and denies.
+ *
  * @param {Object} context - Universal context with pathInfo
- * @param {Object<string, string>} routeMap - Route pattern to value map
- * @returns {string|null} The matched value or null
+ * @param {Object<string, string|string[]>} routeMap - Route pattern to value map
+ * @returns {string|string[]|null} The matched value or null
  */
 export function resolveRouteCapability(context, routeMap) {
   const method = context.pathInfo?.method?.toUpperCase();

--- a/packages/spacecat-shared-http-utils/src/auth/s2s-wrapper.js
+++ b/packages/spacecat-shared-http-utils/src/auth/s2s-wrapper.js
@@ -108,12 +108,20 @@ export function s2sAuthWrapper(fn, { routeCapabilities } = {}) {
 
       if (isObject(routeCapabilities)) {
         const requiredCapability = resolveRouteCapability(context, routeCapabilities);
-        if (!hasText(requiredCapability)) {
+        // A route maps to either a single capability string or an array of acceptable
+        // capabilities, in which case the consumer needs to hold at least one of them
+        // (e.g. a route reachable by both `site:read` and `site:readAll`). Normalize to
+        // an array and drop empty entries so a malformed `[]` / `['']` mapping can't
+        // silently disable the check.
+        const acceptedCapabilities = (
+          Array.isArray(requiredCapability) ? requiredCapability : [requiredCapability]
+        ).filter((cap) => hasText(cap));
+        if (acceptedCapabilities.length === 0) {
           log.warn(`[s2s] Route ${context.pathInfo?.method} ${context.pathInfo?.suffix} is not allowed for S2S consumers`);
           return new Response('Forbidden', { status: 403 });
         }
-        if (!capabilities.includes(requiredCapability)) {
-          log.warn(`[s2s] Consumer "${clientId}" is missing required capability: ${requiredCapability}`);
+        if (!acceptedCapabilities.some((cap) => capabilities.includes(cap))) {
+          log.warn(`[s2s] Consumer "${clientId}" is missing a required capability (one of: ${acceptedCapabilities.join(', ')})`);
           return new Response('Forbidden', { status: 403 });
         }
       }

--- a/packages/spacecat-shared-http-utils/test/auth/s2s-wrapper.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/s2s-wrapper.test.js
@@ -344,8 +344,89 @@ describe('s2sAuthWrapper', () => {
       const result = await wrapped({}, context);
 
       expect(result.status).to.equal(403);
-      expect(logStub.warn.calledWithMatch('missing required capability: opportunity:write')).to.be.true;
+      expect(logStub.warn.calledWithMatch('missing a required capability (one of: opportunity:write)')).to.be.true;
       expect(handler.called).to.be.false;
+    });
+
+    describe('multi-capability routes (array values)', () => {
+      // A route may map to an array of acceptable capabilities; the consumer needs
+      // to hold at least one of them (e.g. by-base-url reachable by read OR readAll).
+      const multiRouteCapabilities = {
+        'GET /sites/by-base-url/:baseURL': ['site:read', 'site:readAll'],
+      };
+      const suffix = '/sites/by-base-url/aHR0cHM6Ly9leGFtcGxlLmNvbQ==';
+
+      it('grants when consumer holds the first acceptable capability', async () => {
+        context.dataAccess = createMockDataAccess(
+          createMockConsumer({ getCapabilities: () => ['site:read'] }),
+        );
+        const token = await createToken(createTokenPayload(s2sTokenPayload));
+        context.pathInfo = { method: 'GET', suffix, headers: { authorization: `Bearer ${token}` } };
+        const wrapped = s2sAuthWrapper(handler, { routeCapabilities: multiRouteCapabilities });
+        const result = await wrapped({}, context);
+
+        expect(result).to.deep.equal({ status: 200 });
+        expect(handler.calledOnce).to.be.true;
+      });
+
+      it('grants when consumer holds a later acceptable capability (readAll only)', async () => {
+        context.dataAccess = createMockDataAccess(
+          createMockConsumer({ getCapabilities: () => ['site:readAll'] }),
+        );
+        const token = await createToken(createTokenPayload(s2sTokenPayload));
+        context.pathInfo = { method: 'GET', suffix, headers: { authorization: `Bearer ${token}` } };
+        const wrapped = s2sAuthWrapper(handler, { routeCapabilities: multiRouteCapabilities });
+        const result = await wrapped({}, context);
+
+        expect(result).to.deep.equal({ status: 200 });
+        expect(handler.calledOnce).to.be.true;
+      });
+
+      it('returns 403 when consumer holds none of the acceptable capabilities', async () => {
+        context.dataAccess = createMockDataAccess(
+          createMockConsumer({ getCapabilities: () => ['organization:read'] }),
+        );
+        const token = await createToken(createTokenPayload(s2sTokenPayload));
+        context.pathInfo = { method: 'GET', suffix, headers: { authorization: `Bearer ${token}` } };
+        const wrapped = s2sAuthWrapper(handler, { routeCapabilities: multiRouteCapabilities });
+        const result = await wrapped({}, context);
+
+        expect(result.status).to.equal(403);
+        expect(logStub.warn.calledWithMatch('missing a required capability (one of: site:read, site:readAll)')).to.be.true;
+        expect(handler.called).to.be.false;
+      });
+
+      it('grants when an array mixes valid and empty entries and consumer holds a valid one', async () => {
+        // Empty/null entries are silently dropped; a held valid capability still grants.
+        context.dataAccess = createMockDataAccess(
+          createMockConsumer({ getCapabilities: () => ['site:read'] }),
+        );
+        const token = await createToken(createTokenPayload(s2sTokenPayload));
+        context.pathInfo = { method: 'GET', suffix, headers: { authorization: `Bearer ${token}` } };
+        const wrapped = s2sAuthWrapper(handler, {
+          routeCapabilities: { 'GET /sites/by-base-url/:baseURL': ['site:read', '', null] },
+        });
+        const result = await wrapped({}, context);
+
+        expect(result).to.deep.equal({ status: 200 });
+        expect(handler.calledOnce).to.be.true;
+      });
+
+      it('returns 403 when the array value has no usable (non-empty) capability', async () => {
+        context.dataAccess = createMockDataAccess(
+          createMockConsumer({ getCapabilities: () => ['site:read'] }),
+        );
+        const token = await createToken(createTokenPayload(s2sTokenPayload));
+        context.pathInfo = { method: 'GET', suffix, headers: { authorization: `Bearer ${token}` } };
+        const wrapped = s2sAuthWrapper(handler, {
+          routeCapabilities: { 'GET /sites/by-base-url/:baseURL': ['', null] },
+        });
+        const result = await wrapped({}, context);
+
+        expect(result.status).to.equal(403);
+        expect(logStub.warn.calledWithMatch('not allowed for S2S consumers')).to.be.true;
+        expect(handler.called).to.be.false;
+      });
     });
 
     it('returns 403 when route is not in the capabilities map', async () => {


### PR DESCRIPTION
## What

`s2sAuthWrapper` route values in `routeCapabilities` may now be **either a single capability string or an array of acceptable capabilities** — the S2S consumer needs to hold at least one of them.

- `src/auth/s2s-wrapper.js`: normalize the resolved value to an array, drop empty/`null` entries, and grant when the consumer holds any one. An empty / all-empty array is rejected (cannot silently disable the check).
- `src/auth/route-utils.js`: JSDoc updated to reflect `string | string[] | null`.

## Why

Lets a route be reachable by both a tenant-scoped capability (`site:read`) and its cross-tenant variant (`site:readAll`). Consumed by spacecat-api-service to open `GET /sites/by-base-url` and `GET /organizations/by-ims-org-id` to cross-tenant `readAll` S2S consumers without breaking tenant-scoped `read` consumers.

## Compatibility

Backward compatible — existing string values are normalized to a single-element array; behavior for all current routes is unchanged.

## Downstream

spacecat-api-service has a companion PR that maps two routes to array values. **This must be released first** and the dependency bumped there before that PR merges, or the old string-only wrapper would 403 those routes.

## Tests

- 5 new wrapper tests (first-match, later-match, mixed valid/empty, all-empty → 403, none-held → 403).
- `npm test -w packages/spacecat-shared-http-utils` → 351 passing, coverage thresholds met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)