### PR TITLE
fix: sync package-lock.json with released workspace versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25942,7 +25942,7 @@
     },
     "packages/spacecat-shared-cloud-manager-client": {
       "name": "@adobe/spacecat-shared-cloud-manager-client",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -25960,6 +25960,23 @@
         "sinon": "22.0.0",
         "sinon-chai": "4.0.1",
         "typescript": "6.0.3"
+      },
+      "engines": {
+        "node": ">=22.0.0 <25.0.0",
+        "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloud-manager-client/node_modules/@adobe/spacecat-shared-ims-client": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-ims-client/-/spacecat-shared-ims-client-1.13.3.tgz",
+      "integrity": "sha512-0rr1vcJXQb95hVGaAf1C/OVo7ZkqbpAOjDQ3Rh4JK1PWMI2vLTM6lFtYMTNVUrLKyzhu/ZSCzuRip8BP5BiXqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/fetch": "4.3.0",
+        "@adobe/helix-universal": "5.4.2",
+        "@adobe/spacecat-shared-utils": "1.81.1",
+        "@aws-sdk/client-secrets-manager": "3.1057.0",
+        "aws-xray-sdk": "3.12.0"
       },
       "engines": {
         "node": ">=22.0.0 <25.0.0",
@@ -27556,7 +27573,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "3.75.4",
+      "version": "3.78.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",
@@ -30538,7 +30555,7 @@
     },
     "packages/spacecat-shared-ims-client": {
       "name": "@adobe/spacecat-shared-ims-client",
-      "version": "1.13.3",
+      "version": "1.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",
@@ -37045,7 +37062,7 @@
     },
     "packages/spacecat-shared-utils": {
       "name": "@adobe/spacecat-shared-utils",
-      "version": "1.119.3",
+      "version": "1.120.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",


### PR DESCRIPTION
## Problem

`npm ci` fails on every branch off `main` during CI setup:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: @adobe/spacecat-shared-ims-client@1.13.3 from lock file
```

This blocks the `Test` job (and therefore release) on unrelated PRs — it is a pre-existing drift on `main`, not introduced by any single feature branch.

## Root cause

- `spacecat-shared-cloud-manager-client` pins `@adobe/spacecat-shared-ims-client` at the **exact** version `1.13.3` (introduced in PR 1687 to drop the electrodb/jsonschema transitive deps). While the workspace `ims-client` package was itself `1.13.3`, the lockfile recorded that dependency as a workspace link and `npm ci` was satisfied.
- The `ims-client` `1.14.0` release (PR 1689) then moved the workspace package past the exact pin. semantic-release bumps `package.json` + `CHANGELOG` but does **not** run `npm install`, so the root `package-lock.json` was never regenerated: no registry node for `1.13.3` was added, and several recorded workspace `version` fields went stale relative to the `package.json` values `main` already ships.

`brand-client` / `gpt-client` pin `1.11.10` and stay green only because the lock already contains registry nodes for that version.

## Fix

Regenerate the lockfile only (`npm install --package-lock-only`):

- Adds the nested registry resolution for `@adobe/spacecat-shared-ims-client@1.13.3` under `cloud-manager-client/node_modules`, satisfying its exact pin.
- Syncs the recorded workspace `version` fields (`data-access`, `ims-client`, `utils`, `cloud-manager-client`) to the values already in each package's `package.json` on `main`.

No `package.json` or source changes — lockfile-only.

## Follow-up (not in this PR)

The deeper trigger is exact-pinning an internal workspace dependency (`cloud-manager-client` → `ims-client: "1.13.3"`): it re-breaks the lock every time `ims-client` releases. A separate change could move it to the workspace/caret range so releases don't leave the lock stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)