### PR TITLE
chore(ci): document SR_NO_NPM_AUTH guard as permanent; retire ADOBE_BOT_NPM_TOKEN

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,18 +51,18 @@ jobs:
           persist-credentials: 'false'
 
       - name: Verify SR_NO_NPM_AUTH guard consistency
-        # The @semantic-release/npm gate (process.env.SR_NO_NPM_AUTH === 'true') must
-        # stay consistent across all .releaserc.cjs files while the workflow's
-        # SR_NO_NPM_AUTH env var is declared. After OIDC publishing is verified working
-        # (per SITES-42702 rollback policy: 2 successful releases), the cleanup PR
-        # atomically removes (a) the env var declaration below, (b) the strict guard
-        # from every .releaserc.cjs. Phase is auto-detected — no marker file required.
+        # @semantic-release/npm must be skipped in the Test-job dry-run: that job has no
+        # npm publish auth (OIDC works only in the release job, which has id-token: write
+        # + the npm-publish environment), so the plugin's verifyConditions npm-whoami would
+        # fail here. The skip is driven by SR_NO_NPM_AUTH: 'true' on the dry-run step below,
+        # gated in every .releaserc.cjs. This is PERMANENT, not a bootstrap shim — #1592
+        # added SR_NO_NPM_AUTH in the same change that removed NPM_TOKEN from the dry-run.
+        # This step enforces that the env var AND the guard in every .releaserc.cjs stay
+        # present; neither may be removed (doing so red-lines the dry-run on every PR).
         #
-        # Phase detection uses a YAML-key-anchored regex on the SR_NO_NPM_AUTH env var
-        # declaration. The pattern (indented key + 'true' | "true" | true) is robust to
-        # quote-style reformatting from Prettier/yamllint and is syntactically distinct
-        # from the JS strict-equality this step looks for in configs, so it cannot
-        # self-reference. The JS guard pattern likewise accepts both quote styles.
+        # The anchored regex (indented key + 'true' | "true" | true) is robust to quote-style
+        # reformatting from Prettier/yamllint and is syntactically distinct from the JS
+        # strict-equality this step looks for in configs, so it cannot self-reference.
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -79,33 +79,29 @@ jobs:
             [ -f "$f" ] || { echo "FAIL: expected config not found or not a regular file: $f"; exit 1; }
           done
 
-          # Phase 1 anchor: YAML mapping `<indent>SR_NO_NPM_AUTH: 'true' | "true" | true`
-          # at end-of-value (no trailing chars that would denote a different key/value).
-          if grep -qE "^[[:space:]]+SR_NO_NPM_AUTH:[[:space:]]+('true'|\"true\"|true)[[:space:]]*\$" .github/workflows/main.yaml; then
-            # Phase 1 (shim active): every .releaserc.cjs must include the strict guard.
-            # Accept both JS quote styles so Prettier reformats don't cause spurious fails.
-            missing=$(grep -L -E "SR_NO_NPM_AUTH === ['\"]true['\"]" "${files[@]}" || true)
-            if [ -n "$missing" ]; then
-              echo "FAIL: SR_NO_NPM_AUTH guard missing in:"
-              echo "$missing"
-              echo ""
-              echo "Each .releaserc.cjs must gate @semantic-release/npm on:"
-              echo "  ...(process.env.SR_NO_NPM_AUTH === 'true' ? [] : [\"@semantic-release/npm\"]),"
-              exit 1
-            fi
-          else
-            # Phase 2 (shim removed from workflow): no .releaserc.cjs may still reference
-            # SR_NO_NPM_AUTH. Catches a partial cleanup that leaves leftover guards in
-            # some configs after the env var was removed.
-            leftover=$(grep -l "SR_NO_NPM_AUTH" "${files[@]}" || true)
-            if [ -n "$leftover" ]; then
-              echo "FAIL: SR_NO_NPM_AUTH removed from workflow env but still referenced in:"
-              echo "$leftover"
-              echo ""
-              echo "Cleanup is partial. Remove every SR_NO_NPM_AUTH reference from these"
-              echo "files to complete the OIDC bootstrap cleanup."
-              exit 1
-            fi
+          # The SR_NO_NPM_AUTH skip is permanent (see comment above). Enforce BOTH legs:
+          # the workflow env var must stay declared, and every .releaserc.cjs must keep the
+          # matching guard. Removing either breaks the dry-run.
+          #
+          # Anchor: YAML mapping `<indent>SR_NO_NPM_AUTH: 'true' | "true" | true` at
+          # end-of-value (no trailing chars that would denote a different key/value).
+          if ! grep -qE "^[[:space:]]+SR_NO_NPM_AUTH:[[:space:]]+('true'|\"true\"|true)[[:space:]]*\$" .github/workflows/main.yaml; then
+            echo "FAIL: SR_NO_NPM_AUTH: 'true' is missing from the dry-run step env."
+            echo ""
+            echo "It is required and permanent — the Test-job dry-run has no npm publish auth,"
+            echo "so @semantic-release/npm must be skipped there. Restore it; do not remove it."
+            exit 1
+          fi
+          # Every .releaserc.cjs must include the strict guard. Accept both JS quote styles
+          # so Prettier reformats don't cause spurious fails.
+          missing=$(grep -L -E "SR_NO_NPM_AUTH === ['\"]true['\"]" "${files[@]}" || true)
+          if [ -n "$missing" ]; then
+            echo "FAIL: SR_NO_NPM_AUTH guard missing in:"
+            echo "$missing"
+            echo ""
+            echo "Each .releaserc.cjs must gate @semantic-release/npm on:"
+            echo "  ...(process.env.SR_NO_NPM_AUTH === 'true' ? [] : [\"@semantic-release/npm\"]),"
+            exit 1
           fi
 
       - name: Set up JDK 17
@@ -161,8 +157,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
           # SR_NO_NPM_AUTH skips @semantic-release/npm in the plugin chain (see all .releaserc.cjs).
-          # Remove this env var AND the matching guard from every .releaserc.cjs after 2 successful
-          # OIDC releases on main confirm publishing works without a token (tracked in SITES-42702).
+          # PERMANENT, not a bootstrap shim: this dry-run has no npm publish auth (OIDC is
+          # release-job-only), so @semantic-release/npm's verifyConditions npm-whoami would fail
+          # here without it. #1592 added it in the same change that removed NPM_TOKEN from this
+          # step. Do not remove (the "Verify SR_NO_NPM_AUTH guard consistency" step enforces it).
           SR_NO_NPM_AUTH: 'true'
 
   release:

--- a/docs/RELEASE-RUNBOOK.md
+++ b/docs/RELEASE-RUNBOOK.md
@@ -115,10 +115,12 @@ removal and the SR_NO_NPM_AUTH guards leaves an intermediate state where
 the release job has no working publish auth. The OIDC migration must come
 back as a single PR equivalent in scope to #1592.
 
-`ADOBE_BOT_NPM_TOKEN` is intentionally retained in GitHub repo secrets for
-≥ 2 successful release cycles (per SITES-42702). The revert re-adds
-`NPM_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}` to the workflow env and the
-next release publishes via the token path.
+`ADOBE_BOT_NPM_TOKEN` was retained in GitHub repo secrets as rollback insurance
+during the migration (per SITES-42702) and is being retired now that OIDC is
+proven (see "ADOBE_BOT_NPM_TOKEN retirement"). A token-path revert would first
+re-create the `ADOBE_BOT_NPM_TOKEN` secret, then re-add
+`NPM_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}` to the workflow env so the next
+release publishes via the token path.
 
 Investigate the OIDC failure:
 
@@ -495,26 +497,27 @@ To revert (drop the gate again), repeat the PUT with `"reviewers": []`.
 
 ---
 
-## ADOBE_BOT_NPM_TOKEN rotation
+## ADOBE_BOT_NPM_TOKEN retirement
 
-Per SITES-42702, retain `ADOBE_BOT_NPM_TOKEN` in GitHub repo secrets for at
-least 2 successful OIDC releases as rollback insurance. After that, complete
-the cleanup in this order (each step is a separate PR; the CI tripwire
-validates atomicity of step 3):
+`ADOBE_BOT_NPM_TOKEN` was the pre-OIDC publish token, retained in GitHub repo
+secrets as rollback insurance during the migration. OIDC has been the live
+publish path since #1592 (2026-05-21) with many successful releases, and no
+workflow references the token any more (grep `.github/` — only this runbook
+mentions it). Retire it:
 
 1. Delete the `ADOBE_BOT_NPM_TOKEN` secret from
-   `Settings → Secrets and variables → Actions`.
+   `Settings → Secrets and variables → Actions` (it may already be gone — it is
+   no longer present in the repo secret list).
 2. Revoke the npm-side token on npmjs.com (separate from GitHub deletion).
-3. In a single PR: remove the `SR_NO_NPM_AUTH: 'true'` env var from
-   `.github/workflows/main.yaml` AND remove the strict guard
-   (`...(process.env.SR_NO_NPM_AUTH === 'true' ? [] : ["@semantic-release/npm"]),`)
-   from all 23 `.releaserc.cjs` files. The CI step
-   `Verify SR_NO_NPM_AUTH guard consistency` auto-detects this transition
-   and validates that the cleanup is complete (it would fail if env var is
-   removed while some configs still reference `SR_NO_NPM_AUTH`).
-4. (Optional follow-up) Remove the `Verify SR_NO_NPM_AUTH guard consistency`
-   CI step itself — it becomes a no-op once `SR_NO_NPM_AUTH` is gone from
-   the workflow.
+
+Do NOT remove the `SR_NO_NPM_AUTH` guard as part of this. It is permanent, not a
+bootstrap artifact: the Test-job dry-run has no npm publish auth (OIDC works only
+in the release job, which has `id-token: write` + the `npm-publish` environment),
+so `@semantic-release/npm`'s verifyConditions would fail `npm whoami` there.
+#1592 added `SR_NO_NPM_AUTH` in the same change that removed `NPM_TOKEN` from the
+dry-run step. The `Verify SR_NO_NPM_AUTH guard consistency` CI step enforces that
+the env var and all `.releaserc.cjs` guards stay present; removing them would
+red-line the dry-run on every PR.
 
 ---
 


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Corrects the SITES-42702 documentation and CI guard so `SR_NO_NPM_AUTH` is treated as a **permanent** part of the release pipeline rather than a removable bootstrap shim, and reframes the `ADOBE_BOT_NPM_TOKEN` cleanup as token retirement only.

## 2. Reasoning
The runbook and workflow comments instructed a future "cleanup" to remove `SR_NO_NPM_AUTH` (the env var + the guard in all 23 `.releaserc.cjs`) "after 2 successful OIDC releases." That instruction is wrong and would break CI:

- The `SR_NO_NPM_AUTH` guard skips `@semantic-release/npm` **in the Test-job dry-run**, which has no npm publish auth — OIDC works only in the release job (`id-token: write` + the `npm-publish` environment). `@semantic-release/npm`'s `verifyConditions` runs `npm whoami` unconditionally (no dry-run exemption), so without the guard the dry-run fails `EINVALIDNPMTOKEN`.
- #1592 (the OIDC migration) added `SR_NO_NPM_AUTH: 'true'` in the **same change** that removed `NPM_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}` from the dry-run step — i.e. the guard is the token's direct replacement, not bootstrap residue.

Following the documented removal would have red-lined the dry-run on every PR. The genuinely removable artifact is the now-unused `ADOBE_BOT_NPM_TOKEN`, not the guard.

## 3. High-level overview of the changes
Docs/CI-comments plus one CI-logic change; no application code, no package release.

- Workflow `Verify SR_NO_NPM_AUTH guard consistency` step: reframed comments to "permanent," and rewrote the body from a dual-phase (active/cleanup) check into a single enforcement that **fails if the env var OR any `.releaserc.cjs` guard is missing**. The old phase-2 branch actively guided toward the broken removal; it's gone.
- Workflow dry-run step comment: reframed to "permanent — do not remove," with the #1592 rationale.
- `docs/RELEASE-RUNBOOK.md`: the "ADOBE_BOT_NPM_TOKEN rotation" section becomes "retirement" — keeps steps 1-2 (delete the GitHub secret, revoke the npm token) and **drops the guard-removal step**; the OIDC-revert paragraph notes the token is being retired.

Net behaviour: CI stays green (env var + all guards are present and unchanged); the guard can no longer be "cleaned up" by mistake.

## 4. Required information
- Jira / issue: SITES-42702 (npm OIDC Trusted Publishing rollout) - https://jira.corp.adobe.com/browse/SITES-42702

## 6. Additional information outside the code
Verified locally this session:

- Read the installed `@semantic-release/npm` source: `verifyConditions` calls `verifyNpmAuth` (→ `npm whoami`) whenever `npmPublish !== false` and the package isn't private, with no dry-run guard.
- Confirmed the Test job has no npm registry auth (the `setup-node-npm` composite sets up Node + git auth only; the dry-run step env carries only `GITHUB_TOKEN`).
- `git show` of #1592 confirms `NPM_TOKEN` was removed from the dry-run step and `SR_NO_NPM_AUTH: 'true'` added in the same commit.
- `gh secret list` shows `ADOBE_BOT_NPM_TOKEN` is already absent from the repo secrets; the npm-side token revocation remains a manual admin step.
- Extracted the rewritten `Verify SR_NO_NPM_AUTH guard consistency` script, ran `bash -n` (syntax OK) and executed it against the tree (exit 0 — env var present, no `.releaserc.cjs` missing the guard).

## 7. Test plan
(a) Local: `bash -n` + real execution of the rewritten verify-step script pass against the current tree.

(b) On CI for this PR: the `Test` job runs the verify step and the dry-run; both stay green because the env var and all 23 guards are present and unchanged. No deployed-service environments apply (release tooling + docs).

## 8. Deployment & merge order
Independent. No release is triggered (no package files touched). After merge, the only remaining manual step is the npm-side revocation of the `ADOBE_BOT_NPM_TOKEN` token on npmjs.com (admin).
