### PR TITLE
feat(project-engine-client): make project AIO tags a stateful mock resource

### DIFF
--- a/packages/spacecat-shared-project-engine-client/CLAUDE.md
+++ b/packages/spacecat-shared-project-engine-client/CLAUDE.md
@@ -56,7 +56,7 @@ is guarded by the `.ts` type-tests under `test/types/` rather than per-spec `@ts
 
 Build seed/fixture entities with the typed factories in `mock/factories.js` — `createProjectMock`,
 `createProjectAiModelMock`, `createAiModelMock`, `createPromptMock`, `createBenchmarkMock`,
-`createBrandUrlMock`, `createLanguageMock`, `createTagNodeMock`, `createBrandTopicMock`,
+`createBrandUrlMock`, `createLanguageMock`, `createTagNodeMock`, `createAIOTagMock`, `createBrandTopicMock`,
 `createBasicResponseMock`, `createInitStatusMock`, `createCiCompetitorMock` — each
 `(Partial<T>) => T` typed against `components['schemas'][...]` (the
 [mock factory pattern](https://dev.to/davelosert/mock-factory-pattern-in-typescript-44l9)). Never

--- a/packages/spacecat-shared-project-engine-client/docs/mock-statefulness.md
+++ b/packages/spacecat-shared-project-engine-client/docs/mock-statefulness.md
@@ -36,6 +36,9 @@ api-service calls (`src/support/serenity/handlers/*`):
 | `POST /v2/workspaces/{id}/projects/{id}/aio/prompts/by_tags` | prompts | no (read) | **stateful** (list) |
 | `POST /v2/workspaces/{id}/projects/{id}/aio/prompts/tagged` | prompts | yes | **stateful** |
 | `DELETE /v2/workspaces/{id}/projects/{id}/aio/prompts` | prompts | yes | **stateful** |
+| `POST /v2/workspaces/{id}/projects/{id}/aio/tags` | tags | yes | **stateful** (project-tag create, idempotent by name) |
+| `GET  /v2/workspaces/{id}/projects/{id}/aio/tags` | tags | yes | **stateful** (list — surfaces 0-prompt categories) |
+| `DELETE /v2/workspaces/{id}/projects/{id}/aio/tags` | tags | yes | **stateful** (project-tag remove; prompts untouched) |
 | `POST /v2/workspaces/{id}/projects/{id}/ai_models/benchmarks` | benchmarks | yes | **stateful** (competitor-benchmark create) |
 | `GET  /v1/workspaces/{id}/projects/{id}/ai_models/benchmarks` | benchmarks | yes | **stateful** (list) |
 | `PUT  /v1/workspaces/{id}/projects/{id}/ai_models/benchmarks/{id}` | benchmarks | yes | **stateful** (in-place `updateBenchmark`) |
@@ -45,16 +48,18 @@ api-service calls (`src/support/serenity/handlers/*`):
 | `DELETE /v2/workspaces/{id}/projects/{id}/aio/benchmarks/{id}/brand_urls` | brand_urls | yes | **stateful** |
 
 ## Confirmed stateful set
-**projects (per workspace), ai_models / prompts / benchmarks (per project), brand_urls (per
-benchmark).** These five are `STATEFUL_RESOURCES` in `mock/stateful.js`. This matches the
+**projects (per workspace), ai_models / prompts / benchmarks / tags (per project), brand_urls (per
+benchmark).** These six are `STATEFUL_RESOURCES` in `mock/stateful.js`. This matches the
 recommended first cut plus the competitor-benchmark + brand-URL sync the consumer drives
 (`spacecat-api-service` `syncCompetitorBenchmarksAcrossMarkets` / `syncBrandUrlsAcrossMarkets` /
 `attachBrandUrlsToProject` — each write-then-reads, so by the decision rule above they belong in
-the set). The `publish` action and the `GET /v1/ai_models` / `GET /v1/languages` reference lookups
-are thin hand-authored echo/catalog handlers (no store, no auto-stub). The store is generic, so
-growing the stateful set
-later is cheap and needs no rework — benchmarks + brand_urls were added as ops with no store
-change, the live proof.
+the set). `tags` joined the set for the Categories surface: the consumer registers a standalone
+`category:<name>` tag per market project (one `createProjectTags` per market — a category spans N
+projects, so the collection is scoped per project, never global) and must read it back via
+`GET /aio/tags` even before any prompt carries it. The `publish` action and the `GET /v1/ai_models`
+/ `GET /v1/languages` reference lookups are thin hand-authored echo/catalog handlers (no store, no
+auto-stub). The store is generic, so growing the stateful set later is cheap and needs no rework —
+benchmarks + brand_urls + tags were added as ops with no store change, the live proof.
 
 ## How it plugs in
 - `mock/store.js` — generic `InMemoryStore` (collection-keyed CRUD + seed/reset, deep-clone

--- a/packages/spacecat-shared-project-engine-client/docs/mock-usage.md
+++ b/packages/spacecat-shared-project-engine-client/docs/mock-usage.md
@@ -116,7 +116,9 @@ method that calls it.
 | `POST /v2/workspaces/{id}/projects/{project_id}/aio/prompts/tagged` | `createTaggedPrompts` | create; body `{ prompts: { [promptText]: [tagName, …] } }` → `201 { ids, existing_count }`; **metered** (all-or-nothing 405 on the prompts allocation) |
 | `POST /v2/workspaces/{id}/projects/{project_id}/aio/prompts/by_tags` | `listPromptsByTags` | list → `{ items, page, total, unassigned }` (empty `tag_ids` lists all; else OR-filter) |
 | `DELETE /v2/workspaces/{id}/projects/{project_id}/aio/prompts` | `deletePromptsByIds` | batch-delete (body `{ ids }`) → `204` |
-| `POST /v2/workspaces/{id}/projects/{project_id}/aio/tags` | `createProjectTags` | create tags (body `{ names }`) → `201` top-level array |
+| `POST /v2/workspaces/{id}/projects/{project_id}/aio/tags` | `createProjectTags` | create tags (body `{ names }`) → `201` top-level array of `TreeNodeResponse`; **persists** each tag (idempotent on the deterministic `tag-<name>` id) into the per-project `tags` collection |
+| `GET /v2/workspaces/{id}/projects/{project_id}/aio/tags` | `getProjectTags` | list the project's stored tags → `200 { items, page, total }` (`AIOTagsListResponse`); `parent_id` + `search` are `required` query params (omitting either → `400`), a non-empty `search` filters by case-insensitive name substring, `parent_id` is accepted but not used to filter (the mock's tags are a flat collection) |
+| `DELETE /v2/workspaces/{id}/projects/{project_id}/aio/tags` | `deleteProjectTags` | remove standalone tags by id (body `{ ids }`) → `204`; prompts carrying a removed tag are a separate collection and stay intact (the `prompt_id` query param is `required` by the spec but not load-bearing in the mock) |
 
 ### Catalogs, CI competitors, init status
 

--- a/packages/spacecat-shared-project-engine-client/mock/context.js
+++ b/packages/spacecat-shared-project-engine-client/mock/context.js
@@ -44,6 +44,7 @@ import { authError } from './auth.js';
 import { emptyAck } from './responses.js';
 import * as factories from './factories.js';
 import { LANGUAGE_CATALOG } from './language-catalog.js';
+import { tagId } from './tag-id.js';
 import { SEEDS, DEFAULT_SEED } from './seeds.js';
 
 /**
@@ -87,6 +88,11 @@ export class Context {
     // route serves it without duplicating the 38-entry list, mirroring how `factories` is shared —
     // every route reads its lib data through `$.context`, never an import.
     this.languageCatalog = LANGUAGE_CATALOG;
+    // The deterministic tag-id derivation (mock/tag-id.js). Exposed so the two routes that mint tag
+    // ids — `POST /aio/tags` and `POST /aio/prompts/tagged` — share one definition and can't drift
+    // out of the cross-endpoint id contract that lets `by_tags` / the Categories surface correlate
+    // a standalone tag with the same tag attached to a prompt.
+    this.tagId = tagId;
   }
 
   /**

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/prompts/tagged.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/prompts/tagged.js
@@ -17,12 +17,11 @@
  * `{ prompts: { [promptText]: [tagName, ...] } }` — keyed by PROMPT TEXT (verified live
  * 2026-06-25), each value the tag names to attach. One stored prompt is created per text key,
  * carrying an `AIOTag` synthesized from each tag name (stable id so `by_tags` filtering works),
- * so a later `by_tags` list reflects the write. Returns 201 `IDsWithStatsResponse`.
+ * so a later `by_tags` list reflects the write. The tag ids are minted via `context.tagId` (the
+ * shared mock/tag-id.js helper) so they match the ids `POST /aio/tags` persists for the same name.
+ * Returns 201 `IDsWithStatsResponse`.
  * Materialized into `.counterfact/routes/` by the mock runner; excluded from coverage.
  */
-
-/** Deterministic tag id from a tag name so repeated creates under the same name share an id. */
-const tagId = (name) => `tag-${encodeURIComponent(name)}`;
 
 /**
  * POST — create prompts → 201 { ids, existing_count }. Body is `AIOTaggedPromptsCreateRequest`
@@ -48,7 +47,7 @@ export function POST($) {
     .createPromptMock({
       name: text,
       is_new: true,
-      tags: (tags ?? []).map((name) => ({ id: tagId(name), name })),
+      tags: (tags ?? []).map((name) => ({ id: context.tagId(name), name })),
     }));
 
   if (!context.quota.canCreatePrompts(path.id, toCreate.length)) {

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags.js
@@ -56,7 +56,9 @@ export function GET($) {
   const items = search
     ? stored.filter((t) => String(t.name).toLowerCase().includes(search))
     : stored;
-  return $.response[200].json({ items, page: query?.page ?? 1, total: items.length });
+  // `page` arrives as a query string (e.g. "2"); coerce so the response field stays the numeric
+  // type AIOTagsListResponse declares, regardless of whether the param was passed.
+  return $.response[200].json({ items, page: Number(query?.page ?? 1), total: items.length });
 }
 
 /** DELETE — remove standalone project tags by id (prompts are untouched) → 204 No Content. */

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags.js
@@ -11,21 +11,60 @@
  */
 
 /**
- * Handler for POST /v2/workspaces/{id}/projects/{project_id}/aio/tags — creates project-level
- * AIO tags (the consumer's `createProjectTags`). Request is `TreeNodeListRequest` `{ names }`.
- * The live API returns a TOP-LEVEL ARRAY of `TreeNodeResponse` `[{ id, name, children_count,
- * keyword_count }]` (verified 2026-06-25; overlay CR6 retypes the 201 as an array). A
- * deterministic id per name keeps a repeated create idempotent in the mock's view. Excluded
- * from coverage (materialized handler).
+ * Stateful handlers for /v2/workspaces/{id}/projects/{project_id}/aio/tags — the project-level AIO
+ * tag taxonomy (the Categories surface). The per-project `tags` collection (`tags:{ws}:{pid}`) is
+ * scoped so the same category registered across N market projects keeps N independent collections.
+ * Materialized into `.counterfact/routes/` by the mock runner; excluded from coverage.
+ *
+ * - POST (`createProjectTags`): request `TreeNodeListRequest` `{ names }`; persists each tag
+ *   idempotently (deterministic `tag-<name>` id, so a repeated create reuses the stored tag,
+ *   matching the live reuse-by-name) and returns the live shape — a TOP-LEVEL ARRAY of
+ *   `TreeNodeResponse` `[{ id, name, children_count, keyword_count }]` (verified 2026-06-25;
+ *   overlay CR6 retypes the 201 as an array).
+ * - GET (`aio-get-project-tags`): returns the project's stored tags as `AIOTagsListResponse`
+ *   `{ items, page, total }`, so a 0-prompt category created via POST reads back. The spec marks
+ *   `parent_id` + `search` as required query params (request validation 400s a request missing
+ *   either, matching live); the mock's tags are a flat per-project collection, so `parent_id` is
+ *   accepted but not used to filter, while a non-empty `search` filters by case-insensitive name
+ *   substring.
+ * - DELETE (`aio-delete-tags`): removes the body's tag ids (`BatchDeleteRequest` `{ ids }`) from
+ *   the standalone tag collection → 204. Prompts that carry a removed tag are a separate
+ *   collection and stay intact (the spec's `prompt_id` query param is accepted but not load-bearing
+ *   here — the mock's project-tag delete targets the standalone collection, never cascading to
+ *   prompts).
  */
 
-/** Deterministic tag id from a name so repeated creates under the same name share an id. */
-const tagId = (name) => `tag-${encodeURIComponent(name)}`;
-
-/** POST — create project tags → 201 array of TreeNodeResponse. */
+/** POST — create (persist, idempotent) project tags → 201 array of TreeNodeResponse. */
 export function POST($) {
-  const { body, context } = $;
+  const { path, body, context } = $;
+  const scope = { workspaceId: path.id, projectId: path.project_id };
   const names = Array.isArray(body?.names) ? body.names : [];
-  const tags = names.map((name) => context.factories.createTagNodeMock({ id: tagId(name), name }));
+  const stored = context.ops.tags.upsertMany(
+    scope,
+    names.map((name) => context.factories.createAIOTagMock({ id: context.tagId(name), name })),
+  );
+  const tags = stored.map((t) => context.factories.createTagNodeMock({ id: t.id, name: t.name }));
   return $.response[201].json(tags);
+}
+
+/** GET — list the project's stored tags (optional `search` name filter) → 200 list response. */
+export function GET($) {
+  const { path, query, context } = $;
+  const scope = { workspaceId: path.id, projectId: path.project_id };
+  const search = String(query?.search ?? '').toLowerCase();
+  const stored = context.ops.tags.list(scope);
+  const items = search
+    ? stored.filter((t) => String(t.name).toLowerCase().includes(search))
+    : stored;
+  return $.response[200].json({ items, page: query?.page ?? 1, total: items.length });
+}
+
+/** DELETE — remove standalone project tags by id (prompts are untouched) → 204 No Content. */
+export function DELETE($) {
+  const { path, body, context } = $;
+  context.ops.tags.removeMany(
+    { workspaceId: path.id, projectId: path.project_id },
+    body?.ids ?? [],
+  );
+  return { status: 204 };
 }

--- a/packages/spacecat-shared-project-engine-client/mock/factories.js
+++ b/packages/spacecat-shared-project-engine-client/mock/factories.js
@@ -35,6 +35,7 @@
 /** @typedef {Schemas['model.BrandURL']} BrandUrl */
 /** @typedef {Schemas['model.LanguageResponse']} Language */
 /** @typedef {Schemas['model.TreeNodeResponse']} TreeNode */
+/** @typedef {Schemas['model.AIOTag']} AIOTag */
 /** @typedef {Schemas['aiseo.BrandTopicWithPrompts']} BrandTopic */
 /** @typedef {Schemas['http_server.BasicResponse']} BasicResponse */
 /** @typedef {Schemas['model.AIOProjectInitializedResponse']} InitStatus */
@@ -282,6 +283,24 @@ export const createTagNodeMock = (overrides = {}) => ({
   name: 'type:branded',
   children_count: 0,
   keyword_count: 0,
+  ...overrides,
+});
+
+/**
+ * A stored/listed project tag (`AIOTag`) — the `GET /aio/tags` (`AIOTagsListResponse`) item and
+ * the shape the mock persists in the per-project `tags` collection. A standalone `category:<name>`
+ * tag is a flat, top-level node, so `parent_id`/`path` are omitted by default; counts default to 0.
+ * Distinct from {@link createTagNodeMock}: the create path returns a `TreeNodeResponse`
+ * (`keyword_count`) while the list/store shape is an `AIOTag` (`prompts_count`) — two genuinely
+ * different live shapes.
+ * @param {Partial<AIOTag>} [overrides]
+ * @returns {AIOTag}
+ */
+export const createAIOTagMock = (overrides = {}) => ({
+  id: uuid(),
+  name: 'category:Running Shoes',
+  children_count: 0,
+  prompts_count: 0,
   ...overrides,
 });
 

--- a/packages/spacecat-shared-project-engine-client/mock/seeds.js
+++ b/packages/spacecat-shared-project-engine-client/mock/seeds.js
@@ -125,6 +125,8 @@ export const SEED_IDS = Object.freeze({
  *   {@link createPromptMock} so the shape is checked
  * @property {Array<Schemas['model.AIOBenchmarkWithCounters']>} [benchmarks] build with
  *   {@link createBenchmarkMock} (the competitor + own-brand benchmarks the consumer syncs)
+ * @property {Array<Schemas['model.AIOTag']>} [tags] standalone project tags (the `category:<name>`
+ *   taxonomy); build with {@link createAIOTagMock} so the shape is checked
  * @property {Array<{ benchmarkId: string, urls: Array<Schemas['model.BrandURL']> }>} [brandUrls]
  *   brand URLs grouped by their benchmark id; build each url with {@link createBrandUrlMock}
  */
@@ -149,13 +151,14 @@ export function buildSeed({ workspaceId, projects = [], quota }) {
   /** @type {import('./store.js').Snapshot} */
   const snapshot = { [projectsKey]: [] };
   for (const {
-    id, name, aiModels = [], prompts = [], benchmarks = [], brandUrls = [],
+    id, name, aiModels = [], prompts = [], benchmarks = [], tags = [], brandUrls = [],
   } of projects) {
     snapshot[projectsKey].push(createProjectMock({ id, name }));
     const scope = { workspaceId, projectId: id };
     snapshot[collectionKey('ai_models', scope)] = aiModels;
     snapshot[collectionKey('prompts', scope)] = prompts;
     snapshot[collectionKey('benchmarks', scope)] = benchmarks;
+    snapshot[collectionKey('tags', scope)] = tags;
     for (const { benchmarkId, urls } of brandUrls) {
       snapshot[collectionKey('brand_urls', { workspaceId, projectId: id, benchmarkId })] = urls;
     }

--- a/packages/spacecat-shared-project-engine-client/mock/stateful.js
+++ b/packages/spacecat-shared-project-engine-client/mock/stateful.js
@@ -15,9 +15,10 @@
 /**
  * The stateful slice of the Project Engine mock.
  *
- * The confirmed consumer inventory (see docs/mock-statefulness.md) makes five resource groups
- * write-then-read: **projects** (per workspace), **ai_models** / **prompts** / **benchmarks** (per
- * project), and **brand_urls** (per benchmark) — see {@link STATEFUL_RESOURCES}. This module
+ * The confirmed consumer inventory (see docs/mock-statefulness.md) makes six resource groups
+ * write-then-read: **projects** (per workspace), **ai_models** / **prompts** / **benchmarks** /
+ * **tags** (per project), and **brand_urls** (per benchmark) — see {@link STATEFUL_RESOURCES}.
+ * This module
  * encodes that set as pure operations over an {@link InMemoryStore} —
  * collection-key scoping plus the CRUD each group needs — with no Counterfact / HTTP coupling,
  * so it is unit-testable on its own. The Counterfact runner adapts these into per-path handlers
@@ -36,17 +37,19 @@
  * Resource groups the live audit confirmed the consumer
  * write-then-reads: projects, ai_models, prompts, plus benchmarks (per project) and brand_urls
  * (per benchmark) — the competitor-benchmark and brand-URL sync flows create→list→update→delete,
- * so they need real state to be faithfully testable.
+ * so they need real state to be faithfully testable. `tags` are the project-level AIO taxonomy
+ * (the Categories surface): the consumer creates a standalone `category:<name>` tag per market
+ * project and must read it back even before any prompt carries it, so it needs real state too.
  */
 export const STATEFUL_RESOURCES = Object.freeze([
-  'projects', 'ai_models', 'prompts', 'benchmarks', 'brand_urls',
+  'projects', 'ai_models', 'prompts', 'benchmarks', 'tags', 'brand_urls',
 ]);
 
 /**
  * Builds the store collection key for a resource, scoped so two workspaces (or projects, or
  * benchmarks) never share state. `projects` are scoped per workspace; `ai_models`, `prompts`,
- * and `benchmarks` per project; `brand_urls` per benchmark (within a project).
- * @param {'projects' | 'ai_models' | 'prompts' | 'benchmarks' | 'brand_urls'} resource
+ * `benchmarks`, and `tags` per project; `brand_urls` per benchmark (within a project).
+ * @param {'projects' | 'ai_models' | 'prompts' | 'benchmarks' | 'tags' | 'brand_urls'} resource
  * @param {{ workspaceId?: string | number, projectId?: string | number,
  *   benchmarkId?: string | number }} scope
  * @returns {string}
@@ -209,6 +212,42 @@ export function createStatefulOps(store) {
        */
       removeMany(scope, ids) {
         const key = collectionKey('benchmarks', scope);
+        return ids.reduce((removed, id) => (store.delete(key, id) ? removed + 1 : removed), 0);
+      },
+    },
+
+    tags: {
+      /**
+       * @param {{ workspaceId: string | number, projectId: string | number }} scope
+       * @returns {Entity[]}
+       */
+      list(scope) {
+        return store.list(collectionKey('tags', scope));
+      },
+      /**
+       * Idempotently persists one tag per supplied entity, returning ALL of them (existing +
+       * newly created) in request order. The handler derives a deterministic id per tag name, so a
+       * repeated create of the same name resolves to the already-stored tag instead of throwing on
+       * the duplicate id — mirroring the live API, which reuses a tag by name rather than
+       * duplicating it.
+       * @param {{ workspaceId: string | number, projectId: string | number }} scope
+       * @param {Array<Entity>} tags each carrying its deterministic `id`
+       * @returns {Entity[]}
+       */
+      upsertMany(scope, tags) {
+        const key = collectionKey('tags', scope);
+        return tags.map((tag) => store.get(key, tag.id) ?? store.create(key, tag));
+      },
+      /**
+       * Removes the given tag ids from the project's tag collection, reporting how many were
+       * actually removed. Only the standalone tag collection is touched — prompts that carry a
+       * removed tag are a separate collection and keep their tag map intact.
+       * @param {{ workspaceId: string | number, projectId: string | number }} scope
+       * @param {Array<string>} ids
+       * @returns {number}
+       */
+      removeMany(scope, ids) {
+        const key = collectionKey('tags', scope);
         return ids.reduce((removed, id) => (store.delete(key, id) ? removed + 1 : removed), 0);
       },
     },

--- a/packages/spacecat-shared-project-engine-client/mock/tag-id.js
+++ b/packages/spacecat-shared-project-engine-client/mock/tag-id.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * The deterministic tag id derived from a tag name — the single source of truth shared by the two
+ * routes that mint tag ids: `POST /aio/tags` (which persists a standalone project tag with this id)
+ * and `POST /aio/prompts/tagged` (which embeds the same id in each prompt's tag map). Because both
+ * routes derive the id the same way, a category registered standalone and the same category
+ * attached to a prompt resolve to ONE id, so `by_tags` filtering and the Categories surface
+ * correlate them. Exposed on the per-request context as `context.tagId` (every route reads its lib
+ * helpers through `$.context`, never an import — see {@link Context}), so the contract lives in one
+ * place and the two handlers can't drift.
+ *
+ * @param {string} name the tag name
+ * @returns {string} the deterministic id (`tag-<url-encoded name>`)
+ */
+export const tagId = (name) => `tag-${encodeURIComponent(name)}`;

--- a/packages/spacecat-shared-project-engine-client/python/serenity_project_engine/model.py
+++ b/packages/spacecat-shared-project-engine-client/python/serenity_project_engine/model.py
@@ -578,7 +578,7 @@ class AIModelListResponse(BaseModel):
 
 class AIOTag(BaseModel):
     children_count: int | None = None
-    id: str | None = None
+    id: str
     name: str | None = None
     parent_id: str | None = None
     path: list[AIOTagLeaf] | None = None

--- a/packages/spacecat-shared-project-engine-client/spec/overlays/corrections.yaml
+++ b/packages/spacecat-shared-project-engine-client/spec/overlays/corrections.yaml
@@ -200,6 +200,14 @@ actions:
     update:
       required: [id]
 
+  - target: "$.components.schemas['model.AIOTag']"
+    description: "CR5: a listed/stored project tag always carries id"
+    # Now that project tags are stateful-served by the mock (GET /aio/tags), the served list item
+    # always has an id (the deterministic `tag-<name>`). Conservative: id only — the count fields
+    # default to 0 but are not asserted required, and parent_id/path are absent on a flat tag.
+    update:
+      required: [id]
+
   # ── CR6: createProjectTags returns a top-level ARRAY ─────────────────────
   # Live: POST /v2/.../aio/tags -> 201 [{ id, name, children_count, keyword_count }].
   # The vendored 201 schema is a single TreeNodeResponse; replace it with an array.

--- a/packages/spacecat-shared-project-engine-client/src/generated/types.ts
+++ b/packages/spacecat-shared-project-engine-client/src/generated/types.ts
@@ -1682,7 +1682,7 @@ export interface components {
         };
         "model.AIOTag": {
             children_count?: number;
-            id?: string;
+            id: string;
             name?: string;
             parent_id?: string;
             path?: components["schemas"]["model.AIOTagLeaf"][];

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -520,6 +520,173 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     expect(data).to.be.an('array');
   });
 
+  // The core fix: a standalone tag created via createProjectTags must PERSIST so a 0-prompt
+  // category reads back via GET /aio/tags (today the elmo Categories surface falls back to an
+  // optimistic add because the mock couldn't persist it). parent_id + search are spec-required
+  // query params (the consumer sends them); empty search lists every stored tag.
+  it('persists createProjectTags and reads the 0-prompt category back via GET /aio/tags', async () => {
+    const { error: createError } = await client.POST(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      {
+        params: { path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT } },
+        body: { names: ['category:Running Shoes'] },
+      },
+    );
+    expect(createError).to.equal(undefined);
+
+    const { data: listed, error: listError } = await client.GET(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      {
+        params: {
+          path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT },
+          query: { parent_id: '', search: '' },
+        },
+      },
+    );
+    expect(listError).to.equal(undefined);
+    expect(listed.total).to.equal(1);
+    expect(listed.items.map((t) => t.name)).to.deep.equal(['category:Running Shoes']);
+    // The stored/listed shape is an AIOTag (prompts_count), not a TreeNodeResponse (keyword_count).
+    expect(listed.items[0]).to.include.keys('id', 'name', 'prompts_count');
+  });
+
+  // Re-creating the same category name is idempotent (deterministic tag-<name> id) — no duplicate.
+  // The `search` query filters by name substring, so it can target one of several stored tags.
+  it('createProjectTags is idempotent by name; GET search filters by name substring', async () => {
+    const post = (names) => client.POST(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      { params: { path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT } }, body: { names } },
+    );
+    await post(['category:Alpha', 'category:Beta']);
+    await post(['category:Alpha']); // repeat — must not duplicate
+
+    const { data: all } = await client.GET(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      {
+        params: {
+          path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT },
+          query: { parent_id: '', search: '' },
+        },
+      },
+    );
+    expect(all.total).to.equal(2); // Alpha once, Beta once
+
+    const { data: filtered } = await client.GET(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      {
+        params: {
+          path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT },
+          query: { parent_id: '', search: 'beta' },
+        },
+      },
+    );
+    expect(filtered.items.map((t) => t.name)).to.deep.equal(['category:Beta']);
+  });
+
+  // __reset restores the boot seed (no tags), so created standalone tags are cleared — proving the
+  // tags collection rides the seed/reset lifecycle like every other stateful resource.
+  it('clears created tags on __reset (tags ride the seed lifecycle)', async () => {
+    await client.POST('/v2/workspaces/{id}/projects/{project_id}/aio/tags', {
+      params: { path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT } },
+      body: { names: ['category:Ephemeral'] },
+    });
+    await fetch(`${baseUrl}/__reset`, { method: 'POST' });
+
+    const { data: listed } = await client.GET(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      {
+        params: {
+          path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT },
+          query: { parent_id: '', search: '' },
+        },
+      },
+    );
+    expect(listed.total).to.equal(0);
+  });
+
+  // Multi-market: one category name is registered on N market projects via N createProjectTags
+  // calls; each project keeps its OWN tag collection (tags:{ws}:{pid}), never global. Creating a
+  // tag on project A must not surface on project B in the same workspace.
+  it('scopes tags per project (multi-market isolation)', async () => {
+    const ws = globalThis.crypto.randomUUID();
+    const projectA = globalThis.crypto.randomUUID();
+    const projectB = globalThis.crypto.randomUUID();
+    const snapshot = buildSeed({
+      workspaceId: ws,
+      projects: [{ id: projectA, name: 'Market A' }, { id: projectB, name: 'Market B' }],
+    });
+    await fetch(`${baseUrl}/__seed`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(snapshot),
+    });
+
+    await client.POST('/v2/workspaces/{id}/projects/{project_id}/aio/tags', {
+      params: { path: { id: ws, project_id: projectA } },
+      body: { names: ['category:Shared'] },
+    });
+
+    const listTags = (pid) => client.GET('/v2/workspaces/{id}/projects/{project_id}/aio/tags', {
+      params: { path: { id: ws, project_id: pid }, query: { parent_id: '', search: '' } },
+    });
+    const { data: aTags } = await listTags(projectA);
+    const { data: bTags } = await listTags(projectB);
+    expect(aTags.items.map((t) => t.name)).to.deep.equal(['category:Shared']);
+    expect(bTags.total).to.equal(0);
+
+    // restore the boot seed (__seed rewrote the reset baseline) so later cases stay independent.
+    await fetch(`${baseUrl}/__seed`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(SEEDS['workspace-with-data']),
+    });
+  });
+
+  // DELETE removes the standalone project tag (so a 0-prompt orphan can be cleaned up), but the
+  // prompts collection is independent — a prompt that happens to carry the tag is NOT deleted.
+  it('deletes a project tag without touching prompts', async () => {
+    const { data: created } = await client.POST(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      {
+        params: { path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT } },
+        body: { names: ['category:Doomed'] },
+      },
+    );
+    const { response: delRes } = await client.DELETE(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      {
+        params: {
+          path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT },
+          query: { prompt_id: '' },
+        },
+        body: { ids: [created[0].id] },
+      },
+    );
+    expect(delRes.status).to.equal(204);
+
+    const { data: tagsAfter } = await client.GET(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      {
+        params: {
+          path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT },
+          query: { parent_id: '', search: '' },
+        },
+      },
+    );
+    expect(tagsAfter.total).to.equal(0);
+
+    // The seeded prompt is untouched — the tag delete does not cascade to the prompts collection.
+    const { data: prompts } = await client.POST(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/prompts/by_tags',
+      {
+        params: { path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT } },
+        body: { tag_ids: [] },
+      },
+    );
+    expect(prompts.total).to.equal(1);
+    expect(prompts.items[0].id).to.equal(SEED_IDS.promptId);
+  });
+
   // The catalog is the FULL live taxonomy (captured 2026-06-25), so assert the real counts +
   // a known entry, not just the envelope — the consumer resolves language code → UUID against it.
   it('listLanguages returns the full live language taxonomy (38, real UUIDs)', async () => {

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -687,6 +687,23 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     expect(prompts.items[0].id).to.equal(SEED_IDS.promptId);
   });
 
+  // Request validation is enabled, so GET /aio/tags 400s when a required query param
+  // (parent_id/search are swagger-`required`) is omitted, before the handler runs — matching the
+  // live 400 and the contract the PR/docs/JSDoc claim. Mirrors the getBrandTopics 400 test: raw
+  // fetch so we can omit a param the typed client would otherwise require.
+  it('getProjectTags 400s when a required query param is missing (request validation)', async () => {
+    const base = `${baseUrl}/v2/workspaces/${SEED_WORKSPACE}/projects/${SEED_PROJECT}/aio/tags`;
+    const auth = { headers: { Authorization: 'Bearer e2e-token' } };
+
+    const noParent = await fetch(`${base}?search=`, auth);
+    expect(noParent.status).to.equal(400);
+    expect(await noParent.text()).to.match(/parent_id/);
+
+    const noSearch = await fetch(`${base}?parent_id=`, auth);
+    expect(noSearch.status).to.equal(400);
+    expect(await noSearch.text()).to.match(/search/);
+  });
+
   // The catalog is the FULL live taxonomy (captured 2026-06-25), so assert the real counts +
   // a known entry, not just the envelope — the consumer resolves language code → UUID against it.
   it('listLanguages returns the full live language taxonomy (38, real UUIDs)', async () => {

--- a/packages/spacecat-shared-project-engine-client/test/mock/context.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/context.test.js
@@ -36,6 +36,11 @@ describe('mock Context', () => {
     });
   });
 
+  it('exposes the shared tagId helper for the tag-minting routes', () => {
+    const ctx = new Context();
+    expect(ctx.tagId('category:Running Shoes')).to.equal('tag-category%3ARunning%20Shoes');
+  });
+
   it('selects a named seed', () => {
     const ctx = new Context({ seed: 'empty-workspace' });
     expect(ctx.seedName).to.equal('empty-workspace');

--- a/packages/spacecat-shared-project-engine-client/test/mock/factories.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/factories.test.js
@@ -19,6 +19,7 @@ import {
   createBrandUrlMock,
   createLanguageMock,
   createTagNodeMock,
+  createAIOTagMock,
   createBrandTopicMock,
   createBasicResponseMock,
   createInitStatusMock,
@@ -179,6 +180,13 @@ describe('factories — live-shaped entities', () => {
   it('createTagNodeMock yields a TreeNodeResponse', () => {
     const t = createTagNodeMock({ name: 'topic:Probe' });
     expect(t).to.include({ name: 'topic:Probe', children_count: 0, keyword_count: 0 });
+  });
+
+  it('createAIOTagMock yields an AIOTag (prompts_count, not keyword_count)', () => {
+    const t = createAIOTagMock({ id: 'tag-x', name: 'category:Probe' });
+    expect(t).to.deep.equal({
+      id: 'tag-x', name: 'category:Probe', children_count: 0, prompts_count: 0,
+    });
   });
 
   it('createBrandTopicMock yields { topic, volume, prompts }', () => {

--- a/packages/spacecat-shared-project-engine-client/test/mock/seeds.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/seeds.test.js
@@ -23,6 +23,7 @@ import {
 } from '../../mock/seeds.js';
 import {
   createProjectAiModelMock, createPromptMock, createBenchmarkMock, createBrandUrlMock,
+  createAIOTagMock,
 } from '../../mock/factories.js';
 
 describe('seeds', () => {
@@ -130,6 +131,27 @@ describe('buildSeed', () => {
     const ops = createStatefulOps(store);
     expect(ops.benchmarks.list({ workspaceId, projectId })).to.have.length(1);
     expect(ops.brand_urls.list({ workspaceId, projectId, benchmarkId })).to.have.length(1);
+  });
+
+  it('seeds standalone project tags, scoped per project', () => {
+    const workspaceId = 'ws-t';
+    const projectId = 'pr-t';
+    const snapshot = buildSeed({
+      workspaceId,
+      projects: [
+        {
+          id: projectId,
+          name: 'Tagged',
+          tags: [createAIOTagMock({ id: 'tag-cat', name: 'category:Running' })],
+        },
+      ],
+    });
+
+    const store = new InMemoryStore();
+    store.load(snapshot);
+    const tags = createStatefulOps(store).tags.list({ workspaceId, projectId });
+    expect(tags).to.have.length(1);
+    expect(tags[0]).to.include({ id: 'tag-cat', name: 'category:Running' });
   });
 
   it('handles an empty workspace (no projects)', () => {

--- a/packages/spacecat-shared-project-engine-client/test/mock/stateful.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/stateful.test.js
@@ -19,9 +19,9 @@ import {
 } from '../../mock/stateful.js';
 
 describe('stateful — confirmed resource set', () => {
-  it('is projects, ai_models, prompts, benchmarks, brand_urls (live-audited surface)', () => {
+  it('is projects, ai_models, prompts, benchmarks, tags, brand_urls (live-audited surface)', () => {
     expect([...STATEFUL_RESOURCES]).to.deep.equal([
-      'projects', 'ai_models', 'prompts', 'benchmarks', 'brand_urls',
+      'projects', 'ai_models', 'prompts', 'benchmarks', 'tags', 'brand_urls',
     ]);
   });
 });
@@ -31,10 +31,11 @@ describe('stateful — collectionKey scoping', () => {
     expect(collectionKey('projects', { workspaceId: 'w1' })).to.equal('projects:w1');
   });
 
-  it('scopes ai_models, prompts and benchmarks per project', () => {
+  it('scopes ai_models, prompts, benchmarks and tags per project', () => {
     expect(collectionKey('ai_models', { workspaceId: 'w1', projectId: 'p1' })).to.equal('ai_models:w1:p1');
     expect(collectionKey('prompts', { workspaceId: 'w1', projectId: 'p1' })).to.equal('prompts:w1:p1');
     expect(collectionKey('benchmarks', { workspaceId: 'w1', projectId: 'p1' })).to.equal('benchmarks:w1:p1');
+    expect(collectionKey('tags', { workspaceId: 'w1', projectId: 'p1' })).to.equal('tags:w1:p1');
   });
 
   it('scopes brand_urls per benchmark (within a project)', () => {
@@ -117,6 +118,35 @@ describe('stateful — benchmarks ops', () => {
   it('isolates benchmarks across projects', () => {
     const ops = createStatefulOps(new InMemoryStore()).benchmarks;
     ops.createMany({ workspaceId: 'w1', projectId: 'p1' }, [{ domain: 'a.example' }]);
+    expect(ops.list({ workspaceId: 'w1', projectId: 'p2' })).to.have.length(0);
+  });
+});
+
+describe('stateful — tags ops', () => {
+  const scope = { workspaceId: 'w1', projectId: 'p1' };
+
+  it('upserts idempotently (reuses an existing id), lists and bulk-removes', () => {
+    const ops = createStatefulOps(new InMemoryStore()).tags;
+    const created = ops.upsertMany(scope, [
+      { id: 'tag-a', name: 'category:A' },
+      { id: 'tag-b', name: 'category:B' },
+    ]);
+    expect(created).to.have.length(2);
+    expect(ops.list(scope)).to.have.length(2);
+    // a repeated upsert of an existing id reuses the stored tag — no duplicate, no throw
+    const again = ops.upsertMany(scope, [
+      { id: 'tag-a', name: 'category:A' },
+      { id: 'tag-c', name: 'category:C' },
+    ]);
+    expect(again.map((t) => t.id)).to.deep.equal(['tag-a', 'tag-c']);
+    expect(ops.list(scope)).to.have.length(3);
+    expect(ops.removeMany(scope, ['tag-a', 'missing'])).to.equal(1);
+    expect(ops.list(scope)).to.have.length(2);
+  });
+
+  it('isolates tags across projects (the multi-market scoping invariant)', () => {
+    const ops = createStatefulOps(new InMemoryStore()).tags;
+    ops.upsertMany({ workspaceId: 'w1', projectId: 'p1' }, [{ id: 'tag-a', name: 'category:A' }]);
     expect(ops.list({ workspaceId: 'w1', projectId: 'p2' })).to.have.length(0);
   });
 });

--- a/packages/spacecat-shared-project-engine-client/test/mock/tag-id.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/tag-id.test.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { tagId } from '../../mock/tag-id.js';
+
+describe('tag-id', () => {
+  it('derives a deterministic, url-encoded id from a tag name', () => {
+    expect(tagId('brand')).to.equal('tag-brand');
+    // the `category:<name>` taxonomy: `:` and spaces are url-encoded so the id is path-safe
+    expect(tagId('category:Running Shoes')).to.equal('tag-category%3ARunning%20Shoes');
+  });
+
+  it('is stable for the same name (so the two tag-minting routes share one id)', () => {
+    expect(tagId('type:branded')).to.equal(tagId('type:branded'));
+  });
+});

--- a/packages/spacecat-shared-project-engine-client/test/types/factories.type-test.ts
+++ b/packages/spacecat-shared-project-engine-client/test/types/factories.type-test.ts
@@ -26,6 +26,7 @@ import {
   createPromptMock,
   createBenchmarkMock,
   createBrandUrlMock,
+  createAIOTagMock,
 } from '../../mock/factories.js';
 import type { components } from '../../src/index.js';
 
@@ -35,6 +36,7 @@ type Prompt = components['schemas']['model.AIOPromptWithStatus'];
 type AIModel = components['schemas']['model.AIModelResponse'];
 type Benchmark = components['schemas']['model.AIOBenchmarkWithCounters'];
 type BrandUrl = components['schemas']['model.BrandURL'];
+type AIOTag = components['schemas']['model.AIOTag'];
 
 // 1. Each factory returns exactly its spec type (assignable in both directions).
 const project: Project = createProjectMock();
@@ -60,6 +62,12 @@ void updatedProject;
 // 1d. the benchmark + brand-url factories (the overlay drift-guarded list shapes).
 const benchmark: Benchmark = createBenchmarkMock();
 const brandUrl: BrandUrl = createBrandUrlMock();
+// 1e. the AIO tag factory (the GET /aio/tags list item + persisted shape).
+const aioTag: AIOTag = createAIOTagMock({ id: 'tag-x', name: 'category:X' });
+void aioTag.prompts_count;
+void aioTag;
+// @ts-expect-error — keyword_count is a TreeNodeResponse field, not on AIOTag.
+createAIOTagMock({ keyword_count: 0 });
 // CR10: primary_url + root_domain are added to AIOBenchmarkWithCounters by the overlay (live
 // returns them). These reads only compile while CR10 is in the schema — drop CR10 and they error.
 void benchmark.primary_url;


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Makes project-level AIO **tags** a stateful resource in the Project Engine Counterfact mock (`spacecat-shared-project-engine-client`): `POST /aio/tags` now persists, and new `GET` and `DELETE` handlers let a standalone `category:<name>` tag be read back and removed.

## 2. Reasoning
The mock did not persist project tags — `POST /aio/tags` synthesized a `201` array without writing to the store, and there was no `GET` handler. So a standalone category created via `createProjectTags` (a category that has no prompts yet) could not be listed back and disappeared on refresh. This blocked end-to-end verification of the new Categories management surface in elmo, where the UI had to fall back to showing a freshly-added category optimistically because the mock couldn't round-trip it.

## 3. High-level overview of the changes
Adds `tags` as a per-project stateful resource, scoped `tags:{workspaceId}:{projectId}` so the same category registered across multiple market projects keeps an independent collection per project (the multi-market model: one category name is registered on N projects via N `createProjectTags` calls).

Behaviour deltas:
- **`POST /aio/tags`** — before: returned a synthesized array, wrote nothing. After: persists each tag idempotently (deterministic `tag-<name>` id, so re-creating the same name reuses the stored tag, matching the live reuse-by-name) and returns the live top-level `TreeNodeResponse` array.
- **`GET /aio/tags`** — new. Returns the project's stored tags as `AIOTagsListResponse`, so a 0-prompt category reads back. The spec-required `parent_id` / `search` query params are honoured (a request missing either `400`s, matching live); a non-empty `search` filters by case-insensitive name substring; `parent_id` is accepted but not used to filter (the mock's tags are a flat per-project collection).
- **`DELETE /aio/tags`** — new. Removes standalone tags by id so an orphaned 0-prompt project tag can be cleaned up. Prompts that carry a removed tag are a separate collection and stay fully intact — the tag delete never cascades to prompts.
- The deterministic tag-id derivation is now shared via `context.tagId` so the two routes that mint tag ids (`POST /aio/tags` and `POST /aio/prompts/tagged`) can't drift out of the cross-endpoint id contract that lets the Categories surface correlate a standalone tag with the same tag attached to a prompt.
- Spec overlay correction (CR5): `model.AIOTag.id` is marked required (a tag always has an id live), with the generated TypeScript types and the Python model regenerated to match. This is the only change to the published client surface.

Note: a mock GHCR image republish (on the next `@adobe/spacecat-shared-project-engine-client` release, per `project-engine-client-mock-image.yaml`) is required for the local-dev / integration-test stacks to pick this up.

## 4. Required information
- Jira / issue: adobe/spacecat-shared issue 1751 — https://github.com/adobe/spacecat-shared/issues/1751
- Other: related mock-fixture-fidelity issue — https://github.com/adobe/mysticat-data-service/issues/757

## 5. Affected / used mysticat-workspace projects
- `spacecat-api-service` — consumes the mock through the serenity transport `createProjectTags` (`POST /aio/tags`); the new `GET /aio/tags` is what unblocks end-to-end verification of the `POST /v2/orgs/:org/brands/:brand/serenity/tags` Categories endpoint. Contract: the persisted tag id and the id embedded in prompt tags now share one derivation.
- `mysticat-data-service` / local-dev + integration-test stacks — consume the containerized mock (GHCR image); they pick up this change only after the mock image is republished on the next package release.

## 7. Test plan
(a) Local end-to-end: exercised the change against a live Counterfact mock booted by the package runner, driving the real generated client through the full tag spine — create-then-`GET` round-trip of a 0-prompt category, idempotent re-create by name, `search` substring filtering, `__reset` lifecycle (created tags cleared back to the seed baseline), two-project multi-market isolation (a tag created on project A does not surface on project B in the same workspace), and `DELETE` of a project tag while the seeded prompt remains listable. All round-tripped as expected.

(b) Per-environment: this is a shared-library mock, not deployed infrastructure — there is no dev/stage/prod deploy for the mock itself. The only published-client delta is the regenerated types (`model.AIOTag.id` now required). For the local-dev / integration-test stacks to consume the new stateful behaviour, republish the mock GHCR image on the next `@adobe/spacecat-shared-project-engine-client` release (`project-engine-client-mock-image.yaml`), then verify a standalone category created via `createProjectTags` reads back through `GET /aio/tags` in the offline serenity local-dev stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
