### PR TITLE
fix(ims-client): use application/x-www-form-urlencoded instead of multipart/form-data

### DIFF
--- a/packages/spacecat-shared-ims-client/src/utils.js
+++ b/packages/spacecat-shared-ims-client/src/utils.js
@@ -26,15 +26,11 @@ export const IMS_ADMIN_PROFILE_ENDPOINT = '/ims/admin_profile/v3';
 export const IMS_ACCOUNT_CLUSTER_ENDPOINT = '/ims/account_cluster/v2';
 export const IMS_ADMIN_ORGANIZATIONS_ENDPOINT = '/ims/admin_organizations/v4';
 /**
- * Creates and populates a FormData object from key-value pairs.
- * @param {Object} fields - Object containing key-value pairs to append to FormData.
- * @returns {FormData} A populated FormData object.
+ * Encodes key-value pairs as application/x-www-form-urlencoded.
+ * @param {Object} fields - Object containing key-value pairs to encode.
+ * @returns {URLSearchParams} A URLSearchParams object ready to use as a fetch body.
  */
-export const createFormData = (fields) => {
-  const formData = new FormData();
-  Object.entries(fields).forEach(([key, value]) => formData.append(key, value));
-  return formData;
-};
+export const createFormData = (fields) => new URLSearchParams(Object.entries(fields));
 
 /**
  * Generates the IMS groups endpoint URL.

--- a/packages/spacecat-shared-ims-client/test/clients/ims-client.test.js
+++ b/packages/spacecat-shared-ims-client/test/clients/ims-client.test.js
@@ -422,12 +422,7 @@ describe('ImsClient', () => {
     it('includes org_id in the POST body to IMS token v3', async () => {
       const orgId = '1234567890ABCDEF12345678@AdobeOrg';
       nock(`https://${DUMMY_HOST}`)
-        .post('/ims/token/v3', (body) => {
-          const str = typeof body === 'object' && body !== null
-            ? Object.entries(body).map(([k, v]) => `${k}=${v}`).join('&')
-            : String(body);
-          return str.includes('org_id') && str.includes('1234567890ABCDEF12345678');
-        })
+        .post('/ims/token/v3', (body) => 'org_id' in body && body.org_id === orgId)
         .query(true)
         .reply(200, {
           access_token: 'org-scoped-token',

--- a/packages/spacecat-shared-ims-client/test/clients/ims-client.test.js
+++ b/packages/spacecat-shared-ims-client/test/clients/ims-client.test.js
@@ -423,8 +423,10 @@ describe('ImsClient', () => {
       const orgId = '1234567890ABCDEF12345678@AdobeOrg';
       nock(`https://${DUMMY_HOST}`)
         .post('/ims/token/v3', (body) => {
-          const str = typeof body === 'string' ? body : body.toString('utf8');
-          return str.includes('org_id') && str.includes('1234567890ABCDEF12345678@AdobeOrg');
+          const str = typeof body === 'object' && body !== null
+            ? Object.entries(body).map(([k, v]) => `${k}=${v}`).join('&')
+            : String(body);
+          return str.includes('org_id') && str.includes('1234567890ABCDEF12345678');
         })
         .query(true)
         .reply(200, {

--- a/packages/spacecat-shared-ims-client/test/clients/ims-promise-client.test.js
+++ b/packages/spacecat-shared-ims-client/test/clients/ims-promise-client.test.js
@@ -101,9 +101,9 @@ describe('ImsPromiseClient', () => {
       nock(`https://${DUMMY_HOST}`)
         .post(
           IMS_TOKEN_ENDPOINT,
-          (body) => body.match('name="grant_type"\r\n\r\npromise')
-            && body.match('name="promise_definition_id"\r\n\r\npromiseDefinitionIdExample')
-            && body.match(`name="authenticating_token"\r\n\r\n${testAccessToken}`),
+          (body) => body.grant_type === 'promise'
+            && body.promise_definition_id === 'promiseDefinitionIdExample'
+            && body.authenticating_token === testAccessToken,
         )
         .reply(200, {
           scope: 'AdobeID,openid,read_organizations,additional_info.projectedProductContext',
@@ -113,9 +113,9 @@ describe('ImsPromiseClient', () => {
         })
         .post(
           IMS_TOKEN_ENDPOINT,
-          (body) => body.match('name="grant_type"\r\n\r\npromise')
-            && body.match('name="promise_definition_id"\r\n\r\npromiseDefinitionIdExample')
-            && !body.match(`name="authenticating_token"\r\n\r\n${testAccessToken}`),
+          (body) => body.grant_type === 'promise'
+            && body.promise_definition_id === 'promiseDefinitionIdExample'
+            && body.authenticating_token !== testAccessToken,
         )
         .reply(401, {
           error: 'invalid_authenticating_token',
@@ -179,8 +179,8 @@ describe('ImsPromiseClient', () => {
       nock(`https://${DUMMY_HOST}`)
         .post(
           IMS_TOKEN_ENDPOINT,
-          (body) => body.match('name="grant_type"\r\n\r\npromise_exchange')
-            && body.match(`name="promise_token"\r\n\r\n${testToken}`),
+          (body) => body.grant_type === 'promise_exchange'
+            && body.promise_token === testToken,
         )
         .reply(200, {
           scope: 'AdobeID,openid,read_organizations,additional_info.projectedProductContext',
@@ -193,8 +193,8 @@ describe('ImsPromiseClient', () => {
         })
         .post(
           IMS_TOKEN_ENDPOINT,
-          (body) => body.match('name="grant_type"\r\n\r\npromise_exchange')
-            && !body.match(`name="authenticating_token"\r\n\r\n${testToken}`),
+          (body) => body.grant_type === 'promise_exchange'
+            && body.authenticating_token !== testToken,
         )
         .reply(401, {
           error: 'invalid_promise_token',
@@ -267,14 +267,14 @@ describe('ImsPromiseClient', () => {
       nock(`https://${DUMMY_HOST}`)
         .post(
           IMS_INVALIDATE_TOKEN_ENDPOINT,
-          (body) => body.match('name="token_type"\r\n\r\npromise_token')
-            && body.match(`name="token"\r\n\r\n${testToken}`),
+          (body) => body.token_type === 'promise_token'
+            && body.token === testToken,
         )
         .reply(200)
         .post(
           IMS_INVALIDATE_TOKEN_ENDPOINT,
-          (body) => body.match('name="token_type"\r\n\r\npromise_token')
-            && !body.match(`name="token"\r\n\r\n${testToken}`),
+          (body) => body.token_type === 'promise_token'
+            && body.token !== testToken,
         )
         .reply(400, {
           error: 'invalid_parameter_value',

--- a/packages/spacecat-shared-ims-client/test/utils.test.js
+++ b/packages/spacecat-shared-ims-client/test/utils.test.js
@@ -11,9 +11,17 @@
  */
 
 import { expect } from 'chai';
-import { encrypt, decrypt } from '../src/utils.js';
+import { encrypt, decrypt, createFormData } from '../src/utils.js';
 
 describe('Utils Tests', () => {
+  describe('createFormData', () => {
+    it('encodes fields as application/x-www-form-urlencoded', () => {
+      const result = createFormData({ token: 'abc123', client_id: 'my-client', type: 'access_token' });
+      expect(result).to.be.instanceOf(URLSearchParams);
+      expect(result.toString()).to.equal('token=abc123&client_id=my-client&type=access_token');
+    });
+  });
+
   describe('encrypt/decrypt', () => {
     it('encrypt/decrypt of a string with default values', async () => {
       const text = 'Hello, World!';


### PR DESCRIPTION
## Summary

- IMS flagged that requests using `multipart/form-data` are breaking
- The native `FormData` API (used via `createFormData`) causes fetch to send `multipart/form-data` automatically — even when `noContentType: true` is set, since fetch overrides the header for FormData bodies
- OAuth/token and validate-token endpoints expect `application/x-www-form-urlencoded`
- Switched `createFormData` to return a `URLSearchParams` object, which fetch encodes as `application/x-www-form-urlencoded; charset=utf-8` automatically
- This affects all `imsApiCall` POST requests: `validateAccessToken`, `getServiceAccessToken`, `getServiceAccessTokenV3`, `getServicePrincipalAccessToken`, `getProductContextByImsOrgId`

## Test plan

- [x] Updated `createFormData` unit test to assert `URLSearchParams` output
- [x] Fixed `includes org_id in the POST body to IMS token v3` test body matcher for the new encoding
- [x] Verified `content-type: application/x-www-form-urlencoded` in nock debug output for POST requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)