### PR TITLE
ci: prevent and detect package-lock.json drift on release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -271,13 +271,28 @@ jobs:
           # skips this commit (belt-and-suspenders alongside the native [skip ci]
           # skip), matching how that guard is documented.
           git commit -m "chore(release): sync package-lock.json after release [skip ci]"
-          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          # Authenticate via http.extraHeader (base64 Basic auth) rather than
+          # embedding the token in the remote URL. git echoes the remote URL in
+          # push/pull error output, so a URL-embedded token can leak into logs if
+          # Actions' secret masking misses the exact substring; the header value
+          # is never echoed. Mirrors how actions/checkout injects credentials.
+          # Pre-mask the base64 form (which is NOT auto-masked, being a distinct
+          # string from the raw secret) before it can reach any log line.
+          auth_b64="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 | tr -d '\n')"
+          echo "::add-mask::${auth_b64}"
+          remote="https://github.com/${GITHUB_REPOSITORY}.git"
+          git_auth() { git -c "http.extraheader=AUTHORIZATION: basic ${auth_b64}" "$@"; }
           # Releases are serialized (concurrency: npm-publish-main), so a race is
-          # unlikely, but retry once against the latest main just in case.
-          if ! git push "${remote}" HEAD:main; then
+          # unlikely, but retry once against the latest main just in case. KNOWN
+          # LIMITATION: a SECOND concurrent push landing within this retry window
+          # still loses — by design we do not loop. continue-on-error keeps it
+          # from failing the release, the ERR trap surfaces a ::warning::, and the
+          # residual drift is recovered via the next PR's drift guard +
+          # RELEASE-RUNBOOK Failure mode 7 (the manual lockfile-only PR).
+          if ! git_auth push "${remote}" HEAD:main; then
             echo "push rejected; rebasing on latest main and retrying once."
-            git pull --rebase "${remote}" main
-            git push "${remote}" HEAD:main
+            git_auth pull --rebase "${remote}" main
+            git_auth push "${remote}" HEAD:main
           fi
           echo "Pushed package-lock.json sync to main."
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -248,7 +248,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
         run: |
-          set -uo pipefail
+          set -euo pipefail
+          # continue-on-error keeps this step from failing a release, which also
+          # means a failure is otherwise invisible. Surface ANY failure (regen,
+          # commit, or the push+rebase retry) as a workflow ::warning:: + run
+          # summary line so the operator sees it without digging through logs;
+          # the next PR's drift guard is still the backstop (RELEASE-RUNBOOK
+          # Failure mode 7). errexit makes a failed `npm install` an honest red
+          # mark instead of a false "already in sync" — the `if ! git push`
+          # retry below is errexit-safe (the negated condition suppresses it).
+          trap 'echo "::warning title=package-lock sync after release failed::Lockfile sync did not complete; see RELEASE-RUNBOOK Failure mode 7. The next PR drift guard will surface residual drift."; echo "package-lock.json sync after release failed — see RELEASE-RUNBOOK Failure mode 7." >> "$GITHUB_STEP_SUMMARY"' ERR
           npm install --package-lock-only --ignore-scripts
           if git diff --quiet -- package-lock.json; then
             echo "OK: package-lock.json already in sync; nothing to commit."
@@ -258,7 +267,10 @@ jobs:
           git config user.name "semantic-release-bot"
           git config user.email "semantic-release-bot@martynus.net"
           git add package-lock.json
-          git commit -m "chore(deps): sync package-lock.json after release [skip ci]"
+          # `chore(release):` subject so the release-job skip guard above also
+          # skips this commit (belt-and-suspenders alongside the native [skip ci]
+          # skip), matching how that guard is documented.
+          git commit -m "chore(release): sync package-lock.json after release [skip ci]"
           remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           # Releases are serialized (concurrency: npm-publish-main), so a race is
           # unlikely, but retry once against the latest main just in case.

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -121,6 +121,34 @@ jobs:
         env:
           MYSTICAT_DATA_SERVICE_REPO_READ_TOKEN: ${{ secrets.MYSTICAT_DATA_SERVICE_REPO_READ_TOKEN }}
 
+      - name: Verify package-lock.json is in sync
+        # Lockfile drift guard. semantic-release bumps each package's
+        # package.json + CHANGELOG on release but does NOT regenerate the root
+        # package-lock.json (the @semantic-release/git `assets` list in every
+        # .releaserc.cjs is package.json + CHANGELOG.md only). When a released
+        # workspace version later crosses a consumer's exact internal pin (e.g.
+        # cloud-manager-client -> spacecat-shared-ims-client), the lock loses
+        # the matching resolution and EVERY branch then fails `npm ci` with
+        # "Missing <pkg>@<ver> from lock file" — a main-wide breakage that first
+        # surfaces on unrelated PRs. Regenerate the lock with the same pinned
+        # npm (11.13.0, installed by the Setup Node & NPM composite above) and
+        # fail if it changed, so drift is caught on the PR that introduces it.
+        # The Release job keeps main's lock in sync after every release (see the
+        # "Sync package-lock.json after release" step), so on a healthy main
+        # this regeneration is a no-op.
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --package-lock-only --ignore-scripts
+          if ! git diff --quiet -- package-lock.json; then
+            echo "FAIL: package-lock.json is out of sync with the workspace package.json files."
+            echo "      Fix: run 'npm install --package-lock-only' locally and commit package-lock.json."
+            echo "----- drift -----"
+            git --no-pager diff -- package-lock.json
+            exit 1
+          fi
+          echo "OK: package-lock.json is in sync."
+
       - name: Lint, Test, Coverage Upload
         uses: ./.github/actions/lint-test-coverage
         with:
@@ -200,6 +228,46 @@ jobs:
         run: npm run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
+
+      - name: Sync package-lock.json after release
+        # semantic-release bumps the released package versions but does not
+        # regenerate the root package-lock.json (see the Test job's drift
+        # guard). Left unsynced, the lock's resolutions for internal exact pins
+        # go stale the moment a released workspace version crosses a consumer's
+        # pin, breaking `npm ci` on every branch. Regenerate the lock against
+        # the just-published versions and, if it changed, commit it straight to
+        # main with [skip ci] (GitHub natively skips workflow runs for commits
+        # whose head message contains [skip ci], so this triggers no new CI or
+        # release run). Best-effort: this must NEVER fail a release — the
+        # packages are already published and the Test-job drift guard is the
+        # backstop — hence continue-on-error. If the push loses a race it is
+        # left for the next PR's drift guard to surface.
+        if: success()
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          npm install --package-lock-only --ignore-scripts
+          if git diff --quiet -- package-lock.json; then
+            echo "OK: package-lock.json already in sync; nothing to commit."
+            exit 0
+          fi
+          echo "package-lock.json drifted after release; committing a sync commit to main."
+          git config user.name "semantic-release-bot"
+          git config user.email "semantic-release-bot@martynus.net"
+          git add package-lock.json
+          git commit -m "chore(deps): sync package-lock.json after release [skip ci]"
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          # Releases are serialized (concurrency: npm-publish-main), so a race is
+          # unlikely, but retry once against the latest main just in case.
+          if ! git push "${remote}" HEAD:main; then
+            echo "push rejected; rebasing on latest main and retrying once."
+            git pull --rebase "${remote}" main
+            git push "${remote}" HEAD:main
+          fi
+          echo "Pushed package-lock.json sync to main."
 
       - name: Surface failure pointer to release runbook
         # On failure OR in-progress cancellation, write a pointer to the runbook

--- a/docs/RELEASE-RUNBOOK.md
+++ b/docs/RELEASE-RUNBOOK.md
@@ -425,6 +425,17 @@ The step is `continue-on-error: true` — it can never fail a release. So a
 failure here is **silent** and surfaces later as the `Verify package-lock.json
 is in sync` check going red on the next unrelated PR.
 
+Known limitation — single-retry push race: the step pushes the sync commit to
+`main` and, if that push is rejected (someone else advanced `main` first),
+rebases and retries **once**. A *second* concurrent push landing inside that
+retry window still loses; by design the step does not loop. Releases are
+serialized (`concurrency: npm-publish-main`), so two release jobs cannot race,
+and a non-release push to `main` in the same sub-second window is vanishingly
+rare — so this is accepted rather than guarded with an unbounded retry. When it
+does happen the outcome is identical to any other sync failure: `continue-on-error`
+absorbs it, the `ERR` trap emits a `::warning::`, and recovery is the manual
+lockfile-only PR below.
+
 Symptoms:
 
 - The `Sync package-lock.json after release` step shows a red ✗ in the release

--- a/docs/RELEASE-RUNBOOK.md
+++ b/docs/RELEASE-RUNBOOK.md
@@ -410,6 +410,43 @@ Recovery options:
 that defeats the human gate's purpose. Use cancel-and-retry or temporary
 removal instead.
 
+## Failure mode 7: package-lock.json sync after release failed
+
+The release job's `Sync package-lock.json after release` step regenerates the
+root `package-lock.json` against the just-published versions and commits it back
+to `main` with `[skip ci]`. This exists because semantic-release bumps each
+package's `package.json` but its `@semantic-release/git` `assets` list does not
+include the lockfile, so the lock drifts every release; once a released version
+crosses a consumer's exact internal pin, the lock loses that resolution and
+`npm ci` fails on **every** branch (the `Missing <pkg>@<ver> from lock file`
+outage).
+
+The step is `continue-on-error: true` — it can never fail a release. So a
+failure here is **silent** and surfaces later as the `Verify package-lock.json
+is in sync` check going red on the next unrelated PR.
+
+Symptoms:
+
+- The `Sync package-lock.json after release` step shows a red ✗ in the release
+  run (push rejected after the one-shot rebase retry, or registry hiccup during
+  regeneration), **or**
+- An unrelated PR's `Test` job fails at `Verify package-lock.json is in sync`
+  with a `package-lock.json` diff it did not author.
+
+Recovery (same as the manual unblock that PR #1694 performed):
+
+```bash
+git checkout main && git pull
+npm install --package-lock-only --ignore-scripts
+git checkout -b fix/sync-package-lock
+git add package-lock.json
+git commit -m "fix: sync package-lock.json with released workspace versions"
+# open a PR; the lock-only change merges and unblocks all branches
+```
+
+No package is republished — this is a lockfile-only commit. The drift guard on
+the recovery PR confirms the fix (it will pass once the lock is regenerated).
+
 ## Re-enabling the environment approval gate
 
 Status today: **the `npm-publish` environment has no required reviewers** —

--- a/package-lock.json
+++ b/package-lock.json
@@ -27573,7 +27573,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "3.78.0",
+      "version": "3.79.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",


### PR DESCRIPTION
## Why

PR #1694 hot-fixed a `main`-wide outage: every branch failed `npm ci` with `Missing @adobe/spacecat-shared-ims-client@1.13.3 from lock file`. This PR fixes the **mechanism** so it cannot recur.

### Root cause

semantic-release bumps each package's `package.json` + `CHANGELOG` on release, but the `@semantic-release/git` `assets` list in every `.releaserc.cjs` is `["package.json", "CHANGELOG.md"]` — it **never regenerates the root `package-lock.json`**. So the lock drifts on every release. When a released workspace version later crosses a consumer's **exact internal pin** (e.g. `cloud-manager-client` → `spacecat-shared-ims-client: "1.13.3"`, satisfied by a workspace link until `ims-client` released `1.14.0`), the lock loses that resolution and `npm ci` breaks on every branch — first surfacing on unrelated PRs.

Internal deps are **uniformly exact-pinned** across the monorepo (no carets anywhere), so de-pinning would be a convention change. This PR instead keeps the lock authoritative, preserving the exact-pin convention.

## What

Two complementary layers in `.github/workflows/main.yaml`:

- **Prevention — release job (`Sync package-lock.json after release`):** after `Semantic Release`, regenerate the root lock against the just-published versions and, if it changed, commit it back to `main` with a skip-ci marker (GitHub natively skips workflow runs for such commits — no new CI/release). `continue-on-error: true` so it can **never** fail a release; the packages are already published and the detection gate is the backstop.
- **Detection — test job (`Verify package-lock.json is in sync`):** regenerate the lock with the same pinned npm (`11.13.0`, from the `setup-node-npm` composite) and fail if it differs, so residual drift is caught on the PR that introduces it instead of silently breaking `main`.

Plus `RELEASE-RUNBOOK.md` **Failure mode 7** documenting recovery if the sync step ever fails (a lockfile-only PR, exactly what #1694 did).

## Safety / layering

- On a healthy `main` the detection regeneration is a **no-op** (verified locally: `npm install --package-lock-only` on current `main` produces no diff, post-#1694).
- npm/node versions match the repo pins (`11.13.0` / `24.16.0`), so no lockfile-format false-diffs.
- If the release auto-sync loses a push race (serialized concurrency makes this unlikely; one rebase-retry is built in), it is `continue-on-error`, and the next PR's detection gate surfaces the residual drift → manual lockfile-only PR per Failure mode 7.

## Reviewer note (SRE)

The prevention step **writes to `main` from CI** (mirrors how semantic-release already pushes its release commits with `ADOBE_BOT_GITHUB_TOKEN`). If you'd prefer not to auto-commit, the **detection gate stands on its own** — drop the `Sync package-lock.json after release` step and recovery is the manual lockfile PR (Failure mode 7) whenever the gate goes red after a release.

> Note: the prose here intentionally avoids the literal bracketed skip-ci token so a squash-merge message derived from it does not skip the post-merge Build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)