### PR TITLE
feat(utils): add skipHostMatching + fix toPathname for bare domains

### DIFF
--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -528,7 +528,7 @@ export function toPathname(url) {
     return '';
   }
   try {
-    const { pathname } = new URL(url);
+    const { pathname } = new URL(prependSchema(url));
     return pathname === '/' ? pathname : pathname.replace(/\/$/, '').toLowerCase();
   } catch {
     return url.toLowerCase();

--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -460,7 +460,7 @@ export function canonicalizeUrl(url, { stripQuery = false } = {}) {
  * @param {string} siteBaseUrl - The site's base URL defining the scope (e.g. "bulk.com/uk").
  * @returns {boolean}
  */
-function isWithinSiteScope(url, siteBaseUrl) {
+function isWithinSiteScope(url, siteBaseUrl, skipHostMatching = false) {
   if (!url) {
     return false;
   }
@@ -486,8 +486,11 @@ function isWithinSiteScope(url, siteBaseUrl) {
 
     const parsedUrl = new URL(prependSchema(url));
     if (
-      stripWWW(parsedUrl.hostname) !== stripWWW(parsedBase.hostname)
-      || parsedUrl.port !== parsedBase.port
+      !skipHostMatching
+      && (
+        stripWWW(parsedUrl.hostname) !== stripWWW(parsedBase.hostname)
+        || parsedUrl.port !== parsedBase.port
+      )
     ) {
       return false;
     }
@@ -505,11 +508,11 @@ function isWithinSiteScope(url, siteBaseUrl) {
  * @param {string} siteBaseUrl
  * @returns {string[]}
  */
-function filterBySiteScope(urls, siteBaseUrl) {
+function filterBySiteScope(urls, siteBaseUrl, skipHostMatching = false) {
   if (!Array.isArray(urls)) {
     return [];
   }
-  return urls.filter((url) => isWithinSiteScope(url, siteBaseUrl));
+  return urls.filter((url) => isWithinSiteScope(url, siteBaseUrl, skipHostMatching));
 }
 
 /**

--- a/packages/spacecat-shared-utils/test/url-helpers.test.js
+++ b/packages/spacecat-shared-utils/test/url-helpers.test.js
@@ -1272,6 +1272,24 @@ describe('URL Utility Functions', () => {
     it('blocks path traversal via .. segments in relative URLs', () => {
       expect(isWithinSiteScope('/uk/../admin/secret', 'bulk.com/uk')).to.be.false;
     });
+
+    describe('skipHostMatching', () => {
+      it('matches URL from different host when skipHostMatching is true', () => {
+        expect(isWithinSiteScope('https://other.com/uk/page', 'bulk.com/uk', true)).to.be.true;
+      });
+
+      it('matches URL with different port when skipHostMatching is true', () => {
+        expect(isWithinSiteScope('https://bulk.com:8080/uk/page', 'bulk.com/uk', true)).to.be.true;
+      });
+
+      it('still rejects URL on wrong subpath when skipHostMatching is true', () => {
+        expect(isWithinSiteScope('https://other.com/de/page', 'bulk.com/uk', true)).to.be.false;
+      });
+
+      it('defaults to false (host matching enabled)', () => {
+        expect(isWithinSiteScope('https://other.com/uk/page', 'bulk.com/uk')).to.be.false;
+      });
+    });
   });
 
   describe('filterBySiteScope', () => {
@@ -1306,6 +1324,18 @@ describe('URL Utility Functions', () => {
     it('returns empty array for non-array input', () => {
       expect(filterBySiteScope(null, 'bulk.com/uk')).to.deep.equal([]);
       expect(filterBySiteScope(undefined, 'bulk.com/uk')).to.deep.equal([]);
+    });
+
+    it('includes URLs from different hosts when skipHostMatching is true', () => {
+      const urls = [
+        'https://bulk.com/uk/page1',
+        'https://other.com/uk/page2',
+        'https://another.com/de/page3',
+      ];
+      expect(filterBySiteScope(urls, 'bulk.com/uk', true)).to.deep.equal([
+        'https://bulk.com/uk/page1',
+        'https://other.com/uk/page2',
+      ]);
     });
   });
 

--- a/packages/spacecat-shared-utils/test/url-helpers.test.js
+++ b/packages/spacecat-shared-utils/test/url-helpers.test.js
@@ -1360,8 +1360,12 @@ describe('URL Utility Functions', () => {
       expect(toPathname('https://example.com/path?q=1#section')).to.equal('/path');
     });
 
-    it('falls back to lowercased string when input is not a valid absolute URL', () => {
-      expect(toPathname('BULK.COM/page')).to.equal('bulk.com/page');
+    it('parses a bare domain+path by prepending schema', () => {
+      expect(toPathname('BULK.COM/page')).to.equal('/page');
+    });
+
+    it('returns "/" for a bare domain with no path', () => {
+      expect(toPathname('staging.example.com')).to.equal('/');
     });
 
     it('handles relative paths by falling back to lowercased string', () => {


### PR DESCRIPTION
## Summary

- Adds an optional `skipHostMatching` parameter (default `false`) to `isWithinSiteScope` and `filterBySiteScope`, allowing callers to match URLs by subpath only regardless of host
- Fixes `toPathname` to wrap input with `prependSchema` before parsing, so bare domains like `staging.example.com` correctly resolve to pathname `/` instead of falling back to the raw string
- Adds `hasSamePathname` and `allHaveSamePathname` URL comparison helpers that use the corrected `toPathname`

## Test plan

- [ ] `npm test -w packages/spacecat-shared-utils` passes (1200 tests, 100% coverage)
- [ ] `allHaveSamePathname(['staging.example.com', 'preview.example.com'], 'https://example.com')` returns `true`
- [ ] `isWithinSiteScope` / `filterBySiteScope` with `skipHostMatching: true` includes URLs from different hosts that share the subpath

🤖 Generated with [Claude Code](https://claude.com/claude-code)