### PR TITLE
chore(scripts): add cloudflare-client to npm trusted-publisher PACKAGES

### DIFF
--- a/scripts/setup-npm-trusted-publishers.sh
+++ b/scripts/setup-npm-trusted-publishers.sh
@@ -256,6 +256,7 @@ PACKAGES=(
   "@adobe/spacecat-shared-athena-client"
   "@adobe/spacecat-shared-brand-client"
   "@adobe/spacecat-shared-cloud-manager-client"
+  "@adobe/spacecat-shared-cloudflare-client"
   "@adobe/spacecat-shared-content-client"
   "@adobe/spacecat-shared-data-access"
   "@adobe/spacecat-shared-drs-client"


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Adds `@adobe/spacecat-shared-cloudflare-client` to the `PACKAGES` array in `scripts/setup-npm-trusted-publishers.sh` so the npm OIDC trusted-publisher setup script recognises it and its forward-drift check passes.

## 2. Reasoning
`spacecat-shared-cloudflare-client` was introduced in #1720 as a publishable package but was never added to the `PACKAGES` array the trusted-publisher setup script audits. That script's forward-drift check fails closed when a publishable workspace package is missing from `PACKAGES`, so leaving it out would abort the next trusted-publisher setup/verify run. This is the same onboarding step already done for the other client packages.

## 3. High-level overview of the changes
One-line addition to a release-tooling array - no application code, no package release.

- `scripts/setup-npm-trusted-publishers.sh`: `@adobe/spacecat-shared-cloudflare-client` added to `PACKAGES`, alphabetically between `cloud-manager-client` and `content-client`. After this the script's drift check sees zero forward drift and the package is covered by trusted-publisher registration/audit.

No behaviour change for any running service.

## 4. Required information
- Jira / issue: SITES-42702 (migrate spacecat-shared npm publishing to OIDC Trusted Publishers) - https://jira.corp.adobe.com/browse/SITES-42702
- Other: https://www.npmjs.com/package/@adobe/spacecat-shared-cloudflare-client

## 6. Additional information outside the code
Done this session, out of band from this PR (the OIDC bootstrap proper):

- First publish: `@adobe/spacecat-shared-cloudflare-client@1.0.0` manually published to npmjs.org (OIDC cannot bootstrap a name that does not yet exist on npm). Verified via the version-specific manifest and the tarball (both 200).
- Trust binding: GitHub Actions trusted publisher registered for the package on npmjs.com - `{repository: adobe/spacecat-shared, workflow: main.yaml, environment: npm-publish}` - matching the other packages.
- Drift check: ran the setup script's publishable-workspace enumeration against the edited `PACKAGES` array - no forward drift, no stale entries.

## 7. Test plan
(a) Local: replicated the setup script's drift check (node enumeration of publishable workspace packages diffed against `PACKAGES`) - clean in both directions.

(b) On merge: no package release is triggered - the commit touches `scripts/`, not any `packages/<pkg>` source, so semantic-release does not cut a version. The next run of `setup-npm-trusted-publishers.sh` now has cloudflare-client in scope. The package's first OIDC release happens on the next merge to `main` touching its source, publishing with no npm token.
