### PR TITLE
fix(project-engine-client): resolve added AI model to real catalog name/icon in mock

### DIFF
--- a/packages/spacecat-shared-project-engine-client/docs/mock-usage.md
+++ b/packages/spacecat-shared-project-engine-client/docs/mock-usage.md
@@ -135,7 +135,9 @@ method that calls it.
 > `BasicResponse` envelope. `createProject` returns a **draft `ProjectResponse`** — the request's
 > flat `brand_*`/`language_id`/`country_code`/`location_*` fields are nested under `settings.ai`,
 > with `live_id`/`draft_id` mirrored and `is_draft: true`/`publish_status: 'draft'` — NOT a flat
-> echo of the request body. `addAiModel` resolves the catalog model's `icon` onto the response.
+> echo of the request body. `addAiModel` resolves the catalog model's `name` and `icon` onto the
+> response (with an empty `key`), matching the live add path; an unmodelled `model_id` keeps the
+> factory default (GPT-4o).
 
 ---
 

--- a/packages/spacecat-shared-project-engine-client/mock/ai-model-catalog.js
+++ b/packages/spacecat-shared-project-engine-client/mock/ai-model-catalog.js
@@ -40,6 +40,8 @@ export const CATALOG_CAPTURED = '2026-06-25';
  * @typedef {{ id: string, name: string, key: string, icon: string }} AiModelCatalogEntry
  */
 
+// Both the array and each entry are frozen, so a consumer holding a reference can't mutate shared
+// catalog state within the mock process (`Object.freeze` on the array alone is shallow).
 /** @type {ReadonlyArray<AiModelCatalogEntry>} */
 export const AI_MODEL_CATALOG = Object.freeze([
   {
@@ -108,4 +110,4 @@ export const AI_MODEL_CATALOG = Object.freeze([
     key: 'deepseek',
     icon: 'deepseek',
   },
-]);
+].map(Object.freeze));

--- a/packages/spacecat-shared-project-engine-client/mock/ai-model-catalog.js
+++ b/packages/spacecat-shared-project-engine-client/mock/ai-model-catalog.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * The canonical Project Engine AI-model catalog — the single source of truth shared by the
+ * `GET /v1/ai_models` route (the GLOBAL "available models" list the consumer reads) and the
+ * project-scoped add handler (`POST /v2/.../ai_models`), which resolves the posted `model_id`
+ * back to the catalog model's `name` + `icon` the live add path echoes. It is the FULL live
+ * catalog (real keys/ids/icons), captured verbatim 2026-06-25 against the test workspace.
+ *
+ * Live reports `total: 22` while returning these 11 distinct models — a Semrush counting quirk;
+ * the catalog route keeps `total` consistent with the items it serves.
+ *
+ * Exposing the list here (instead of inline in the route) is what lets the add path return the
+ * REAL selected model's name/icon: before this, every added model echoed the `createAiModelMock`
+ * default (GPT-4o), so a project that tracked e.g. Perplexity + Gemini read back as three GPT-4o
+ * rows. The add handler now looks the posted id up here and only the `key` comes back empty,
+ * matching live (verified 2026-06-25).
+ */
+
+/**
+ * The date the catalog was captured verbatim from the live Semrush gateway, so drift from the live
+ * taxonomy is discoverable/greppable rather than buried in prose. Bump it when the catalog is
+ * re-captured.
+ */
+export const CATALOG_CAPTURED = '2026-06-25';
+
+/**
+ * @typedef {{ id: string, name: string, key: string, icon: string }} AiModelCatalogEntry
+ */
+
+/** @type {ReadonlyArray<AiModelCatalogEntry>} */
+export const AI_MODEL_CATALOG = Object.freeze([
+  {
+    id: 'ee6a9130-3d57-4196-b1a2-43a6edd2d0d6',
+    name: 'OpenEvidence',
+    key: 'open-evidence',
+    icon: 'openEvidence',
+  },
+  {
+    id: 'eab23d14-df70-463f-8779-3f6a4ba770bc',
+    name: 'ChatGPT',
+    key: 'search-gpt',
+    icon: 'openai',
+  },
+  {
+    id: '7e372c8f-d9a8-4255-a049-d4cd60772f20',
+    name: 'ChatGPT (No Search)',
+    key: 'gpt-5',
+    icon: 'openai',
+  },
+  {
+    id: 'a041f7d9-abb7-4b02-9967-b37459ef0d80',
+    name: 'Google AI Overview',
+    key: 'google-ai-overview',
+    icon: 'google',
+  },
+  {
+    id: 'a31bd3b2-deb2-4e22-8191-9c255671835d',
+    name: 'Google AI Mode',
+    key: 'google-ai-mode',
+    icon: 'google',
+  },
+  {
+    id: '4e0afe27-c9cc-4730-9dd1-f307309bafe3',
+    name: 'Perplexity',
+    key: 'perplexity',
+    icon: 'perplexity',
+  },
+  {
+    id: '56423570-b83d-4dc9-a743-52f8521c986c',
+    name: 'MS Copilot',
+    key: 'microsoft-copilot',
+    icon: 'microsoftCopilot',
+  },
+  {
+    id: 'b549432a-bb68-40d0-9901-6aeab4e975a2',
+    name: 'Grok',
+    key: 'grok-3',
+    icon: 'grok',
+  },
+  {
+    id: '58c396de-85a4-4f7f-adfb-240019c6375f',
+    name: 'Gemini',
+    key: 'gemini-2.5-flash',
+    icon: 'gemini',
+  },
+  {
+    id: '8663d87f-f2cc-43e6-851e-c5fc38527c9c',
+    name: 'Claude',
+    key: 'claude-sonnet-4',
+    icon: 'claude',
+  },
+  {
+    id: '452163e0-dcd6-4f48-9610-192848e52694',
+    name: 'Deepseek',
+    key: 'deepseek',
+    icon: 'deepseek',
+  },
+]);

--- a/packages/spacecat-shared-project-engine-client/mock/ai-model-catalog.js
+++ b/packages/spacecat-shared-project-engine-client/mock/ai-model-catalog.js
@@ -110,4 +110,4 @@ export const AI_MODEL_CATALOG = Object.freeze([
     key: 'deepseek',
     icon: 'deepseek',
   },
-].map(Object.freeze));
+].map((entry) => Object.freeze(entry)));

--- a/packages/spacecat-shared-project-engine-client/mock/context.js
+++ b/packages/spacecat-shared-project-engine-client/mock/context.js
@@ -44,6 +44,7 @@ import { authError } from './auth.js';
 import { emptyAck } from './responses.js';
 import * as factories from './factories.js';
 import { LANGUAGE_CATALOG } from './language-catalog.js';
+import { AI_MODEL_CATALOG } from './ai-model-catalog.js';
 import { tagId } from './tag-id.js';
 import { SEEDS, DEFAULT_SEED } from './seeds.js';
 
@@ -88,6 +89,10 @@ export class Context {
     // route serves it without duplicating the 38-entry list, mirroring how `factories` is shared —
     // every route reads its lib data through `$.context`, never an import.
     this.languageCatalog = LANGUAGE_CATALOG;
+    // The canonical AI-model catalog (mock/ai-model-catalog.js). Exposed so the global
+    // `GET /v1/ai_models` route serves it AND the project-scoped add handler resolves a posted
+    // `model_id` to the real model's name/icon — same `$.context` lib-data convention as above.
+    this.aiModelCatalog = AI_MODEL_CATALOG;
     // The deterministic tag-id derivation (mock/tag-id.js). Exposed so the two routes that mint tag
     // ids — `POST /aio/tags` and `POST /aio/prompts/tagged` — share one definition and can't drift
     // out of the cross-endpoint id contract that lets `by_tags` / the Categories surface correlate

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v1/ai_models.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v1/ai_models.js
@@ -14,84 +14,15 @@
  * Static handler for GET /v1/ai_models — the GLOBAL AI-model catalog (not workspace/project
  * scoped) the consumer (spacecat-api-service `listGlobalAiModels`) reads to populate the
  * "available models" list. Added to the spec by overlay CR1. Live shape:
- * `{ page, total, items: [{ id, name, key, icon }] }`. This is the FULL live catalog (the real
- * model keys/ids/icons), captured verbatim 2026-06-25 so the mock returns the same taxonomy the
- * consumer maps `model.key` from. (Live reports `total: 22` while returning these 11 distinct
- * models — a Semrush counting quirk; the mock keeps `total` consistent with the items it serves.)
- * Materialized into `.counterfact/routes/` by the mock runner; excluded from coverage.
+ * `{ page, total, items: [{ id, name, key, icon }] }`. The taxonomy lives in
+ * mock/ai-model-catalog.js (exposed as `$.context.aiModelCatalog`) so the project-scoped add
+ * handler can resolve a posted `model_id` to the same model's name/icon — never an import, the
+ * `$.context` lib-data convention. Materialized into `.counterfact/routes/` by the mock runner;
+ * excluded from coverage.
  */
-
-const MODELS = [
-  {
-    id: 'ee6a9130-3d57-4196-b1a2-43a6edd2d0d6',
-    name: 'OpenEvidence',
-    key: 'open-evidence',
-    icon: 'openEvidence',
-  },
-  {
-    id: 'eab23d14-df70-463f-8779-3f6a4ba770bc',
-    name: 'ChatGPT',
-    key: 'search-gpt',
-    icon: 'openai',
-  },
-  {
-    id: '7e372c8f-d9a8-4255-a049-d4cd60772f20',
-    name: 'ChatGPT (No Search)',
-    key: 'gpt-5',
-    icon: 'openai',
-  },
-  {
-    id: 'a041f7d9-abb7-4b02-9967-b37459ef0d80',
-    name: 'Google AI Overview',
-    key: 'google-ai-overview',
-    icon: 'google',
-  },
-  {
-    id: 'a31bd3b2-deb2-4e22-8191-9c255671835d',
-    name: 'Google AI Mode',
-    key: 'google-ai-mode',
-    icon: 'google',
-  },
-  {
-    id: '4e0afe27-c9cc-4730-9dd1-f307309bafe3',
-    name: 'Perplexity',
-    key: 'perplexity',
-    icon: 'perplexity',
-  },
-  {
-    id: '56423570-b83d-4dc9-a743-52f8521c986c',
-    name: 'MS Copilot',
-    key: 'microsoft-copilot',
-    icon: 'microsoftCopilot',
-  },
-  {
-    id: 'b549432a-bb68-40d0-9901-6aeab4e975a2',
-    name: 'Grok',
-    key: 'grok-3',
-    icon: 'grok',
-  },
-  {
-    id: '58c396de-85a4-4f7f-adfb-240019c6375f',
-    name: 'Gemini',
-    key: 'gemini-2.5-flash',
-    icon: 'gemini',
-  },
-  {
-    id: '8663d87f-f2cc-43e6-851e-c5fc38527c9c',
-    name: 'Claude',
-    key: 'claude-sonnet-4',
-    icon: 'claude',
-  },
-  {
-    id: '452163e0-dcd6-4f48-9610-192848e52694',
-    name: 'Deepseek',
-    key: 'deepseek',
-    icon: 'deepseek',
-  },
-];
 
 /** GET — list the global AI model catalog (each row shaped via the factory). */
 export function GET($) {
-  const items = MODELS.map((m) => $.context.factories.createAiModelMock(m));
+  const items = $.context.aiModelCatalog.map((m) => $.context.factories.createAiModelMock(m));
   return $.response[200].json({ page: 1, total: items.length, items });
 }

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/ai_models.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/ai_models.js
@@ -33,11 +33,17 @@ export function POST($) {
   const { path, body, context } = $;
   const catalogModel = context.aiModelCatalog.find((m) => m.id === body.model_id);
   // Live echoes the catalog model's name + icon on add; only `key` comes back empty there.
-  const modelOverrides = catalogModel
-    ? {
+  // A missing model_id can't reach here on the validated route (the request schema marks it
+  // required → 400), but guard anyway so the unmodelled fallback never overrides the factory's
+  // generated id with `undefined`.
+  let modelOverrides = {};
+  if (catalogModel) {
+    modelOverrides = {
       id: body.model_id, key: '', name: catalogModel.name, icon: catalogModel.icon,
-    }
-    : { id: body.model_id };
+    };
+  } else if (body.model_id) {
+    modelOverrides = { id: body.model_id };
+  }
   const created = context.ops.ai_models.add(
     { workspaceId: path.id, projectId: path.project_id },
     context.factories.createProjectAiModelMock({

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/ai_models.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/ai_models.js
@@ -18,16 +18,30 @@
  * version-agnostic store key (`ai_models:{workspaceId}:{projectId}`), so a subsequent v1 GET
  * reflects it. v2 has no list/delete variant, so only POST is wired here.
  *
+ * The posted `model_id` is resolved against the global AI-model catalog
+ * (`$.context.aiModelCatalog`) so the stored/echoed model carries the REAL model's `name` + `icon`
+ * — only `key` comes back empty, matching the live add path (verified 2026-06-25). Without this
+ * lookup every added model fell back to the `createAiModelMock` default (GPT-4o), so a project
+ * tracking e.g. Perplexity + Gemini read back as identical "GPT-4o" rows. An unknown id keeps the
+ * factory default (the id is still preserved), a faithful-enough floor for the unmodelled case.
+ *
  * Materialized into `.counterfact/routes/` by the mock runner; excluded from coverage.
  */
 
 /** POST — add an AI model to the project (body: { model_id }) → 201 (matches live). */
 export function POST($) {
   const { path, body, context } = $;
+  const catalogModel = context.aiModelCatalog.find((m) => m.id === body.model_id);
+  // Live echoes the catalog model's name + icon on add; only `key` comes back empty there.
+  const modelOverrides = catalogModel
+    ? {
+      id: body.model_id, key: '', name: catalogModel.name, icon: catalogModel.icon,
+    }
+    : { id: body.model_id };
   const created = context.ops.ai_models.add(
     { workspaceId: path.id, projectId: path.project_id },
     context.factories.createProjectAiModelMock({
-      model: context.factories.createAiModelMock({ id: body.model_id }),
+      model: context.factories.createAiModelMock(modelOverrides),
       prompts_count: 0,
     }),
   );

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -29,6 +29,7 @@ import { fileURLToPath } from 'node:url';
 import { createSerenityProjectEngineApiClient } from '../../src/index.js';
 import { buildSeed, SEEDS, SEED_IDS } from '../../mock/seeds.js';
 import { createBenchmarkMock } from '../../mock/factories.js';
+import { AI_MODEL_CATALOG } from '../../mock/ai-model-catalog.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packageRoot = join(here, '..', '..');
@@ -505,6 +506,27 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     expect(response.status).to.equal(201);
     // Live resolves the catalog model's icon onto the add response (verified 2026-06-25).
     expect(data.model).to.include.keys('id', 'icon');
+  });
+
+  // Regression: a known catalog model_id must echo THAT model's name + icon — not the
+  // createAiModelMock GPT-4o default. Before the catalog lookup, every added model read back as
+  // GPT-4o, so a project tracking Perplexity/Gemini showed identical "GPT-4o" rows. Live returns
+  // the catalog name + icon with an EMPTY key on the add path (verified 2026-06-25).
+  it('addAiModel (v2) resolves the posted model_id to the real catalog name + icon', async () => {
+    const perplexity = AI_MODEL_CATALOG.find((m) => m.key === 'perplexity');
+    const { data, error } = await client.POST(
+      '/v2/workspaces/{id}/projects/{project_id}/ai_models',
+      {
+        params: { path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT } },
+        body: { model_id: perplexity.id },
+      },
+    );
+    expect(error).to.equal(undefined);
+    expect(data.model.id).to.equal(perplexity.id);
+    expect(data.model.name).to.equal('Perplexity');
+    expect(data.model.icon).to.equal('perplexity');
+    // Live add path returns the catalog name + icon but an empty `key`.
+    expect(data.model.key).to.equal('');
   });
 
   it('createProjectTags returns a top-level array, matching the live API (drift D1/CR6)', async () => {

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -506,6 +506,10 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     expect(response.status).to.equal(201);
     // Live resolves the catalog model's icon onto the add response (verified 2026-06-25).
     expect(data.model).to.include.keys('id', 'icon');
+    // SEED_IDS.aiModelId is NOT a catalog id, so this exercises the unmodelled fallback:
+    // the factory default (GPT-4o) is kept, with the posted id preserved.
+    expect(data.model.name).to.equal('GPT-4o');
+    expect(data.model.key).to.equal('gpt-4o');
   });
 
   // Regression: a known catalog model_id must echo THAT model's name + icon — not the

--- a/packages/spacecat-shared-project-engine-client/test/mock/context.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/context.test.js
@@ -43,7 +43,7 @@ describe('mock Context', () => {
 
   it('exposes the ai-model catalog for the catalog route + add-path resolution', () => {
     const ctx = new Context();
-    expect(ctx.aiModelCatalog).to.be.an('array').with.length(11);
+    expect(ctx.aiModelCatalog).to.be.an('array').with.length.greaterThan(0);
     expect(ctx.aiModelCatalog).to.deep.include({
       id: '4e0afe27-c9cc-4730-9dd1-f307309bafe3', name: 'Perplexity', key: 'perplexity', icon: 'perplexity',
     });

--- a/packages/spacecat-shared-project-engine-client/test/mock/context.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/context.test.js
@@ -41,6 +41,14 @@ describe('mock Context', () => {
     expect(ctx.tagId('category:Running Shoes')).to.equal('tag-category%3ARunning%20Shoes');
   });
 
+  it('exposes the ai-model catalog for the catalog route + add-path resolution', () => {
+    const ctx = new Context();
+    expect(ctx.aiModelCatalog).to.be.an('array').with.length(11);
+    expect(ctx.aiModelCatalog).to.deep.include({
+      id: '4e0afe27-c9cc-4730-9dd1-f307309bafe3', name: 'Perplexity', key: 'perplexity', icon: 'perplexity',
+    });
+  });
+
   it('selects a named seed', () => {
     const ctx = new Context({ seed: 'empty-workspace' });
     expect(ctx.seedName).to.equal('empty-workspace');


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
The Project Engine mock now resolves an added AI model's id to the real catalog model's name + icon, instead of stamping every added model with the GPT-4o default.

## 2. Reasoning
Found while e2e-testing the Serenity Markets/Models flow on the local stack: a newly created project that tracked several distinct LLMs (e.g. ChatGPT + ChatGPT (No Search) + Google AI Overview) read back as three identical "GPT-4o" rows. The mock's add-model handler preserved the posted `model_id` but used the `createAiModelMock` default (`key=gpt-4o`, `name=GPT-4o`, `icon=openai`) for the model's display fields, so the real selections were invisible to any consumer reading the project's models. Live Semrush resolves the catalog model's name + icon from the posted id (only `key` comes back empty there).

## 3. High-level overview of the changes
Behaviour delta on `POST /v2/workspaces/{id}/projects/{project_id}/ai_models` (add a model to a project):

- Before: the stored/echoed model always carried `name=GPT-4o`, `key=gpt-4o`, `icon=openai`, regardless of the posted `model_id` (the id itself was preserved). A project tracking N distinct models read back as N identical GPT-4o rows.
- After: the handler resolves `model_id` against the global AI-model catalog and stores/echoes that model's real `name` + `icon`, with an empty `key` — matching the live add path. An unknown id keeps the prior default.

Supporting refactor: the 11-model catalog moved out of the `GET /v1/ai_models` route into a shared `mock/ai-model-catalog.js`, exposed on the mock `Context` as `$.context.aiModelCatalog` (same lib-data-via-context convention already used for `languageCatalog`). The global catalog route now reads it from the context; its output is unchanged.

User-visible effect: a project's tracked models display their real names (Perplexity, Gemini, Claude, …) in any consumer driving the mock — e.g. the Serenity Markets "Models" column in elmo-ui.

## 4. Required information
- Other: builds on the AIO-tags statefulness mock work in  https://github.com/adobe/spacecat-shared/pull/1752  (released as `project-engine-client` 1.4.0)

## 5. Affected / used mysticat-workspace projects
- spacecat-api-service — consumes the published GHCR mock image for offline `/serenity/*` dev; picks up this fix only after the mock image is republished and the `@adobe/spacecat-shared-project-engine-client` dep is bumped.
- mysticat-workspace (local-dev) — pins the mock image tag to the installed client version, so a client release is what carries this fix to local stacks.

## 6. Additional information outside the code
Verified against the running local mock + Postgres this session. Dumping the PE mock store (`GET .../__dump`) for a freshly created project showed three AI-model assignments with three distinct `model.id`s but every `model.name` = "GPT-4o". Cross-checking those ids against the global catalog (`GET /v1/ai_models`) resolved them to ChatGPT (`search-gpt`), ChatGPT (No Search) (`gpt-5`), and Google AI Overview (`google-ai-overview`) — confirming the consumer sent the correct models and only the mock's echo was wrong. After the fix, driving the mock from source returns the real catalog name + icon for a posted model id.

## 7. Test plan
(a) Local: booting the mock from source (`npm run mock` path used by the package e2e), a posted catalog model id reads back the real model name + icon with an empty key; the existing add/list and global-catalog behaviour is unchanged.
(b) This is a dev/test mock, not deployed to envs. End-to-end check after release: re-pull the republished mock image (`make up-semrush-mocks`), create a market in elmo-ui selecting one or more non-default LLMs, and confirm the Markets "Models" column shows the selected models' real names rather than "GPT-4o".

## 8. Deployment & merge order
- Related:  https://github.com/adobe/spacecat-shared/pull/1752  (project-engine-client 1.4.0) — this PR is rebased on top of it.

Ordered sequence: merge this PR → semantic-release publishes the new `project-engine-client` version and republishes the GHCR mock image → bump `@adobe/spacecat-shared-project-engine-client` in spacecat-api-service and re-pull the local mock to surface the real model names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
