### PR TITLE
fix(project-engine-client): build mock image on release event, not tag push

### DIFF
--- a/.github/workflows/project-engine-client-mock-image.yaml
+++ b/.github/workflows/project-engine-client-mock-image.yaml
@@ -98,9 +98,10 @@ jobs:
         with:
           context: packages/spacecat-shared-project-engine-client
           push: true
-          tags: |
-            ghcr.io/adobe/spacecat-shared-project-engine-client-mock:${{ steps.ver.outputs.version }}
-            ghcr.io/adobe/spacecat-shared-project-engine-client-mock:latest
+          # Only an immutable, exact X.Y.Z tag that pins to the published npm version. No `:latest`:
+          # consumers reference a known version, and a floating tag would otherwise be clobbered
+          # backwards by a workflow_dispatch recovery build of an older version.
+          tags: ghcr.io/adobe/spacecat-shared-project-engine-client-mock:${{ steps.ver.outputs.version }}
           # Keep the manifest a plain image (no attestation manifest) so `services:`/`docker run`
           # consumers pull a single platform cleanly.
           provenance: false

--- a/.github/workflows/project-engine-client-mock-image.yaml
+++ b/.github/workflows/project-engine-client-mock-image.yaml
@@ -3,10 +3,19 @@ name: Project Engine Client Mock Image
 # Build + push the runnable mock image to GHCR when @adobe/spacecat-shared-project-engine-client
 # releases.
 #
-# semantic-release-monorepo tags each release `@adobe/spacecat-shared-project-engine-client-vX.Y.Z`.
-# That tag is pushed by main.yaml's release job using the ADOBE_BOT_GITHUB_TOKEN PAT which — unlike
-# the default GITHUB_TOKEN — DOES trigger downstream workflows, so keying off the tag fires this
-# build exactly once per release and pins the image version to the published npm version.
+# semantic-release-monorepo tags each release `@adobe/spacecat-shared-project-engine-client-vX.Y.Z`
+# and (via @semantic-release/github) publishes a matching GitHub Release — both authored by
+# main.yaml's release job with the ADOBE_BOT_GITHUB_TOKEN PAT (which, unlike the default
+# GITHUB_TOKEN, DOES trigger downstream workflows).
+#
+# We key off `release: published`, NOT the tag push. @semantic-release/git tags the
+# `chore(release): X.Y.Z [skip ci]` commit, and GitHub suppresses every push-triggered workflow —
+# a tag push included — when the head commit message contains `[skip ci]`. So an `on: push: tags:`
+# trigger here silently never fires: that is exactly why v1.3.0's image was never built and had to
+# be recovered by hand via workflow_dispatch. A `release` event is not a push event, so `[skip ci]`
+# does not apply; it fires once per published release and pins the image to the published npm
+# version. `release` fires for EVERY package in the monorepo, so the job is gated on the
+# tag-name prefix below.
 #
 # Deliberately separate from main.yaml (mirroring project-engine-mock-e2e.yaml): main.yaml carries
 # the npm Trusted Publisher binding, and an image-build failure must never be able to touch the npm
@@ -14,9 +23,8 @@ name: Project Engine Client Mock Image
 permissions: {}
 
 on:
-  push:
-    tags:
-      - '@adobe/spacecat-shared-project-engine-client-v*'
+  release:
+    types: [published]
   # Manual rebuild for a specific already-published version (incident recovery / first publish).
   workflow_dispatch:
     inputs:
@@ -32,6 +40,12 @@ concurrency:
 jobs:
   build-push:
     name: Build & push mock image
+    # `release` fires for all 21 packages; only act on this package's releases. workflow_dispatch
+    # (manual recovery) always passes. github.event.release is absent on dispatch, so the
+    # startsWith operand is the empty string there — harmless, the OR short-circuits first.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.release.tag_name, '@adobe/spacecat-shared-project-engine-client-v')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -51,18 +65,19 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
           EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             VERSION="$INPUT_VERSION"
           else
             # Strip the package-name tag prefix: @adobe/…-client-v1.2.0 -> 1.2.0
-            VERSION="${GITHUB_REF_NAME##*-v}"
+            VERSION="${RELEASE_TAG##*-v}"
           fi
           # Anchored both ends: the image tag must be exactly X.Y.Z — reject any trailing junk
           # (a malformed tag or pre-release suffix) rather than minting a surprising image tag.
           if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "FAIL: could not parse a semver from '${GITHUB_REF_NAME:-$VERSION}'"
+            echo "FAIL: could not parse a semver from '${RELEASE_TAG:-$VERSION}'"
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Switches the `project-engine-client-mock-image.yaml` GHCR build workflow from an `on: push: tags:` trigger to an `on: release: published` trigger, so the mock image is actually built when `@adobe/spacecat-shared-project-engine-client` releases.

## 2. Reasoning
The mock-image build workflow shipped in PR 1732 keyed off the release tag push (`on: push: tags: '@adobe/spacecat-shared-project-engine-client-v*'`). That trigger never fires: `@semantic-release/git` tags the `chore(release): X.Y.Z [skip ci]` commit, and GitHub suppresses every push-triggered workflow — a tag push included — when the head commit message contains `[skip ci]`. As a result the v1.3.0 release (from PR 1732's own merge) published to npm but never built the Docker image; the run list for the workflow was empty. The 1.3.0 image had to be recovered by hand via `workflow_dispatch`.

## 3. High-level overview of the changes
- Trigger changes from `on: push: tags:` to `on: release: { types: [published] }`. A `release` event is not a push event, so the `[skip ci]` suppression that killed the tag-push trigger does not apply. `@semantic-release/github` (already in the plugin chain) publishes the GitHub Release using the `ADOBE_BOT_GITHUB_TOKEN` PAT, which — unlike the default `GITHUB_TOKEN` — does trigger downstream workflows.
- `release` fires for every package in the 21-package monorepo, so the `build-push` job is now gated with `if:` on the tag-name prefix (`@adobe/spacecat-shared-project-engine-client-v`). Non-matching releases are no-ops; `workflow_dispatch` still always runs.
- Version resolution now reads `github.event.release.tag_name` instead of `GITHUB_REF_NAME` for the automatic path; the `workflow_dispatch` manual path and the strict `X.Y.Z` semver guard are unchanged.
- The image is now tagged with only the immutable `X.Y.Z` version (no `:latest`). The mock image versions track the published `@adobe/spacecat-shared-project-engine-client` npm versions one-to-one; a floating `:latest` is dropped because a `workflow_dispatch` recovery build of an older version would otherwise clobber it backwards.
- Behaviour delta: before — a PE-client release built no image (silent miss, manual recovery required); after — each published PE-client release builds and pushes `ghcr.io/adobe/spacecat-shared-project-engine-client-mock:<version>` exactly once.

## 4. Required information
- Jira / issue: LLMO-5460

## 6. Additional information outside the code
- Recovered the missed v1.3.0 image manually during this session: dispatched the workflow with `version=1.3.0` (run 28231347345) — completed successfully. `ghcr.io/adobe/spacecat-shared-project-engine-client-mock:1.3.0` is present on GHCR. (That run predated this PR and also pushed a `:latest` tag; with `:latest` now removed from the workflow, the leftover `:latest` on GHCR is orphaned and can be deleted.)
- Confirmed the root cause from the tag object: `@adobe/spacecat-shared-project-engine-client-v1.3.0` points at commit `46138136` whose subject is `chore(release): 1.3.0 [skip ci]`, and the mock-image workflow had zero runs in its run history.

## 7. Test plan
- The change cannot be fully exercised pre-merge: the `release: published` workflow definition takes effect from the default branch, and a real release event only occurs on the next PE-client release to `main`. The manual `workflow_dispatch` path is unaffected and was exercised this session (v1.3.0 recovery, above).
- Verify after merge: on the next release that bumps `@adobe/spacecat-shared-project-engine-client`, confirm the "Project Engine Client Mock Image" workflow runs once from the `release` event and pushes the matching version tag to GHCR. If a release lands before then for a different package, confirm this workflow is correctly skipped by the `if:` gate (no image built).

## 8. Deployment & merge order
- Related: PR 1735 (`feat(user-manager-client): publish stateful mock as an HTTPS Docker image`) is open and mirrors this exact `on: push: tags:` pattern for the user-manager mock image. It will ship with the same silent-miss bug unless its trigger is switched to `release: published` the same way before it merges. No hard ordering dependency with this PR — flagging so the fix is carried into 1735 rather than discovered after its first release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
