### PR TITLE
build(mock-image): slim Semrush mock Docker images (~711MB to 416MB)

### DIFF
--- a/packages/spacecat-shared-project-engine-client/.dockerignore
+++ b/packages/spacecat-shared-project-engine-client/.dockerignore
@@ -11,3 +11,4 @@ docs
 python
 *.log
 test-results.xml
+.DS_Store

--- a/packages/spacecat-shared-project-engine-client/Dockerfile
+++ b/packages/spacecat-shared-project-engine-client/Dockerfile
@@ -8,35 +8,36 @@
 # on a non-`https:` scheme), and Counterfact only speaks plain HTTP, so this image runs Caddy as a
 # TLS terminator in front of the mock. TLS is satisfied for real, not bypassed.
 #
-# Build context = THIS package dir. The package has no in-monorepo dependencies (only openapi-fetch
-# + public devDeps incl. counterfact), so a standalone `npm install` resolves everything without
-# the monorepo. `npm run docker:build` invokes this from the package dir.
-FROM node:24-alpine
+# Build context = THIS package dir. The package has no in-monorepo dependencies, so a standalone
+# install resolves everything without the monorepo. `npm run docker:build` invokes this from the
+# package dir.
+#
+# Two stages keep the runtime image lean: the BUILDER carries the full dev toolchain (to convert +
+# overlay the vendored swagger and mint the cert); the RUNTIME stage ships only the mock engine
+# (counterfact), the built spec, the cert, and Caddy/curl — none of the build/test toolchain.
 
-# caddy   — TLS terminator in front of the plain-HTTP mock
-# openssl — mints the self-signed cert at BUILD time (no private key is committed to this public repo)
-# bash    — entrypoint uses `wait -n` (not available in busybox ash)
-# curl    — HEALTHCHECK probe
-RUN apk add --no-cache caddy openssl bash curl
+# Pinned to the multi-arch index digest of node:24-alpine for reproducibility (works on amd64 CI
+# and arm64 local alike). Bump the digest deliberately when upgrading the base.
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS builder
+
+# openssl is BUILD-ONLY: it mints the self-signed cert below, which is then copied into the runtime
+# stage. The runtime stage never needs openssl.
+RUN apk add --no-cache openssl
 
 WORKDIR /app
 
-# Deps first for layer caching. counterfact is a devDependency but is REQUIRED at runtime
-# (mock/run.js spawns its CLI), so a full install — not --omit=dev — is intentional.
-# --legacy-peer-deps: a standalone install (no monorepo lockfile) otherwise ERESOLVE-fails on a
-# build-time-only devDep peer range (openapi-typescript wants typescript@^5, the package pins 6) that
-# the hoisted monorepo install tolerates. openapi-typescript/typescript are unused at runtime.
+# Full install (incl. devDeps) so spec:convert / spec:overlay can run. --legacy-peer-deps: a
+# standalone install (no monorepo lockfile) otherwise ERESOLVE-fails on a build-only devDep peer
+# range (openapi-typescript wants typescript@^5, the package pins 6) that the hoisted monorepo
+# install tolerates. openapi-typescript/typescript are unused at runtime.
 COPY package.json ./
 RUN npm install --no-audit --no-fund --ignore-scripts --legacy-peer-deps
 
-# Mock source + spec + overlay tooling.
-COPY mock ./mock
+# Bake build/openapi3.json — the gitignored intermediate the runner requires. Only the convert +
+# overlay steps are needed to serve; generate:ts/generate:pydantic produce committed artifacts and
+# need Python, neither of which is needed to run the mock.
 COPY spec ./spec
 COPY scripts ./scripts
-
-# Bake build/openapi3.json — the gitignored intermediate the runner requires. Only the
-# convert + overlay steps are needed to serve; generate:ts/generate:pydantic produce committed
-# artifacts and need Python, neither of which is needed at runtime.
 RUN npm run spec:convert && npm run spec:overlay
 
 # Self-signed cert for https://…:8443, minted at build time so no key lives in this public repo.
@@ -50,9 +51,56 @@ RUN mkdir -p /etc/tls && openssl req -x509 -newkey rsa:2048 -nodes \
       -days 36500 -subj "/CN=project-engine-client-mock" \
       -addext "subjectAltName=DNS:localhost,DNS:project-engine-client-mock,IP:127.0.0.1"
 
+
+# ---- runtime stage -------------------------------------------------------------------------------
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
+
+# caddy — TLS terminator in front of the plain-HTTP mock
+# curl  — HEALTHCHECK probe
+# (openssl and bash are intentionally NOT installed: cert minting happens in the builder, and the
+#  entrypoint is POSIX sh.)
+RUN apk add --no-cache caddy curl
+
+WORKDIR /app
+
+# Runtime deps only. counterfact is the mock's runtime engine (mock/run.js spawns its CLI) but stays
+# a devDependency in package.json so consumers of the PUBLISHED client (files: ["src"]) do NOT
+# inherit it and its ~100 MB build toolchain. The image installs it explicitly here instead: we
+# derive a throwaway runtime-only manifest that promotes counterfact into `dependencies` (pinned to
+# the exact version package.json declares — single source of truth, no drift) and drops every
+# devDependency. With the devDeps gone the ERESOLVE conflict is gone too, so no --legacy-peer-deps.
+COPY package.json ./
+RUN node -e "const p=require('./package.json'); require('fs').writeFileSync('package.json', JSON.stringify({ name: p.name, version: p.version, type: p.type, dependencies: { ...p.dependencies, counterfact: p.devDependencies.counterfact } }, null, 2));" \
+ && npm install --no-audit --no-fund --ignore-scripts --omit=dev \
+ && npm cache clean --force \
+ && find node_modules -type f \( -name '*.map' -o -name '*.md' -o -name '*.markdown' -o -name '*.d.ts' \) -delete
+# ^ npm cache clean + strip runtime-irrelevant files from the dep tree, in the same layer so they
+#   never reach the image: source maps (debug-only), docs, and *.d.ts TYPE DECLARATIONS (type-only,
+#   never executed — counterfact's runtime transpiler is transpile-only, verified by the smoke test).
+#   LICENSE files are kept (3rd-party license compliance); *.ts SOURCE files and package test dirs
+#   are left alone (small, and counterfact's runtime transpile path isn't worth risking for the MB).
+
+# Mock source + the built spec. spec/ and scripts/ are build-only (convert/overlay already ran in
+# the builder), so the runtime image carries only the materialization inputs the runner reads:
+# mock/** and build/openapi3.json.
+COPY mock ./mock
+COPY --from=builder /app/build/openapi3.json ./build/openapi3.json
+# --chown=node so caddy (which runs as the unprivileged `node` user below) can read the TLS key
+# without widening its mode. The key is a build-time self-signed test cert with no real trust.
+COPY --from=builder --chown=node:node /etc/tls /etc/tls
+
 COPY Caddyfile /etc/caddy/Caddyfile
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Run as the unprivileged `node` user (uid 1000, present in the base image) rather than root. Only
+# /app must be writable — the runner materializes handlers into /app/.counterfact at boot — so we
+# chown just the /app DIR (not -R: a recursive chown would duplicate the whole node_modules tree
+# into a new layer). node_modules/build/mock stay root-owned and are read-only at runtime; the
+# world-readable default perms let `node` read them. HOME is set so caddy's storage path is writable.
+ENV HOME=/home/node
+RUN chown node:node /app
+USER node
 
 # 8443 (TLS) is the ONLY exposed surface. The mock's plain-HTTP 4010 stays internal: its __* control
 # routes are unauthenticated and /__dump returns the entire store, so the image must only ever be

--- a/packages/spacecat-shared-project-engine-client/Dockerfile
+++ b/packages/spacecat-shared-project-engine-client/Dockerfile
@@ -70,15 +70,17 @@ WORKDIR /app
 # the exact version package.json declares — single source of truth, no drift) and drops every
 # devDependency. With the devDeps gone the ERESOLVE conflict is gone too, so no --legacy-peer-deps.
 COPY package.json ./
-RUN node -e "const p=require('./package.json'); require('fs').writeFileSync('package.json', JSON.stringify({ name: p.name, version: p.version, type: p.type, dependencies: { ...p.dependencies, counterfact: p.devDependencies.counterfact } }, null, 2));" \
+RUN node -e "const p=require('./package.json'); const cf=p.devDependencies&&p.devDependencies.counterfact; if(!cf){console.error('counterfact missing from devDependencies'); process.exit(1);} require('fs').writeFileSync('package.json', JSON.stringify({ name: p.name, version: p.version, type: p.type, dependencies: { ...p.dependencies, counterfact: cf } }, null, 2));" \
  && npm install --no-audit --no-fund --ignore-scripts --omit=dev \
  && npm cache clean --force \
- && find node_modules -type f \( -name '*.map' -o -name '*.md' -o -name '*.markdown' -o -name '*.d.ts' \) -delete
+ && find node_modules -type f \( -name '*.map' -o -name '*.md' -o -name '*.markdown' -o -name '*.d.ts' \) ! -iname 'LICENSE*' ! -iname 'COPYING*' -delete
 # ^ npm cache clean + strip runtime-irrelevant files from the dep tree, in the same layer so they
 #   never reach the image: source maps (debug-only), docs, and *.d.ts TYPE DECLARATIONS (type-only,
 #   never executed — counterfact's runtime transpiler is transpile-only, verified by the smoke test).
-#   LICENSE files are kept (3rd-party license compliance); *.ts SOURCE files and package test dirs
-#   are left alone (small, and counterfact's runtime transpile path isn't worth risking for the MB).
+#   LICENSE/COPYING files are kept for 3rd-party license compliance — including the `.md` ones, hence
+#   the `! -iname` excludes. *.ts SOURCE files and package test dirs are left alone (small, and
+#   counterfact's runtime transpile path isn't worth risking for the MB). The node -e guard fails the
+#   build loudly if counterfact ever leaves devDependencies (rather than shipping a broken mock).
 
 # Mock source + the built spec. spec/ and scripts/ are build-only (convert/overlay already ran in
 # the builder), so the runtime image carries only the materialization inputs the runner reads:

--- a/packages/spacecat-shared-project-engine-client/docker-entrypoint.sh
+++ b/packages/spacecat-shared-project-engine-client/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # Copyright 2025 Adobe. All rights reserved.
 # This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -16,10 +16,16 @@
 #
 # Exits as soon as EITHER process exits, so a dead component stops the container (the healthcheck /
 # orchestrator then fails fast) instead of the container lingering half-up with a 502-ing proxy.
-set -euo pipefail
+#
+# POSIX sh (busybox ash), NOT bash: the runtime image no longer ships bash. bash was here only for
+# `wait -n` (return when the first background job exits), which ash lacks; we poll the two PIDs
+# instead (see the loop below). Everything else is plain POSIX.
+set -eu
 
-# Forward termination to the whole process group so a `docker stop` tears down both children.
-trap 'kill 0' INT TERM
+# Forward termination to the whole process group so a `docker stop` tears down both children. EXIT
+# is included so the surviving process is reaped when the script exits after one dies, not only on a
+# signal-driven `docker stop`.
+trap 'kill 0' INT TERM EXIT
 
 node mock/run.js &
 mock_pid=$!
@@ -43,7 +49,18 @@ done
 [ -n "$mock_ready" ] || { echo "mock did not become ready within timeout: ${mock_url}" >&2; exit 1; }
 
 caddy run --config /etc/caddy/Caddyfile --adapter caddyfile &
+caddy_pid=$!
 
-# `wait -n` returns when the first background job exits; propagate its status.
-wait -n
-exit $?
+# POSIX sh has no `wait -n`, so poll until EITHER child exits, then propagate the status of the one
+# that died. The 1s granularity is irrelevant for a test mock; the surviving child is torn down by
+# the EXIT trap on the `exit` below.
+while kill -0 "$mock_pid" 2>/dev/null && kill -0 "$caddy_pid" 2>/dev/null; do
+  sleep 1
+done
+status=0
+if ! kill -0 "$mock_pid" 2>/dev/null; then
+  wait "$mock_pid" || status=$?   # mock died first — propagate its status
+else
+  wait "$caddy_pid" || status=$?  # caddy died first — propagate its status
+fi
+exit "$status"

--- a/packages/spacecat-shared-project-engine-client/docker-entrypoint.sh
+++ b/packages/spacecat-shared-project-engine-client/docker-entrypoint.sh
@@ -63,4 +63,8 @@ if ! kill -0 "$mock_pid" 2>/dev/null; then
 else
   wait "$caddy_pid" || status=$?  # caddy died first — propagate its status
 fi
+# Clear the traps before the final exit so the EXIT trap's `kill 0` cannot fire mid-exit and
+# overwrite the status the orchestrator must see; then reap the surviving child explicitly.
+trap - INT TERM EXIT
+kill "$mock_pid" "$caddy_pid" 2>/dev/null || true
 exit "$status"

--- a/packages/spacecat-shared-project-engine-client/docs/mock-docker.md
+++ b/packages/spacecat-shared-project-engine-client/docs/mock-docker.md
@@ -14,6 +14,29 @@ is the only cross-repo distribution of it.
 - **Exposed:** `8443` (HTTPS only)
 - **Base URL inside:** `https://<host>:8443/enterprise/projects/api`
 
+## Image size & the multi-stage build
+
+The image is built in two stages (see `Dockerfile`) to keep the runtime layer lean:
+
+- **builder** — full `npm install` (incl. devDeps), runs `spec:convert && spec:overlay` to bake
+  `build/openapi3.json`, and mints the self-signed cert with `openssl`.
+- **runtime** — clean base + only what the mock needs to *run*: a prod-only `node_modules` (the
+  `counterfact` engine; the build/test toolchain is dropped), the baked spec, `mock/`, the cert,
+  and `caddy` (TLS) + `curl` (healthcheck). `openssl` (build-only) and `bash` (the entrypoint is
+  POSIX `sh`) are not installed, and `spec/` / `scripts/` are absent (their only job ran in the
+  builder). The container runs as the unprivileged `node` user (uid 1000), not root.
+
+`counterfact` stays a **devDependency** in `package.json` so consumers of the *published* client
+(`files: ["src"]`) never inherit it. The runtime stage installs it explicitly from a derived,
+throwaway runtime-only manifest, pinned to the exact version `package.json` declares.
+
+The dominant remaining weight is `counterfact` itself: it transpiles the materialized `.ts`
+handlers at runtime, so it drags `typescript`/`esbuild`/`tsx` (plus a dashboard/telemetry) as
+genuine runtime deps — that toolchain is the floor and cannot be pruned without redesigning the
+mock. The base is pinned to a `node:24-alpine` digest for reproducibility; a distroless runtime
+would shave the node-alpine layer further but is a stretch (no shell/apk → Caddy/curl/entrypoint
+rework).
+
 ## Why HTTPS / why Caddy
 
 `spacecat-api-service`'s transport (`rest-transport.js` `baseUrl()`) **throws `503` on any non-https

--- a/packages/spacecat-shared-user-manager-client/.dockerignore
+++ b/packages/spacecat-shared-user-manager-client/.dockerignore
@@ -11,3 +11,4 @@ docs
 python
 *.log
 test-results.xml
+.DS_Store

--- a/packages/spacecat-shared-user-manager-client/Dockerfile
+++ b/packages/spacecat-shared-user-manager-client/Dockerfile
@@ -8,35 +8,36 @@
 # on a non-`https:` scheme), and Counterfact only speaks plain HTTP, so this image runs Caddy as a
 # TLS terminator in front of the mock. TLS is satisfied for real, not bypassed.
 #
-# Build context = THIS package dir. The package has no in-monorepo dependencies (only openapi-fetch
-# + public devDeps incl. counterfact), so a standalone `npm install` resolves everything without
-# the monorepo. `npm run docker:build` invokes this from the package dir.
-FROM node:24-alpine
+# Build context = THIS package dir. The package has no in-monorepo dependencies, so a standalone
+# install resolves everything without the monorepo. `npm run docker:build` invokes this from the
+# package dir.
+#
+# Two stages keep the runtime image lean: the BUILDER carries the full dev toolchain (to convert +
+# overlay the vendored swagger and mint the cert); the RUNTIME stage ships only the mock engine
+# (counterfact), the built spec, the cert, and Caddy/curl — none of the build/test toolchain.
 
-# caddy   — TLS terminator in front of the plain-HTTP mock
-# openssl — mints the self-signed cert at BUILD time (no private key is committed to this public repo)
-# bash    — entrypoint uses `wait -n` (not available in busybox ash)
-# curl    — HEALTHCHECK probe
-RUN apk add --no-cache caddy openssl bash curl
+# Pinned to the multi-arch index digest of node:24-alpine for reproducibility (works on amd64 CI
+# and arm64 local alike). Bump the digest deliberately when upgrading the base.
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS builder
+
+# openssl is BUILD-ONLY: it mints the self-signed cert below, which is then copied into the runtime
+# stage. The runtime stage never needs openssl.
+RUN apk add --no-cache openssl
 
 WORKDIR /app
 
-# Deps first for layer caching. counterfact is a devDependency but is REQUIRED at runtime
-# (mock/run.js spawns its CLI), so a full install — not --omit=dev — is intentional.
-# --legacy-peer-deps: a standalone install (no monorepo lockfile) otherwise ERESOLVE-fails on a
-# build-time-only devDep peer range (openapi-typescript wants typescript@^5, the package pins 6) that
-# the hoisted monorepo install tolerates. openapi-typescript/typescript are unused at runtime.
+# Full install (incl. devDeps) so spec:convert / spec:overlay can run. --legacy-peer-deps: a
+# standalone install (no monorepo lockfile) otherwise ERESOLVE-fails on a build-only devDep peer
+# range (openapi-typescript wants typescript@^5, the package pins 6) that the hoisted monorepo
+# install tolerates. openapi-typescript/typescript are unused at runtime.
 COPY package.json ./
 RUN npm install --no-audit --no-fund --ignore-scripts --legacy-peer-deps
 
-# Mock source + spec + overlay tooling.
-COPY mock ./mock
+# Bake build/openapi3.json — the gitignored intermediate the runner requires. Only the convert +
+# overlay steps are needed to serve; generate:ts/generate:pydantic produce committed artifacts and
+# need Python, neither of which is needed to run the mock.
 COPY spec ./spec
 COPY scripts ./scripts
-
-# Bake build/openapi3.json — the gitignored intermediate the runner requires. Only the
-# convert + overlay steps are needed to serve; generate:ts/generate:pydantic produce committed
-# artifacts and need Python, neither of which is needed at runtime.
 RUN npm run spec:convert && npm run spec:overlay
 
 # Self-signed cert for https://…:8443, minted at build time so no key lives in this public repo.
@@ -50,9 +51,56 @@ RUN mkdir -p /etc/tls && openssl req -x509 -newkey rsa:2048 -nodes \
       -days 36500 -subj "/CN=user-manager-client-mock" \
       -addext "subjectAltName=DNS:localhost,DNS:user-manager-client-mock,IP:127.0.0.1"
 
+
+# ---- runtime stage -------------------------------------------------------------------------------
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
+
+# caddy — TLS terminator in front of the plain-HTTP mock
+# curl  — HEALTHCHECK probe
+# (openssl and bash are intentionally NOT installed: cert minting happens in the builder, and the
+#  entrypoint is POSIX sh.)
+RUN apk add --no-cache caddy curl
+
+WORKDIR /app
+
+# Runtime deps only. counterfact is the mock's runtime engine (mock/run.js spawns its CLI) but stays
+# a devDependency in package.json so consumers of the PUBLISHED client (files: ["src"]) do NOT
+# inherit it and its ~100 MB build toolchain. The image installs it explicitly here instead: we
+# derive a throwaway runtime-only manifest that promotes counterfact into `dependencies` (pinned to
+# the exact version package.json declares — single source of truth, no drift) and drops every
+# devDependency. With the devDeps gone the ERESOLVE conflict is gone too, so no --legacy-peer-deps.
+COPY package.json ./
+RUN node -e "const p=require('./package.json'); require('fs').writeFileSync('package.json', JSON.stringify({ name: p.name, version: p.version, type: p.type, dependencies: { ...p.dependencies, counterfact: p.devDependencies.counterfact } }, null, 2));" \
+ && npm install --no-audit --no-fund --ignore-scripts --omit=dev \
+ && npm cache clean --force \
+ && find node_modules -type f \( -name '*.map' -o -name '*.md' -o -name '*.markdown' -o -name '*.d.ts' \) -delete
+# ^ npm cache clean + strip runtime-irrelevant files from the dep tree, in the same layer so they
+#   never reach the image: source maps (debug-only), docs, and *.d.ts TYPE DECLARATIONS (type-only,
+#   never executed — counterfact's runtime transpiler is transpile-only, verified by the smoke test).
+#   LICENSE files are kept (3rd-party license compliance); *.ts SOURCE files and package test dirs
+#   are left alone (small, and counterfact's runtime transpile path isn't worth risking for the MB).
+
+# Mock source + the built spec. spec/ and scripts/ are build-only (convert/overlay already ran in
+# the builder), so the runtime image carries only the materialization inputs the runner reads:
+# mock/** and build/openapi3.json.
+COPY mock ./mock
+COPY --from=builder /app/build/openapi3.json ./build/openapi3.json
+# --chown=node so caddy (which runs as the unprivileged `node` user below) can read the TLS key
+# without widening its mode. The key is a build-time self-signed test cert with no real trust.
+COPY --from=builder --chown=node:node /etc/tls /etc/tls
+
 COPY Caddyfile /etc/caddy/Caddyfile
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Run as the unprivileged `node` user (uid 1000, present in the base image) rather than root. Only
+# /app must be writable — the runner materializes handlers into /app/.counterfact at boot — so we
+# chown just the /app DIR (not -R: a recursive chown would duplicate the whole node_modules tree
+# into a new layer). node_modules/build/mock stay root-owned and are read-only at runtime; the
+# world-readable default perms let `node` read them. HOME is set so caddy's storage path is writable.
+ENV HOME=/home/node
+RUN chown node:node /app
+USER node
 
 # 8443 (TLS) is the ONLY exposed surface. The mock's plain-HTTP 4010 stays internal: its __* control
 # routes are unauthenticated and /__dump returns the entire store, so the image must only ever be

--- a/packages/spacecat-shared-user-manager-client/Dockerfile
+++ b/packages/spacecat-shared-user-manager-client/Dockerfile
@@ -70,15 +70,17 @@ WORKDIR /app
 # the exact version package.json declares — single source of truth, no drift) and drops every
 # devDependency. With the devDeps gone the ERESOLVE conflict is gone too, so no --legacy-peer-deps.
 COPY package.json ./
-RUN node -e "const p=require('./package.json'); require('fs').writeFileSync('package.json', JSON.stringify({ name: p.name, version: p.version, type: p.type, dependencies: { ...p.dependencies, counterfact: p.devDependencies.counterfact } }, null, 2));" \
+RUN node -e "const p=require('./package.json'); const cf=p.devDependencies&&p.devDependencies.counterfact; if(!cf){console.error('counterfact missing from devDependencies'); process.exit(1);} require('fs').writeFileSync('package.json', JSON.stringify({ name: p.name, version: p.version, type: p.type, dependencies: { ...p.dependencies, counterfact: cf } }, null, 2));" \
  && npm install --no-audit --no-fund --ignore-scripts --omit=dev \
  && npm cache clean --force \
- && find node_modules -type f \( -name '*.map' -o -name '*.md' -o -name '*.markdown' -o -name '*.d.ts' \) -delete
+ && find node_modules -type f \( -name '*.map' -o -name '*.md' -o -name '*.markdown' -o -name '*.d.ts' \) ! -iname 'LICENSE*' ! -iname 'COPYING*' -delete
 # ^ npm cache clean + strip runtime-irrelevant files from the dep tree, in the same layer so they
 #   never reach the image: source maps (debug-only), docs, and *.d.ts TYPE DECLARATIONS (type-only,
 #   never executed — counterfact's runtime transpiler is transpile-only, verified by the smoke test).
-#   LICENSE files are kept (3rd-party license compliance); *.ts SOURCE files and package test dirs
-#   are left alone (small, and counterfact's runtime transpile path isn't worth risking for the MB).
+#   LICENSE/COPYING files are kept for 3rd-party license compliance — including the `.md` ones, hence
+#   the `! -iname` excludes. *.ts SOURCE files and package test dirs are left alone (small, and
+#   counterfact's runtime transpile path isn't worth risking for the MB). The node -e guard fails the
+#   build loudly if counterfact ever leaves devDependencies (rather than shipping a broken mock).
 
 # Mock source + the built spec. spec/ and scripts/ are build-only (convert/overlay already ran in
 # the builder), so the runtime image carries only the materialization inputs the runner reads:

--- a/packages/spacecat-shared-user-manager-client/docker-entrypoint.sh
+++ b/packages/spacecat-shared-user-manager-client/docker-entrypoint.sh
@@ -63,4 +63,8 @@ if ! kill -0 "$mock_pid" 2>/dev/null; then
 else
   wait "$caddy_pid" || status=$?  # caddy died first — propagate its status
 fi
+# Clear the traps before the final exit so the EXIT trap's `kill 0` cannot fire mid-exit and
+# overwrite the status the orchestrator must see; then reap the surviving child explicitly.
+trap - INT TERM EXIT
+kill "$mock_pid" "$caddy_pid" 2>/dev/null || true
 exit "$status"

--- a/packages/spacecat-shared-user-manager-client/docker-entrypoint.sh
+++ b/packages/spacecat-shared-user-manager-client/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # Copyright 2026 Adobe. All rights reserved.
 # This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -16,11 +16,15 @@
 #
 # Exits as soon as EITHER process exits, so a dead component stops the container (the healthcheck /
 # orchestrator then fails fast) instead of the container lingering half-up with a 502-ing proxy.
-set -euo pipefail
+#
+# POSIX sh (busybox ash), NOT bash: the runtime image no longer ships bash. bash was here only for
+# `wait -n` (return when the first background job exits), which ash lacks; we poll the two PIDs
+# instead (see the loop below). Everything else is plain POSIX.
+set -eu
 
-# Forward termination to the whole process group so a `docker stop` tears down both children.
-# EXIT is included so that when `wait -n` returns (one process died) and the script exits, the
-# surviving process is reaped too, not just on a signal-driven `docker stop`.
+# Forward termination to the whole process group so a `docker stop` tears down both children. EXIT
+# is included so the surviving process is reaped when the script exits after one dies, not only on a
+# signal-driven `docker stop`.
 trap 'kill 0' INT TERM EXIT
 
 node mock/run.js &
@@ -45,7 +49,18 @@ done
 [ -n "$mock_ready" ] || { echo "mock did not become ready within timeout: ${mock_url}" >&2; exit 1; }
 
 caddy run --config /etc/caddy/Caddyfile --adapter caddyfile &
+caddy_pid=$!
 
-# `wait -n` returns when the first background job exits; propagate its status.
-wait -n
-exit $?
+# POSIX sh has no `wait -n`, so poll until EITHER child exits, then propagate the status of the one
+# that died. The 1s granularity is irrelevant for a test mock; the surviving child is torn down by
+# the EXIT trap on the `exit` below.
+while kill -0 "$mock_pid" 2>/dev/null && kill -0 "$caddy_pid" 2>/dev/null; do
+  sleep 1
+done
+status=0
+if ! kill -0 "$mock_pid" 2>/dev/null; then
+  wait "$mock_pid" || status=$?   # mock died first — propagate its status
+else
+  wait "$caddy_pid" || status=$?  # caddy died first — propagate its status
+fi
+exit "$status"

--- a/packages/spacecat-shared-user-manager-client/docs/mock-docker.md
+++ b/packages/spacecat-shared-user-manager-client/docs/mock-docker.md
@@ -15,6 +15,29 @@ is the only cross-repo distribution of it.
 - **Exposed:** `8443` (HTTPS only)
 - **Base URL inside:** `https://<host>:8443/enterprise/users/api`
 
+## Image size & the multi-stage build
+
+The image is built in two stages (see `Dockerfile`) to keep the runtime layer lean:
+
+- **builder** — full `npm install` (incl. devDeps), runs `spec:convert && spec:overlay` to bake
+  `build/openapi3.json`, and mints the self-signed cert with `openssl`.
+- **runtime** — clean base + only what the mock needs to *run*: a prod-only `node_modules` (the
+  `counterfact` engine; the build/test toolchain is dropped), the baked spec, `mock/`, the cert,
+  and `caddy` (TLS) + `curl` (healthcheck). `openssl` (build-only) and `bash` (the entrypoint is
+  POSIX `sh`) are not installed, and `spec/` / `scripts/` are absent (their only job ran in the
+  builder). The container runs as the unprivileged `node` user (uid 1000), not root.
+
+`counterfact` stays a **devDependency** in `package.json` so consumers of the *published* client
+(`files: ["src"]`) never inherit it. The runtime stage installs it explicitly from a derived,
+throwaway runtime-only manifest, pinned to the exact version `package.json` declares.
+
+The dominant remaining weight is `counterfact` itself: it transpiles the materialized `.ts`
+handlers at runtime, so it drags `typescript`/`esbuild`/`tsx` (plus a dashboard/telemetry) as
+genuine runtime deps — that toolchain is the floor and cannot be pruned without redesigning the
+mock. The base is pinned to a `node:24-alpine` digest for reproducibility; a distroless runtime
+would shave the node-alpine layer further but is a stretch (no shell/apk → Caddy/curl/entrypoint
+rework).
+
 ## Why HTTPS / why Caddy
 
 `spacecat-api-service`'s transport (`rest-transport.js` `baseUrl()`) **throws `503` on any non-https


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Slims the two Counterfact mock Docker images published from the Semrush client packages (`spacecat-shared-project-engine-client` and `spacecat-shared-user-manager-client`) from ~711 MB to ~416 MB on disk, with identical runtime behaviour.

## 2. Reasoning
The two mock images are consumed for API-level e2e tests in spacecat-api-service. Each was ~719 MB on disk, dominated by an `npm install` of the full build/test toolchain into the runtime image and an in-layer npm cache, even though the mock only needs the Counterfact engine at runtime. This is registry + disk hygiene — not urgent, just wasteful. Both Dockerfiles were identical, so both packages change together.

## 3. High-level overview of the changes
Each image is now a two-stage build:

- **builder** — full `npm install` (incl. devDeps), runs `spec:convert && spec:overlay` to bake `build/openapi3.json`, and mints the self-signed TLS cert with `openssl`.
- **runtime** — a clean base carrying only what the mock needs to run.

Behaviour deltas:

- **counterfact stays a devDependency** (no `package.json` change), so consumers of the *published* client (`files: ["src"]`) do not inherit it or its ~100 MB toolchain. The runtime stage installs it explicitly from a derived, throwaway runtime-only manifest, pinned to the exact version `package.json` declares.
- Runtime `node_modules` is prod-only (`--omit=dev`); the in-layer npm cache is cleaned and `*.map` / `*.md` / `*.d.ts` are stripped from the dep tree, all in the same layer.
- `openssl` (build-only) and `bash` are no longer installed — the entrypoint is POSIX `sh` and polls the two child PIDs instead of bash's `wait -n`.
- `spec/` and `scripts/` are absent from the runtime image (their only job ran in the builder).
- The base is pinned to the `node:24-alpine` multi-arch index digest for reproducibility.
- The container now runs as the unprivileged `node` user (uid 1000) instead of root.

Net: ~711 MB → ~416 MB (~42%) per image, with the exposed surface, TLS, auth guard, seeds, and control routes all unchanged. The dominant remaining weight is Counterfact itself, which transpiles the materialized handlers at runtime and so legitimately keeps `typescript`/`tsx`/`esbuild` — that is the floor without redesigning the mock.

## 4. Required information
- Jira / issue: https://github.com/adobe/spacecat-shared/issues/1739
- Other: consumed by the serenity API-level e2e suite in https://github.com/adobe/spacecat-api-service/pull/2709 ; original image plumbing in https://github.com/adobe/spacecat-shared/pull/1732 and https://github.com/adobe/spacecat-shared/pull/1735

## 5. Affected / used mysticat-workspace projects
- `spacecat-api-service` — consumes both GHCR mock images as CI `services:` for its serenity API-level e2e tests. Contract unchanged (same exposed `:8443` HTTPS surface, base URL, seeds, and control routes); this PR only changes how the image is built, so no consumer change is required.

## 6. Additional information outside the code
Both images were built locally and validated end to end this session (not just unit tests):

- Built `project-engine-client` and `user-manager-client` images from the new Dockerfiles; both reach the image `HEALTHCHECK` `healthy` state.
- Ran each package's own smoke assertions against the running container over Caddy on `:8443`: `__dump` returns 200 (TLS terminates + proxy reaches the mock), a real route without a bearer token returns 401 (auth guard wired), and the same route with a token returns 200 with seeded data (handler serves real data — exercising Counterfact's runtime handler transpile, which confirms the `*.d.ts` strip is safe).
- Verified the container runs as `uid=1000(node)` and that `bash` / `openssl` are absent.
- Verified the POSIX-`sh` entrypoint exits the container when a child process dies (killed Caddy in-container; the container stopped rather than lingering).
- Measured the size delta with matched single-platform builds: old 711 MB → new 416 MB; the runtime npm layer dropped 314 MB → ~96 MB.

## 7. Test plan
- Local e2e: done (see section 6) — both images build, go healthy, and pass the full smoke flow.
- CI: the existing `*-mock-image-smoke.yaml` workflows build + boot + smoke-test each image on this PR (they path-trigger on the Dockerfile / entrypoint / `.dockerignore` / `mock` / `spec` / `scripts`). spacecat-api-service's serenity IT is the second end-to-end check.
- No environment (eph/dev/stage/prod) deploy applies — these are test-only mock images consumed in CI, never deployed to a runtime environment.

## 8. Deployment & merge order
- Independent — no dependent PRs. Note: the slimmed images are republished to GHCR by the existing per-package image workflows on the next release of each client (or on demand via their `workflow_dispatch`); this PR's commit is `build:` and does not itself cut a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
