### PR TITLE
fix(cloudflare-client): filter scripts-search results by script_name not id

### DIFF
--- a/packages/spacecat-shared-cloudflare-client/src/cloudflare-client.js
+++ b/packages/spacecat-shared-cloudflare-client/src/cloudflare-client.js
@@ -191,11 +191,13 @@ export default class CloudflareClient {
   }
 
   async #findWorker(accountId, scriptName) {
-    // name param returns partial matches — filter to exact id.
+    // name param returns partial matches — filter to exact script_name.
+    // Note: the result objects use `script_name` for the worker name (used in URLs/routes);
+    // `id` is the script tag identifier and is not the same value.
     const workers = await this.#cfFetch(
       `/accounts/${accountId}/workers/scripts-search?name=${encodeURIComponent(scriptName)}&per_page=100`,
     );
-    return workers.find((w) => w.id === scriptName) ?? null;
+    return (workers ?? []).find((w) => w.script_name === scriptName) ?? null;
   }
 
   async #getWorkerSettings(accountId, scriptName) {

--- a/packages/spacecat-shared-cloudflare-client/test/cloudflare-client.test.js
+++ b/packages/spacecat-shared-cloudflare-client/test/cloudflare-client.test.js
@@ -265,7 +265,7 @@ describe('CloudflareClient', () => {
     it('throws by default when the script already exists', async () => {
       nock(CF_API_BASE)
         .get(`/accounts/${ACCOUNT_ID}/workers/scripts-search?name=${SCRIPT_NAME}&per_page=100`)
-        .reply(200, { success: true, result: [{ id: SCRIPT_NAME }] });
+        .reply(200, { success: true, result: [{ script_name: SCRIPT_NAME }] });
 
       await expect(
         client.deployWorkerScript(ACCOUNT_ID, SCRIPT_NAME, 'export default {}'),
@@ -277,6 +277,19 @@ describe('CloudflareClient', () => {
       nock(CF_API_BASE)
         .get(`/accounts/${ACCOUNT_ID}/workers/scripts-search?name=${SCRIPT_NAME}&per_page=100`)
         .reply(200, { success: true, result: [] });
+      nock(CF_API_BASE)
+        .put(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
+        .reply(200, { success: true, result });
+
+      const res = await client.deployWorkerScript(ACCOUNT_ID, SCRIPT_NAME, 'export default {}');
+      expect(res).to.deep.equal(result);
+    });
+
+    it('deploys when search returns a null result', async () => {
+      const result = { id: SCRIPT_NAME, etag: 'abc123' };
+      nock(CF_API_BASE)
+        .get(`/accounts/${ACCOUNT_ID}/workers/scripts-search?name=${SCRIPT_NAME}&per_page=100`)
+        .reply(200, { success: true, result: null });
       nock(CF_API_BASE)
         .put(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}`)
         .reply(200, { success: true, result });
@@ -357,7 +370,7 @@ describe('CloudflareClient', () => {
       // search → found; script-settings → has our tag → skip
       nock(CF_API_BASE)
         .get(`/accounts/${ACCOUNT_ID}/workers/scripts-search?name=${SCRIPT_NAME}&per_page=100`)
-        .reply(200, { success: true, result: [{ id: SCRIPT_NAME }] });
+        .reply(200, { success: true, result: [{ script_name: SCRIPT_NAME }] });
       nock(CF_API_BASE)
         .get(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}/script-settings`)
         .reply(200, { success: true, result: { tags: ['createdBy=adobe'] } });
@@ -373,7 +386,7 @@ describe('CloudflareClient', () => {
       // search → found; script-settings → no matching tag → error
       nock(CF_API_BASE)
         .get(`/accounts/${ACCOUNT_ID}/workers/scripts-search?name=${SCRIPT_NAME}&per_page=100`)
-        .reply(200, { success: true, result: [{ id: SCRIPT_NAME }] });
+        .reply(200, { success: true, result: [{ script_name: SCRIPT_NAME }] });
       nock(CF_API_BASE)
         .get(`/accounts/${ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}/script-settings`)
         .reply(200, { success: true, result: { tags: ['createdBy=other'] } });


### PR DESCRIPTION
## Summary

- The `scripts-search` API response objects have two distinct fields: `id` (an internal UUID tag like `abb716cad07c40b4b4ddfd0907b3c9d5`) and `script_name` (the worker name used in URLs/routes)
- `#findWorker` was comparing `w.id === scriptName`, which always evaluates to `false` since `id` is never equal to the worker name
- This caused the existence check to always return `null`, so every second deploy silently overwrote the existing worker instead of returning a conflict error (propagated as 409 from the API service)

## Test plan

- [ ] `npm test -w packages/spacecat-shared-cloudflare-client` — all 52 tests pass, 100% coverage
- [ ] Verified against the live Cloudflare API: `scripts-search` response confirmed `id` = `"abb716cad07c40b4b4ddfd0907b3c9d5"` vs `script_name` = `"edge-optimize-router-frescopa-aem-screens-net"` for the same worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)