### PR TITLE
fix(cloudflare-client): use GET for worker existence check before deploy

### DIFF
--- a/packages/spacecat-shared-cloudflare-client/src/cloudflare-client.js
+++ b/packages/spacecat-shared-cloudflare-client/src/cloudflare-client.js
@@ -70,10 +70,6 @@ export default class CloudflareClient {
       throw new Error(`Cloudflare API returned ${res.status} on ${path}: ${text.slice(0, 200)}`);
     }
 
-    if (fetchOptions.method === 'HEAD') {
-      return true;
-    }
-
     let body;
     try {
       body = await res.json();
@@ -115,7 +111,7 @@ export default class CloudflareClient {
    * @param {string}  [opts.compatibilityDate]
    * @param {boolean} [opts.observability] - Enable Workers Logs (default: true)
    * @param {boolean} [opts.overwrite=false] - Allow replacing an existing script. When false a
-   *   HEAD existence check is performed before upload. This guard is best-effort and not atomic —
+   *   GET existence check is performed before upload. This guard is best-effort and not atomic —
    *   a concurrent deploy could create the script between the check and the PUT.
    * @returns {Promise<object>}
    */
@@ -186,9 +182,10 @@ export default class CloudflareClient {
   }
 
   async #workerExists(accountId, scriptName) {
+    // Cloudflare Workers Scripts API supports GET/PUT on this path, not HEAD (returns 405).
     const result = await this.#cfFetch(
       `/accounts/${accountId}/workers/scripts/${scriptName}`,
-      { method: 'HEAD', allowNotFound: true },
+      { method: 'GET', allowNotFound: true },
     );
     return result !== null;
   }

--- a/packages/spacecat-shared-cloudflare-client/test/cloudflare-client.test.js
+++ b/packages/spacecat-shared-cloudflare-client/test/cloudflare-client.test.js
@@ -264,8 +264,8 @@ describe('CloudflareClient', () => {
 
     it('throws by default when the script already exists', async () => {
       nock(CF_API_BASE)
-        .head(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
-        .reply(200);
+        .get(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
+        .reply(200, { success: true, result: { id: SCRIPT_NAME } });
 
       await expect(
         client.deployWorkerScript(ACCOUNT_ID, SCRIPT_NAME, 'export default {}'),
@@ -275,7 +275,7 @@ describe('CloudflareClient', () => {
     it('deploys when script does not exist and overwrite is false', async () => {
       const result = { id: SCRIPT_NAME, etag: 'abc123' };
       nock(CF_API_BASE)
-        .head(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
+        .get(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
         .reply(404);
       nock(CF_API_BASE)
         .put(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
@@ -297,7 +297,7 @@ describe('CloudflareClient', () => {
 
     it('throws when existence check returns a non-404 error status', async () => {
       nock(CF_API_BASE)
-        .head(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
+        .get(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
         .reply(403, 'Forbidden');
 
       await expect(
@@ -305,9 +305,19 @@ describe('CloudflareClient', () => {
       ).to.be.rejectedWith('Cloudflare API returned 403');
     });
 
+    it('throws when existence check returns 405 (HEAD is not supported on this endpoint)', async () => {
+      nock(CF_API_BASE)
+        .get(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
+        .reply(405, 'Method Not Allowed');
+
+      await expect(
+        client.deployWorkerScript(ACCOUNT_ID, SCRIPT_NAME, 'export default {}'),
+      ).to.be.rejectedWith('Cloudflare API returned 405');
+    });
+
     it('throws when existence check fetch itself fails', async () => {
       nock(CF_API_BASE)
-        .head(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
+        .get(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
         .replyWithError('ECONNREFUSED');
 
       await expect(


### PR DESCRIPTION
## Summary

- Replace `HEAD` with `GET` in `#workerExists` before `deployWorkerScript` uploads a Worker.
- Cloudflare's Workers Scripts API documents **GET** and **PUT** on `/accounts/{account_id}/workers/scripts/{script_name}` but returns **405 Method Not Allowed** for `HEAD`.
- This blocked LLMO Cloudflare onboarding deploys (`Cloudflare API returned 405 on /accounts/.../workers/scripts/edge-optimize-router-...`).

## Root cause

`deployWorkerScript()` runs a pre-upload existence guard when `overwrite: false` (default). The guard used `HEAD`, which Cloudflare rejects on this endpoint, so first-time deploys never reached the `PUT` upload.

## Test plan

- [x] `npm test` in `packages/spacecat-shared-cloudflare-client` — 47 passing, 100% coverage
- [ ] After release, bump `@adobe/spacecat-shared-cloudflare-client` in `spacecat-api-service` and re-test Cloudflare onboarding deploy on dev


Made with [Cursor](https://cursor.com)