### PR TITLE
fix: data structure for Sitemap "error" suggestions

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/suggestion/suggestion.data-schemas.js
+++ b/packages/spacecat-shared-data-access/src/models/suggestion/suggestion.data-schemas.js
@@ -436,15 +436,30 @@ export const DATA_SCHEMAS = {
       },
     },
   },
+  // Sitemap has two data shapes from the audit worker:
+  // 1. URL-type (type='url'): sitemapUrl + pageUrl identify a probed page issue
+  // 2. Error-type (type='error'): site/sitemap infrastructure failures; sitemapUrl may be empty
   [OPPORTUNITY_TYPES.SITEMAP]: {
     schema: Joi.object({
-      sitemapUrl: Joi.string().uri().required(),
-      pageUrl: Joi.string().uri().required(),
       type: Joi.string().valid('url', 'error').optional(),
+      error: Joi.when('type', {
+        is: 'error',
+        then: Joi.string().required(),
+        otherwise: Joi.string().optional(),
+      }),
+      sitemapUrl: Joi.when('type', {
+        is: 'error',
+        then: Joi.string().uri().allow('').optional(),
+        otherwise: Joi.string().uri().required(),
+      }),
+      pageUrl: Joi.when('type', {
+        is: 'error',
+        then: Joi.string().uri().allow('').optional(),
+        otherwise: Joi.string().uri().required(),
+      }),
       statusCode: Joi.number().optional(),
-      urlsSuggested: Joi.string().uri().optional(),
-      recommendedAction: Joi.string().optional(),
-      error: Joi.string().optional(),
+      urlsSuggested: Joi.string().uri().allow('').optional(),
+      recommendedAction: Joi.string().allow('').optional(),
       aggregationKey: Joi.string().allow(null).optional(),
     }).unknown(true),
     projections: {

--- a/packages/spacecat-shared-data-access/test/unit/models/suggestion/suggestion.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/suggestion/suggestion.model.test.js
@@ -483,6 +483,76 @@ describe('SuggestionModel', () => {
         });
       });
 
+      describe('SITEMAP opportunity type', () => {
+        it('passes for error-type suggestions with empty sitemapUrl (robots-level errors)', () => {
+          const data = {
+            type: 'error',
+            error: 'robots-missing-sitemap',
+            sitemapUrl: '',
+            recommendedAction: '',
+          };
+          expect(() => Suggestion.validateData(data, 'sitemap')).to.not.throw();
+        });
+
+        it('passes for error-type suggestions with sitemapUrl populated', () => {
+          const data = {
+            type: 'error',
+            error: 'sitemap-not-found',
+            sitemapUrl: 'https://example.com/sitemap.xml',
+            recommendedAction: '',
+          };
+          expect(() => Suggestion.validateData(data, 'sitemap')).to.not.throw();
+        });
+
+        it('passes for error-type suggestions with recommendedAction (general-error)', () => {
+          const data = {
+            type: 'error',
+            error: 'general-error',
+            sitemapUrl: '',
+            recommendedAction: 'Something went wrong during the audit.',
+          };
+          expect(() => Suggestion.validateData(data, 'sitemap')).to.not.throw();
+        });
+
+        it('passes for url-type suggestions with required sitemapUrl and pageUrl', () => {
+          const data = {
+            type: 'url',
+            sitemapUrl: 'https://example.com/sitemap.xml',
+            pageUrl: 'https://example.com/missing-page',
+            statusCode: 404,
+            urlsSuggested: '',
+            recommendedAction: 'Make sure your sitemaps only include URLs that return the 200 (OK) response code.',
+          };
+          expect(() => Suggestion.validateData(data, 'sitemap')).to.not.throw();
+        });
+
+        it('rejects error-type suggestions missing the error code', () => {
+          const data = {
+            type: 'error',
+            sitemapUrl: '',
+            recommendedAction: '',
+          };
+          expect(() => Suggestion.validateData(data, 'sitemap')).to.throw();
+        });
+
+        it('rejects url-type suggestions missing pageUrl', () => {
+          const data = {
+            type: 'url',
+            sitemapUrl: 'https://example.com/sitemap.xml',
+          };
+          expect(() => Suggestion.validateData(data, 'sitemap')).to.throw();
+        });
+
+        it('rejects url-type suggestions with invalid pageUrl', () => {
+          const data = {
+            type: 'url',
+            sitemapUrl: 'https://example.com/sitemap.xml',
+            pageUrl: 'not-a-uri',
+          };
+          expect(() => Suggestion.validateData(data, 'sitemap')).to.throw();
+        });
+      });
+
       describe('BROKEN_INTERNAL_LINKS opportunity type', () => {
         it('passes with malformed http/https URLs', () => {
           const data = {


### PR DESCRIPTION
 * allow for co-existence of both "url" and "error" type suggestions for the Sitemap audit

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues

 * related ticket: https://jira.corp.adobe.com/browse/SITES-45985

Thanks for contributing!
