### PR TITLE
test(project-engine-client): gate overlay corrections against the vendored swagger

### DIFF
--- a/packages/spacecat-shared-project-engine-client/scripts/apply-overlay.mjs
+++ b/packages/spacecat-shared-project-engine-client/scripts/apply-overlay.mjs
@@ -14,7 +14,7 @@
  * Applies the OpenAPI Overlay in spec/overlays/corrections.yaml to the
  * swagger2openapi output build/openapi3.json, in place. The overlay is the single
  * source of truth for the corrections that align the vendored swagger with the
- * live API's actual behaviour (see that file for CR1-CR10); this script just
+ * live API's actual behaviour (see that file for the full CR list); this script just
  * executes it. The vendored spec/projectengine_swagger_public.yaml is never modified.
  *
  * It implements the subset of the Overlay spec the overlay uses — `update`
@@ -218,8 +218,10 @@ export function applyOverlay(spec, overlay) {
  * Returns a process exit code so the build fails loudly when a correction has gone stale: a
  * 0-match `remove` (`staleRemove`) means upstream may have caught up and the correction should be
  * pruned, so we exit 1. (A 0-match `update` throws from {@link applyAction} and aborts before any
- * write — also a hard failure.) Paths and the logger are injectable so the behaviour is testable
- * without spawning a subprocess; the defaults target this package's real build artefact.
+ * write — also a hard failure.) The overlaid spec is written back BEFORE the stale check, so a
+ * failed run still leaves the produced artefact on disk for local inspection. Paths and the logger
+ * are injectable so the behaviour is testable without spawning a subprocess; the defaults target
+ * this package's real build artefact.
  *
  * @param {object} [opts]
  * @param {string} [opts.specPath] OAS3 doc to overlay (default: build/openapi3.json)

--- a/packages/spacecat-shared-project-engine-client/scripts/apply-overlay.mjs
+++ b/packages/spacecat-shared-project-engine-client/scripts/apply-overlay.mjs
@@ -14,7 +14,7 @@
  * Applies the OpenAPI Overlay in spec/overlays/corrections.yaml to the
  * swagger2openapi output build/openapi3.json, in place. The overlay is the single
  * source of truth for the corrections that align the vendored swagger with the
- * live API's actual behaviour (see that file for CR1-CR3); this script just
+ * live API's actual behaviour (see that file for CR1-CR10); this script just
  * executes it. The vendored spec/projectengine_swagger_public.yaml is never modified.
  *
  * It implements the subset of the Overlay spec the overlay uses — `update`
@@ -212,29 +212,49 @@ export function applyOverlay(spec, overlay) {
   return { total, results };
 }
 
-/** CLI entry: read the converted spec + the overlay, apply in place, log, write back. */
-function main() {
+/**
+ * CLI entry: read the converted spec + the overlay, apply in place, log, write back.
+ *
+ * Returns a process exit code so the build fails loudly when a correction has gone stale: a
+ * 0-match `remove` (`staleRemove`) means upstream may have caught up and the correction should be
+ * pruned, so we exit 1. (A 0-match `update` throws from {@link applyAction} and aborts before any
+ * write — also a hard failure.) Paths and the logger are injectable so the behaviour is testable
+ * without spawning a subprocess; the defaults target this package's real build artefact.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.specPath] OAS3 doc to overlay (default: build/openapi3.json)
+ * @param {string} [opts.overlayPath] overlay file (default: spec/overlays/corrections.yaml)
+ * @param {Pick<Console, 'log' | 'error'>} [opts.logger] sink for progress + failure output
+ * @returns {number} process exit code — 0 on success, 1 when any correction is stale
+ */
+export function main({ specPath, overlayPath, logger = console } = {}) {
   const here = dirname(fileURLToPath(import.meta.url));
   const pkgRoot = resolve(here, '..');
-  const specPath = resolve(pkgRoot, 'build/openapi3.json');
-  const overlayPath = resolve(pkgRoot, 'spec/overlays/corrections.yaml');
-  const spec = JSON.parse(readFileSync(specPath, 'utf-8'));
-  const overlay = yaml.load(readFileSync(overlayPath, 'utf-8'));
+  const resolvedSpecPath = specPath ?? resolve(pkgRoot, 'build/openapi3.json');
+  const resolvedOverlayPath = overlayPath ?? resolve(pkgRoot, 'spec/overlays/corrections.yaml');
+  const spec = JSON.parse(readFileSync(resolvedSpecPath, 'utf-8'));
+  const overlay = yaml.load(readFileSync(resolvedOverlayPath, 'utf-8'));
   const { results } = applyOverlay(spec, overlay);
+  const stale = [];
   for (const r of results) {
-    // eslint-disable-next-line no-console
-    console.log(`overlay: ${r.remove ? 'remove' : 'update'} ${r.target} -> ${r.hits} node(s)`);
+    logger.log(`overlay: ${r.remove ? 'remove' : 'update'} ${r.target} -> ${r.hits} node(s)`);
     if (r.staleRemove) {
-      // eslint-disable-next-line no-console
-      console.warn(`overlay: WARNING remove matched 0 nodes (stale correction?): ${r.target}`);
+      stale.push(r.target);
     }
   }
-  writeFileSync(specPath, JSON.stringify(spec, null, 2), 'utf-8');
-  // eslint-disable-next-line no-console
-  console.log(`✔ overlay applied (${results.length} actions) → ${specPath}`);
+  writeFileSync(resolvedSpecPath, JSON.stringify(spec, null, 2), 'utf-8');
+  if (stale.length > 0) {
+    logger.error(`overlay: FAIL ${stale.length} stale correction(s) matched 0 nodes — upstream may have caught up; prune them from corrections.yaml:`);
+    for (const target of stale) {
+      logger.error(`overlay:   - ${target}`);
+    }
+    return 1;
+  }
+  logger.log(`✔ overlay applied (${results.length} actions) → ${resolvedSpecPath}`);
+  return 0;
 }
 
 // Run only when executed directly (`node scripts/apply-overlay.mjs`), not when imported by tests.
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main();
+  process.exitCode = main();
 }

--- a/packages/spacecat-shared-project-engine-client/spec/overlays/corrections.yaml
+++ b/packages/spacecat-shared-project-engine-client/spec/overlays/corrections.yaml
@@ -53,6 +53,15 @@ info:
 #      swagger's AISettings schema omits it, so a typed fixture/handler that populates it fails
 #      tsc. Add it (string) so the type, the factory, and the live API agree. Remove if Semrush
 #      adds the field upstream.
+# CR10 Add `primary_url` + `root_domain` to model.AIOBenchmarkWithCounters. The live benchmarks
+#      list returns both alongside the already-present `project_id` (verified 2026-06-25 against
+#      prod) — same pattern as CR9 — but the vendored swagger omits them. Add them (string).
+#      Remove if Semrush adds the fields upstream.
+#
+# Freshness gate: test/overlay.test.js asserts every action above still APPLIES (matches >0
+# nodes) and is still NECESSARY (changes the converted vendored swagger) — so a re-vendored
+# spec that makes a correction stale or redundant fails CI. `npm run spec:overlay` likewise
+# exits non-zero on a stale (0-match) correction.
 actions:
   # ── CR1: Add GET /v1/ai_models ──────────────────────────────────────────
   # Live: 200 -> { page:int, total:int, items:[AIModelResponse] }.

--- a/packages/spacecat-shared-project-engine-client/test/overlay.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/overlay.test.js
@@ -12,12 +12,35 @@
 
 import { expect } from 'chai';
 import {
+  readFileSync, writeFileSync, mkdtempSync, rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import {
+  join, resolve, dirname,
+} from 'node:path';
+import { fileURLToPath } from 'node:url';
+import sinon from 'sinon';
+import yaml from 'js-yaml';
+import swagger2openapi from 'swagger2openapi';
+import {
   parsePath,
   select,
   deepMerge,
   applyAction,
   applyOverlay,
+  main,
 } from '../scripts/apply-overlay.mjs';
+
+const PKG_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const VENDORED_SPEC = resolve(PKG_ROOT, 'spec/projectengine_swagger_public.yaml');
+const OVERLAY = resolve(PKG_ROOT, 'spec/overlays/corrections.yaml');
+
+/** Reproduces `npm run spec:convert`: the vendored swagger 2.0 → the OAS3 doc the overlay edits. */
+async function convertVendoredSpec() {
+  const swagger = yaml.load(readFileSync(VENDORED_SPEC, 'utf-8'));
+  const { openapi } = await swagger2openapi.convertObj(swagger, { patch: true });
+  return openapi;
+}
 
 describe('apply-overlay: parsePath', () => {
   it('parses key, bracketed-key, wildcard and filter segments', () => {
@@ -165,5 +188,88 @@ describe('apply-overlay: applyOverlay', () => {
         target: "$.params[?(@.name == 'gone')]", remove: true, hits: 0, staleRemove: true,
       },
     ]);
+  });
+});
+
+// The freshness gate (issue #1731): every correction in corrections.yaml must still do real work
+// against the swagger we vendor. This runs the SAME pipeline as `npm run spec:convert` (vendored
+// swagger 2.0 → OAS3) and then applies each correction, asserting it both still applies (matches
+// >0 nodes) and is still necessary (actually changes the spec). It is fully offline — no live API,
+// no credentials, no cron — so a re-vendored swagger that makes a correction stale or redundant
+// fails CI here, instead of drifting silently until the next manual live-capture pass.
+describe('apply-overlay: freshness gate (corrections vs the vendored swagger)', () => {
+  it('every correction still applies (>0 nodes) and is still necessary (changes the spec)', async () => {
+    const spec = await convertVendoredSpec();
+    const overlay = yaml.load(readFileSync(OVERLAY, 'utf-8'));
+    expect(overlay.actions.length, 'the overlay must declare at least one correction').to.be.greaterThan(0);
+
+    for (const action of overlay.actions) {
+      const label = action.description || action.target;
+      const before = structuredClone(spec);
+      // A 0-match `update` throws from applyAction; a 0-match `remove` returns 0 (caught below).
+      // Actions apply in order to the running doc, as applyOverlay/main run them.
+      const hits = applyAction(spec, action);
+      expect(
+        hits,
+        `correction matched 0 nodes — it is STALE (upstream moved/removed the target): ${label}`,
+      ).to.be.greaterThan(0);
+      expect(
+        spec,
+        `correction is a no-op — it is REDUNDANT (the vendored swagger already declares it): ${label}`,
+      ).to.not.deep.equal(before);
+    }
+  });
+});
+
+describe('apply-overlay: main (CLI exit code)', () => {
+  const sandbox = sinon.createSandbox();
+  let tmp;
+  let logger;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'pe-overlay-'));
+    logger = { log: sandbox.spy(), error: sandbox.spy() };
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    sandbox.restore();
+  });
+
+  const errorOutput = () => logger.error.getCalls().map((c) => c.args.join(' ')).join('\n');
+
+  it('returns 0, applies the overlay, and writes the spec back', () => {
+    const specPath = join(tmp, 'openapi3.json');
+    const overlayPath = join(tmp, 'corrections.yaml');
+    writeFileSync(specPath, JSON.stringify({ paths: { '/a': { get: {} } }, components: {} }));
+    writeFileSync(overlayPath, yaml.dump({
+      actions: [
+        { target: '$.components.x', update: { v: 1 } },
+        { target: "$.paths['/a']", remove: true },
+      ],
+    }));
+
+    const code = main({ specPath, overlayPath, logger });
+
+    expect(code).to.equal(0);
+    expect(logger.error.called).to.equal(false);
+    const written = JSON.parse(readFileSync(specPath, 'utf-8'));
+    expect(written.components.x).to.deep.equal({ v: 1 });
+    expect(written.paths).to.deep.equal({});
+  });
+
+  it('returns 1 and reports every stale (0-match remove) correction', () => {
+    const specPath = join(tmp, 'openapi3.json');
+    const overlayPath = join(tmp, 'corrections.yaml');
+    writeFileSync(specPath, JSON.stringify({ params: [{ name: 'id' }] }));
+    writeFileSync(overlayPath, yaml.dump({
+      actions: [{ target: "$.params[?(@.name == 'gone')]", remove: true }],
+    }));
+
+    const code = main({ specPath, overlayPath, logger });
+
+    expect(code).to.equal(1);
+    expect(errorOutput()).to.include('stale correction');
+    expect(errorOutput()).to.include("$.params[?(@.name == 'gone')]");
   });
 });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Adds an offline CI freshness gate to `spacecat-shared-project-engine-client` that asserts every overlay correction in `spec/overlays/corrections.yaml` still applies and is still necessary against the vendored Semrush swagger, and hardens the overlay build script to fail loudly on a stale correction.

## 2. Reasoning
The package mocks the Semrush Project Engine API by applying overlay corrections (CR1–CR10) on top of a vendored swagger that is never hand-edited. Each correction patches a divergence between that vendored spec and the real live API. Until now nothing detected when a correction silently drifted — became a dead no-op because its target moved, or became redundant because the vendored swagger caught up. That only surfaced when someone re-ran the manual live-capture recipe. The build script already computed a `staleRemove` signal but merely warned and exited zero, so drift could land unnoticed.

## 3. High-level overview of the changes
Behaviour delta:

- **New CI gate (offline).** A test reproduces the `spec:convert` step (vendored swagger 2.0 → OAS3) and then applies each overlay action against that converted doc, asserting per correction that it (a) still matches more than zero nodes — *still applies* — and (b) actually mutates the spec — *still necessary*. A re-vendored swagger that makes any correction stale (target moved/removed) or redundant (upstream now declares it) now fails CI, instead of drifting silently until the next manual pass. No live API, credentials, or scheduled job are involved.
- **Build script now fails loudly.** `scripts/apply-overlay.mjs` `main()` previously printed a warning and exited zero on a 0-match (stale) `remove`. It now returns a process exit code that is non-zero when any correction is stale, so `npm run spec:overlay` — and the `npm run generate` chain — stops rather than producing types/models from a quietly-degraded overlay. `main()` is exported and accepts injectable spec/overlay paths and a logger so the exit-code behaviour is directly testable.
- **Docs.** Added the missing CR10 entry to the corrections summary comment and a short note describing the gate; corrected a stale "CR1–CR3" reference in the script docblock to "CR1–CR10".

Scope note: detecting an *insufficient* correction (upstream added a field the consumer uses that the mock does not model) is intentionally out of scope — that needs live-API / consumer knowledge, which this offline gate deliberately avoids.

## 4. Required information
- Jira / issue: https://github.com/adobe/spacecat-shared/issues/1731

## 6. Additional information outside the code
Ran the real overlay pipeline against the committed sources this session — `npm run spec:convert` followed by `npm run spec:overlay` — and observed it apply all 21 overlay actions and exit zero (no stale corrections today), confirming the hardened CLI's success path on the real default paths. `build/openapi3.json` is gitignored, so the gate reproduces the convert step from the vendored YAML rather than reading a committed artefact.

## 7. Test plan
- Local: the freshness gate runs as part of the package's normal test suite (`npm test -w packages/spacecat-shared-project-engine-client`) — fully offline, no setup. It is also exercised by the real `spec:convert` + `spec:overlay` run described in section 6.
- Per-environment: none. This change touches only the package's test suite and a build-time script (`scripts/`), neither of which is published (`files: ["src"]`) or deployed. There is no eph/dev/stage/prod verification step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
