### PR TITLE
fix(project-engine-client): correct workspace-id param location (CR4) + publish to npm

### DIFF
--- a/packages/spacecat-shared-project-engine-client/package.json
+++ b/packages/spacecat-shared-project-engine-client/package.json
@@ -3,7 +3,6 @@
   "version": "1.1.0",
   "description": "Shared modules of the Spacecat Services - Semrush Project Engine client and generated types",
   "type": "module",
-  "private": true,
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "exports": {

--- a/packages/spacecat-shared-project-engine-client/spec/overlays/corrections.yaml
+++ b/packages/spacecat-shared-project-engine-client/spec/overlays/corrections.yaml
@@ -109,6 +109,11 @@ actions:
   # rest. The single-equality overlay filter cannot express "name == 'id' && in ==
   # 'query'", but the blanket flip is equivalent and safe here. deep-merge sets
   # `in` to `path` (scalar overwrite); `required: true` is already present.
+  # CAUTION (for future spec-refresh reviewers): this is a BLANKET filter on the
+  # param name alone. If a future spec revision adds a legitimately query-bound
+  # parameter literally named `id` on some new operation, this overlay would
+  # silently relocate it to `in: path`. If that ever happens, narrow the filter
+  # (or special-case that operation) rather than dropping CR4.
   - target: "$.paths.*.*.parameters[?(@.name == 'id')]"
     description: "CR4: workspace `id` is a path parameter on every operation (not query)"
     update:

--- a/packages/spacecat-shared-project-engine-client/spec/overlays/corrections.yaml
+++ b/packages/spacecat-shared-project-engine-client/spec/overlays/corrections.yaml
@@ -13,6 +13,12 @@ info:
 #      Remove when Semrush fixes securityDefinitions upstream.
 # CR3  Correct GET /v2/.../projects summary+description — it also returns initial
 #      (never-yet-published) drafts, not only published projects.
+# CR4  Relocate the workspace `id` parameter from query → path. 11 operations
+#      declare `id` as `in: query` though `{id}` is a path-template variable in
+#      every one of them; openapi-typescript then emits an unsatisfiable `{id}`
+#      path key + a `query: { id }`, so a caller passing the runtime-correct
+#      `path: { id }` fails to type-check. Remove when Semrush fixes the param
+#      location upstream.
 actions:
   # ── CR1: Add GET /v1/ai_models ──────────────────────────────────────────
   # Live: 200 -> { page:int, total:int, items:[AIModelResponse] }.
@@ -95,3 +101,15 @@ actions:
         a project that has never been published yet (its initial draft) also appears
         in this list; once a project has been published at least once, the list
         reflects its published view.
+
+  # ── CR4: Workspace `id` is a path param on every operation, not query ─────
+  # Verified: all 11 operations that declare `id` as `in: query` have `{id}` in
+  # their path template, and the other 87 `id` params are already `in: path`, so
+  # forcing every `id` param to `in: path` corrects the 11 and is a no-op for the
+  # rest. The single-equality overlay filter cannot express "name == 'id' && in ==
+  # 'query'", but the blanket flip is equivalent and safe here. deep-merge sets
+  # `in` to `path` (scalar overwrite); `required: true` is already present.
+  - target: "$.paths.*.*.parameters[?(@.name == 'id')]"
+    description: "CR4: workspace `id` is a path parameter on every operation (not query)"
+    update:
+      in: path

--- a/packages/spacecat-shared-project-engine-client/src/generated/types.ts
+++ b/packages/spacecat-shared-project-engine-client/src/generated/types.ts
@@ -3395,8 +3395,6 @@ export interface operations {
     "ai-list-categories": {
         parameters: {
             query: {
-                /** @description workspace ID */
-                id: string;
                 /** @description project ID */
                 project_id: string;
                 /** @description AI model ID */
@@ -3415,7 +3413,10 @@ export interface operations {
                 draft?: boolean;
             };
             header?: never;
-            path?: never;
+            path: {
+                /** @description workspace ID */
+                id: string;
+            };
             cookie?: never;
         };
         requestBody?: never;
@@ -3461,8 +3462,6 @@ export interface operations {
     "ai-create-category": {
         parameters: {
             query: {
-                /** @description workspace ID */
-                id: string;
                 /** @description project ID */
                 project_id: string;
                 /** @description AI model ID */
@@ -3471,7 +3470,10 @@ export interface operations {
                 keyword_id: string;
             };
             header?: never;
-            path?: never;
+            path: {
+                /** @description workspace ID */
+                id: string;
+            };
             cookie?: never;
         };
         requestBody: components["requestBodies"]["model.TreeNodeRequest"];
@@ -3575,12 +3577,11 @@ export interface operations {
     };
     "ai-create-keywords-with-category": {
         parameters: {
-            query: {
-                /** @description workspace ID */
-                id: string;
-            };
+            query?: never;
             header?: never;
             path: {
+                /** @description workspace ID */
+                id: string;
                 /** @description project ID */
                 project_id: string;
                 /** @description AI model ID */
@@ -3635,14 +3636,14 @@ export interface operations {
     };
     "ai-download-tagged-keywords": {
         parameters: {
-            query: {
-                /** @description workspace ID */
-                id: string;
+            query?: {
                 /** @description Get draft project data */
                 draft?: boolean;
             };
             header?: never;
             path: {
+                /** @description workspace ID */
+                id: string;
                 /** @description project ID */
                 project_id: string;
                 /** @description AI model ID */
@@ -3917,12 +3918,11 @@ export interface operations {
     };
     "ai-replace-model-settings": {
         parameters: {
-            query: {
-                /** @description workspace ID */
-                id: string;
-            };
+            query?: never;
             header?: never;
             path: {
+                /** @description workspace ID */
+                id: string;
                 /** @description project ID */
                 project_id: string;
                 /** @description AI model ID */
@@ -4038,12 +4038,11 @@ export interface operations {
     };
     "ai-create-model-category": {
         parameters: {
-            query: {
-                /** @description workspace ID */
-                id: string;
-            };
+            query?: never;
             header?: never;
             path: {
+                /** @description workspace ID */
+                id: string;
                 /** @description project ID */
                 project_id: string;
                 /** @description AI model ID */
@@ -4094,8 +4093,6 @@ export interface operations {
     "ai-delete-category": {
         parameters: {
             query: {
-                /** @description workspace ID */
-                id: string;
                 /** @description project ID */
                 project_id: string;
                 /** @description AI model ID */
@@ -4104,7 +4101,10 @@ export interface operations {
                 keyword_id: string;
             };
             header?: never;
-            path?: never;
+            path: {
+                /** @description workspace ID */
+                id: string;
+            };
             cookie?: never;
         };
         requestBody: components["requestBodies"]["model.BatchDeleteRequest"];
@@ -5100,13 +5100,14 @@ export interface operations {
     "project-set-favourite": {
         parameters: {
             query: {
-                /** @description workspace ID */
-                id: string;
                 /** @description project ID */
                 project_id: string;
             };
             header?: never;
-            path?: never;
+            path: {
+                /** @description workspace ID */
+                id: string;
+            };
             cookie?: never;
         };
         /** @description request body */
@@ -6271,8 +6272,6 @@ export interface operations {
     "ai-update-tag": {
         parameters: {
             query: {
-                /** @description workspace ID */
-                id: string;
                 /** @description project ID */
                 project_id: string;
                 /** @description AI model ID */
@@ -6281,7 +6280,10 @@ export interface operations {
                 tag_id: string;
             };
             header?: never;
-            path?: never;
+            path: {
+                /** @description workspace ID */
+                id: string;
+            };
             cookie?: never;
         };
         requestBody: components["requestBodies"]["model.TreeNodeRequest"];
@@ -6599,14 +6601,14 @@ export interface operations {
     };
     "ai-download-tagged-keywords with flat hierarchy": {
         parameters: {
-            query: {
-                /** @description workspace ID */
-                id: string;
+            query?: {
                 /** @description Get draft project data */
                 draft?: boolean;
             };
             header?: never;
             path: {
+                /** @description workspace ID */
+                id: string;
                 /** @description project ID */
                 project_id: string;
                 /** @description AI model ID */
@@ -7699,12 +7701,11 @@ export interface operations {
     };
     "aio-create-prompts-with-tags": {
         parameters: {
-            query: {
-                /** @description workspace ID */
-                id: string;
-            };
+            query?: never;
             header?: never;
             path: {
+                /** @description workspace ID */
+                id: string;
                 /** @description project ID */
                 project_id: string;
             };

--- a/packages/spacecat-shared-project-engine-client/test/foundation.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/foundation.test.js
@@ -66,4 +66,18 @@ describe('Project Engine foundation: overlay guard', () => {
   it('has no Auth-Data-Jwt header in generated types (CR2)', () => {
     expect(types).to.not.include('Auth-Data-Jwt');
   });
+
+  it('types the workspace id as a path param, not query (CR4)', () => {
+    // aio-create-prompts-with-tags (and 10 other ops) declared the workspace
+    // `id` as in:query in the vendored swagger, though `{id}` is a path-template
+    // variable. CR4 relocates it to `path`; if a spec refresh silently drops the
+    // overlay the op reverts to `query: { id }` / `path?: never` and this fails.
+    // Target the operation DEFINITION (`...": {`), not the paths-section
+    // reference (`operations["..."]`).
+    const start = types.indexOf('"aio-create-prompts-with-tags": {');
+    expect(start, 'operation present in generated types').to.be.greaterThan(-1);
+    const op = types.slice(start, types.indexOf('requestBody', start));
+    expect(op).to.match(/path:\s*\{[\s\S]*\bid: string/);
+    expect(op).to.match(/query\?: never/);
+  });
 });

--- a/packages/spacecat-shared-project-engine-client/test/foundation.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/foundation.test.js
@@ -74,9 +74,18 @@ describe('Project Engine foundation: overlay guard', () => {
     // overlay the op reverts to `query: { id }` / `path?: never` and this fails.
     // Target the operation DEFINITION (`...": {`), not the paths-section
     // reference (`operations["..."]`).
+    // aio-create-prompts-with-tags is the representative op because `id` was its
+    // ONLY query param: with the overlay applied it emits `query?: never`, so the
+    // `query?: never` assertion below is a uniquely strong regression signal that
+    // would not survive the overlay being dropped (the op would regain `query`).
     const start = types.indexOf('"aio-create-prompts-with-tags": {');
     expect(start, 'operation present in generated types').to.be.greaterThan(-1);
-    const op = types.slice(start, types.indexOf('requestBody', start));
+    // Guard the slice boundary: if a spec refresh drops `requestBody` from the op,
+    // indexOf returns -1 and slice(start, -1) would capture nearly the whole file,
+    // making the assertions pass vacuously instead of failing loudly.
+    const end = types.indexOf('requestBody', start);
+    expect(end, 'requestBody boundary present after the operation').to.be.greaterThan(start);
+    const op = types.slice(start, end);
     expect(op).to.match(/path:\s*\{[\s\S]*\bid: string/);
     expect(op).to.match(/query\?: never/);
   });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Corrects the workspace `id` parameter location in the generated Semrush Project Engine types (overlay correction CR4) and removes the `private` flag so `@adobe/spacecat-shared-project-engine-client` publishes to npm.

## 2. Reasoning
The vendored Semrush swagger declares the workspace `id` as a query parameter on 11 operations where `{id}` is in fact a path-template variable. openapi-typescript faithfully reproduced that, so a consumer passing the runtime-correct `path: { id }` fails to type-check while still working at runtime. Separately, spacecat-api-service needs to consume this typed client from the registry to back its Semrush transport, but the package was foundation-gated with `private: true` and therefore never published, despite already carrying public publish config, a release config, and git tags to v1.1.0.

## 3. High-level overview of the changes
- Adds overlay correction CR4 to `spec/overlays/corrections.yaml`: relocates every `id` parameter to `in: path`. This corrects the 11 mis-located operations and is a no-op for the 87 that were already correct (verified: all 11 have `{id}` in their path template, and `id` is a workspace path identifier everywhere it appears). The generated `types.ts` is regenerated from the overlaid spec, so the affected operations now type the workspace id as a path parameter.
- Adds a foundation guard test pinning the corrected shape, so a future Semrush spec refresh that silently drops the overlay fails loudly (matching the existing CR1/CR2 guards).
- Removes `private: true` so the next release publishes the package to npm with the CR4 fix.
- Runtime behaviour is unchanged for callers — the fix is type-only; openapi-fetch already substituted the path variable correctly at runtime.

## 4. Required information
- Other: consumer adoption — https://github.com/adobe/spacecat-api-service/pull/2643

## 5. Affected / used mysticat-workspace projects
- spacecat-api-service — consumes this published typed client (contract): its Semrush Project Engine transport is backed by `createSerenityProjectEngineApiClient`, and it pins the version this release publishes.

## 6. Additional information outside the code
- Verified the defect two-sided: traced the generated types back to the vendored swagger, where the workspace `id` is declared `in: query` on the affected operations, and confirmed every one of those 11 operations carries `{id}` in its path template — so the relocation to `in: path` matches both the URL contract and the live API (which the deployed transport already calls successfully with the path-substituted id).
- After applying the overlay and regenerating, confirmed the affected operations type `id` under `path` (and no longer under `query`).

## 7. Test plan
- (a) Local: the consuming spacecat-api-service Semrush transport was run against this package's source and behaves identically to the prior vendored copy — expected, since the correction is type-only and the runtime URL was already correct.
- (b) Per-env: this is a library package with no service runtime. After merge, confirm the semantic-release pipeline publishes the package to npm, then confirm spacecat-api-service can install the published version and its transport/serenity suites pass against it.

## 8. Deployment & merge order
- https://github.com/adobe/spacecat-api-service/pull/2643 — related / blocks: it switches its Semrush transport from a vendored copy to this published package, pinned to the version this release publishes; its `npm install` cannot resolve that version until this publishes.
- Sequence: merge this PR → semantic-release publishes the package → update/verify the spacecat-api-service lockfile against the published version → merge the api-service PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
