### PR TITLE
feat(cloudflare-client): add spacecat-shared-cloudflare-client package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -518,6 +518,10 @@
       "resolved": "packages/spacecat-shared-cloud-manager-client",
       "link": true
     },
+    "node_modules/@adobe/spacecat-shared-cloudflare-client": {
+      "resolved": "packages/spacecat-shared-cloudflare-client",
+      "link": true
+    },
     "node_modules/@adobe/spacecat-shared-content-client": {
       "resolved": "packages/spacecat-shared-content-client",
       "link": true
@@ -2334,6 +2338,18 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
+      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/util-dynamodb": {
@@ -24195,18 +24211,6 @@
         "node": ">=18.0.0"
       }
     },
-    "packages/mysticat-shared-seo-client/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "packages/mysticat-shared-seo-client/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
@@ -24991,18 +24995,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-athena-client/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -25880,18 +25872,6 @@
         "node": ">=18.0.0"
       }
     },
-    "packages/spacecat-shared-brand-client/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "packages/spacecat-shared-brand-client/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
@@ -26704,18 +26684,6 @@
         "node": ">=18.0.0"
       }
     },
-    "packages/spacecat-shared-cloud-manager-client/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "packages/spacecat-shared-cloud-manager-client/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
@@ -26839,6 +26807,795 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
       "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client": {
+      "name": "@adobe/spacecat-shared-cloudflare-client",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/spacecat-shared-utils": "1.81.1"
+      },
+      "devDependencies": {
+        "chai": "6.2.2",
+        "chai-as-promised": "8.0.2",
+        "nock": "14.0.15",
+        "sinon": "22.0.0",
+        "sinon-chai": "4.0.1",
+        "typescript": "6.0.3"
+      },
+      "engines": {
+        "node": ">=22.0.0 <25.0.0",
+        "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@adobe/fetch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.2.3.tgz",
+      "integrity": "sha512-Sn1oRY9WMnLWTIa0nibWJkuck/LWypnckZk1Ude/COAQbanI0mn3jLecJMP0DcGITsl7lWfdcoUpT+a5DpBy8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.4.3",
+        "http-cache-semantics": "4.2.0",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@adobe/spacecat-shared-utils": {
+      "version": "1.81.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.81.1.tgz",
+      "integrity": "sha512-GSQuLJsPsT6SDJNydhozgRNHl5qat4f+W7/IwyAvNfAqgPrF6Eb7+h4ZUz8Nb01Rm13Z18f6NY/u/wW12sdxtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/fetch": "4.2.3",
+        "@aws-sdk/client-s3": "3.940.0",
+        "@aws-sdk/client-sqs": "3.940.0",
+        "@json2csv/plainjs": "7.0.6",
+        "aws-xray-sdk": "3.12.0",
+        "cheerio": "1.1.2",
+        "date-fns": "4.1.0",
+        "franc-min": "6.2.0",
+        "iso-639-3": "3.0.1",
+        "validator": "^13.15.15",
+        "world-countries": "5.1.0",
+        "zod": "^4.1.11"
+      },
+      "engines": {
+        "node": ">=22.0.0 <25.0.0",
+        "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/client-s3": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.940.0.tgz",
+      "integrity": "sha512-Wi4qnBT6shRRMXuuTgjMFTU5mu2KFWisgcigEMPptjPGUtJvBVi4PTGgS64qsLoUk/obqDAyOBOfEtRZ2ddC2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.936.0",
+        "@aws-sdk/middleware-expect-continue": "3.936.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-location-constraint": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-sdk-s3": "3.940.0",
+        "@aws-sdk/middleware-ssec": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/signature-v4-multi-region": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/eventstream-serde-browser": "^4.2.5",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.5",
+        "@smithy/eventstream-serde-node": "^4.2.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-blob-browser": "^4.2.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/hash-stream-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/md5-js": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/client-sqs": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.940.0.tgz",
+      "integrity": "sha512-tXPi9OlELbiewGDb9maXDMhdYW617I9osGo/C1GAR6eLYwj40/TfOBeOQf3tX9EcH8NpDBuMksxoAvkpvqYIKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-node": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/md5-js": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/core": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.940.0.tgz",
+      "integrity": "sha512-KsGD2FLaX5ngJao1mHxodIVU9VYd1E8810fcYiGwO1PFHDzf5BEkp6D9IdMeQwT8Q6JLYtiiT1Y/o3UCScnGoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/xml-builder": "3.930.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.940.0.tgz",
+      "integrity": "sha512-/G3l5/wbZYP2XEQiOoIkRJmlv15f1P3MSd1a0gz27lHEMrOJOGq66rF1Ca4OJLzapWt3Fy9BPrZAepoAX11kMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.940.0.tgz",
+      "integrity": "sha512-dOrc03DHElNBD6N9Okt4U0zhrG4Wix5QUBSZPr5VN8SvmjD9dkrrxOkkJaMCl/bzrW7kbQEp7LuBdbxArMmOZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.940.0.tgz",
+      "integrity": "sha512-gn7PJQEzb/cnInNFTOaDoCN/hOKqMejNmLof1W5VW95Qk0TPO52lH8R4RmJPnRrwFMswOWswTOpR1roKNLIrcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/credential-provider-env": "3.940.0",
+        "@aws-sdk/credential-provider-http": "3.940.0",
+        "@aws-sdk/credential-provider-login": "3.940.0",
+        "@aws-sdk/credential-provider-process": "3.940.0",
+        "@aws-sdk/credential-provider-sso": "3.940.0",
+        "@aws-sdk/credential-provider-web-identity": "3.940.0",
+        "@aws-sdk/nested-clients": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.940.0.tgz",
+      "integrity": "sha512-fOKC3VZkwa9T2l2VFKWRtfHQPQuISqqNl35ZhcXjWKVwRwl/o7THPMkqI4XwgT2noGa7LLYVbWMwnsgSsBqglg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/nested-clients": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.940.0.tgz",
+      "integrity": "sha512-M8NFAvgvO6xZjiti5kztFiAYmSmSlG3eUfr4ZHSfXYZUA/KUdZU/D6xJyaLnU8cYRWBludb6K9XPKKVwKfqm4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.940.0",
+        "@aws-sdk/credential-provider-http": "3.940.0",
+        "@aws-sdk/credential-provider-ini": "3.940.0",
+        "@aws-sdk/credential-provider-process": "3.940.0",
+        "@aws-sdk/credential-provider-sso": "3.940.0",
+        "@aws-sdk/credential-provider-web-identity": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.940.0.tgz",
+      "integrity": "sha512-pILBzt5/TYCqRsJb7vZlxmRIe0/T+FZPeml417EK75060ajDGnVJjHcuVdLVIeKoTKm9gmJc9l45gon6PbHyUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.940.0.tgz",
+      "integrity": "sha512-q6JMHIkBlDCOMnA3RAzf8cGfup+8ukhhb50fNpghMs1SNBGhanmaMbZSgLigBRsPQW7fOk2l8jnzdVLS+BB9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.940.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/token-providers": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.940.0.tgz",
+      "integrity": "sha512-9QLTIkDJHHaYL0nyymO41H8g3ui1yz6Y3GmAN1gYQa6plXisuFBnGAbmKVj7zNvjWaOKdF0dV3dd3AFKEDoJ/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/nested-clients": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.936.0.tgz",
+      "integrity": "sha512-XLSVVfAorUxZh6dzF+HTOp4R1B5EQcdpGcPliWr0KUj2jukgjZEcqbBmjyMF/p9bmyQsONX80iURF1HLAlW0qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.936.0.tgz",
+      "integrity": "sha512-Eb4ELAC23bEQLJmUMYnPWcjD3FZIsmz2svDiXEcxRkQU9r7NRID7pM7C5NPH94wOfiCk0b2Y8rVyFXW0lGQwbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.940.0.tgz",
+      "integrity": "sha512-WdsxDAVj5qaa5ApAP+JbpCOMHFGSmzjs2Y2OBSbWPeR9Ew7t/Okj+kUub94QJPsgzhvU1/cqNejhsw5VxeFKSQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
+      "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.936.0.tgz",
+      "integrity": "sha512-SCMPenDtQMd9o5da9JzkHz838w3327iqXk3cbNnXWqnNRx6unyW8FL0DZ84gIY12kAyVHz5WEqlWuekc15ehfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
+      "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.936.0.tgz",
+      "integrity": "sha512-l4aGbHpXM45YNgXggIux1HgsCVAvvBoqHPkqLnqMl9QVapfuSTjJHfDYDsx1Xxct6/m7qSMUzanBALhiaGO2fA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws/lambda-invoke-store": "^0.2.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.940.0.tgz",
+      "integrity": "sha512-JYkLjgS1wLoKHJ40G63+afM1ehmsPsjcmrHirKh8+kSCx4ip7+nL1e/twV4Zicxr8RJi9Y0Ahq5mDvneilDDKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.936.0.tgz",
+      "integrity": "sha512-39WohFCCPeD6LV8zLQq7CyYbIieetEDDNLsEPeGJSh2Uv9qpY9r6zJRSTjb8hTuQbHDSEOGntHMYKpLoHdoxdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.936.0.tgz",
+      "integrity": "sha512-/GLC9lZdVp05ozRik5KsuODR/N7j+W+2TbfdFL3iS+7un+gnP6hC8RDOZd6WhpZp7drXQ9guKiTAxkZQwzS8DA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.940.0.tgz",
+      "integrity": "sha512-nJbLrUj6fY+l2W2rIB9P4Qvpiy0tnTdg/dmixRxrU1z3e8wBdspJlyE+AZN4fuVbeL6rrRrO/zxQC1bB3cw5IA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.940.0.tgz",
+      "integrity": "sha512-x0mdv6DkjXqXEcQj3URbCltEzW6hoy/1uIL+i8gExP6YKrnhiZ7SzuB4gPls2UOpK5UqLiqXjhRLfBb1C9i4Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.940.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
+      "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.940.0.tgz",
+      "integrity": "sha512-ugHZEoktD/bG6mdgmhzLDjMP2VrYRAUPRPF1DpCyiZexkH7DCU7XrSJyXMvkcf0DHV+URk0q2sLf/oqn1D2uYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/token-providers": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.940.0.tgz",
+      "integrity": "sha512-k5qbRe/ZFjW9oWEdzLIa2twRVIEx7p/9rutofyrRysrtEnYh3HAWCngAnwbgKMoiwa806UzcTRx0TjyEpnKcCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.940.0",
+        "@aws-sdk/nested-clients": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/types": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
+      "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
+      "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.940.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.940.0.tgz",
+      "integrity": "sha512-dlD/F+L/jN26I8Zg5x0oDGJiA+/WEQmnSE27fi5ydvYnpfQLwThtQo9SsNS47XSR/SOULaaoC9qx929rZuo74A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.940.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/cheerio": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
+      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.0.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.12.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "packages/spacecat-shared-cloudflare-client/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -27505,18 +28262,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-content-client/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -28751,18 +29496,6 @@
         "node": ">=18.0.0"
       }
     },
-    "packages/spacecat-shared-google-client/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "packages/spacecat-shared-google-client/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
@@ -29655,18 +30388,6 @@
         "node": ">=18.0.0"
       }
     },
-    "packages/spacecat-shared-gpt-client/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "packages/spacecat-shared-gpt-client/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
@@ -30493,18 +31214,6 @@
         "node": ">=18.0.0"
       }
     },
-    "packages/spacecat-shared-http-utils/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "packages/spacecat-shared-http-utils/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
@@ -31298,18 +32007,6 @@
         "node": ">=18.0.0"
       }
     },
-    "packages/spacecat-shared-ims-client/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "packages/spacecat-shared-ims-client/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
@@ -32096,18 +32793,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-launchdarkly-client/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -33081,18 +33766,6 @@
         "node": ">=18.0.0"
       }
     },
-    "packages/spacecat-shared-rum-api-client/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "packages/spacecat-shared-rum-api-client/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
@@ -33878,18 +34551,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-scrape-client/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -34688,18 +35349,6 @@
         "node": ">=18.0.0"
       }
     },
-    "packages/spacecat-shared-slack-client/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "packages/spacecat-shared-slack-client/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
@@ -35486,18 +36135,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-splunk-client/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -36296,18 +36933,6 @@
         "node": ">=18.0.0"
       }
     },
-    "packages/spacecat-shared-tier-client/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "packages/spacecat-shared-tier-client/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
@@ -37099,18 +37724,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "packages/spacecat-shared-tokowaka-client/node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/packages/spacecat-shared-cloudflare-client/.mocha-multi.json
+++ b/packages/spacecat-shared-cloudflare-client/.mocha-multi.json
@@ -1,0 +1,6 @@
+{
+    "reporterEnabled": "spec,xunit",
+    "xunitReporterOptions": {
+        "output": "junit/test-results.xml"
+    }
+}

--- a/packages/spacecat-shared-cloudflare-client/.nycrc.json
+++ b/packages/spacecat-shared-cloudflare-client/.nycrc.json
@@ -1,0 +1,14 @@
+{
+  "reporter": [
+    "lcov",
+    "text"
+  ],
+  "check-coverage": true,
+  "lines": 100,
+  "branches": 97,
+  "statements": 100,
+  "all": true,
+  "include": [
+    "src/**/*.js"
+  ]
+}

--- a/packages/spacecat-shared-cloudflare-client/.releaserc.cjs
+++ b/packages/spacecat-shared-cloudflare-client/.releaserc.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+  extends: "semantic-release-monorepo",
+  plugins: [
+    ["@semantic-release/commit-analyzer", {
+      "preset": "conventionalcommits",
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits",
+    }],
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md",
+    }],
+    ...(process.env.SR_NO_NPM_AUTH === 'true' ? [] : ["@semantic-release/npm"]),
+    ["@semantic-release/git", {
+      "assets": ["package.json", "CHANGELOG.md"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }],
+    ["@semantic-release/github", {}],
+  ],
+  branches: ['main'],
+};

--- a/packages/spacecat-shared-cloudflare-client/CHANGELOG.md
+++ b/packages/spacecat-shared-cloudflare-client/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/spacecat-shared-cloudflare-client/README.md
+++ b/packages/spacecat-shared-cloudflare-client/README.md
@@ -1,0 +1,127 @@
+# Spacecat Shared - Cloudflare Client
+
+## Overview
+
+`@adobe/spacecat-shared-cloudflare-client` is a thin HTTP client wrapping the
+[Cloudflare API](https://developers.cloudflare.com/api/) for use by Spacecat
+services. It exposes a small set of operations for managing accounts, Worker
+scripts (including secrets), zones, and Worker routes.
+
+## Installation
+
+```bash
+npm install @adobe/spacecat-shared-cloudflare-client
+```
+
+## Usage
+
+### Creating a client
+
+#### From a Universal context (recommended)
+
+Reads the API token from `context.env.CLOUDFLARE_API_TOKEN`:
+
+```javascript
+import CloudflareClient from '@adobe/spacecat-shared-cloudflare-client';
+
+const client = CloudflareClient.createFrom(context);
+```
+
+#### Direct constructor
+
+```javascript
+import CloudflareClient from '@adobe/spacecat-shared-cloudflare-client';
+
+const client = new CloudflareClient({ token: process.env.CLOUDFLARE_API_TOKEN }, log);
+```
+
+The constructor accepts an optional `apiBase` to override the Cloudflare API
+base URL (defaults to `https://api.cloudflare.com/client/v4`).
+
+## API
+
+### `listAccounts(options?)`
+
+Lists Cloudflare accounts accessible with the current token. Returns a single
+page of results.
+
+```javascript
+const accounts = await client.listAccounts();           // page 1, 50 per page
+const more = await client.listAccounts({ page: 2, perPage: 50 });
+```
+
+> **Pagination:** `listAccounts` and `listZones` return one page at a time. To
+> retrieve more than `perPage` results, call repeatedly with an incrementing
+> `page`.
+
+### `deployWorkerScript(accountId, scriptName, scriptContent, bindings?, opts?)`
+
+Uploads a Worker script as an ES module, binding env vars and enabling
+Workers Logs by default.
+
+```javascript
+await client.deployWorkerScript(
+  accountId,
+  'edge-optimize-router',
+  scriptSource,
+  [{ name: 'HOST', type: 'plain_text', text: 'example.com' }],
+  { compatibilityDate: '2025-01-01', observability: true },
+);
+```
+
+### `setWorkerSecret(accountId, scriptName, secretName, secretValue)`
+
+Sets an encrypted secret on a deployed Worker script.
+
+```javascript
+await client.setWorkerSecret(accountId, 'edge-optimize-router', 'API_KEY', 's3cr3t');
+```
+
+### `listZones(options?)`
+
+Lists active Cloudflare zones accessible with the current token. Returns a
+single page of results (see pagination note above).
+
+```javascript
+const zones = await client.listZones({ page: 1, perPage: 50 });
+```
+
+### `listRoutes(zoneId)`
+
+Lists all Worker routes for a zone.
+
+```javascript
+const routes = await client.listRoutes(zoneId);
+```
+
+### `addRoute(zoneId, pattern, scriptName)`
+
+Adds a Worker route to a zone.
+
+```javascript
+await client.addRoute(zoneId, 'example.com/*', 'edge-optimize-router');
+```
+
+### `deleteRoute(zoneId, routeId)`
+
+Deletes a Worker route from a zone.
+
+```javascript
+await client.deleteRoute(zoneId, routeId);
+```
+
+## Error handling
+
+All methods reject with a descriptive `Error` when:
+
+- a required argument is missing,
+- the Cloudflare API responds with a non-OK HTTP status,
+- the response body is not valid JSON, or
+- the response carries `success: false`.
+
+The error message includes the targeted path and, where available, the
+Cloudflare error message or the truncated response body.
+
+## License
+
+Apache-2.0

--- a/packages/spacecat-shared-cloudflare-client/package.json
+++ b/packages/spacecat-shared-cloudflare-client/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@adobe/spacecat-shared-cloudflare-client",
+  "version": "1.0.0",
+  "description": "Shared modules of the Spacecat Services - Cloudflare Client",
+  "type": "module",
+  "engines": {
+    "node": ">=22.0.0 <25.0.0",
+    "npm": ">=10.9.0 <12.0.0"
+  },
+  "main": "src/index.js",
+  "types": "src/index.d.ts",
+  "scripts": {
+    "test": "c8 mocha",
+    "lint": "eslint .",
+    "clean": "rm -rf package-lock.json node_modules"
+  },
+  "mocha": {
+    "require": "test/setup-env.js",
+    "reporter": "mocha-multi-reporters",
+    "reporter-options": "configFile=.mocha-multi.json",
+    "spec": "test/**/*.test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/spacecat-shared.git"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/adobe/spacecat-shared/issues"
+  },
+  "homepage": "https://github.com/adobe/spacecat-shared#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@adobe/spacecat-shared-utils": "1.81.1"
+  },
+  "devDependencies": {
+    "chai": "6.2.2",
+    "chai-as-promised": "8.0.2",
+    "nock": "14.0.15",
+    "sinon": "22.0.0",
+    "sinon-chai": "4.0.1",
+    "typescript": "6.0.3"
+  }
+}

--- a/packages/spacecat-shared-cloudflare-client/src/cloudflare-client.js
+++ b/packages/spacecat-shared-cloudflare-client/src/cloudflare-client.js
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { hasText, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+
+const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
+
+export default class CloudflareClient {
+  /**
+   * Creates a CloudflareClient from a Universal context.
+   * Reads the API token from context.env.CLOUDFLARE_API_TOKEN.
+   * @param {object} context - Universal function context
+   * @returns {CloudflareClient}
+   */
+  static createFrom(context) {
+    const { env, log = console } = context;
+    const { CLOUDFLARE_API_TOKEN: token } = env;
+    if (!hasText(token)) {
+      throw new Error('CloudflareClient requires CLOUDFLARE_API_TOKEN in context.env');
+    }
+    return new CloudflareClient({ token }, log);
+  }
+
+  /**
+   * @param {{ token: string, apiBase?: string }} config
+   * @param {object} [log]
+   */
+  constructor({ token, apiBase = CF_API_BASE }, log = console) {
+    if (!hasText(token)) {
+      throw new Error('CloudflareClient requires a token');
+    }
+    this.token = token;
+    this.apiBase = apiBase;
+    this.log = log;
+  }
+
+  async #cfFetch(path, options = {}) {
+    const url = `${this.apiBase}${path}`;
+    const res = await fetch(url, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        ...options.headers,
+      },
+    });
+    const body = await res.json();
+    if (!body.success) {
+      const msg = body.errors?.[0]?.message || `Cloudflare API error on ${path}`;
+      throw new Error(msg);
+    }
+    return body.result;
+  }
+
+  /**
+   * Lists all Cloudflare accounts accessible with the current token.
+   * @returns {Promise<Array<{id: string, name: string}>>}
+   */
+  async listAccounts() {
+    this.log.info('Listing Cloudflare accounts');
+    return this.#cfFetch('/accounts?per_page=50');
+  }
+
+  /**
+   * Uploads a Worker script as an ES module, binding env vars and enabling logs.
+   *
+   * @param {string} accountId
+   * @param {string} scriptName
+   * @param {string} scriptContent - Worker source (ES module)
+   * @param {Array<{name: string, type: string, text?: string}>} [bindings]
+   * @param {object} [opts]
+   * @param {string}  [opts.compatibilityDate]
+   * @param {boolean} [opts.observability] - Enable Workers Logs (default: true)
+   * @returns {Promise<object>}
+   */
+  async deployWorkerScript(accountId, scriptName, scriptContent, bindings = [], opts = {}) {
+    const {
+      compatibilityDate = '2025-01-01',
+      observability = true,
+    } = opts;
+
+    const metadata = {
+      main_module: 'worker.js',
+      bindings,
+      compatibility_date: compatibilityDate,
+      ...(observability && { observability: { enabled: true } }),
+    };
+
+    const form = new FormData();
+    form.append('metadata', new Blob([JSON.stringify(metadata)], { type: 'application/json' }));
+    form.append('worker.js', new Blob([scriptContent], { type: 'application/javascript+module' }), 'worker.js');
+
+    this.log.info(`Deploying worker script '${scriptName}' to account ${accountId}`);
+    return this.#cfFetch(`/accounts/${accountId}/workers/scripts/${scriptName}`, {
+      method: 'PUT',
+      body: form,
+    });
+  }
+
+  /**
+   * Sets an encrypted secret on a deployed Worker script.
+   *
+   * @param {string} accountId
+   * @param {string} scriptName
+   * @param {string} secretName
+   * @param {string} secretValue
+   * @returns {Promise<object>}
+   */
+  async setWorkerSecret(accountId, scriptName, secretName, secretValue) {
+    this.log.info(`Setting secret '${secretName}' on worker '${scriptName}'`);
+    return this.#cfFetch(`/accounts/${accountId}/workers/scripts/${scriptName}/secrets`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: secretName, text: secretValue, type: 'secret_text' }),
+    });
+  }
+
+  /**
+   * Lists active Cloudflare zones accessible with the current token.
+   * @returns {Promise<Array<{id: string, name: string}>>}
+   */
+  async listZones() {
+    this.log.info('Listing Cloudflare zones');
+    return this.#cfFetch('/zones?per_page=50&status=active');
+  }
+
+  /**
+   * Lists all Worker routes for a zone.
+   * @param {string} zoneId
+   * @returns {Promise<Array<{id: string, pattern: string, script: string}>>}
+   */
+  async listRoutes(zoneId) {
+    this.log.info(`Listing routes for zone ${zoneId}`);
+    return this.#cfFetch(`/zones/${zoneId}/workers/routes`);
+  }
+
+  /**
+   * Adds a Worker route to a zone.
+   * @param {string} zoneId
+   * @param {string} pattern - Route pattern, e.g. "example.com/*"
+   * @param {string} scriptName - Worker script name to attach
+   * @returns {Promise<{id: string, pattern: string, script: string}>}
+   */
+  async addRoute(zoneId, pattern, scriptName) {
+    this.log.info(`Adding route '${pattern}' → '${scriptName}' on zone ${zoneId}`);
+    return this.#cfFetch(`/zones/${zoneId}/workers/routes`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pattern, script: scriptName }),
+    });
+  }
+
+  /**
+   * Deletes a Worker route from a zone.
+   * @param {string} zoneId
+   * @param {string} routeId
+   * @returns {Promise<object>}
+   */
+  async deleteRoute(zoneId, routeId) {
+    this.log.info(`Deleting route ${routeId} from zone ${zoneId}`);
+    return this.#cfFetch(`/zones/${zoneId}/workers/routes/${routeId}`, {
+      method: 'DELETE',
+    });
+  }
+}

--- a/packages/spacecat-shared-cloudflare-client/src/cloudflare-client.js
+++ b/packages/spacecat-shared-cloudflare-client/src/cloudflare-client.js
@@ -15,6 +15,8 @@ import { hasText, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
 const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
 
 export default class CloudflareClient {
+  #token;
+
   /**
    * Creates a CloudflareClient from a Universal context.
    * Reads the API token from context.env.CLOUDFLARE_API_TOKEN.
@@ -38,21 +40,38 @@ export default class CloudflareClient {
     if (!hasText(token)) {
       throw new Error('CloudflareClient requires a token');
     }
-    this.token = token;
+    this.#token = token;
     this.apiBase = apiBase;
     this.log = log;
   }
 
   async #cfFetch(path, options = {}) {
     const url = `${this.apiBase}${path}`;
-    const res = await fetch(url, {
-      ...options,
-      headers: {
-        Authorization: `Bearer ${this.token}`,
-        ...options.headers,
-      },
-    });
-    const body = await res.json();
+    let res;
+    try {
+      res = await fetch(url, {
+        ...options,
+        headers: {
+          Authorization: `Bearer ${this.#token}`,
+          ...options.headers,
+        },
+      });
+    } catch (e) {
+      throw new Error(`Cloudflare API request to ${path} failed: ${e.message}`);
+    }
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`Cloudflare API returned ${res.status} on ${path}: ${text.slice(0, 200)}`);
+    }
+
+    let body;
+    try {
+      body = await res.json();
+    } catch {
+      throw new Error(`Cloudflare API returned a non-JSON response on ${path}`);
+    }
+
     if (!body.success) {
       const msg = body.errors?.[0]?.message || `Cloudflare API error on ${path}`;
       throw new Error(msg);
@@ -61,12 +80,19 @@ export default class CloudflareClient {
   }
 
   /**
-   * Lists all Cloudflare accounts accessible with the current token.
+   * Lists Cloudflare accounts accessible with the current token.
+   *
+   * Returns a single page of results. To retrieve more than `perPage` accounts,
+   * call repeatedly with an incrementing `page`.
+   *
+   * @param {object} [options]
+   * @param {number} [options.page=1] - 1-based page number
+   * @param {number} [options.perPage=50] - results per page
    * @returns {Promise<Array<{id: string, name: string}>>}
    */
-  async listAccounts() {
+  async listAccounts({ page = 1, perPage = 50 } = {}) {
     this.log.info('Listing Cloudflare accounts');
-    return this.#cfFetch('/accounts?per_page=50');
+    return this.#cfFetch(`/accounts?page=${page}&per_page=${perPage}`);
   }
 
   /**
@@ -82,6 +108,16 @@ export default class CloudflareClient {
    * @returns {Promise<object>}
    */
   async deployWorkerScript(accountId, scriptName, scriptContent, bindings = [], opts = {}) {
+    if (!hasText(accountId)) {
+      throw new Error('accountId is required');
+    }
+    if (!hasText(scriptName)) {
+      throw new Error('scriptName is required');
+    }
+    if (!hasText(scriptContent)) {
+      throw new Error('scriptContent is required');
+    }
+
     const {
       compatibilityDate = '2025-01-01',
       observability = true,
@@ -115,7 +151,16 @@ export default class CloudflareClient {
    * @returns {Promise<object>}
    */
   async setWorkerSecret(accountId, scriptName, secretName, secretValue) {
-    this.log.info(`Setting secret '${secretName}' on worker '${scriptName}'`);
+    if (!hasText(accountId)) {
+      throw new Error('accountId is required');
+    }
+    if (!hasText(scriptName)) {
+      throw new Error('scriptName is required');
+    }
+    if (!hasText(secretName)) {
+      throw new Error('secretName is required');
+    }
+    this.log.debug(`Setting secret '${secretName}' on worker '${scriptName}'`);
     return this.#cfFetch(`/accounts/${accountId}/workers/scripts/${scriptName}/secrets`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -125,11 +170,18 @@ export default class CloudflareClient {
 
   /**
    * Lists active Cloudflare zones accessible with the current token.
+   *
+   * Returns a single page of results. To retrieve more than `perPage` zones,
+   * call repeatedly with an incrementing `page`.
+   *
+   * @param {object} [options]
+   * @param {number} [options.page=1] - 1-based page number
+   * @param {number} [options.perPage=50] - results per page
    * @returns {Promise<Array<{id: string, name: string}>>}
    */
-  async listZones() {
+  async listZones({ page = 1, perPage = 50 } = {}) {
     this.log.info('Listing Cloudflare zones');
-    return this.#cfFetch('/zones?per_page=50&status=active');
+    return this.#cfFetch(`/zones?page=${page}&per_page=${perPage}&status=active`);
   }
 
   /**
@@ -138,6 +190,9 @@ export default class CloudflareClient {
    * @returns {Promise<Array<{id: string, pattern: string, script: string}>>}
    */
   async listRoutes(zoneId) {
+    if (!hasText(zoneId)) {
+      throw new Error('zoneId is required');
+    }
     this.log.info(`Listing routes for zone ${zoneId}`);
     return this.#cfFetch(`/zones/${zoneId}/workers/routes`);
   }
@@ -150,6 +205,15 @@ export default class CloudflareClient {
    * @returns {Promise<{id: string, pattern: string, script: string}>}
    */
   async addRoute(zoneId, pattern, scriptName) {
+    if (!hasText(zoneId)) {
+      throw new Error('zoneId is required');
+    }
+    if (!hasText(pattern)) {
+      throw new Error('pattern is required');
+    }
+    if (!hasText(scriptName)) {
+      throw new Error('scriptName is required');
+    }
     this.log.info(`Adding route '${pattern}' → '${scriptName}' on zone ${zoneId}`);
     return this.#cfFetch(`/zones/${zoneId}/workers/routes`, {
       method: 'POST',
@@ -165,6 +229,12 @@ export default class CloudflareClient {
    * @returns {Promise<object>}
    */
   async deleteRoute(zoneId, routeId) {
+    if (!hasText(zoneId)) {
+      throw new Error('zoneId is required');
+    }
+    if (!hasText(routeId)) {
+      throw new Error('routeId is required');
+    }
     this.log.info(`Deleting route ${routeId} from zone ${zoneId}`);
     return this.#cfFetch(`/zones/${zoneId}/workers/routes/${routeId}`, {
       method: 'DELETE',

--- a/packages/spacecat-shared-cloudflare-client/src/index.d.ts
+++ b/packages/spacecat-shared-cloudflare-client/src/index.d.ts
@@ -42,12 +42,17 @@ export interface CloudflareClientConfig {
   apiBase?: string;
 }
 
+export interface PaginationOptions {
+  page?: number;
+  perPage?: number;
+}
+
 export default class CloudflareClient {
   static createFrom(context: object): CloudflareClient;
 
-  constructor(config: CloudflareClientConfig, log?: object): void;
+  constructor(config: CloudflareClientConfig, log?: object);
 
-  listAccounts(): Promise<CloudflareAccount[]>;
+  listAccounts(options?: PaginationOptions): Promise<CloudflareAccount[]>;
 
   deployWorkerScript(
     accountId: string,
@@ -64,7 +69,7 @@ export default class CloudflareClient {
     secretValue: string,
   ): Promise<object>;
 
-  listZones(): Promise<CloudflareZone[]>;
+  listZones(options?: PaginationOptions): Promise<CloudflareZone[]>;
 
   listRoutes(zoneId: string): Promise<WorkerRoute[]>;
 

--- a/packages/spacecat-shared-cloudflare-client/src/index.d.ts
+++ b/packages/spacecat-shared-cloudflare-client/src/index.d.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export interface WorkerBinding {
+  name: string;
+  type: string;
+  text?: string;
+}
+
+export interface DeployOptions {
+  compatibilityDate?: string;
+  observability?: boolean;
+}
+
+export interface CloudflareAccount {
+  id: string;
+  name: string;
+}
+
+export interface CloudflareZone {
+  id: string;
+  name: string;
+}
+
+export interface WorkerRoute {
+  id: string;
+  pattern: string;
+  script: string;
+}
+
+export interface CloudflareClientConfig {
+  token: string;
+  apiBase?: string;
+}
+
+export default class CloudflareClient {
+  static createFrom(context: object): CloudflareClient;
+
+  constructor(config: CloudflareClientConfig, log?: object): void;
+
+  listAccounts(): Promise<CloudflareAccount[]>;
+
+  deployWorkerScript(
+    accountId: string,
+    scriptName: string,
+    scriptContent: string,
+    bindings?: WorkerBinding[],
+    opts?: DeployOptions,
+  ): Promise<object>;
+
+  setWorkerSecret(
+    accountId: string,
+    scriptName: string,
+    secretName: string,
+    secretValue: string,
+  ): Promise<object>;
+
+  listZones(): Promise<CloudflareZone[]>;
+
+  listRoutes(zoneId: string): Promise<WorkerRoute[]>;
+
+  addRoute(zoneId: string, pattern: string, scriptName: string): Promise<WorkerRoute>;
+
+  deleteRoute(zoneId: string, routeId: string): Promise<object>;
+}

--- a/packages/spacecat-shared-cloudflare-client/src/index.js
+++ b/packages/spacecat-shared-cloudflare-client/src/index.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import CloudflareClient from './cloudflare-client.js';
+
+export default CloudflareClient;

--- a/packages/spacecat-shared-cloudflare-client/test/cloudflare-client.test.js
+++ b/packages/spacecat-shared-cloudflare-client/test/cloudflare-client.test.js
@@ -31,6 +31,7 @@ const SCRIPT_NAME = 'edge-optimize-router';
 function makeLog() {
   return {
     info: sinon.stub(),
+    debug: sinon.stub(),
     warn: sinon.stub(),
     error: sinon.stub(),
   };
@@ -38,18 +39,15 @@ function makeLog() {
 
 describe('CloudflareClient', () => {
   let client;
-  let sandbox;
   let log;
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
     log = makeLog();
     client = new CloudflareClient({ token: FAKE_TOKEN }, log);
     nock.disableNetConnect();
   });
 
   afterEach(() => {
-    sandbox.restore();
     nock.cleanAll();
     nock.enableNetConnect();
   });
@@ -101,7 +99,7 @@ describe('CloudflareClient', () => {
     it('returns accounts on success', async () => {
       const result = [{ id: ACCOUNT_ID, name: 'Acme Corp' }];
       nock(CF_API_BASE)
-        .get('/accounts?per_page=50')
+        .get('/accounts?page=1&per_page=50')
         .matchHeader('Authorization', `Bearer ${FAKE_TOKEN}`)
         .reply(200, { success: true, result });
 
@@ -110,9 +108,19 @@ describe('CloudflareClient', () => {
       expect(log.info).to.have.been.calledWith('Listing Cloudflare accounts');
     });
 
+    it('passes through custom page and perPage', async () => {
+      const result = [{ id: ACCOUNT_ID, name: 'Acme Corp' }];
+      nock(CF_API_BASE)
+        .get('/accounts?page=3&per_page=10')
+        .reply(200, { success: true, result });
+
+      const accounts = await client.listAccounts({ page: 3, perPage: 10 });
+      expect(accounts).to.deep.equal(result);
+    });
+
     it('throws when the API returns success:false with an error message', async () => {
       nock(CF_API_BASE)
-        .get('/accounts?per_page=50')
+        .get('/accounts?page=1&per_page=50')
         .reply(200, { success: false, errors: [{ message: 'Unauthorized' }] });
 
       await expect(client.listAccounts()).to.be.rejectedWith('Unauthorized');
@@ -120,11 +128,38 @@ describe('CloudflareClient', () => {
 
     it('throws with a generic message when errors array is empty', async () => {
       nock(CF_API_BASE)
-        .get('/accounts?per_page=50')
+        .get('/accounts?page=1&per_page=50')
         .reply(200, { success: false, errors: [] });
 
       await expect(client.listAccounts())
-        .to.be.rejectedWith('Cloudflare API error on /accounts?per_page=50');
+        .to.be.rejectedWith('Cloudflare API error on /accounts?page=1&per_page=50');
+    });
+
+    it('throws a contextual error on a non-OK HTML response', async () => {
+      nock(CF_API_BASE)
+        .get('/accounts?page=1&per_page=50')
+        .reply(502, '<html>Bad Gateway</html>');
+
+      await expect(client.listAccounts())
+        .to.be.rejectedWith('Cloudflare API returned 502 on /accounts?page=1&per_page=50');
+    });
+
+    it('throws a contextual error when fetch itself fails', async () => {
+      nock(CF_API_BASE)
+        .get('/accounts?page=1&per_page=50')
+        .replyWithError('ECONNREFUSED');
+
+      await expect(client.listAccounts())
+        .to.be.rejectedWith('Cloudflare API request to /accounts?page=1&per_page=50 failed');
+    });
+
+    it('throws a contextual error on a non-JSON 200 response', async () => {
+      nock(CF_API_BASE)
+        .get('/accounts?page=1&per_page=50')
+        .reply(200, 'not json', { 'Content-Type': 'text/plain' });
+
+      await expect(client.listAccounts())
+        .to.be.rejectedWith('Cloudflare API returned a non-JSON response on /accounts?page=1&per_page=50');
     });
   });
 
@@ -133,8 +168,12 @@ describe('CloudflareClient', () => {
   describe('deployWorkerScript', () => {
     it('uploads a worker script with default options', async () => {
       const result = { id: SCRIPT_NAME, etag: 'abc123' };
+      let capturedBody;
       nock(CF_API_BASE)
-        .put(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
+        .put(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`, (body) => {
+          capturedBody = body;
+          return true;
+        })
         .reply(200, { success: true, result });
 
       const res = await client.deployWorkerScript(
@@ -144,6 +183,12 @@ describe('CloudflareClient', () => {
         [{ name: 'HOST', type: 'plain_text', text: 'example.com' }],
       );
       expect(res).to.deep.equal(result);
+      // Verify the multipart body carries the expected metadata, bindings and observability flag.
+      expect(capturedBody).to.contain('"main_module":"worker.js"');
+      expect(capturedBody).to.contain('"compatibility_date":"2025-01-01"');
+      expect(capturedBody).to.contain('"observability":{"enabled":true}');
+      expect(capturedBody).to.contain('"name":"HOST"');
+      expect(capturedBody).to.contain('"text":"example.com"');
       expect(log.info).to.have.been.calledWith(
         `Deploying worker script '${SCRIPT_NAME}' to account ${ACCOUNT_ID}`,
       );
@@ -151,8 +196,12 @@ describe('CloudflareClient', () => {
 
     it('deploys without observability when disabled', async () => {
       const result = { id: SCRIPT_NAME };
+      let capturedBody;
       nock(CF_API_BASE)
-        .put(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
+        .put(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`, (body) => {
+          capturedBody = body;
+          return true;
+        })
         .reply(200, { success: true, result });
 
       const res = await client.deployWorkerScript(
@@ -163,12 +212,17 @@ describe('CloudflareClient', () => {
         { observability: false },
       );
       expect(res).to.deep.equal(result);
+      expect(capturedBody).to.not.contain('observability');
     });
 
     it('accepts a custom compatibilityDate', async () => {
       const result = { id: SCRIPT_NAME };
+      let capturedBody;
       nock(CF_API_BASE)
-        .put(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
+        .put(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`, (body) => {
+          capturedBody = body;
+          return true;
+        })
         .reply(200, { success: true, result });
 
       const res = await client.deployWorkerScript(
@@ -179,6 +233,22 @@ describe('CloudflareClient', () => {
         { compatibilityDate: '2024-06-01' },
       );
       expect(res).to.deep.equal(result);
+      expect(capturedBody).to.contain('"compatibility_date":"2024-06-01"');
+    });
+
+    it('throws when accountId is missing', async () => {
+      await expect(client.deployWorkerScript('', SCRIPT_NAME, 'export default {}'))
+        .to.be.rejectedWith('accountId is required');
+    });
+
+    it('throws when scriptName is missing', async () => {
+      await expect(client.deployWorkerScript(ACCOUNT_ID, '', 'export default {}'))
+        .to.be.rejectedWith('scriptName is required');
+    });
+
+    it('throws when scriptContent is missing', async () => {
+      await expect(client.deployWorkerScript(ACCOUNT_ID, SCRIPT_NAME, ''))
+        .to.be.rejectedWith('scriptContent is required');
     });
 
     it('throws when the API returns an error', async () => {
@@ -203,9 +273,24 @@ describe('CloudflareClient', () => {
 
       const res = await client.setWorkerSecret(ACCOUNT_ID, SCRIPT_NAME, 'MY_SECRET', 's3cr3t');
       expect(res).to.deep.equal(result);
-      expect(log.info).to.have.been.calledWith(
+      expect(log.debug).to.have.been.calledWith(
         `Setting secret 'MY_SECRET' on worker '${SCRIPT_NAME}'`,
       );
+    });
+
+    it('throws when accountId is missing', async () => {
+      await expect(client.setWorkerSecret('', SCRIPT_NAME, 'KEY', 'val'))
+        .to.be.rejectedWith('accountId is required');
+    });
+
+    it('throws when scriptName is missing', async () => {
+      await expect(client.setWorkerSecret(ACCOUNT_ID, '', 'KEY', 'val'))
+        .to.be.rejectedWith('scriptName is required');
+    });
+
+    it('throws when secretName is missing', async () => {
+      await expect(client.setWorkerSecret(ACCOUNT_ID, SCRIPT_NAME, '', 'val'))
+        .to.be.rejectedWith('secretName is required');
     });
 
     it('throws when the API returns an error', async () => {
@@ -225,7 +310,7 @@ describe('CloudflareClient', () => {
     it('returns zones on success', async () => {
       const result = [{ id: ZONE_ID, name: 'example.com' }];
       nock(CF_API_BASE)
-        .get('/zones?per_page=50&status=active')
+        .get('/zones?page=1&per_page=50&status=active')
         .reply(200, { success: true, result });
 
       const zones = await client.listZones();
@@ -233,9 +318,19 @@ describe('CloudflareClient', () => {
       expect(log.info).to.have.been.calledWith('Listing Cloudflare zones');
     });
 
+    it('passes through custom page and perPage', async () => {
+      const result = [{ id: ZONE_ID, name: 'example.com' }];
+      nock(CF_API_BASE)
+        .get('/zones?page=2&per_page=25&status=active')
+        .reply(200, { success: true, result });
+
+      const zones = await client.listZones({ page: 2, perPage: 25 });
+      expect(zones).to.deep.equal(result);
+    });
+
     it('throws when the API returns an error', async () => {
       nock(CF_API_BASE)
-        .get('/zones?per_page=50&status=active')
+        .get('/zones?page=1&per_page=50&status=active')
         .reply(200, { success: false, errors: [{ message: 'Forbidden' }] });
 
       await expect(client.listZones()).to.be.rejectedWith('Forbidden');
@@ -254,6 +349,10 @@ describe('CloudflareClient', () => {
       const routes = await client.listRoutes(ZONE_ID);
       expect(routes).to.deep.equal(result);
       expect(log.info).to.have.been.calledWith(`Listing routes for zone ${ZONE_ID}`);
+    });
+
+    it('throws when zoneId is missing', async () => {
+      await expect(client.listRoutes('')).to.be.rejectedWith('zoneId is required');
     });
 
     it('throws when the API returns an error', async () => {
@@ -281,6 +380,21 @@ describe('CloudflareClient', () => {
       );
     });
 
+    it('throws when zoneId is missing', async () => {
+      await expect(client.addRoute('', 'example.com/*', SCRIPT_NAME))
+        .to.be.rejectedWith('zoneId is required');
+    });
+
+    it('throws when pattern is missing', async () => {
+      await expect(client.addRoute(ZONE_ID, '', SCRIPT_NAME))
+        .to.be.rejectedWith('pattern is required');
+    });
+
+    it('throws when scriptName is missing', async () => {
+      await expect(client.addRoute(ZONE_ID, 'example.com/*', ''))
+        .to.be.rejectedWith('scriptName is required');
+    });
+
     it('throws when the API returns an error', async () => {
       nock(CF_API_BASE)
         .post(`/zones/${ZONE_ID}/workers/routes`)
@@ -305,6 +419,14 @@ describe('CloudflareClient', () => {
       expect(log.info).to.have.been.calledWith(
         `Deleting route ${ROUTE_ID} from zone ${ZONE_ID}`,
       );
+    });
+
+    it('throws when zoneId is missing', async () => {
+      await expect(client.deleteRoute('', ROUTE_ID)).to.be.rejectedWith('zoneId is required');
+    });
+
+    it('throws when routeId is missing', async () => {
+      await expect(client.deleteRoute(ZONE_ID, '')).to.be.rejectedWith('routeId is required');
     });
 
     it('throws when the API returns an error', async () => {

--- a/packages/spacecat-shared-cloudflare-client/test/cloudflare-client.test.js
+++ b/packages/spacecat-shared-cloudflare-client/test/cloudflare-client.test.js
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import nock from 'nock';
+
+import CloudflareClient from '../src/index.js';
+
+use(chaiAsPromised);
+use(sinonChai);
+
+const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
+const FAKE_TOKEN = 'test-cf-token-abc123';
+const ACCOUNT_ID = 'acc-0001';
+const ZONE_ID = 'zone-0001';
+const ROUTE_ID = 'route-0001';
+const SCRIPT_NAME = 'edge-optimize-router';
+
+function makeLog() {
+  return {
+    info: sinon.stub(),
+    warn: sinon.stub(),
+    error: sinon.stub(),
+  };
+}
+
+describe('CloudflareClient', () => {
+  let client;
+  let sandbox;
+  let log;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    log = makeLog();
+    client = new CloudflareClient({ token: FAKE_TOKEN }, log);
+    nock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+
+  // ─── createFrom ──────────────────────────────────────────────────────────
+
+  describe('createFrom', () => {
+    it('creates a client when CLOUDFLARE_API_TOKEN is set', () => {
+      const c = CloudflareClient.createFrom({
+        env: { CLOUDFLARE_API_TOKEN: FAKE_TOKEN },
+        log,
+      });
+      expect(c).to.be.instanceOf(CloudflareClient);
+    });
+
+    it('uses console as default log', () => {
+      const c = CloudflareClient.createFrom({ env: { CLOUDFLARE_API_TOKEN: FAKE_TOKEN } });
+      expect(c).to.be.instanceOf(CloudflareClient);
+    });
+
+    it('throws when CLOUDFLARE_API_TOKEN is missing', () => {
+      expect(() => CloudflareClient.createFrom({ env: {}, log }))
+        .to.throw('CloudflareClient requires CLOUDFLARE_API_TOKEN in context.env');
+    });
+
+    it('throws when CLOUDFLARE_API_TOKEN is an empty string', () => {
+      expect(() => CloudflareClient.createFrom({ env: { CLOUDFLARE_API_TOKEN: '' }, log }))
+        .to.throw('CloudflareClient requires CLOUDFLARE_API_TOKEN in context.env');
+    });
+  });
+
+  // ─── constructor ─────────────────────────────────────────────────────────
+
+  describe('constructor', () => {
+    it('throws when token is empty', () => {
+      expect(() => new CloudflareClient({ token: '' }))
+        .to.throw('CloudflareClient requires a token');
+    });
+
+    it('accepts a custom apiBase', () => {
+      const c = new CloudflareClient({ token: FAKE_TOKEN, apiBase: 'https://custom.example.com' }, log);
+      expect(c).to.be.instanceOf(CloudflareClient);
+    });
+  });
+
+  // ─── listAccounts ────────────────────────────────────────────────────────
+
+  describe('listAccounts', () => {
+    it('returns accounts on success', async () => {
+      const result = [{ id: ACCOUNT_ID, name: 'Acme Corp' }];
+      nock(CF_API_BASE)
+        .get('/accounts?per_page=50')
+        .matchHeader('Authorization', `Bearer ${FAKE_TOKEN}`)
+        .reply(200, { success: true, result });
+
+      const accounts = await client.listAccounts();
+      expect(accounts).to.deep.equal(result);
+      expect(log.info).to.have.been.calledWith('Listing Cloudflare accounts');
+    });
+
+    it('throws when the API returns success:false with an error message', async () => {
+      nock(CF_API_BASE)
+        .get('/accounts?per_page=50')
+        .reply(200, { success: false, errors: [{ message: 'Unauthorized' }] });
+
+      await expect(client.listAccounts()).to.be.rejectedWith('Unauthorized');
+    });
+
+    it('throws with a generic message when errors array is empty', async () => {
+      nock(CF_API_BASE)
+        .get('/accounts?per_page=50')
+        .reply(200, { success: false, errors: [] });
+
+      await expect(client.listAccounts())
+        .to.be.rejectedWith('Cloudflare API error on /accounts?per_page=50');
+    });
+  });
+
+  // ─── deployWorkerScript ──────────────────────────────────────────────────
+
+  describe('deployWorkerScript', () => {
+    it('uploads a worker script with default options', async () => {
+      const result = { id: SCRIPT_NAME, etag: 'abc123' };
+      nock(CF_API_BASE)
+        .put(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
+        .reply(200, { success: true, result });
+
+      const res = await client.deployWorkerScript(
+        ACCOUNT_ID,
+        SCRIPT_NAME,
+        'export default { async fetch(r) { return fetch(r); } }',
+        [{ name: 'HOST', type: 'plain_text', text: 'example.com' }],
+      );
+      expect(res).to.deep.equal(result);
+      expect(log.info).to.have.been.calledWith(
+        `Deploying worker script '${SCRIPT_NAME}' to account ${ACCOUNT_ID}`,
+      );
+    });
+
+    it('deploys without observability when disabled', async () => {
+      const result = { id: SCRIPT_NAME };
+      nock(CF_API_BASE)
+        .put(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
+        .reply(200, { success: true, result });
+
+      const res = await client.deployWorkerScript(
+        ACCOUNT_ID,
+        SCRIPT_NAME,
+        'export default {}',
+        [],
+        { observability: false },
+      );
+      expect(res).to.deep.equal(result);
+    });
+
+    it('accepts a custom compatibilityDate', async () => {
+      const result = { id: SCRIPT_NAME };
+      nock(CF_API_BASE)
+        .put(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
+        .reply(200, { success: true, result });
+
+      const res = await client.deployWorkerScript(
+        ACCOUNT_ID,
+        SCRIPT_NAME,
+        'export default {}',
+        [],
+        { compatibilityDate: '2024-06-01' },
+      );
+      expect(res).to.deep.equal(result);
+    });
+
+    it('throws when the API returns an error', async () => {
+      nock(CF_API_BASE)
+        .put(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
+        .reply(200, { success: false, errors: [{ message: 'Script too large' }] });
+
+      await expect(
+        client.deployWorkerScript(ACCOUNT_ID, SCRIPT_NAME, 'export default {}'),
+      ).to.be.rejectedWith('Script too large');
+    });
+  });
+
+  // ─── setWorkerSecret ─────────────────────────────────────────────────────
+
+  describe('setWorkerSecret', () => {
+    it('sets a secret successfully', async () => {
+      const result = { name: 'MY_SECRET', type: 'secret_text' };
+      nock(CF_API_BASE)
+        .put(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}/secrets`)
+        .reply(200, { success: true, result });
+
+      const res = await client.setWorkerSecret(ACCOUNT_ID, SCRIPT_NAME, 'MY_SECRET', 's3cr3t');
+      expect(res).to.deep.equal(result);
+      expect(log.info).to.have.been.calledWith(
+        `Setting secret 'MY_SECRET' on worker '${SCRIPT_NAME}'`,
+      );
+    });
+
+    it('throws when the API returns an error', async () => {
+      nock(CF_API_BASE)
+        .put(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}/secrets`)
+        .reply(200, { success: false, errors: [{ message: 'Worker not found' }] });
+
+      await expect(
+        client.setWorkerSecret(ACCOUNT_ID, SCRIPT_NAME, 'KEY', 'val'),
+      ).to.be.rejectedWith('Worker not found');
+    });
+  });
+
+  // ─── listZones ───────────────────────────────────────────────────────────
+
+  describe('listZones', () => {
+    it('returns zones on success', async () => {
+      const result = [{ id: ZONE_ID, name: 'example.com' }];
+      nock(CF_API_BASE)
+        .get('/zones?per_page=50&status=active')
+        .reply(200, { success: true, result });
+
+      const zones = await client.listZones();
+      expect(zones).to.deep.equal(result);
+      expect(log.info).to.have.been.calledWith('Listing Cloudflare zones');
+    });
+
+    it('throws when the API returns an error', async () => {
+      nock(CF_API_BASE)
+        .get('/zones?per_page=50&status=active')
+        .reply(200, { success: false, errors: [{ message: 'Forbidden' }] });
+
+      await expect(client.listZones()).to.be.rejectedWith('Forbidden');
+    });
+  });
+
+  // ─── listRoutes ──────────────────────────────────────────────────────────
+
+  describe('listRoutes', () => {
+    it('returns routes for a zone', async () => {
+      const result = [{ id: ROUTE_ID, pattern: 'example.com/*', script: SCRIPT_NAME }];
+      nock(CF_API_BASE)
+        .get(`/zones/${ZONE_ID}/workers/routes`)
+        .reply(200, { success: true, result });
+
+      const routes = await client.listRoutes(ZONE_ID);
+      expect(routes).to.deep.equal(result);
+      expect(log.info).to.have.been.calledWith(`Listing routes for zone ${ZONE_ID}`);
+    });
+
+    it('throws when the API returns an error', async () => {
+      nock(CF_API_BASE)
+        .get(`/zones/${ZONE_ID}/workers/routes`)
+        .reply(200, { success: false, errors: [{ message: 'Zone not found' }] });
+
+      await expect(client.listRoutes(ZONE_ID)).to.be.rejectedWith('Zone not found');
+    });
+  });
+
+  // ─── addRoute ────────────────────────────────────────────────────────────
+
+  describe('addRoute', () => {
+    it('adds a route and returns the result', async () => {
+      const result = { id: ROUTE_ID, pattern: 'example.com/*', script: SCRIPT_NAME };
+      nock(CF_API_BASE)
+        .post(`/zones/${ZONE_ID}/workers/routes`, { pattern: 'example.com/*', script: SCRIPT_NAME })
+        .reply(200, { success: true, result });
+
+      const res = await client.addRoute(ZONE_ID, 'example.com/*', SCRIPT_NAME);
+      expect(res).to.deep.equal(result);
+      expect(log.info).to.have.been.calledWith(
+        `Adding route 'example.com/*' → '${SCRIPT_NAME}' on zone ${ZONE_ID}`,
+      );
+    });
+
+    it('throws when the API returns an error', async () => {
+      nock(CF_API_BASE)
+        .post(`/zones/${ZONE_ID}/workers/routes`)
+        .reply(200, { success: false, errors: [{ message: 'Duplicate route' }] });
+
+      await expect(client.addRoute(ZONE_ID, 'example.com/*', SCRIPT_NAME))
+        .to.be.rejectedWith('Duplicate route');
+    });
+  });
+
+  // ─── deleteRoute ─────────────────────────────────────────────────────────
+
+  describe('deleteRoute', () => {
+    it('deletes a route and returns the result', async () => {
+      const result = { id: ROUTE_ID };
+      nock(CF_API_BASE)
+        .delete(`/zones/${ZONE_ID}/workers/routes/${ROUTE_ID}`)
+        .reply(200, { success: true, result });
+
+      const res = await client.deleteRoute(ZONE_ID, ROUTE_ID);
+      expect(res).to.deep.equal(result);
+      expect(log.info).to.have.been.calledWith(
+        `Deleting route ${ROUTE_ID} from zone ${ZONE_ID}`,
+      );
+    });
+
+    it('throws when the API returns an error', async () => {
+      nock(CF_API_BASE)
+        .delete(`/zones/${ZONE_ID}/workers/routes/${ROUTE_ID}`)
+        .reply(200, { success: false, errors: [{ message: 'Route not found' }] });
+
+      await expect(client.deleteRoute(ZONE_ID, ROUTE_ID)).to.be.rejectedWith('Route not found');
+    });
+  });
+});

--- a/packages/spacecat-shared-cloudflare-client/test/setup-env.js
+++ b/packages/spacecat-shared-cloudflare-client/test/setup-env.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+// eslint-disable-next-line no-console
+console.log('Forcing HTTP/1.1 for Adobe Fetch');
+process.env.HELIX_FETCH_FORCE_HTTP1 = 'true';


### PR DESCRIPTION
Introduces @adobe/spacecat-shared-cloudflare-client, a thin HTTP client that wraps the Cloudflare API for use by spacecat-api-service. Exposes listAccounts, deployWorkerScript (with observability enabled by default), setWorkerSecret, listZones, listRoutes, addRoute, and deleteRoute. 100% test coverage.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
