### PR TITLE
feat(user-manager-client): publish stateful mock as an HTTPS Docker image

### DIFF
--- a/.github/workflows/user-manager-client-mock-image-smoke.yaml
+++ b/.github/workflows/user-manager-client-mock-image-smoke.yaml
@@ -1,0 +1,126 @@
+name: User Manager Client Mock Image Smoke
+
+# PR-time guard that the mock Docker image actually BUILDS and BOOTS.
+#
+# The publish workflow (user-manager-client-mock-image.yaml) only runs on the release tag, so
+# without this a broken Dockerfile / Caddyfile / entrypoint would not surface until release — on a
+# tag, where it is hardest to fix. This builds the image and smoke-tests a throwaway container on
+# every PR that touches the package, so the same break is caught on the PR that introduces it.
+#
+# Path-gated (like user-manager-mock-e2e.yaml) so the Docker build cost is only paid when the
+# image's inputs change. Builds locally only — never pushes, no registry/OIDC auth (permissions
+# are read-only), independent of main.yaml's release path.
+
+permissions: {}
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/spacecat-shared-user-manager-client/Dockerfile'
+      - 'packages/spacecat-shared-user-manager-client/Caddyfile'
+      - 'packages/spacecat-shared-user-manager-client/docker-entrypoint.sh'
+      - 'packages/spacecat-shared-user-manager-client/.dockerignore'
+      - 'packages/spacecat-shared-user-manager-client/mock/**'
+      - 'packages/spacecat-shared-user-manager-client/spec/**'
+      - 'packages/spacecat-shared-user-manager-client/scripts/**'
+      - '.github/workflows/user-manager-client-mock-image-smoke.yaml'
+  pull_request:
+    paths:
+      - 'packages/spacecat-shared-user-manager-client/Dockerfile'
+      - 'packages/spacecat-shared-user-manager-client/Caddyfile'
+      - 'packages/spacecat-shared-user-manager-client/docker-entrypoint.sh'
+      - 'packages/spacecat-shared-user-manager-client/.dockerignore'
+      - 'packages/spacecat-shared-user-manager-client/mock/**'
+      - 'packages/spacecat-shared-user-manager-client/spec/**'
+      - 'packages/spacecat-shared-user-manager-client/scripts/**'
+      - '.github/workflows/user-manager-client-mock-image-smoke.yaml'
+  workflow_dispatch:
+
+# One run per PR branch; cancel superseded runs.
+concurrency:
+  group: user-manager-client-mock-image-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE: um-mock-smoke:ci
+  BASE: https://localhost:8443/enterprise/users/api
+  # Seeded by the default MOCK_SEED (parent-with-child): the parent's family listing includes this
+  # child id, so asserting it appears proves the stateful family walk served real data, not an echo
+  # of the path id. Both ids are from mock/seeds.js (SEED_IDS).
+  PARENT_ID: a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
+  CHILD_ID: b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e
+
+jobs:
+  smoke:
+    name: Build & smoke-test mock image
+    runs-on: ubuntu-latest
+    # Bound a wedged build / a container that never goes healthy.
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: 'false'
+
+      - name: Build image
+        # Same context + Dockerfile the publish workflow uses, so a build break here is the build
+        # break that would otherwise only appear at release. Loads into the local daemon (no push).
+        run: docker build -t "$IMAGE" packages/spacecat-shared-user-manager-client
+
+      - name: Run throwaway container
+        run: |
+          docker run -d --name um-mock-smoke -p 127.0.0.1:8443:8443 "$IMAGE"
+
+      - name: Wait for healthy
+        # The image's own HEALTHCHECK is the readiness contract; poll it instead of re-implementing
+        # a probe. Fail fast (and dump logs) if it never goes healthy.
+        run: |
+          for i in $(seq 1 30); do
+            state=$(docker inspect -f '{{.State.Status}}' um-mock-smoke 2>/dev/null || echo missing)
+            health=$(docker inspect -f '{{.State.Health.Status}}' um-mock-smoke 2>/dev/null || echo missing)
+            echo "state[$i]: $state / health: $health"
+            [ "$health" = "healthy" ] && exit 0
+            # Fail fast on a crashed container instead of sleeping through all 30 iterations.
+            case "$state" in
+              exited|dead) echo "::error::container is $state before becoming healthy"; docker logs um-mock-smoke || true; exit 1 ;;
+            esac
+            [ "$health" = "unhealthy" ] && break
+            sleep 2
+          done
+          echo "::error::container did not become healthy"
+          docker logs um-mock-smoke || true
+          exit 1
+
+      - name: Smoke test — TLS, proxy path, auth guard
+        # Exercises the whole image end to end through Caddy on :8443:
+        #   1. __dump (auth-exempt control route) returns 200            -> TLS terminates + proxy reaches the mock
+        #   2. a real route WITHOUT a bearer token returns 401           -> the auth guard is wired end to end
+        #   3. the same route WITH a bearer token returns 200 + the      -> handler serves real stateful data through
+        #      seeded child id                                              the proxy (the family walk, not a path echo)
+        # -k: the cert is self-signed by design (see docs/mock-docker.md).
+        run: |
+          set -euo pipefail
+
+          echo "1) __dump (auth-exempt) -> 200"
+          curl -ksf "$BASE/__dump" >/dev/null || { echo "::error::__dump did not return 200 over HTTPS"; exit 1; }
+
+          echo "2) GET /v1/workspaces/<parent>/family without token -> 401"
+          code=$(curl -ks -o /dev/null -w '%{http_code}' "$BASE/v1/workspaces/$PARENT_ID/family")
+          [ "$code" = "401" ] || { echo "::error::expected 401 without token, got $code"; exit 1; }
+
+          echo "3) GET /v1/workspaces/<parent>/family with token -> 200 + seeded child"
+          body=$(curl -ksf -H 'Authorization: Bearer smoke-test' "$BASE/v1/workspaces/$PARENT_ID/family")
+          echo "$body" | grep -q "$CHILD_ID" || { echo "::error::authed family response missing seeded child: $body"; exit 1; }
+
+          echo "smoke test passed"
+
+      - name: Dump logs on failure
+        if: failure()
+        run: docker logs um-mock-smoke || true
+
+      - name: Tear down
+        if: always()
+        run: docker rm -f um-mock-smoke || true

--- a/.github/workflows/user-manager-client-mock-image-smoke.yaml
+++ b/.github/workflows/user-manager-client-mock-image-smoke.yaml
@@ -2,7 +2,7 @@ name: User Manager Client Mock Image Smoke
 
 # PR-time guard that the mock Docker image actually BUILDS and BOOTS.
 #
-# The publish workflow (user-manager-client-mock-image.yaml) only runs on the release tag, so
+# The publish workflow (user-manager-client-mock-image.yaml) only runs when a release is published, so
 # without this a broken Dockerfile / Caddyfile / entrypoint would not surface until release — on a
 # tag, where it is hardest to fix. This builds the image and smoke-tests a throwaway container on
 # every PR that touches the package, so the same break is caught on the PR that introduces it.

--- a/.github/workflows/user-manager-client-mock-image-smoke.yaml
+++ b/.github/workflows/user-manager-client-mock-image-smoke.yaml
@@ -21,6 +21,9 @@ on:
       - 'packages/spacecat-shared-user-manager-client/Caddyfile'
       - 'packages/spacecat-shared-user-manager-client/docker-entrypoint.sh'
       - 'packages/spacecat-shared-user-manager-client/.dockerignore'
+      # package.json drives the image build (npm install + the spec:convert/spec:overlay scripts the
+      # Dockerfile runs), so a scripts/deps change there must re-run the smoke.
+      - 'packages/spacecat-shared-user-manager-client/package.json'
       - 'packages/spacecat-shared-user-manager-client/mock/**'
       - 'packages/spacecat-shared-user-manager-client/spec/**'
       - 'packages/spacecat-shared-user-manager-client/scripts/**'
@@ -31,6 +34,9 @@ on:
       - 'packages/spacecat-shared-user-manager-client/Caddyfile'
       - 'packages/spacecat-shared-user-manager-client/docker-entrypoint.sh'
       - 'packages/spacecat-shared-user-manager-client/.dockerignore'
+      # package.json drives the image build (npm install + the spec:convert/spec:overlay scripts the
+      # Dockerfile runs), so a scripts/deps change there must re-run the smoke.
+      - 'packages/spacecat-shared-user-manager-client/package.json'
       - 'packages/spacecat-shared-user-manager-client/mock/**'
       - 'packages/spacecat-shared-user-manager-client/spec/**'
       - 'packages/spacecat-shared-user-manager-client/scripts/**'

--- a/.github/workflows/user-manager-client-mock-image.yaml
+++ b/.github/workflows/user-manager-client-mock-image.yaml
@@ -1,0 +1,91 @@
+name: User Manager Client Mock Image
+
+# Build + push the runnable mock image to GHCR when @adobe/spacecat-shared-user-manager-client
+# releases.
+#
+# semantic-release-monorepo tags each release `@adobe/spacecat-shared-user-manager-client-vX.Y.Z`.
+# That tag is pushed by main.yaml's release job using the ADOBE_BOT_GITHUB_TOKEN PAT which — unlike
+# the default GITHUB_TOKEN — DOES trigger downstream workflows, so keying off the tag fires this
+# build exactly once per release and pins the image version to the published npm version.
+#
+# Deliberately separate from main.yaml (mirroring user-manager-mock-e2e.yaml): main.yaml carries
+# the npm Trusted Publisher binding, and an image-build failure must never be able to touch the npm
+# release/publish path. This workflow never publishes to npm and has no npm/OIDC auth.
+permissions: {}
+
+on:
+  push:
+    tags:
+      - '@adobe/spacecat-shared-user-manager-client-v*'
+  # Manual rebuild for a specific already-published version (incident recovery / first publish).
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build, e.g. 1.2.0 (no leading v)'
+        required: true
+
+concurrency:
+  # Serialize per ref; never cancel an in-flight push (a half-pushed manifest is worse than a wait).
+  group: user-manager-client-mock-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-push:
+    name: Build & push mock image
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write   # push to ghcr.io/adobe/spacecat-shared-user-manager-client-mock
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: 'false'
+
+      - name: Resolve version
+        id: ver
+        shell: bash
+        # All ${{ }} values are passed via env (never inlined into the script body) so neither a
+        # workflow_dispatch input nor any GitHub-context value can be interpolated as shell.
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            # Strip the package-name tag prefix: @adobe/…-client-v1.2.0 -> 1.2.0
+            VERSION="${GITHUB_REF_NAME##*-v}"
+          fi
+          # Anchored both ends: the image tag must be exactly X.Y.Z — reject any trailing junk
+          # (a malformed tag or pre-release suffix) rather than minting a surprising image tag.
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "FAIL: could not parse a semver from '${GITHUB_REF_NAME:-$VERSION}'"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building image version $VERSION"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: packages/spacecat-shared-user-manager-client
+          push: true
+          tags: |
+            ghcr.io/adobe/spacecat-shared-user-manager-client-mock:${{ steps.ver.outputs.version }}
+            ghcr.io/adobe/spacecat-shared-user-manager-client-mock:latest
+          # Keep the manifest a plain image (no attestation manifest) so `services:`/`docker run`
+          # consumers pull a single platform cleanly.
+          provenance: false

--- a/.github/workflows/user-manager-client-mock-image.yaml
+++ b/.github/workflows/user-manager-client-mock-image.yaml
@@ -3,10 +3,19 @@ name: User Manager Client Mock Image
 # Build + push the runnable mock image to GHCR when @adobe/spacecat-shared-user-manager-client
 # releases.
 #
-# semantic-release-monorepo tags each release `@adobe/spacecat-shared-user-manager-client-vX.Y.Z`.
-# That tag is pushed by main.yaml's release job using the ADOBE_BOT_GITHUB_TOKEN PAT which — unlike
-# the default GITHUB_TOKEN — DOES trigger downstream workflows, so keying off the tag fires this
-# build exactly once per release and pins the image version to the published npm version.
+# semantic-release-monorepo tags each release `@adobe/spacecat-shared-user-manager-client-vX.Y.Z`
+# and (via @semantic-release/github) publishes a matching GitHub Release — both authored by
+# main.yaml's release job with the ADOBE_BOT_GITHUB_TOKEN PAT (which, unlike the default
+# GITHUB_TOKEN, DOES trigger downstream workflows).
+#
+# We key off `release: published`, NOT the tag push. @semantic-release/git tags the
+# `chore(release): X.Y.Z [skip ci]` commit, and GitHub suppresses every push-triggered workflow —
+# a tag push included — when the head commit message contains `[skip ci]`. So an `on: push: tags:`
+# trigger here silently never fires (this is the bug the sibling project-engine image hit: its
+# v1.3.0 image was never built and had to be recovered by hand via workflow_dispatch). A `release`
+# event is not a push event, so `[skip ci]` does not apply; it fires once per published release and
+# pins the image to the published npm version. `release` fires for EVERY package in the monorepo, so
+# the job is gated on the tag-name prefix below.
 #
 # Deliberately separate from main.yaml (mirroring user-manager-mock-e2e.yaml): main.yaml carries
 # the npm Trusted Publisher binding, and an image-build failure must never be able to touch the npm
@@ -14,9 +23,8 @@ name: User Manager Client Mock Image
 permissions: {}
 
 on:
-  push:
-    tags:
-      - '@adobe/spacecat-shared-user-manager-client-v*'
+  release:
+    types: [published]
   # Manual rebuild for a specific already-published version (incident recovery / first publish).
   workflow_dispatch:
     inputs:
@@ -32,6 +40,12 @@ concurrency:
 jobs:
   build-push:
     name: Build & push mock image
+    # `release` fires for all packages in the monorepo; only act on this package's releases.
+    # workflow_dispatch (manual recovery) always passes. github.event.release is absent on dispatch,
+    # so the startsWith operand is the empty string there — harmless, the OR short-circuits first.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.release.tag_name, '@adobe/spacecat-shared-user-manager-client-v')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -51,18 +65,19 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
           EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             VERSION="$INPUT_VERSION"
           else
             # Strip the package-name tag prefix: @adobe/…-client-v1.2.0 -> 1.2.0
-            VERSION="${GITHUB_REF_NAME##*-v}"
+            VERSION="${RELEASE_TAG##*-v}"
           fi
           # Anchored both ends: the image tag must be exactly X.Y.Z — reject any trailing junk
           # (a malformed tag or pre-release suffix) rather than minting a surprising image tag.
           if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "FAIL: could not parse a semver from '${GITHUB_REF_NAME:-$VERSION}'"
+            echo "FAIL: could not parse a semver from '${RELEASE_TAG:-$VERSION}'"
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -83,9 +98,10 @@ jobs:
         with:
           context: packages/spacecat-shared-user-manager-client
           push: true
-          tags: |
-            ghcr.io/adobe/spacecat-shared-user-manager-client-mock:${{ steps.ver.outputs.version }}
-            ghcr.io/adobe/spacecat-shared-user-manager-client-mock:latest
+          # Only an immutable, exact X.Y.Z tag that pins to the published npm version. No `:latest`:
+          # consumers reference a known version, and a floating tag would otherwise be clobbered
+          # backwards by a workflow_dispatch recovery build of an older version.
+          tags: ghcr.io/adobe/spacecat-shared-user-manager-client-mock:${{ steps.ver.outputs.version }}
           # Keep the manifest a plain image (no attestation manifest) so `services:`/`docker run`
           # consumers pull a single platform cleanly.
           provenance: false

--- a/packages/spacecat-shared-user-manager-client/.dockerignore
+++ b/packages/spacecat-shared-user-manager-client/.dockerignore
@@ -1,0 +1,13 @@
+# The image installs deps fresh and bakes build/openapi3.json itself, so keep the build context
+# lean — none of these are needed (or wanted) inside the image.
+node_modules
+src
+.counterfact
+build
+coverage
+junit
+test
+docs
+python
+*.log
+test-results.xml

--- a/packages/spacecat-shared-user-manager-client/CLAUDE.md
+++ b/packages/spacecat-shared-user-manager-client/CLAUDE.md
@@ -29,7 +29,7 @@ gateway, `/enterprise/projects/api`) — two deliberately separate packages, one
   **containerized HTTPS form** of the mock (a GHCR image consumed by cross-repo e2e like
   spacecat-api-service, which requires an `https:` origin), see `docs/mock-docker.md` — `Dockerfile`
   + `Caddyfile` (TLS terminator) + `docker-entrypoint.sh` + `docker-compose.yml`, published by
-  `.github/workflows/user-manager-client-mock-image.yaml` on each release tag.
+  `.github/workflows/user-manager-client-mock-image.yaml` when a release is published.
 - `spec/` — the vendored swagger (`spec/usermanager_swagger.yaml`, NEVER edited) +
   `spec/overlays/corrections.yaml` (corrections), applied by `scripts/apply-overlay.mjs`.
 

--- a/packages/spacecat-shared-user-manager-client/CLAUDE.md
+++ b/packages/spacecat-shared-user-manager-client/CLAUDE.md
@@ -25,7 +25,11 @@ gateway, `/enterprise/projects/api`) — two deliberately separate packages, one
   `mock/run.js`), which throws if a handler is authored in a shape it can't guard (fail-closed — no
   route can serve unauthenticated by accident).
   A new file imported by `mock/context.js` is materialized automatically — `LIB_FILES` in
-  `mock/run.js` is auto-derived from the `mock/*.js` files, so there is no list to maintain.
+  `mock/run.js` is auto-derived from the `mock/*.js` files, so there is no list to maintain. For the
+  **containerized HTTPS form** of the mock (a GHCR image consumed by cross-repo e2e like
+  spacecat-api-service, which requires an `https:` origin), see `docs/mock-docker.md` — `Dockerfile`
+  + `Caddyfile` (TLS terminator) + `docker-entrypoint.sh` + `docker-compose.yml`, published by
+  `.github/workflows/user-manager-client-mock-image.yaml` on each release tag.
 - `spec/` — the vendored swagger (`spec/usermanager_swagger.yaml`, NEVER edited) +
   `spec/overlays/corrections.yaml` (corrections), applied by `scripts/apply-overlay.mjs`.
 

--- a/packages/spacecat-shared-user-manager-client/Caddyfile
+++ b/packages/spacecat-shared-user-manager-client/Caddyfile
@@ -1,0 +1,14 @@
+# Caddy terminates TLS on :8443 with the build-time self-signed cert and reverse-proxies to the
+# plain-HTTP Counterfact mock on 127.0.0.1:4010 (mock/run.js default MOCK_PORT). This is the only
+# reason Caddy is in the image: api-service's transport requires an https origin.
+{
+	# No automatic HTTPS / ACME — we serve an explicit baked cert on a fixed port.
+	auto_https off
+	# Disable the admin API; nothing should reconfigure this server at runtime.
+	admin off
+}
+
+https://:8443 {
+	tls /etc/tls/cert.pem /etc/tls/key.pem
+	reverse_proxy 127.0.0.1:4010
+}

--- a/packages/spacecat-shared-user-manager-client/Dockerfile
+++ b/packages/spacecat-shared-user-manager-client/Dockerfile
@@ -1,0 +1,65 @@
+# Runnable-server form of the stateful User Manager Counterfact mock, served over HTTPS.
+#
+# The published client ships only `src/` (`files: ["src"]`), so the mock never reaches consumers
+# via npm. This image is how a cross-repo e2e suite (spacecat-api-service) consumes the mock — the
+# same way spacecat-shared-data-access consumes the mysticat-data-service image for its IT tests.
+#
+# api-service's transport rejects any non-https base URL (rest-transport.js `baseUrl()` throws 503
+# on a non-`https:` scheme), and Counterfact only speaks plain HTTP, so this image runs Caddy as a
+# TLS terminator in front of the mock. TLS is satisfied for real, not bypassed.
+#
+# Build context = THIS package dir. The package has no in-monorepo dependencies (only openapi-fetch
+# + public devDeps incl. counterfact), so a standalone `npm install` resolves everything without
+# the monorepo. `npm run docker:build` invokes this from the package dir.
+FROM node:24-alpine
+
+# caddy   — TLS terminator in front of the plain-HTTP mock
+# openssl — mints the self-signed cert at BUILD time (no private key is committed to this public repo)
+# bash    — entrypoint uses `wait -n` (not available in busybox ash)
+# curl    — HEALTHCHECK probe
+RUN apk add --no-cache caddy openssl bash curl
+
+WORKDIR /app
+
+# Deps first for layer caching. counterfact is a devDependency but is REQUIRED at runtime
+# (mock/run.js spawns its CLI), so a full install — not --omit=dev — is intentional.
+# --legacy-peer-deps: a standalone install (no monorepo lockfile) otherwise ERESOLVE-fails on a
+# build-time-only devDep peer range (openapi-typescript wants typescript@^5, the package pins 6) that
+# the hoisted monorepo install tolerates. openapi-typescript/typescript are unused at runtime.
+COPY package.json ./
+RUN npm install --no-audit --no-fund --ignore-scripts --legacy-peer-deps
+
+# Mock source + spec + overlay tooling.
+COPY mock ./mock
+COPY spec ./spec
+COPY scripts ./scripts
+
+# Bake build/openapi3.json — the gitignored intermediate the runner requires. Only the
+# convert + overlay steps are needed to serve; generate:ts/generate:pydantic produce committed
+# artifacts and need Python, neither of which is needed at runtime.
+RUN npm run spec:convert && npm run spec:overlay
+
+# Self-signed cert for https://…:8443, minted at build time so no key lives in this public repo.
+# SANs cover every host the cert is reached by:
+#   localhost / 127.0.0.1 → test process on the host (local dev + non-containerized CI)
+#   user-manager-client-mock     → reached by docker/compose service alias from a containerized CI job
+# 100-year lifetime so it never silently expires. Test-only: it carries no real trust — consumers
+# disable verification (NODE_TLS_REJECT_UNAUTHORIZED=0) for the e2e process. See docs/mock-docker.md.
+RUN mkdir -p /etc/tls && openssl req -x509 -newkey rsa:2048 -nodes \
+      -keyout /etc/tls/key.pem -out /etc/tls/cert.pem \
+      -days 36500 -subj "/CN=user-manager-client-mock" \
+      -addext "subjectAltName=DNS:localhost,DNS:user-manager-client-mock,IP:127.0.0.1"
+
+COPY Caddyfile /etc/caddy/Caddyfile
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# 8443 (TLS) is the ONLY exposed surface. The mock's plain-HTTP 4010 stays internal: its __* control
+# routes are unauthenticated and /__dump returns the entire store, so the image must only ever be
+# reached over loopback / on an ephemeral CI runner, never a shared host (see docs/mock-docker.md).
+EXPOSE 8443
+
+HEALTHCHECK --interval=5s --timeout=3s --start-period=30s --retries=10 \
+  CMD curl -ksf https://localhost:8443/enterprise/users/api/__dump >/dev/null || exit 1
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/packages/spacecat-shared-user-manager-client/docker-compose.yml
+++ b/packages/spacecat-shared-user-manager-client/docker-compose.yml
@@ -1,0 +1,25 @@
+# Local one-command boot of the User Manager mock over HTTPS.
+#
+#   docker compose up --build
+#   curl -ksf https://localhost:8443/enterprise/users/api/__dump | jq
+#
+# Bound to 127.0.0.1 ONLY: the __* control routes are unauthenticated and /__dump dumps the whole
+# store, so the mock must never be reachable off-loopback (see docs/mock-docker.md, "Security").
+name: user-manager-client-mock
+
+services:
+  user-manager-client-mock:
+    build:
+      context: .
+    image: ghcr.io/adobe/spacecat-shared-user-manager-client-mock:local
+    ports:
+      - "127.0.0.1:8443:8443"
+    environment:
+      # Named startup seed: empty-parent | parent-with-child (default). See docs/mock-usage.md.
+      MOCK_SEED: ${MOCK_SEED:-parent-with-child}
+    healthcheck:
+      test: ["CMD", "curl", "-ksf", "https://localhost:8443/enterprise/users/api/__dump"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 30s

--- a/packages/spacecat-shared-user-manager-client/docker-entrypoint.sh
+++ b/packages/spacecat-shared-user-manager-client/docker-entrypoint.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+#
+# Boots the two processes that make up the image:
+#   1. the Counterfact mock (plain HTTP on MOCK_PORT, default 4010) — mock/run.js
+#   2. Caddy, terminating TLS on :8443 and reverse-proxying to the mock
+#
+# Exits as soon as EITHER process exits, so a dead component stops the container (the healthcheck /
+# orchestrator then fails fast) instead of the container lingering half-up with a 502-ing proxy.
+set -euo pipefail
+
+# Forward termination to the whole process group so a `docker stop` tears down both children.
+trap 'kill 0' INT TERM
+
+node mock/run.js &
+mock_pid=$!
+
+# Wait for the mock to bind before starting Caddy, so proxied requests never 502 in the gap
+# between Caddy coming up and the mock binding :4010. Bounded (~10s) and tied to the mock's
+# liveness: if the mock exits before it binds, fail fast instead of looping forever.
+# __dump is auth-exempt, so no token is needed for the readiness probe.
+mock_url="http://127.0.0.1:${MOCK_PORT:-4010}/enterprise/users/api/__dump"
+mock_ready=
+for _ in $(seq 1 50); do
+  # --max-time 1 caps each probe so the ~10s budget is by contract, not at the mercy of the OS
+  # connect timeout if the socket is open-but-hung.
+  if curl -sf --max-time 1 "$mock_url" >/dev/null 2>&1; then mock_ready=1; break; fi
+  kill -0 "$mock_pid" 2>/dev/null || { echo "mock exited before binding ${mock_url}" >&2; exit 1; }
+  sleep 0.2
+done
+# Fail loudly on a timeout (mock alive but unresponsive) rather than starting Caddy into the very
+# 502 gap this probe exists to prevent. The HEALTHCHECK would catch it downstream, but failing here
+# is louder and faster.
+[ -n "$mock_ready" ] || { echo "mock did not become ready within timeout: ${mock_url}" >&2; exit 1; }
+
+caddy run --config /etc/caddy/Caddyfile --adapter caddyfile &
+
+# `wait -n` returns when the first background job exits; propagate its status.
+wait -n
+exit $?

--- a/packages/spacecat-shared-user-manager-client/docker-entrypoint.sh
+++ b/packages/spacecat-shared-user-manager-client/docker-entrypoint.sh
@@ -19,7 +19,9 @@
 set -euo pipefail
 
 # Forward termination to the whole process group so a `docker stop` tears down both children.
-trap 'kill 0' INT TERM
+# EXIT is included so that when `wait -n` returns (one process died) and the script exits, the
+# surviving process is reaped too, not just on a signal-driven `docker stop`.
+trap 'kill 0' INT TERM EXIT
 
 node mock/run.js &
 mock_pid=$!

--- a/packages/spacecat-shared-user-manager-client/docs/mock-docker.md
+++ b/packages/spacecat-shared-user-manager-client/docs/mock-docker.md
@@ -9,8 +9,9 @@ The published client ships only `src/` (`files: ["src"]`), so the mock is never 
 is the only cross-repo distribution of it.
 
 - **Image:** `ghcr.io/adobe/spacecat-shared-user-manager-client-mock`
-- **Tag:** the published client version, e.g. `:1.2.0`, plus `:latest`. The image version always
-  matches the `@adobe/spacecat-shared-user-manager-client` npm version it was built from.
+- **Tag:** the published client version only, e.g. `:1.2.0` (no `:latest` — see Publishing). The
+  image version always matches the `@adobe/spacecat-shared-user-manager-client` npm version it was
+  built from.
 - **Exposed:** `8443` (HTTPS only)
 - **Base URL inside:** `https://<host>:8443/enterprise/users/api`
 
@@ -92,11 +93,17 @@ If the job itself runs inside a container, reach the service by its alias
 
 ## Publishing (CI)
 
-`.github/workflows/user-manager-client-mock-image.yaml` builds and pushes on the per-package release tag
-`@adobe/spacecat-shared-user-manager-client-v*` (pushed by `main.yaml`'s release job via the
-`ADOBE_BOT_GITHUB_TOKEN` PAT, which triggers downstream workflows). It tags `:<version>` + `:latest`
-and pushes with the workflow's built-in `GITHUB_TOKEN` (`packages: write`). `workflow_dispatch`
-(input: `version`) rebuilds a specific already-published version for the first publish or recovery.
+`.github/workflows/user-manager-client-mock-image.yaml` builds and pushes on the GitHub **`release:
+published`** event for this package (published by `main.yaml`'s release job via `@semantic-release/github`
+with the `ADOBE_BOT_GITHUB_TOKEN` PAT, which triggers downstream workflows). It deliberately keys off
+the release event, NOT a tag push: `@semantic-release/git` tags the `chore(release): X.Y.Z [skip ci]`
+commit, and GitHub suppresses push-triggered workflows (tag pushes included) on a `[skip ci]` head
+commit — so an `on: push: tags:` trigger would silently never fire. The job is gated with an `if:` on
+the `@adobe/spacecat-shared-user-manager-client-v` tag-name prefix (the release event fires for every
+package in the monorepo). It tags only the immutable `:<version>` (no `:latest`, so a
+`workflow_dispatch` recovery of an older version can't clobber a floating tag backwards) and pushes
+with the workflow's built-in `GITHUB_TOKEN` (`packages: write`). `workflow_dispatch` (input: `version`)
+rebuilds a specific already-published version for the first publish or recovery.
 
 **One-time after the first publish:** set the GHCR package visibility to **public** in the package
 settings, so local devs and api-service CI pull with no auth. If org policy forbids a public package,

--- a/packages/spacecat-shared-user-manager-client/docs/mock-docker.md
+++ b/packages/spacecat-shared-user-manager-client/docs/mock-docker.md
@@ -1,0 +1,104 @@
+# User Manager mock — Docker image
+
+The runnable-server form of the [stateful mock](./mock-usage.md), packaged as a Docker image so a
+**cross-repo e2e suite** (e.g. `spacecat-api-service`) can boot it without depending on this
+package's `mock/` source — the same way `spacecat-shared-data-access` consumes the
+`mysticat-data-service` image for its integration tests.
+
+The published client ships only `src/` (`files: ["src"]`), so the mock is never on npm. This image
+is the only cross-repo distribution of it.
+
+- **Image:** `ghcr.io/adobe/spacecat-shared-user-manager-client-mock`
+- **Tag:** the published client version, e.g. `:1.2.0`, plus `:latest`. The image version always
+  matches the `@adobe/spacecat-shared-user-manager-client` npm version it was built from.
+- **Exposed:** `8443` (HTTPS only)
+- **Base URL inside:** `https://<host>:8443/enterprise/users/api`
+
+## Why HTTPS / why Caddy
+
+`spacecat-api-service`'s transport (`rest-transport.js` `baseUrl()`) **throws `503` on any non-https
+base URL** — missing, unparseable, or non-`https:` scheme all fail the same check. Counterfact only
+speaks plain HTTP, so the image runs **Caddy as a TLS terminator** on `:8443`, reverse-proxying to
+the mock on `127.0.0.1:4010`. The `https:` requirement is satisfied for real, not bypassed.
+
+The cert is a **self-signed, build-time** cert (no private key is committed to this public repo).
+It carries no real trust, so the consuming test process disables verification:
+`NODE_TLS_REJECT_UNAUTHORIZED=0`. Its SANs cover `localhost`, `127.0.0.1`, and the compose/CI
+service alias `user-manager-client-mock`.
+
+## Security: loopback / ephemeral only
+
+The mock's `__*` control routes (`/__reset`, `/__seed`, `/__quota`, `/__status`, `/__dump`) are
+**unauthenticated by design** and `/__dump` returns the entire store. The image therefore must only
+ever be reached over **loopback** (local dev) or on an **ephemeral CI runner** — never bound to a
+shared host. `docker-compose.yml` binds `127.0.0.1:8443` for exactly this reason; do the same
+anywhere else.
+
+## Local usage
+
+```bash
+# from packages/spacecat-shared-user-manager-client
+npm run docker:build           # docker build -t …user-manager-client-mock:local .
+npm run docker:run             # docker run --rm -p 127.0.0.1:8443:8443 …:local
+
+# or via compose (adds a healthcheck + the loopback binding)
+docker compose up --build
+
+# verify (note -k: self-signed cert; __dump is auth-exempt)
+curl -ksf https://localhost:8443/enterprise/users/api/__dump | jq
+```
+
+Seed selection and the control routes work exactly as in [`mock-usage.md`](./mock-usage.md) — pass
+`MOCK_SEED` as an env var (`-e MOCK_SEED=empty-parent`), drive `__seed` / `__reset` / `__status`
+over HTTPS.
+
+## Consuming from spacecat-api-service e2e
+
+Same image, same env in local and CI — only the orchestration differs. The serenity transport
+derives both Semrush gateways (projects + users) from the **one** `SEMRUSH_PROJECTS_BASE_URL`
+origin and appends each prefix itself, so the User Manager mock is consumed via the same env var as
+the Project Engine mock — just a different image.
+
+**Env the e2e process needs:**
+
+```bash
+SEMRUSH_PROJECTS_BASE_URL=https://localhost:8443
+NODE_TLS_REJECT_UNAUTHORIZED=0          # accept the mock's self-signed cert (test process only)
+```
+
+`baseUrl()` does no host allowlist — only the `protocol === 'https:'` check — so
+`https://localhost:8443` is accepted with no api-service code change.
+
+**CI (GitHub Actions):**
+
+```yaml
+jobs:
+  e2e:
+    services:
+      user-manager-client-mock:
+        image: ghcr.io/adobe/spacecat-shared-user-manager-client-mock:1.2.0   # pin to the client version
+        ports: ["8443:8443"]
+        # credentials: only needed if the GHCR package is kept private (see below)
+    env:
+      SEMRUSH_PROJECTS_BASE_URL: https://localhost:8443
+      NODE_TLS_REJECT_UNAUTHORIZED: '0'
+    steps:
+      - run: |   # wait for TLS to be up before the suite
+          until curl -ksf https://localhost:8443/enterprise/users/api/__dump >/dev/null; do sleep 1; done
+```
+
+If the job itself runs inside a container, reach the service by its alias
+(`https://user-manager-client-mock:8443`) — that hostname is in the cert SANs.
+
+## Publishing (CI)
+
+`.github/workflows/user-manager-client-mock-image.yaml` builds and pushes on the per-package release tag
+`@adobe/spacecat-shared-user-manager-client-v*` (pushed by `main.yaml`'s release job via the
+`ADOBE_BOT_GITHUB_TOKEN` PAT, which triggers downstream workflows). It tags `:<version>` + `:latest`
+and pushes with the workflow's built-in `GITHUB_TOKEN` (`packages: write`). `workflow_dispatch`
+(input: `version`) rebuilds a specific already-published version for the first publish or recovery.
+
+**One-time after the first publish:** set the GHCR package visibility to **public** in the package
+settings, so local devs and api-service CI pull with no auth. If org policy forbids a public package,
+keep it private and grant the consuming repo (`spacecat-api-service`) read access on the package; CI
+then adds a `docker/login-action` step (or `services.*.credentials`) with `GITHUB_TOKEN`.

--- a/packages/spacecat-shared-user-manager-client/docs/mock-usage.md
+++ b/packages/spacecat-shared-user-manager-client/docs/mock-usage.md
@@ -8,7 +8,8 @@ transport calls (`createSubworkspace` / `getWorkspaceStatus` / `listWorkspaceFam
 `/enterprise/projects/api`); the two are deliberately separate packages, one prefix each.
 
 The mock is an in-workspace dev dependency only — it is NOT in the npm tarball (`files: ["src"]`),
-exposed via the `./mock/*` export and the `mock/` symlink.
+exposed via the `./mock/*` export and the `mock/` symlink. To run the mock as a containerized HTTPS
+service for a cross-repo e2e suite (e.g. spacecat-api-service), see [`mock-docker.md`](./mock-docker.md).
 
 ## 1. Quick start
 

--- a/packages/spacecat-shared-user-manager-client/package.json
+++ b/packages/spacecat-shared-user-manager-client/package.json
@@ -30,6 +30,8 @@
     "generate:pydantic": "command -v datamodel-codegen >/dev/null 2>&1 || { echo 'ERROR: datamodel-codegen not found on PATH. Install it first: pip install datamodel-code-generator'; exit 1; }; datamodel-codegen --input build/openapi3.json --input-file-type openapi --output python/serenity_user_manager/ --output-model-type pydantic_v2.BaseModel",
     "generate": "npm run spec:convert && npm run spec:overlay && npm run generate:ts && npm run generate:pydantic",
     "mock": "node mock/run.js",
+    "docker:build": "docker build -t ghcr.io/adobe/spacecat-shared-user-manager-client-mock:local .",
+    "docker:run": "docker run --rm -p 127.0.0.1:8443:8443 ghcr.io/adobe/spacecat-shared-user-manager-client-mock:local",
     "test:e2e": "MOCK_E2E=1 mocha --no-package --reporter spec --timeout 60000 test/e2e/**/*.e2e.js",
     "test:types": "tsc -p tsconfig.json"
   },


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Packages the stateful User Manager (Semrush sub-workspace lifecycle) Counterfact mock as a Docker image served over HTTPS, plus a release-tag-triggered workflow that builds and pushes it to GHCR version-locked to the published npm package, and a PR-time workflow that smoke-tests the image build. Mirrors the project-engine-client mock Docker packaging for the user-manager-client mock.

## 2. Reasoning
The mock shipped in the base branch (`feat/user_manager`) is the offline test double for the api-service serenity transport's sub-workspace lifecycle, but the published client ships only `src/` (`files: ["src"]`), so consumers cannot get the mock off npm. A cross-repo e2e suite (spacecat-api-service) needs to boot it from its own repo/CI without vendoring the mock source. Two hard constraints shaped the design, identical to the project-engine case: api-service's transport (`rest-transport.js` `baseUrl()`) throws `503` on any non-`https:` origin, and Counterfact only speaks plain HTTP. Distributing the mock as a runnable HTTPS image solves cross-repo consumption cleanly and brings the User Manager gateway to parity with the already-packaged Project Engine gateway mock.

## 3. High-level overview of the changes
Before: the user-manager mock could only be run from inside the package via `npm run mock` (plain HTTP on 4010, in-monorepo). After: the same mock is distributable as `ghcr.io/adobe/spacecat-shared-user-manager-client-mock:<version>`, a self-contained HTTPS service any repo's e2e can `docker run`.

- **Dockerfile** (`node:24-alpine`): full `npm install` (counterfact is a devDep but required at runtime), bakes the gitignored `build/openapi3.json` via `spec:convert` + `spec:overlay` (no Python needed), and mints a self-signed multi-SAN cert (`localhost`, `127.0.0.1`, `user-manager-client-mock`) at build time — no private key is committed to this public repo.
- **Caddy** terminates TLS on `:8443` and reverse-proxies to the plain-HTTP mock on `127.0.0.1:4010`, so api-service's `https:` requirement is satisfied for real, not bypassed.
- **Entrypoint** runs the mock + Caddy and fails fast if either exits; it waits for the mock to bind `:4010` (bounded ~10s, fail-loud on timeout) before starting Caddy, so proxied requests never hit a 502 in the startup gap. **docker-compose.yml** binds `127.0.0.1` only — the `__*` control routes are unauthenticated and `/__dump` returns the whole store, so the image is loopback-/ephemeral-CI-only by design.
- **Publish workflow** (`user-manager-client-mock-image.yaml`): on each per-package release tag `@adobe/spacecat-shared-user-manager-client-v*` it builds and pushes `:<version>` + `:latest` to GHCR with the workflow's `GITHUB_TOKEN` (`packages: write`); deliberately decoupled from `main.yaml` so an image-build failure can never touch the npm release path. A `workflow_dispatch` (input: version) rebuilds a given version for the first publish / recovery.
- **Smoke workflow** (`user-manager-client-mock-image-smoke.yaml`): the publish workflow only builds at release, so this PR-gated workflow builds the image and smoke-tests a throwaway container end to end through Caddy — `__dump` 200 (TLS + proxy), `GET /v1/workspaces/{parent}/family` without a token → 401 (auth guard), with a token → 200 + the seeded child id (the stateful family walk serving real data, not a path echo) — catching a broken Dockerfile/Caddyfile/entrypoint at PR time instead of at release. Read-only permissions, no push.
- `docker:build` / `docker:run` package scripts and a `docs/mock-docker.md` usage doc (local + CI consumption, the `NODE_TLS_REJECT_UNAUTHORIZED=0` recipe, the loopback security note), plus `CLAUDE.md` / `mock-usage.md` cross-references.

The api-service serenity transport derives both Semrush gateways from the one `SEMRUSH_PROJECTS_BASE_URL` origin (host-only; each prefix is appended internally), so this image is consumed via the same env var as the project-engine mock — just a different image. No change to the published `src/` or any client behaviour — this is purely additive packaging.

## 4. Required information
- Jira / issue: LLMO-5616
- Other: project-engine-client mock Docker packaging this mirrors — https://github.com/adobe/spacecat-shared/pull/1732 ; user-manager mock core (base branch) — https://github.com/adobe/spacecat-shared/pull/1734

## 5. Affected / used mysticat-workspace projects
- **spacecat-api-service** — consumes the published image in its e2e (contract: `SEMRUSH_PROJECTS_BASE_URL=https://<host>:8443` + `NODE_TLS_REJECT_UNAUTHORIZED=0`, serenity user-manager transport). Not changed here; wiring is a downstream PR.
- **spacecat-shared-project-engine-client** — sibling package whose Docker packaging this mirrors; shared structure, no shared code.

## 6. Additional information outside the code
Built and booted the image locally and verified end-to-end against a running container:
- HTTPS `__dump` (auth-exempt control route) returns 200 over TLS through Caddy → TLS terminates and the proxy reaches the mock.
- `GET /v1/workspaces/{parent}/family` without a bearer token returns 401 → the auth guard is wired end to end.
- The same route with a bearer token returns 200 and the body contains the seeded child workspace id → the stateful family walk serves real data through the proxy.
- Plain-HTTP request against `:8443` is rejected (400) → proves real TLS, not cleartext.
- The container's own HEALTHCHECK goes `healthy` within the start period.

## 7. Test plan
(a) Local e2e (done): `npm run docker:build` then booted the container; ran the HTTPS `__dump` / 401-without-token / 200+seeded-child / cleartext-rejection checks in section 6 — all passed.

(b) CI (this PR): `user-manager-client-mock-image-smoke.yaml` builds the image and smoke-tests a throwaway container (TLS + proxy + auth guard + stateful read) on every PR touching the image's inputs — so the build is exercised at PR time, not only at release.

(c) Verification after release (this is a registry artifact, not a deployed service — no dev/stage/prod service env applies):
- On release, `main.yaml` pushes the per-package tag, which triggers `user-manager-client-mock-image.yaml`; confirm `ghcr.io/adobe/spacecat-shared-user-manager-client-mock:<version>` appears and `docker run` boots it. The first image can also be produced immediately via `workflow_dispatch`.
- One-time after first publish: set the GHCR package visibility to public (so local devs and api-service CI pull with no auth); if org policy forbids a public package, keep it private and grant `spacecat-api-service` read on the package.

## 8. Deployment & merge order
- Stacked on https://github.com/adobe/spacecat-shared/pull/1734 (base branch `feat/user_manager`, the user-manager mock core) — depends-on: this PR's Dockerfile bakes that mock and its spec/overlay.
- Sequence: merge #1734 to `main` first → rebase/merge this onto `main` → the release tag publishes the first image → a downstream spacecat-api-service PR wires its e2e to the published image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
