### PR TITLE
feat(user-manager-client): stateful sub-workspace lifecycle mock handlers (LLMO-5616)

### DIFF
--- a/packages/spacecat-shared-user-manager-client/.counterfact/routes/_.context.ts
+++ b/packages/spacecat-shared-user-manager-client/.counterfact/routes/_.context.ts
@@ -53,6 +53,13 @@ export class Context {
 
   serviceUnits = new Map<string, Dict>();
 
+  // Per-workspace provisioning status queue. GET /v1/workspaces/{id}/status
+  // consumes one entry per call; once drained, status reports the terminal
+  // "created" — the success sentinel the api-service transport polls for (overlay
+  // CR2). Kept apart from the workspace so it never leaks into a workspace GET
+  // body; seeded empty, set via the non-spec /__set-status-sequence route.
+  statusSequences = new Map<string, string[]>();
+
   idCounter = 0;
 
   constructor($: Context$) {
@@ -73,6 +80,7 @@ export class Context {
     );
     this.resources = new Map(Object.entries(f.resources));
     this.serviceUnits = new Map(Object.entries(f.serviceUnits));
+    this.statusSequences = new Map();
     this.idCounter = 0;
   }
 
@@ -126,6 +134,27 @@ export class Context {
     return this.workspaces.delete(id);
   }
 
+  // --- sub-workspace provisioning status ---
+  // Returns the next provisioning status for a workspace, or null when it is
+  // missing (the handler maps that to 404/500). A workspace with a queued
+  // sequence walks it one status per call (e.g. "not ready" -> "created"); once
+  // drained, or with no sequence set, it reports the terminal "created".
+  getStatus(id: string) {
+    if (!this.workspaces.has(id)) return null;
+    const queue = this.statusSequences.get(id);
+    const status = queue && queue.length > 0 ? queue.shift()! : "created";
+    return { status };
+  }
+
+  // Seeds the provisioning sequence GET /status walks through. Returns false
+  // when the workspace is missing. Used by the non-spec /__set-status-sequence
+  // control route to exercise the poll path deterministically.
+  setStatusSequence(id: string, statuses: string[]) {
+    if (!this.workspaces.has(id)) return false;
+    this.statusSequences.set(id, [...statuses]);
+    return true;
+  }
+
   // --- members ---
   listMembers(workspaceId: string) {
     const m = this.members.get(workspaceId);
@@ -174,5 +203,17 @@ export class Context {
 
   getServiceUnitsBalance(workspaceId: string) {
     return this.serviceUnits.get(workspaceId) ?? null;
+  }
+
+  // Reflects a resource transfer onto the target workspace: merges the requested
+  // `resources` into its stored resources so a subsequent GET reflects the new
+  // allocation. Returns null when the workspace is missing (handler -> 404/500).
+  transferResources(id: string, body: Dict) {
+    if (!this.workspaces.has(id)) return null;
+    const requested = (body.resources as Dict) ?? {};
+    const existing = this.resources.get(id) ?? { workspace_id: id };
+    const updated = { ...existing, ...requested };
+    this.resources.set(id, updated);
+    return updated;
   }
 }

--- a/packages/spacecat-shared-user-manager-client/.counterfact/routes/__set-status-sequence.ts
+++ b/packages/spacecat-shared-user-manager-client/.counterfact/routes/__set-status-sequence.ts
@@ -1,0 +1,11 @@
+// LLMO-5616 non-spec control route for tests/local dev (do-not-clobber).
+// Seeds the provisioning status sequence a workspace's GET /v1/workspaces/{id}/status
+// walks through (one entry consumed per call) so the poll path can be exercised
+// deterministically. Body: { id, statuses: string[] }.
+import { nf } from "./_.helpers.js";
+
+export const POST = async ($) => {
+  const body = $.body ?? {};
+  const ok = $.context.setStatusSequence(body.id, body.statuses ?? []);
+  return ok ? $.response[200].json({ ok: true }) : nf($, "workspace not found");
+};

--- a/packages/spacecat-shared-user-manager-client/.counterfact/routes/v1/workspaces/{id}/status.ts
+++ b/packages/spacecat-shared-user-manager-client/.counterfact/routes/v1/workspaces/{id}/status.ts
@@ -1,5 +1,11 @@
-import type { workspacesStatusGet } from "../../../../types/paths/v1/workspaces/{id}/status.types.js";
+// LLMO-5616 stateful handler (do-not-clobber).
+// Returns the provisioning status as a single object ({ status }) — matching the
+// overlay CR2 contract. Reports the terminal "created" for a seeded/created
+// workspace, or walks a seeded sequence (see /__set-status-sequence) so the
+// provisioning poll path is deterministic; 404/500 for an unknown workspace.
+import { nf } from "../../../_.helpers.js";
 
-export const GET: workspacesStatusGet = async ($) => {
-  return $.response[200].random();
+export const GET = async ($) => {
+  const status = $.context.getStatus($.path.id);
+  return status ? $.response[200].json(status) : nf($, "workspace not found");
 };

--- a/packages/spacecat-shared-user-manager-client/.counterfact/routes/v2/workspaces/{id}/child.ts
+++ b/packages/spacecat-shared-user-manager-client/.counterfact/routes/v2/workspaces/{id}/child.ts
@@ -1,5 +1,8 @@
-import type { workspaceChildCreateV2 } from "../../../../types/paths/v2/workspaces/{id}/child.types.js";
-
-export const POST: workspaceChildCreateV2 = async ($) => {
-  return $.response[200].random();
+// LLMO-5616 stateful handler (do-not-clobber).
+// Registers a sub-workspace under {id} and returns it with a deterministic id
+// (ws-new-N) and the posted title/body, so the provisioning flow can use the id
+// downstream (status poll, resource transfer). Mirrors the v1 child handler.
+export const POST = async ($) => {
+  const ws = $.context.createChild($.path.id, $.body ?? {});
+  return $.response[200].json(ws);
 };

--- a/packages/spacecat-shared-user-manager-client/.counterfact/routes/v2/workspaces/{id}/resources/transfer.ts
+++ b/packages/spacecat-shared-user-manager-client/.counterfact/routes/v2/workspaces/{id}/resources/transfer.ts
@@ -1,5 +1,10 @@
-import type { workspaceTransferResourcesV2 } from "../../../../../types/paths/v2/workspaces/{id}/resources/transfer.types.js";
+// LLMO-5616 stateful handler (do-not-clobber).
+// Reflects a resource transfer onto {id} in the store and returns the updated
+// allocation, so a subsequent GET /v1/workspaces/{id}/resources sees it;
+// 404/500 for an unknown workspace.
+import { nf } from "../../../../_.helpers.js";
 
-export const POST: workspaceTransferResourcesV2 = async ($) => {
-  return $.response[200].random();
+export const POST = async ($) => {
+  const result = $.context.transferResources($.path.id, $.body ?? {});
+  return result ? $.response[200].json(result) : nf($, "workspace not found");
 };

--- a/packages/spacecat-shared-user-manager-client/test/mock.test.js
+++ b/packages/spacecat-shared-user-manager-client/test/mock.test.js
@@ -180,6 +180,81 @@ describe('User Manager mock (LLMO-5616)', () => {
     expect((await api('GET', '/v1/workspaces/does-not-exist')).status).to.be.gte(400);
   });
 
+  describe('sub-workspace lifecycle (LLMO-5616)', () => {
+    it('POST /v2/workspaces/:id/child registers a child with a deterministic id, reachable via GET', async () => {
+      const created = await api('POST', '/v2/workspaces/ws-root/child', {
+        title: 'Market Mirror', resources: { ai: { units: 100 } },
+      });
+      expect(created.status).to.equal(200);
+      expect(created.body.id).to.be.a('string').and.match(/^ws-new-/);
+      expect(created.body.parent_id).to.equal('ws-root');
+      expect(created.body.title).to.equal('Market Mirror');
+      // the child is stored, so a subsequent workspace GET finds it
+      const got = await api('GET', `/v1/workspaces/${created.body.id}`);
+      expect(got.status).to.equal(200);
+      expect(got.body.parent_id).to.equal('ws-root');
+    });
+
+    it('GET /v1/workspaces/:id/status returns the terminal "created" as a single object', async () => {
+      const res = await api('GET', '/v1/workspaces/ws-root/status');
+      expect(res.status).to.equal(200);
+      // CR2: a single object, not an array
+      expect(res.body).to.be.an('object');
+      expect(res.body.status).to.equal('created');
+    });
+
+    it('GET /v1/workspaces/:id/status returns an error status for an unknown workspace', async () => {
+      expect((await api('GET', '/v1/workspaces/no-such-ws/status')).status).to.be.gte(400);
+    });
+
+    it('GET status walks a seeded "not ready" -> "created" sequence, then stays created (poll path)', async () => {
+      const seeded = await api('POST', '/__set-status-sequence', {
+        id: 'ws-root', statuses: ['not ready', 'not ready', 'created'],
+      });
+      expect(seeded.status).to.equal(200);
+      const poll = async () => (await api('GET', '/v1/workspaces/ws-root/status')).body.status;
+      expect(await poll()).to.equal('not ready');
+      expect(await poll()).to.equal('not ready');
+      expect(await poll()).to.equal('created');
+      // drained -> stays at the terminal created
+      expect(await poll()).to.equal('created');
+    });
+
+    it('POST /__set-status-sequence on an unknown workspace returns an error status', async () => {
+      const res = await api('POST', '/__set-status-sequence', { id: 'no-such-ws', statuses: ['created'] });
+      expect(res.status).to.be.gte(400);
+    });
+
+    it('POST /v2/workspaces/:id/resources/transfer reflects the allocation in the store', async () => {
+      const res = await api('POST', '/v2/workspaces/ws-child/resources/transfer', {
+        resources: { projects: 5, keywords: 500 },
+      });
+      expect(res.status).to.equal(200);
+      expect(res.body).to.include({ projects: 5, keywords: 500 });
+      // reflected on a subsequent resources GET
+      const got = await api('GET', '/v1/workspaces/ws-child/resources');
+      expect(got.body).to.include({ projects: 5, keywords: 500 });
+    });
+
+    it('transfer to a missing workspace returns an error status', async () => {
+      const res = await api('POST', '/v2/workspaces/no-such-ws/resources/transfer', {
+        resources: { projects: 1 },
+      });
+      expect(res.status).to.be.gte(400);
+    });
+
+    it('end-to-end: child -> status -> transfer is deterministic across the chain', async () => {
+      const child = await api('POST', '/v2/workspaces/ws-root/child', { title: 'Mirror' });
+      const { id } = child.body;
+      expect((await api('GET', `/v1/workspaces/${id}/status`)).body.status).to.equal('created');
+      const transfer = await api('POST', `/v2/workspaces/${id}/resources/transfer`, {
+        resources: { projects: 3 },
+      });
+      expect(transfer.status).to.equal(200);
+      expect(transfer.body).to.include({ projects: 3 });
+    });
+  });
+
   it('uses committed custom handlers (delegate to $.context)', () => {
     const profile = fs.readFileSync(path.join(PKG_ROOT, '.counterfact/routes/v1/profile.ts'), 'utf8');
     expect(profile).to.include('$.context');


### PR DESCRIPTION
## What

Makes the sub-workspace provisioning lifecycle **stateful and deterministic** in the User Manager Counterfact mock. The three endpoints `spacecat-api-service`'s market-mirror provisioning calls were still auto-generated random stubs, so the provisioning poll never reliably read the success state and sub-workspace creation hung/failed against the mock:

- `POST /v2/workspaces/{id}/child` — random id
- `GET /v1/workspaces/{id}/status` — random status
- `POST /v2/workspaces/{id}/resources/transfer` — random 200

## How

Hand-authored stateful handlers delegating to `$.context` (mirroring the existing `v1/workspaces/{id}/child` pattern), surviving Counterfact regeneration (append-don't-clobber on existing route files):

- **`_.context.ts`** — `getStatus` (terminal `created`; seedable `not ready` → `created` sequence), `setStatusSequence`, `transferResources`; `statusSequences` re-seeded on `reset()`.
- **`v2 child` / `v1 status` / `v2 transfer`** — random stubs → stateful.
- **`__set-status-sequence`** — non-spec control route (like `__reset`) to drive the poll path deterministically.
- **`mock.test.js`** — E2E for the full `create → status → transfer` chain, the poll sequence, and missing-workspace paths.

## Notes

- **Success status is `created`, not `ready`.** That's the value the api-service transport polls for, per the merged overlay's CR2 (`status.status === 'created'`); `ready` isn't in the `WorkspaceCheckResponse` enum.
- **Scope:** strictly the three endpoints in the issue. Deliberately did **not** touch `family` or add a transfer balance guard — both would bake unvalidated behavior into the mock (the consumer path isn't live-validated yet).
- **Stacked on PR #1685** (`feat/llmo-5616-user-manager-mock`), since the mock infrastructure isn't on `main` yet. Will retarget to `main` once #1685 merges.
- Independent of the overlay work (#1699), which is already merged to `main`.

## Validation

- `npm test -w packages/spacecat-shared-user-manager-client` — **30 passing** (8 new), 100% coverage.
- `npm run lint -w packages/spacecat-shared-user-manager-client` — clean.

Closes #1700

🤖 Generated with [Claude Code](https://claude.com/claude-code)
