### PR TITLE
feat(http-utils): surface a ReBAC session flag on the no-resource defer path

### DIFF
--- a/packages/spacecat-shared-http-utils/src/auth/facs-wrapper.js
+++ b/packages/spacecat-shared-http-utils/src/auth/facs-wrapper.js
@@ -378,6 +378,24 @@ export function facsWrapper(fn, { routeFacsCapabilities } = {}) {
     });
 
     if (!resource) {
+      // Reaching here means the session is FACS-enrolled (passed the internal,
+      // internal-org and LD-flag gates) and resource-scoped (the JWT short-circuit
+      // at step 5 did not fire, so the caller lacks the org-wide capability), yet
+      // there is no single ReBAC resource to enforce against. Surface that to the
+      // controller via `context.attributes.facs` so collection endpoints (whose
+      // path param is the org, not a resource — e.g. list-sites, list-brands) can
+      // ReBAC-filter their results to the resources the caller may view. Callers
+      // that bypass earlier (admin / internal org / LD-off) or short-circuit on an
+      // org-wide JWT capability never set this flag, so those sessions see the
+      // unfiltered collection — the controller treats an absent flag as "no filter".
+      // `context.attributes` is always present here: reaching this point past the
+      // per-product LD-flag gate required a tenant (`orgId`), read from `authInfo`
+      // on `context.attributes`.
+      context.attributes.facs = {
+        enabled: true,
+        product: upperProduct,
+        subjectId: subjectUserId,
+      };
       log.info({
         tag: 'facs',
         defer: 'no-resolvable-resource',

--- a/packages/spacecat-shared-http-utils/test/auth/facs-wrapper.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/facs-wrapper.test.js
@@ -503,6 +503,13 @@ describe('facsWrapper', () => {
       expect(logStub.info.calledWithMatch(
         { tag: 'facs', defer: 'no-resolvable-resource' },
       )).to.be.true;
+      // The enrolled, resource-scoped defer surfaces a ReBAC session flag so
+      // collection endpoints can filter their results.
+      expect(context.attributes.facs).to.deep.equal({
+        enabled: true,
+        product: 'LLMO',
+        subjectId: 'user@example.com',
+      });
     });
 
     it('defers when product has no alias lookup at all', async () => {


### PR DESCRIPTION
## What

`facsWrapper` now sets `context.attributes.facs = { enabled, product, subjectId }` on the **no-resolvable-resource defer path** — the branch where the session is FACS-enrolled but the route carries no single ReBAC resource to enforce against (its path param is the org, not a resource — e.g. `GET /organizations/:id/sites`, `GET /v2/orgs/:id/brands`).

## Why

These are **collection endpoints**: there is no single resource for the wrapper to resolve and allow/deny. The wrapper already defers them to the controller. This change lets the controller know the session is ReBAC-enrolled so it can **filter the collection** to the resources the caller may view — without re-implementing LD-flag/enrollment logic in the consuming service.

## Semantics (who gets the flag)

Reaching the defer point means all of: not an internal identity, not an internal/exempt org, the per-product **LD flag is ON**, and the **JWT short-circuit did not fire** (caller lacks the org-wide capability). So:

| Session | Flag set? | Controller behavior |
|---|---|---|
| admin / S2S / internal-org / LD-off | no | full collection (unfiltered) |
| org-wide JWT capability holder | no (short-circuits at step 5) | full collection |
| enrolled, resource-scoped user | **yes** | filter to viewable resources |

Purely additive — no consumer reads the flag yet. `facs-wrapper.js` stays at 100% coverage (478 tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
