### PR TITLE
fix(brand-client): correct JSDoc for getBrandGuidelinesForUrl return type and add throws

### DIFF
--- a/packages/spacecat-shared-brand-client/src/brand-governance-client.js
+++ b/packages/spacecat-shared-brand-client/src/brand-governance-client.js
@@ -96,7 +96,10 @@ export class BrandGovernanceClient {
    * @param {string} siteBaseUrl - The site's base URL to resolve brand by domain
    * @param {string} imsOrgId - The IMS org ID sent as x-gw-ims-org-id header
    * @param {object} imsConfig - IMS auth config: { host, clientId, clientCode, clientSecret }
-   * @returns {Promise<object|null>} Brand guidelines or null if not registered
+   * @returns {Promise<object|null>} Raw brand profile from the Brand Governance Agent
+   *   /profile endpoint, or null if the brand is not registered or has no profile
+   * @throws {Error} If siteBaseUrl, imsOrgId, or imsConfig fields are invalid
+   * @throws {Error} If the Brand Governance Agent returns a non-404 error
    */
   async getBrandGuidelinesForUrl(siteBaseUrl, imsOrgId, imsConfig) {
     if (!isValidUrl(siteBaseUrl)) {


### PR DESCRIPTION
## Summary

- Fixes stale `@returns` JSDoc on `getBrandGuidelinesForUrl` — now correctly describes the raw `/profile` response instead of "Brand guidelines"
- Adds missing `@throws` entries for invalid input and non-404 API errors

Follows up on #1667 which switched from `/checks` to `/profile` but left the JSDoc partially outdated.

🤖 Generated with [Claude Code](https://claude.ai/code)