### PR TITLE
refactor(utils): reuse normalizePathname inside toPathname

### DIFF
--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -530,7 +530,7 @@ export function toPathname(url) {
       return url;
     }
     const { pathname } = new URL(prependSchema(url));
-    return pathname === '/' ? pathname : pathname.replace(/\/$/, '').toLowerCase();
+    return normalizePathname(pathname).toLowerCase();
   } catch {
     return url.toLowerCase();
   }


### PR DESCRIPTION
## Summary

- `toPathname` previously inlined the same logic as `normalizePathname` (root `/` guard + trailing-slash strip) plus a `.toLowerCase()` call
- Replaced the inline expression with `normalizePathname(pathname).toLowerCase()` to eliminate the duplication

## Test plan

- [ ] `npm test -w packages/spacecat-shared-utils` passes with 100% branch coverage on `url-helpers.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)