### PR TITLE
feat(project-engine-client): model 1-level nested AIO tags in the mock

### DIFF
--- a/packages/spacecat-shared-project-engine-client/mock/context.js
+++ b/packages/spacecat-shared-project-engine-client/mock/context.js
@@ -46,6 +46,7 @@ import * as factories from './factories.js';
 import { LANGUAGE_CATALOG } from './language-catalog.js';
 import { AI_MODEL_CATALOG } from './ai-model-catalog.js';
 import { tagId } from './tag-id.js';
+import { parentIdField } from './parent-id.js';
 import { SEEDS, DEFAULT_SEED } from './seeds.js';
 
 /**
@@ -98,6 +99,11 @@ export class Context {
     // out of the cross-endpoint id contract that lets `by_tags` / the Categories surface correlate
     // a standalone tag with the same tag attached to a prompt.
     this.tagId = tagId;
+    // The optional-`parent_id` spread helper (mock/parent-id.js). Exposed so the two tag routes
+    // that build a tag with an optional parent link — `POST /aio/tags` and
+    // `PATCH /aio/tags/{tag_id}` — share one coerce-then-spread definition and can't drift, the
+    // same `$.context` lib-helper convention as `tagId` above.
+    this.parentIdField = parentIdField;
   }
 
   /**

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags.js
@@ -62,6 +62,9 @@ export function POST($) {
   const names = Array.isArray(body?.names) ? body.names : [];
   // A non-empty `parent_id` makes the created tags children under that category; absent/empty ⇒
   // roots (the created tags carry no `parent_id`) — `context.parentIdField` owns that coercion.
+  // `upsertMany` is idempotent by the name-derived id, so re-POSTing an EXISTING name with a
+  // different `parent_id` is a no-op on parentage: it returns the already-stored tag (original
+  // parent) rather than re-parenting it — re-parenting goes through PATCH, not a repeated POST.
   const parentField = context.parentIdField(body?.parent_id);
   const stored = context.ops.tags.upsertMany(
     scope,
@@ -87,6 +90,14 @@ export function GET($) {
   const search = String(query?.search ?? '').toLowerCase();
   const stored = context.ops.tags.list(scope);
   const byId = new Map(stored.map((t) => [t.id, t]));
+  // Pre-count children per parent in one O(n) pass, so the per-item map below is O(n) overall
+  // (not an O(n^2) re-scan of `stored` inside every iteration).
+  const childCounts = new Map();
+  for (const t of stored) {
+    if (t.parent_id) {
+      childCounts.set(t.parent_id, (childCounts.get(t.parent_id) ?? 0) + 1);
+    }
+  }
 
   // `parent_id=''` ⇒ roots (no parent); a non-empty `parent_id` ⇒ that category's children.
   const scoped = parentId
@@ -101,7 +112,7 @@ export function GET($) {
     return context.factories.createAIOTagMock({
       ...t,
       // Derived, never stored: the live tree carries these on every read.
-      children_count: stored.filter((c) => c.parent_id === t.id).length,
+      children_count: childCounts.get(t.id) ?? 0,
       path: parent
         ? [context.factories.createAIOTagLeafMock({
           id: parent.id, name: parent.name, parent_id: String(parent.parent_id ?? ''),

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags.js
@@ -35,7 +35,7 @@
  *   non-empty `parent_id` returns that category's CHILDREN; a non-empty `search` additionally
  *   filters by case-insensitive name substring. Each returned tag carries a DERIVED
  *   `children_count` (stored tags whose `parent_id` is this tag's id) and, for a child, a `path[]`
- *   breadcrumb (a single leaf: its root category); a root's `path` is `[]`.
+ *   breadcrumb (a single leaf: its root category); a root's `parent_id` and `path` are `null`.
  * - DELETE (`aio-delete-tags`): removes the body's tag ids (`BatchDeleteRequest` `{ ids }`) from
  *   the standalone tag collection → 204. Prompts that carry a removed tag are a separate
  *   collection and stay intact (the spec's `prompt_id` query param is accepted but not load-bearing

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags.js
@@ -12,26 +12,47 @@
 
 /**
  * Stateful handlers for /v2/workspaces/{id}/projects/{project_id}/aio/tags — the project-level AIO
- * tag taxonomy (the Categories surface). The per-project `tags` collection (`tags:{ws}:{pid}`) is
- * scoped so the same category registered across N market projects keeps N independent collections.
- * Materialized into `.counterfact/routes/` by the mock runner; excluded from coverage.
+ * tag taxonomy (the Categories surface), modelled as a 1-level tree (see serenity-docs#21): a root
+ * category (`category:<name>`, no `parent_id`) can own bare-named children (sub-categories /
+ * migrated topics) whose `parent_id` is the root's id. The per-project `tags` collection
+ * (`tags:{ws}:{pid}`) is scoped so the same category registered across N market projects keeps N
+ * independent collections. Materialized into `.counterfact/routes/` by the mock runner; excluded
+ * from coverage.
  *
- * - POST (`createProjectTags`): request `TreeNodeListRequest` `{ names }`; persists each tag
- *   idempotently (deterministic `tag-<name>` id, so a repeated create reuses the stored tag,
- *   matching the live reuse-by-name) and returns the live shape — a TOP-LEVEL ARRAY of
- *   `TreeNodeResponse` `[{ id, name, children_count, keyword_count }]` (verified 2026-06-25;
- *   overlay CR6 retypes the 201 as an array).
+ * - POST (`createProjectTags`): request `TreeNodeListRequest` `{ names, parent_id? }`; persists
+ *   each tag idempotently (deterministic `tag-<name>` id, so a repeated create reuses the tag,
+ *   matching the live reuse-by-name) — when `parent_id` is present the created tags are stored as
+ *   children under it. Returns the live shape — a TOP-LEVEL ARRAY of `TreeNodeResponse`
+ *   `[{ id, name, parent_id?, children_count, keyword_count }]` (verified 2026-06-25; overlay CR6
+ *   retypes the 201 as an array). NB the tag id is derived from the name ALONE (shared with
+ *   `POST /aio/prompts/tagged`, which only knows names), so two same-named children under different
+ *   parents collapse to one id — a documented mock limitation while the live prompt→child-tag
+ *   reference contract stays unverified (serenity-docs#21 §7-Q1).
  * - GET (`aio-get-project-tags`): returns the project's stored tags as `AIOTagsListResponse`
  *   `{ items, page, total }`, so a 0-prompt category created via POST reads back. The spec marks
  *   `parent_id` + `search` as required query params (request validation 400s a request missing
- *   either, matching live); the mock's tags are a flat per-project collection, so `parent_id` is
- *   accepted but not used to filter, while a non-empty `search` filters by case-insensitive name
- *   substring.
+ *   either, matching live). The mock is tree-aware: `parent_id=''` (empty) returns ROOTS, a
+ *   non-empty `parent_id` returns that category's CHILDREN; a non-empty `search` additionally
+ *   filters by case-insensitive name substring. Each returned tag carries a DERIVED
+ *   `children_count` (stored tags whose `parent_id` is this tag's id) and, for a child, a `path[]`
+ *   breadcrumb (a single leaf: its root category); a root's `path` is `[]`.
  * - DELETE (`aio-delete-tags`): removes the body's tag ids (`BatchDeleteRequest` `{ ids }`) from
  *   the standalone tag collection → 204. Prompts that carry a removed tag are a separate
  *   collection and stay intact (the spec's `prompt_id` query param is accepted but not load-bearing
  *   here — the mock's project-tag delete targets the standalone collection, never cascading to
  *   prompts).
+ *
+ * Known limitations (edges whose LIVE behaviour is NOT yet verified — serenity-docs#21 §7 — so the
+ * mock deliberately does not invent a resolution):
+ * - DELETE of a parent category does NOT cascade to, or re-parent, its children: a child left
+ *   behind keeps a `parent_id` pointing at the removed root, so it drops out of the roots listing
+ *   (`parent_id` is truthy) and is only reachable by querying the now-deleted parent's id. Whether
+ *   live Semrush cascades, promotes-to-root, or blocks the delete is unconfirmed (§7).
+ * - The tag id is derived from the name (`tag-<name>`, see tag-id.js) but PATCH keeps the id stable
+ *   on rename, so after a rename the stored id no longer equals `tagId(currentName)`; a later
+ *   create or prompt-tag by the NEW name mints a fresh id and thus a duplicate tag. Faithfully
+ *   modelling
+ *   this needs the live prompt→child-tag reference contract (id vs name), still open (§7-Q1).
  */
 
 /** POST — create (persist, idempotent) project tags → 201 array of TreeNodeResponse. */
@@ -39,23 +60,55 @@ export function POST($) {
   const { path, body, context } = $;
   const scope = { workspaceId: path.id, projectId: path.project_id };
   const names = Array.isArray(body?.names) ? body.names : [];
+  // A non-empty `parent_id` makes the created tags children under that category; absent/empty ⇒
+  // roots (the created tags carry no `parent_id`) — `context.parentIdField` owns that coercion.
+  const parentField = context.parentIdField(body?.parent_id);
   const stored = context.ops.tags.upsertMany(
     scope,
-    names.map((name) => context.factories.createAIOTagMock({ id: context.tagId(name), name })),
+    names.map((name) => context.factories.createAIOTagMock({
+      id: context.tagId(name),
+      name,
+      ...parentField,
+    })),
   );
-  const tags = stored.map((t) => context.factories.createTagNodeMock({ id: t.id, name: t.name }));
+  const tags = stored.map((t) => context.factories.createTagNodeMock({
+    id: t.id,
+    name: t.name,
+    ...context.parentIdField(t.parent_id),
+  }));
   return $.response[201].json(tags);
 }
 
-/** GET — list the project's stored tags (optional `search` name filter) → 200 list response. */
+/** GET — list the project's stored tags, tree-aware (`parent_id` scope + `search`) → 200 list. */
 export function GET($) {
   const { path, query, context } = $;
   const scope = { workspaceId: path.id, projectId: path.project_id };
+  const parentId = String(query?.parent_id ?? '');
   const search = String(query?.search ?? '').toLowerCase();
   const stored = context.ops.tags.list(scope);
-  const items = search
-    ? stored.filter((t) => String(t.name).toLowerCase().includes(search))
-    : stored;
+  const byId = new Map(stored.map((t) => [t.id, t]));
+
+  // `parent_id=''` ⇒ roots (no parent); a non-empty `parent_id` ⇒ that category's children.
+  const scoped = parentId
+    ? stored.filter((t) => t.parent_id === parentId)
+    : stored.filter((t) => !t.parent_id);
+  const matched = search
+    ? scoped.filter((t) => String(t.name).toLowerCase().includes(search))
+    : scoped;
+
+  const items = matched.map((t) => {
+    const parent = t.parent_id ? byId.get(t.parent_id) : undefined;
+    return context.factories.createAIOTagMock({
+      ...t,
+      // Derived, never stored: the live tree carries these on every read.
+      children_count: stored.filter((c) => c.parent_id === t.id).length,
+      path: parent
+        ? [context.factories.createAIOTagLeafMock({
+          id: parent.id, name: parent.name, parent_id: String(parent.parent_id ?? ''),
+        })]
+        : [],
+    });
+  });
   // `page` arrives as a query string (e.g. "2"); coerce so the response field stays the numeric
   // type AIOTagsListResponse declares, regardless of whether the param was passed.
   return $.response[200].json({ items, page: Number(query?.page ?? 1), total: items.length });

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags.js
@@ -42,6 +42,11 @@
  *   here — the mock's project-tag delete targets the standalone collection, never cascading to
  *   prompts).
  *
+ * The "1-level" tree is a PRODUCT convention, not an API constraint: a live probe (2026-07-01,
+ * prod) confirmed Semrush accepts a grandchild (`parent_id` pointing at a child), returning 201 —
+ * there is no depth cap on the wire. The mock likewise does not cap depth; keeping the taxonomy to
+ * one level is the onboarding writer's job, not this endpoint's.
+ *
  * Known limitations (edges whose LIVE behaviour is NOT yet verified — serenity-docs#21 §7 — so the
  * mock deliberately does not invent a resolution):
  * - DELETE of a parent category does NOT cascade to, or re-parent, its children: a child left
@@ -111,13 +116,15 @@ export function GET($) {
     const parent = t.parent_id ? byId.get(t.parent_id) : undefined;
     return context.factories.createAIOTagMock({
       ...t,
-      // Derived, never stored: the live tree carries these on every read.
+      // Derived, never stored: the live tree carries these on every read. Live returns `null`
+      // (not an omitted field / an empty array) for a flat root's parent_id + path, and a child's
+      // path leaf is `{ id, name }` — no parent_id (all verified 2026-07-01 against prod; CR13
+      // makes parent_id/path nullable).
       children_count: childCounts.get(t.id) ?? 0,
+      parent_id: t.parent_id || null,
       path: parent
-        ? [context.factories.createAIOTagLeafMock({
-          id: parent.id, name: parent.name, parent_id: String(parent.parent_id ?? ''),
-        })]
-        : [],
+        ? [context.factories.createAIOTagLeafMock({ id: parent.id, name: parent.name })]
+        : null,
     });
   });
   // `page` arrives as a query string (e.g. "2"); coerce so the response field stays the numeric

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Stateful handler for PATCH /v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}
+ * (`aio-update-tag`) — re-parent / rename one tag in the 1-level category tree (see
+ * serenity-docs#21). Request is `TreeNodeRequest` `{ name, parent_id? }`; the stored tag's
+ * `name` + `parent_id` are updated in place while its id stays stable (Semrush tag ids are opaque
+ * and don't move on rename). NB because the mock derives ids from the name, a rename leaves the id
+ * keyed to the OLD name — a documented, live-unverified limitation (see the `tags.js` header's
+ * "Known limitations": a later create/tag by the new name would mint a duplicate). A non-empty
+ * `parent_id` re-parents the tag under that category; an
+ * absent/empty `parent_id` promotes it to a root (`parent_id` cleared to `''`, which the read path
+ * treats as a root). `children_count`/`path` are derived at read time, so they are not part of the
+ * update. Returns 201 `TreeNodeResponse` (the live status for this op, per the spec). An unknown
+ * `tag_id` has nothing to update → 500 (live behaviour here is unverified — serenity-docs#21 §7-Q4;
+ * the consumer only PATCHes tags it just read). Materialized into `.counterfact/routes/` by the
+ * mock runner; excluded from coverage.
+ */
+
+/** PATCH — re-parent / rename a tag (body: `{ name, parent_id? }`) → 201 TreeNodeResponse. */
+export function PATCH($) {
+  const { path, body, context } = $;
+  const scope = { workspaceId: path.id, projectId: path.project_id };
+  // Empty `parent_id` (or omitted) promotes the tag to a root — clear it to '' so the stored shape
+  // reflects "no parent" (the read path treats a falsy parent_id as a root).
+  const parentId = String(body?.parent_id ?? '');
+  const updated = context.ops.tags.update(scope, path.tag_id, {
+    name: body?.name,
+    parent_id: parentId,
+  });
+  if (!updated) {
+    return $.response[500].json(
+      context.factories.createBasicResponseMock({ message: `tag ${path.tag_id} not found` }),
+    );
+  }
+  return $.response[201].json(context.factories.createTagNodeMock({
+    id: updated.id,
+    name: updated.name,
+    ...context.parentIdField(updated.parent_id),
+  }));
+}

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}.js
@@ -32,7 +32,12 @@ export function PATCH($) {
   const { path, body, context } = $;
   const scope = { workspaceId: path.id, projectId: path.project_id };
   // Empty `parent_id` (or omitted) promotes the tag to a root — clear it to '' so the stored shape
-  // reflects "no parent" (the read path treats a falsy parent_id as a root).
+  // reflects "no parent" (the read path treats a falsy parent_id as a root). A degenerate
+  // self-referential `parent_id` (== `tag_id`) is NOT guarded: the consumer never parents a
+  // category to itself, and live Semrush's handling of it is unverified (serenity-docs#21 §7), so
+  // the mock stores it verbatim rather than inventing a rejection — a read would then show a
+  // self-loop (path/children_count pointing at the tag itself), an artefact of that degenerate
+  // input.
   const parentId = String(body?.parent_id ?? '');
   const updated = context.ops.tags.update(scope, path.tag_id, {
     name: body?.name,

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}.js
@@ -27,7 +27,7 @@
  * by the mock runner; excluded from coverage.
  */
 
-/** PATCH — re-parent / rename a tag (body: `{ name, parent_id? }`) → 201 TreeNodeResponse. */
+/** PATCH — re-parent / rename a tag (body: `{ name, parent_id? }`) → 200 TreeNodeResponse. */
 export function PATCH($) {
   const { path, body, context } = $;
   const scope = { workspaceId: path.id, projectId: path.project_id };

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}.js
@@ -21,10 +21,10 @@
  * `parent_id` re-parents the tag under that category; an
  * absent/empty `parent_id` promotes it to a root (`parent_id` cleared to `''`, which the read path
  * treats as a root). `children_count`/`path` are derived at read time, so they are not part of the
- * update. Returns 201 `TreeNodeResponse` (the live status for this op, per the spec). An unknown
- * `tag_id` has nothing to update → 500 (live behaviour here is unverified — serenity-docs#21 §7-Q4;
- * the consumer only PATCHes tags it just read). Materialized into `.counterfact/routes/` by the
- * mock runner; excluded from coverage.
+ * update. Returns 200 `TreeNodeResponse` and 404 `{ message: 'not found' }` for an unknown
+ * `tag_id` — both verified 2026-07-01 against prod (`adobe-hackathon.semrush.com`); the vendored
+ * swagger's 201/no-404 is corrected by overlay CR11/CR12. Materialized into `.counterfact/routes/`
+ * by the mock runner; excluded from coverage.
  */
 
 /** PATCH — re-parent / rename a tag (body: `{ name, parent_id? }`) → 201 TreeNodeResponse. */
@@ -44,11 +44,12 @@ export function PATCH($) {
     parent_id: parentId,
   });
   if (!updated) {
-    return $.response[500].json(
-      context.factories.createBasicResponseMock({ message: `tag ${path.tag_id} not found` }),
-    );
+    // Live returns `404 {"message":"not found"}` for an unknown tag id (verified 2026-07-01 against
+    // prod — CR12 declares the 404 so response validation accepts it).
+    return $.response[404].json(context.factories.createBasicResponseMock({ message: 'not found' }));
   }
-  return $.response[201].json(context.factories.createTagNodeMock({
+  // Live responds 200 (not 201) to aio-update-tag (verified 2026-07-01 against prod — CR11).
+  return $.response[200].json(context.factories.createTagNodeMock({
     id: updated.id,
     name: updated.name,
     ...context.parentIdField(updated.parent_id),

--- a/packages/spacecat-shared-project-engine-client/mock/factories.js
+++ b/packages/spacecat-shared-project-engine-client/mock/factories.js
@@ -315,18 +315,17 @@ export const createAIOTagMock = (overrides = {}) => ({
 });
 
 /**
- * A tag ancestry-breadcrumb leaf (`AIOTagLeaf`) — one `{ id, name, parent_id }` level of an
- * {@link AIOTag}'s `path[]`. In the 1-level tree a child's `path` is a single leaf: its root
- * category. Built through this factory (rather than an inline literal) so the `GET /aio/tags`
- * handler's derived breadcrumb stays tsc-checked against the schema. `parent_id` defaults to `''`
- * (a root ancestor has no parent of its own).
+ * A tag ancestry-breadcrumb leaf (`AIOTagLeaf`) — one level of an {@link AIOTag}'s `path[]`. In the
+ * 1-level tree a child's `path` is a single leaf: its root category. Live returns each path leaf
+ * as `{ id, name }` — `parent_id` is NOT echoed on the breadcrumb (verified 2026-07-01 against
+ * prod) — so it is omitted by default (still overridable, the schema keeps it optional). Built
+ * through this factory (not an inline literal) so the derived breadcrumb stays tsc-checked.
  * @param {Partial<AIOTagLeaf>} [overrides]
  * @returns {AIOTagLeaf}
  */
 export const createAIOTagLeafMock = (overrides = {}) => ({
   id: uuid(),
   name: 'category:Running Shoes',
-  parent_id: '',
   ...overrides,
 });
 

--- a/packages/spacecat-shared-project-engine-client/mock/factories.js
+++ b/packages/spacecat-shared-project-engine-client/mock/factories.js
@@ -36,6 +36,7 @@
 /** @typedef {Schemas['model.LanguageResponse']} Language */
 /** @typedef {Schemas['model.TreeNodeResponse']} TreeNode */
 /** @typedef {Schemas['model.AIOTag']} AIOTag */
+/** @typedef {Schemas['model.AIOTagLeaf']} AIOTagLeaf */
 /** @typedef {Schemas['aiseo.BrandTopicWithPrompts']} BrandTopic */
 /** @typedef {Schemas['http_server.BasicResponse']} BasicResponse */
 /** @typedef {Schemas['model.AIOProjectInitializedResponse']} InitStatus */
@@ -288,8 +289,17 @@ export const createTagNodeMock = (overrides = {}) => ({
 
 /**
  * A stored/listed project tag (`AIOTag`) — the `GET /aio/tags` (`AIOTagsListResponse`) item and
- * the shape the mock persists in the per-project `tags` collection. A standalone `category:<name>`
- * tag is a flat, top-level node, so `parent_id`/`path` are omitted by default; counts default to 0.
+ * the shape the mock persists in the per-project `tags` collection.
+ *
+ * The tag taxonomy is a 1-level tree (see serenity-docs#21): a **root category** is a top-level
+ * node named `category:<name>` with no `parent_id`; a **child** (sub-category / migrated topic) is
+ * a bare `<name>` (no prefix) whose `parent_id` is its root's id. Because roots legitimately have
+ * no parent, `parent_id` is left OUT of the defaults (optional, supplied via override on a child) —
+ * a plain `createAIOTagMock()` is a root. `children_count` and `path` are DERIVED at read time by
+ * the `GET /aio/tags` handler from the stored collection (count of children; the ancestor
+ * breadcrumb), never stored — so they stay consistent as children are added; the
+ * `children_count: 0` default is only the empty baseline a childless root carries in the store.
+ *
  * Distinct from {@link createTagNodeMock}: the create path returns a `TreeNodeResponse`
  * (`keyword_count`) while the list/store shape is an `AIOTag` (`prompts_count`) — two genuinely
  * different live shapes.
@@ -301,6 +311,22 @@ export const createAIOTagMock = (overrides = {}) => ({
   name: 'category:Running Shoes',
   children_count: 0,
   prompts_count: 0,
+  ...overrides,
+});
+
+/**
+ * A tag ancestry-breadcrumb leaf (`AIOTagLeaf`) — one `{ id, name, parent_id }` level of an
+ * {@link AIOTag}'s `path[]`. In the 1-level tree a child's `path` is a single leaf: its root
+ * category. Built through this factory (rather than an inline literal) so the `GET /aio/tags`
+ * handler's derived breadcrumb stays tsc-checked against the schema. `parent_id` defaults to `''`
+ * (a root ancestor has no parent of its own).
+ * @param {Partial<AIOTagLeaf>} [overrides]
+ * @returns {AIOTagLeaf}
+ */
+export const createAIOTagLeafMock = (overrides = {}) => ({
+  id: uuid(),
+  name: 'category:Running Shoes',
+  parent_id: '',
   ...overrides,
 });
 

--- a/packages/spacecat-shared-project-engine-client/mock/parent-id.js
+++ b/packages/spacecat-shared-project-engine-client/mock/parent-id.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * Normalizes a raw `parent_id` into an OPTIONAL-key spread fragment for a tag entity: a non-empty
+ * parent yields `{ parent_id }`, an empty/absent one yields `{}` (so the key is omitted entirely —
+ * a root tag carries no `parent_id`). Shared by the two tag routes that build entities with an
+ * optional parent link (`POST /aio/tags` and `PATCH /aio/tags/{tag_id}`), so the coerce-then-spread
+ * idiom lives in one place and can't drift between them — the same single-source-of-truth reasoning
+ * as {@link tagId} in tag-id.js. Exposed on the per-request context as `context.parentIdField`
+ * (every route reads its lib helpers through `$.context`, never an import — see {@link Context}).
+ *
+ * NB this is only for building a tag whose parent is optional. It is NOT for the PATCH *store
+ * write*, which must set `parent_id` unconditionally (to `''` when promoting a child to a root) so
+ * a previous parent is cleared rather than left in place.
+ *
+ * @param {string | undefined | null} raw the raw `parent_id` (query/body value or a stored field)
+ * @returns {{ parent_id?: string }} `{ parent_id }` when non-empty, else `{}`
+ */
+export const parentIdField = (raw) => {
+  const parentId = String(raw ?? '');
+  return parentId ? { parent_id: parentId } : {};
+};

--- a/packages/spacecat-shared-project-engine-client/mock/seeds.js
+++ b/packages/spacecat-shared-project-engine-client/mock/seeds.js
@@ -25,6 +25,7 @@
 
 import { collectionKey } from './stateful.js';
 import { QUOTA_COLLECTION } from './quota.js';
+import { tagId } from './tag-id.js';
 import {
   createProjectMock,
   createProjectAiModelMock,
@@ -32,6 +33,7 @@ import {
   createPromptMock,
   createBenchmarkMock,
   createBrandUrlMock,
+  createAIOTagMock,
 } from './factories.js';
 
 // Real-shaped fixtures: the Project Engine API types every id as `format: uuid`, so the seeds
@@ -44,6 +46,12 @@ const AI_MODEL_CATALOG_ID = 'd4e5f6a7-b8c9-4d0e-9f1a-3b4c5d6e7f80'; // AIModelRe
 const PROMPT_ID = 'e5f6a7b8-c9d0-4e1f-8a2b-4c5d6e7f8091'; // AIOPromptWithStatus.id
 const BENCHMARK_ID = 'f6a7b8c9-d0e1-4f2a-9b3c-5d6e7f809102'; // AIOBenchmarkWithCounters.id (own brand)
 const BRAND_URL_ID = 'a7b8c9d0-e1f2-4a3b-8c4d-6e7f80910213'; // BrandURL.id
+// Nested category taxonomy (1-level tree, serenity-docs#21): a root `category:` tag with one bare
+// child. Ids are derived by the shared `tagId(name)` helper — the same derivation the two
+// tag-minting routes use — so the seeded ids line up with a POST/tagged create of the same name and
+// `by_tags` / the Categories surface correlate them.
+const CATEGORY_TAG_ID = tagId('category:Running Shoes'); // root category
+const CHILD_TAG_ID = tagId('Trail'); // bare child (sub-category / migrated topic) under the root
 
 /**
  * @typedef {import('./store.js').Snapshot} Snapshot
@@ -70,7 +78,25 @@ export const WORKSPACE_WITH_DATA = Object.freeze({
     }),
   ],
   [collectionKey('prompts', { workspaceId: WORKSPACE_ID, projectId: PROJECT_ID })]: [
-    createPromptMock({ id: PROMPT_ID, name: 'What is the best running shoe?' }),
+    // The seeded prompt carries the nested taxonomy: its root `category:` tag + the bare child, so
+    // the Categories surface and `by_tags` render a populated tree out of the box. Same ids as the
+    // standalone `tags` collection below (both via `tagId`), so the standalone tag and the
+    // prompt-attached tag correlate.
+    createPromptMock({
+      id: PROMPT_ID,
+      name: 'What is the best running shoe?',
+      tags: [
+        createAIOTagMock({ id: CATEGORY_TAG_ID, name: 'category:Running Shoes' }),
+        createAIOTagMock({ id: CHILD_TAG_ID, name: 'Trail', parent_id: CATEGORY_TAG_ID }),
+      ],
+    }),
+  ],
+  // The project's standalone category taxonomy (the `GET /aio/tags` collection): a root category
+  // and one bare child under it. A 0-prompt category still reads back here; `children_count`/`path`
+  // are derived by the read handler from these stored `parent_id` links.
+  [collectionKey('tags', { workspaceId: WORKSPACE_ID, projectId: PROJECT_ID })]: [
+    createAIOTagMock({ id: CATEGORY_TAG_ID, name: 'category:Running Shoes' }),
+    createAIOTagMock({ id: CHILD_TAG_ID, name: 'Trail', parent_id: CATEGORY_TAG_ID }),
   ],
   // The project's own-brand benchmark (main_brand: true) — the `benchmark_id` brand URLs attach
   // to. Mirrors the live listBenchmarks own-brand row.
@@ -111,6 +137,8 @@ export const SEED_IDS = Object.freeze({
   promptId: PROMPT_ID,
   benchmarkId: BENCHMARK_ID,
   brandUrlId: BRAND_URL_ID,
+  categoryTagId: CATEGORY_TAG_ID,
+  childTagId: CHILD_TAG_ID,
 });
 
 /**

--- a/packages/spacecat-shared-project-engine-client/mock/stateful.js
+++ b/packages/spacecat-shared-project-engine-client/mock/stateful.js
@@ -239,6 +239,20 @@ export function createStatefulOps(store) {
         return tags.map((tag) => store.get(key, tag.id) ?? store.create(key, tag));
       },
       /**
+       * Re-parents / renames one tag in place (the `PATCH /aio/tags/{tag_id}` — `aio-update-tag`
+       * surface), returning the updated entity or undefined if the id is unknown. The id stays
+       * stable (Semrush tag ids are opaque; only `name`/`parent_id` change). Promoting a child to a
+       * root is expressed by patching `parent_id` to `''` (the read path treats a falsy `parent_id`
+       * as a root); `children_count`/`path` are never stored, so they are not part of the patch.
+       * @param {{ workspaceId: string | number, projectId: string | number }} scope
+       * @param {string} id
+       * @param {Record<string, unknown>} patch
+       * @returns {Entity | undefined}
+       */
+      update(scope, id, patch) {
+        return store.update(collectionKey('tags', scope), id, patch);
+      },
+      /**
        * Removes the given tag ids from the project's tag collection, reporting how many were
        * actually removed. Only the standalone tag collection is touched — prompts that carry a
        * removed tag are a separate collection and keep their tag map intact.

--- a/packages/spacecat-shared-project-engine-client/spec/overlays/corrections.yaml
+++ b/packages/spacecat-shared-project-engine-client/spec/overlays/corrections.yaml
@@ -57,6 +57,21 @@ info:
 #      list returns both alongside the already-present `project_id` (verified 2026-06-25 against
 #      prod) — same pattern as CR9 — but the vendored swagger omits them. Add them (string).
 #      Remove if Semrush adds the fields upstream.
+# CR11 aio-update-tag (PATCH /v2/.../aio/tags/{tag_id}) responds 200, not 201. The vendored swagger
+#      declares the success response under 201; the live API responds 200 OK (verified 2026-07-01
+#      against prod `adobe-hackathon.semrush.com`, workspace bb0f4e1c-… child, PATCH re-parent+rename
+#      of a tag → 200 with the updated TreeNodeResponse). Move the response 201→200 so the type, the
+#      mock, and the live API agree. Remove if Semrush changes the status upstream.
+# CR12 aio-update-tag returns 404 (not 500) for an unknown tag id. The vendored swagger declares no
+#      404; the live API responds `404 {"message":"not found"}` for a missing tag (verified
+#      2026-07-01 against prod — same shape as the projects delete/patch 404). Add a 404 response
+#      (http_server.BasicResponse) so the mock can return the live status and Counterfact response
+#      validation accepts it. Remove if Semrush declares/relocates it upstream.
+# CR13 model.AIOTag `parent_id` + `path` are NULLABLE. The live tag read returns `parent_id: null`
+#      and `path: null` for a flat / root tag (no parent), not an omitted field or an empty array
+#      (verified 2026-07-01 against prod). The vendored swagger types them non-nullable, so a mock
+#      emitting the live `null` fails response validation / the generated type. Mark both nullable.
+#      Remove if Semrush stops returning null (e.g. omits the fields) upstream.
 #
 # Freshness gate: test/overlay.test.js asserts every action above still APPLIES (matches >0
 # nodes) and is still NECESSARY (changes the converted vendored swagger) — so a re-vendored
@@ -297,3 +312,48 @@ actions:
       properties:
         primary_url: { type: string }
         root_domain: { type: string }
+
+  # ── CR11: aio-update-tag success is 200, not 201 ─────────────────────────
+  # Live: PATCH /v2/.../aio/tags/{tag_id} -> 200 TreeNodeResponse (verified 2026-07-01 against prod).
+  # Add the 200 (copy of the 201 body), then remove the stale 201 (mirrors the CR7 pattern).
+  - target: "$.paths['/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}'].patch.responses"
+    description: "CR11: add the 200 OK success response on aio-update-tag"
+    update:
+      "200":
+        description: "OK"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/model.TreeNodeResponse"
+  - target: "$.paths['/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}'].patch.responses['201']"
+    description: "CR11: remove the stale 201 success response on aio-update-tag"
+    remove: true
+
+  # ── CR12: aio-update-tag returns 404 for an unknown tag id ────────────────
+  # Live: PATCH .../aio/tags/<bogus> -> 404 {"message":"not found"} (verified 2026-07-01 against
+  # prod). The vendored swagger declares no 404; add it (http_server.BasicResponse) so the mock can
+  # return the live status and Counterfact response validation accepts it.
+  - target: "$.paths['/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}'].patch.responses"
+    description: "CR12: add the 404 Not Found response on aio-update-tag"
+    update:
+      "404":
+        description: "Not Found"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/http_server.BasicResponse"
+
+  # ── CR13: AIOTag parent_id + path are nullable (roots return null) ────────
+  # Live: a flat / root tag reads back `parent_id: null` and `path: null` (verified 2026-07-01
+  # against prod) — not an omitted field or an empty array. Deep-merge adds `nullable: true` to the
+  # existing property nodes (keeps their type/items).
+  - target: "$.components.schemas['model.AIOTag']"
+    description: "CR13: AIOTag parent_id + path are nullable (roots return null)"
+    update:
+      properties:
+        parent_id: { type: string, nullable: true }
+        path:
+          type: array
+          nullable: true
+          items:
+            $ref: "#/components/schemas/model.AIOTagLeaf"

--- a/packages/spacecat-shared-project-engine-client/src/generated/types.ts
+++ b/packages/spacecat-shared-project-engine-client/src/generated/types.ts
@@ -1684,8 +1684,8 @@ export interface components {
             children_count?: number;
             id: string;
             name?: string;
-            parent_id?: string;
-            path?: components["schemas"]["model.AIOTagLeaf"][];
+            parent_id?: string | null;
+            path?: components["schemas"]["model.AIOTagLeaf"][] | null;
             prompts_count?: number;
         };
         "model.AIOTagLeaf": {
@@ -8119,8 +8119,8 @@ export interface operations {
         };
         requestBody: components["requestBodies"]["model.TreeNodeRequest"];
         responses: {
-            /** @description Created */
-            201: {
+            /** @description OK */
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -8139,6 +8139,15 @@ export interface operations {
             };
             /** @description Forbidden */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["http_server.BasicResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -549,13 +549,14 @@ async function waitForReady(baseUrl, deadline, getStderr) {
   // The core fix: a standalone tag created via createProjectTags must PERSIST so a 0-prompt
   // category reads back via GET /aio/tags (today the elmo Categories surface falls back to an
   // optimistic add because the mock couldn't persist it). parent_id + search are spec-required
-  // query params (the consumer sends them); empty search lists every stored tag.
-  it('persists createProjectTags and reads the 0-prompt category back via GET /aio/tags', async () => {
+  // query params (the consumer sends them); empty parent_id lists the root categories. A brand-new
+  // name (distinct from the baked seed's `category:Running Shoes`) proves the create→read path.
+  it('persists createProjectTags and reads a new 0-prompt category back via GET /aio/tags', async () => {
     const { error: createError } = await client.POST(
       '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
       {
         params: { path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT } },
-        body: { names: ['category:Running Shoes'] },
+        body: { names: ['category:Hydration'] },
       },
     );
     expect(createError).to.equal(undefined);
@@ -570,10 +571,14 @@ async function waitForReady(baseUrl, deadline, getStderr) {
       },
     );
     expect(listError).to.equal(undefined);
-    expect(listed.total).to.equal(1);
-    expect(listed.items.map((t) => t.name)).to.deep.equal(['category:Running Shoes']);
+    // Roots: the baked `category:Running Shoes` + the just-created `category:Hydration`.
+    expect(listed.total).to.equal(2);
+    expect(listed.items.map((t) => t.name)).to.have.members([
+      'category:Running Shoes', 'category:Hydration',
+    ]);
     // The stored/listed shape is an AIOTag (prompts_count), not a TreeNodeResponse (keyword_count).
-    expect(listed.items[0]).to.include.keys('id', 'name', 'prompts_count');
+    const created = listed.items.find((t) => t.name === 'category:Hydration');
+    expect(created).to.include.keys('id', 'name', 'prompts_count');
   });
 
   // Re-creating the same category name is idempotent (deterministic tag-<name> id) — no duplicate.
@@ -595,7 +600,8 @@ async function waitForReady(baseUrl, deadline, getStderr) {
         },
       },
     );
-    expect(all.total).to.equal(2); // Alpha once, Beta once
+    // roots: the baked `category:Running Shoes` + Alpha (once, not duplicated) + Beta
+    expect(all.total).to.equal(3);
 
     const { data: filtered } = await client.GET(
       '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
@@ -609,8 +615,9 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     expect(filtered.items.map((t) => t.name)).to.deep.equal(['category:Beta']);
   });
 
-  // __reset restores the boot seed (no tags), so created standalone tags are cleared — proving the
-  // tags collection rides the seed/reset lifecycle like every other stateful resource.
+  // __reset restores the boot seed (the baked root category, no ad-hoc tags), so a created
+  // standalone tag is cleared — proving the tags collection rides the seed/reset lifecycle like
+  // every other stateful resource.
   it('clears created tags on __reset (tags ride the seed lifecycle)', async () => {
     await client.POST('/v2/workspaces/{id}/projects/{project_id}/aio/tags', {
       params: { path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT } },
@@ -627,7 +634,120 @@ async function waitForReady(baseUrl, deadline, getStderr) {
         },
       },
     );
-    expect(listed.total).to.equal(0);
+    // back to the baked baseline (the created `category:Ephemeral` is gone)
+    expect(listed.total).to.equal(1);
+    expect(listed.items.map((t) => t.name)).to.deep.equal(['category:Running Shoes']);
+  });
+
+  // Nested create: a child is created with a `parent_id` and reads back under that parent, with a
+  // `path[]` ancestor breadcrumb; the parent's `children_count` reflects it.
+  it('creates a child under a parent (parent_id) and reads it back with path + children_count', async () => {
+    const { data: roots } = await client.POST(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      {
+        params: { path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT } },
+        body: { names: ['category:Footwear'] },
+      },
+    );
+    const parentId = roots[0].id;
+
+    const { data: childCreate } = await client.POST(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      {
+        params: { path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT } },
+        body: { names: ['Sneakers'], parent_id: parentId },
+      },
+    );
+    // the create echo carries the parent linkage
+    expect(childCreate[0]).to.include({ name: 'Sneakers', parent_id: parentId });
+
+    // GET with a non-empty parent_id returns that category's children, each with a path breadcrumb
+    const { data: children } = await client.GET(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      {
+        params: {
+          path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT },
+          query: { parent_id: parentId, search: '' },
+        },
+      },
+    );
+    expect(children.items.map((t) => t.name)).to.deep.equal(['Sneakers']);
+    expect(children.items[0].parent_id).to.equal(parentId);
+    expect(children.items[0].path).to.deep.equal([
+      { id: parentId, name: 'category:Footwear', parent_id: '' },
+    ]);
+
+    // the parent root now reports children_count 1
+    const { data: rootList } = await client.GET(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      {
+        params: {
+          path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT },
+          query: { parent_id: '', search: 'footwear' },
+        },
+      },
+    );
+    expect(rootList.items[0]).to.include({ name: 'category:Footwear', children_count: 1 });
+    expect(rootList.items[0].path).to.deep.equal([]); // a root has no ancestors
+  });
+
+  // The boot seed bakes a nested taxonomy (root `category:Running Shoes` → bare child `Trail`), so
+  // consumers get a populated Categories tree out of the box.
+  it('reads the baked nested taxonomy from the boot seed', async () => {
+    const { data: children } = await client.GET(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      {
+        params: {
+          path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT },
+          query: { parent_id: SEED_IDS.categoryTagId, search: '' },
+        },
+      },
+    );
+    expect(children.items.map((t) => t.name)).to.deep.equal(['Trail']);
+    expect(children.items[0].path).to.deep.equal([
+      { id: SEED_IDS.categoryTagId, name: 'category:Running Shoes', parent_id: '' },
+    ]);
+  });
+
+  // PATCH (aio-update-tag) re-parents / promotes a tag in place. Promoting the baked child `Trail`
+  // to a root clears its parent_id, so it leaves the parent's children and appears among the roots.
+  it('re-parents a tag via PATCH (promote a child to a root)', async () => {
+    const { data: patched, error: patchError } = await client.PATCH(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}',
+      {
+        params: {
+          path: {
+            id: SEED_WORKSPACE, project_id: SEED_PROJECT, tag_id: SEED_IDS.childTagId,
+          },
+        },
+        body: { name: 'Trail', parent_id: '' },
+      },
+    );
+    expect(patchError).to.equal(undefined);
+    expect(patched).to.include({ id: SEED_IDS.childTagId, name: 'Trail' });
+
+    // the promoted tag now appears as a root, and the old parent has no children left
+    const { data: rootsAfter } = await client.GET(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      {
+        params: {
+          path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT },
+          query: { parent_id: '', search: '' },
+        },
+      },
+    );
+    expect(rootsAfter.items.map((t) => t.name)).to.have.members(['category:Running Shoes', 'Trail']);
+
+    const { data: childrenAfter } = await client.GET(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      {
+        params: {
+          path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT },
+          query: { parent_id: SEED_IDS.categoryTagId, search: '' },
+        },
+      },
+    );
+    expect(childrenAfter.total).to.equal(0);
   });
 
   // Multi-market: one category name is registered on N market projects via N createProjectTags
@@ -699,7 +819,8 @@ async function waitForReady(baseUrl, deadline, getStderr) {
         },
       },
     );
-    expect(tagsAfter.total).to.equal(0);
+    // `category:Doomed` is gone; the baked root survives (delete targets only the id sent).
+    expect(tagsAfter.items.map((t) => t.name)).to.deep.equal(['category:Running Shoes']);
 
     // The seeded prompt is untouched — the tag delete does not cascade to the prompts collection.
     const { data: prompts } = await client.POST(

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -674,11 +674,10 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     expect(children.items.map((t) => t.name)).to.deep.equal(['Sneakers']);
     expect(children.items[0].parent_id).to.equal(parentId);
     expect(children.items[0].children_count).to.equal(0); // the new leaf has no children of its own
-    expect(children.items[0].path).to.deep.equal([
-      { id: parentId, name: 'category:Footwear', parent_id: '' },
-    ]);
+    // the path leaf is { id, name } — live does not echo parent_id on the breadcrumb (D6)
+    expect(children.items[0].path).to.deep.equal([{ id: parentId, name: 'category:Footwear' }]);
 
-    // the parent root now reports children_count 1
+    // the parent root now reports children_count 1, and a root's parent_id + path are null (D5)
     const { data: rootList } = await client.GET(
       '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
       {
@@ -689,7 +688,8 @@ async function waitForReady(baseUrl, deadline, getStderr) {
       },
     );
     expect(rootList.items[0]).to.include({ name: 'category:Footwear', children_count: 1 });
-    expect(rootList.items[0].path).to.deep.equal([]); // a root has no ancestors
+    expect(rootList.items[0].parent_id).to.equal(null); // live returns null for a root
+    expect(rootList.items[0].path).to.equal(null); // live returns null (not []) for a root
   });
 
   // The boot seed bakes a nested taxonomy (root `category:Running Shoes` → bare child `Trail`), so
@@ -706,14 +706,14 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     );
     expect(children.items.map((t) => t.name)).to.deep.equal(['Trail']);
     expect(children.items[0].path).to.deep.equal([
-      { id: SEED_IDS.categoryTagId, name: 'category:Running Shoes', parent_id: '' },
+      { id: SEED_IDS.categoryTagId, name: 'category:Running Shoes' },
     ]);
   });
 
   // PATCH (aio-update-tag) re-parents / promotes a tag in place. Promoting the baked child `Trail`
   // to a root clears its parent_id, so it leaves the parent's children and appears among the roots.
   it('re-parents a tag via PATCH (promote a child to a root)', async () => {
-    const { data: patched, error: patchError } = await client.PATCH(
+    const { data: patched, error: patchError, response: patchResp } = await client.PATCH(
       '/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}',
       {
         params: {
@@ -725,6 +725,7 @@ async function waitForReady(baseUrl, deadline, getStderr) {
       },
     );
     expect(patchError).to.equal(undefined);
+    expect(patchResp.status).to.equal(200); // live responds 200, not 201 (D1/CR11)
     expect(patched).to.include({ id: SEED_IDS.childTagId, name: 'Trail' });
 
     // the promoted tag now appears as a root, and the old parent has no children left
@@ -783,6 +784,26 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     );
     expect(children.items.map((t) => t.name)).to.deep.equal(['Hiking']);
     expect(children.items[0].id).to.equal(SEED_IDS.childTagId);
+  });
+
+  // PATCH an unknown tag id → 404 { message: 'not found' } (verified live 2026-07-01; D2/CR12).
+  it('PATCHing an unknown tag id returns 404 not found', async () => {
+    const { data, error, response } = await client.PATCH(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}',
+      {
+        params: {
+          path: {
+            id: SEED_WORKSPACE,
+            project_id: SEED_PROJECT,
+            tag_id: '00000000-0000-4000-8000-000000000000',
+          },
+        },
+        body: { name: 'ZZ-nope', parent_id: '' },
+      },
+    );
+    expect(data).to.equal(undefined);
+    expect(response.status).to.equal(404);
+    expect(error).to.deep.equal({ message: 'not found' });
   });
 
   // Multi-market: one category name is registered on N market projects via N createProjectTags

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -752,7 +752,7 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     expect(childrenAfter.total).to.equal(0);
   });
 
-  // PATCH also RENAMES in place: changing `name` (keeping the parent) is reflected in the 201
+  // PATCH also RENAMES in place: changing `name` (keeping the parent) is reflected in the 200
   // response and a subsequent GET. Exercises the full route-handler→response roundtrip for a
   // rename — the stateful unit test covers only the store layer, not the handler's response build.
   it('renames a tag via PATCH (new name reflected in the response and on read)', async () => {

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -869,6 +869,36 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     expect(prompts.items[0].id).to.equal(SEED_IDS.promptId);
   });
 
+  // Anchors the DELETE-orphan limitation documented in the tags.js header: deleting a parent does
+  // NOT cascade to or re-parent its children (live behaviour unverified — serenity-docs#21 §7). The
+  // orphaned child then drops out of BOTH listings a consumer would use — it is not among the roots
+  // (its parent_id is still truthy), and reaching it as a "child" needs the deleted parent's id.
+  it('leaves a child orphaned (invisible) when its parent is deleted (documented limitation)', async () => {
+    const delTag = (ids) => client.DELETE('/v2/workspaces/{id}/projects/{project_id}/aio/tags', {
+      params: {
+        path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT },
+        query: { prompt_id: '' },
+      },
+      body: { ids },
+    });
+    // delete the baked root category while its child `Trail` still points at it
+    const { response: delRes } = await delTag([SEED_IDS.categoryTagId]);
+    expect(delRes.status).to.equal(204);
+
+    const listTags = (parentId) => client.GET('/v2/workspaces/{id}/projects/{project_id}/aio/tags', {
+      params: {
+        path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT },
+        query: { parent_id: parentId, search: '' },
+      },
+    });
+    // the child is not among the roots (its parent_id is still the deleted id, so it's not a root)
+    const { data: roots } = await listTags('');
+    expect(roots.items.map((t) => t.name)).to.not.include('Trail');
+    // it survives ONLY as a child of the now-deleted parent id — reachable only via that stale id
+    const { data: orphans } = await listTags(SEED_IDS.categoryTagId);
+    expect(orphans.items.map((t) => t.id)).to.deep.equal([SEED_IDS.childTagId]);
+  });
+
   // Request validation is enabled, so GET /aio/tags 400s when a required query param
   // (parent_id/search are swagger-`required`) is omitted, before the handler runs — matching the
   // live 400 and the contract the PR/docs/JSDoc claim. Mirrors the getBrandTopics 400 test: raw

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -673,6 +673,7 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     );
     expect(children.items.map((t) => t.name)).to.deep.equal(['Sneakers']);
     expect(children.items[0].parent_id).to.equal(parentId);
+    expect(children.items[0].children_count).to.equal(0); // the new leaf has no children of its own
     expect(children.items[0].path).to.deep.equal([
       { id: parentId, name: 'category:Footwear', parent_id: '' },
     ]);
@@ -748,6 +749,40 @@ async function waitForReady(baseUrl, deadline, getStderr) {
       },
     );
     expect(childrenAfter.total).to.equal(0);
+  });
+
+  // PATCH also RENAMES in place: changing `name` (keeping the parent) is reflected in the 201
+  // response and a subsequent GET. Exercises the full route-handler→response roundtrip for a
+  // rename — the stateful unit test covers only the store layer, not the handler's response build.
+  it('renames a tag via PATCH (new name reflected in the response and on read)', async () => {
+    const { data: renamed, error: renameError } = await client.PATCH(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}',
+      {
+        params: {
+          path: {
+            id: SEED_WORKSPACE, project_id: SEED_PROJECT, tag_id: SEED_IDS.childTagId,
+          },
+        },
+        body: { name: 'Hiking', parent_id: SEED_IDS.categoryTagId },
+      },
+    );
+    expect(renameError).to.equal(undefined);
+    expect(renamed).to.include({
+      id: SEED_IDS.childTagId, name: 'Hiking', parent_id: SEED_IDS.categoryTagId,
+    });
+
+    // the child still sits under the same parent, now carrying the new name
+    const { data: children } = await client.GET(
+      '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
+      {
+        params: {
+          path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT },
+          query: { parent_id: SEED_IDS.categoryTagId, search: '' },
+        },
+      },
+    );
+    expect(children.items.map((t) => t.name)).to.deep.equal(['Hiking']);
+    expect(children.items[0].id).to.equal(SEED_IDS.childTagId);
   });
 
   // Multi-market: one category name is registered on N market projects via N createProjectTags

--- a/packages/spacecat-shared-project-engine-client/test/mock/context.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/context.test.js
@@ -41,6 +41,12 @@ describe('mock Context', () => {
     expect(ctx.tagId('category:Running Shoes')).to.equal('tag-category%3ARunning%20Shoes');
   });
 
+  it('exposes the shared parentIdField helper for the tag routes', () => {
+    const ctx = new Context();
+    expect(ctx.parentIdField('tag-root')).to.deep.equal({ parent_id: 'tag-root' });
+    expect(ctx.parentIdField('')).to.deep.equal({});
+  });
+
   it('exposes the ai-model catalog for the catalog route + add-path resolution', () => {
     const ctx = new Context();
     expect(ctx.aiModelCatalog).to.be.an('array').with.length.greaterThan(0);

--- a/packages/spacecat-shared-project-engine-client/test/mock/factories.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/factories.test.js
@@ -204,14 +204,13 @@ describe('factories — live-shaped entities', () => {
       path: [createAIOTagLeafMock({ id: 'tag-root', name: 'category:Running' })],
     });
     expect(child).to.include({ id: 'tag-child', name: 'Trail', parent_id: 'tag-root' });
-    expect(child.path).to.deep.equal([
-      { id: 'tag-root', name: 'category:Running', parent_id: '' },
-    ]);
+    // the path leaf is { id, name } — live does not echo parent_id on the breadcrumb
+    expect(child.path).to.deep.equal([{ id: 'tag-root', name: 'category:Running' }]);
   });
 
-  it('createAIOTagLeafMock yields an AIOTagLeaf { id, name, parent_id }', () => {
+  it('createAIOTagLeafMock yields an AIOTagLeaf { id, name } (no parent_id, matching live)', () => {
     const leaf = createAIOTagLeafMock({ id: 'tag-root', name: 'category:Running' });
-    expect(leaf).to.deep.equal({ id: 'tag-root', name: 'category:Running', parent_id: '' });
+    expect(leaf).to.deep.equal({ id: 'tag-root', name: 'category:Running' });
   });
 
   it('createBrandTopicMock yields { topic, volume, prompts }', () => {

--- a/packages/spacecat-shared-project-engine-client/test/mock/factories.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/factories.test.js
@@ -20,6 +20,7 @@ import {
   createLanguageMock,
   createTagNodeMock,
   createAIOTagMock,
+  createAIOTagLeafMock,
   createBrandTopicMock,
   createBasicResponseMock,
   createInitStatusMock,
@@ -187,6 +188,30 @@ describe('factories — live-shaped entities', () => {
     expect(t).to.deep.equal({
       id: 'tag-x', name: 'category:Probe', children_count: 0, prompts_count: 0,
     });
+  });
+
+  it('createAIOTagMock omits parent_id/path by default (a root has none)', () => {
+    const root = createAIOTagMock();
+    expect(root).to.not.have.property('parent_id');
+    expect(root).to.not.have.property('path');
+  });
+
+  it('createAIOTagMock models a child via parent_id + path override', () => {
+    const child = createAIOTagMock({
+      id: 'tag-child',
+      name: 'Trail',
+      parent_id: 'tag-root',
+      path: [createAIOTagLeafMock({ id: 'tag-root', name: 'category:Running' })],
+    });
+    expect(child).to.include({ id: 'tag-child', name: 'Trail', parent_id: 'tag-root' });
+    expect(child.path).to.deep.equal([
+      { id: 'tag-root', name: 'category:Running', parent_id: '' },
+    ]);
+  });
+
+  it('createAIOTagLeafMock yields an AIOTagLeaf { id, name, parent_id }', () => {
+    const leaf = createAIOTagLeafMock({ id: 'tag-root', name: 'category:Running' });
+    expect(leaf).to.deep.equal({ id: 'tag-root', name: 'category:Running', parent_id: '' });
   });
 
   it('createBrandTopicMock yields { topic, volume, prompts }', () => {

--- a/packages/spacecat-shared-project-engine-client/test/mock/parent-id.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/parent-id.test.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { parentIdField } from '../../mock/parent-id.js';
+
+describe('parent-id', () => {
+  it('yields { parent_id } for a non-empty parent (a child tag)', () => {
+    expect(parentIdField('tag-root')).to.deep.equal({ parent_id: 'tag-root' });
+  });
+
+  it('yields {} for an empty/absent parent (a root tag carries no parent_id)', () => {
+    expect(parentIdField('')).to.deep.equal({});
+    expect(parentIdField(undefined)).to.deep.equal({});
+    expect(parentIdField(null)).to.deep.equal({});
+  });
+});

--- a/packages/spacecat-shared-project-engine-client/test/mock/seeds.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/seeds.test.js
@@ -58,6 +58,26 @@ describe('seeds', () => {
     expect(ops.brand_urls.list({ workspaceId, projectId, benchmarkId })).to.have.length(1);
   });
 
+  it('workspace-with-data seeds a nested category taxonomy (root + bare child)', () => {
+    const store = new InMemoryStore();
+    store.load(SEEDS['workspace-with-data']);
+    const {
+      workspaceId, projectId, categoryTagId, childTagId,
+    } = SEED_IDS;
+
+    const tags = createStatefulOps(store).tags.list({ workspaceId, projectId });
+    expect(tags).to.have.length(2);
+    const root = tags.find((t) => t.id === categoryTagId);
+    const child = tags.find((t) => t.id === childTagId);
+    expect(root.name).to.equal('category:Running Shoes');
+    expect(root).to.not.have.property('parent_id'); // a root carries no parent
+    expect(child).to.include({ name: 'Trail', parent_id: categoryTagId });
+
+    // the seeded prompt carries both tags so the Categories surface renders populated
+    const [prompt] = createStatefulOps(store).prompts.list({ workspaceId, projectId });
+    expect(prompt.tags.map((t) => t.id)).to.deep.equal([categoryTagId, childTagId]);
+  });
+
   it('reset restores a seed after mutation', () => {
     const store = new InMemoryStore();
     store.load(SEEDS['workspace-with-data']);

--- a/packages/spacecat-shared-project-engine-client/test/mock/stateful.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/stateful.test.js
@@ -149,6 +149,25 @@ describe('stateful — tags ops', () => {
     ops.upsertMany({ workspaceId: 'w1', projectId: 'p1' }, [{ id: 'tag-a', name: 'category:A' }]);
     expect(ops.list({ workspaceId: 'w1', projectId: 'p2' })).to.have.length(0);
   });
+
+  it('re-parents / renames a tag in place, keeping the id stable', () => {
+    const ops = createStatefulOps(new InMemoryStore()).tags;
+    ops.upsertMany(scope, [
+      { id: 'tag-root', name: 'category:Root' },
+      { id: 'tag-child', name: 'Child' },
+    ]);
+    // re-parent the child under the root
+    const parented = ops.update(scope, 'tag-child', { name: 'Child', parent_id: 'tag-root' });
+    expect(parented).to.include({ id: 'tag-child', name: 'Child', parent_id: 'tag-root' });
+    // promote back to a root (parent_id cleared to '')
+    const promoted = ops.update(scope, 'tag-child', { name: 'Child', parent_id: '' });
+    expect(promoted).to.include({ id: 'tag-child', parent_id: '' });
+  });
+
+  it('returns undefined when updating an unknown tag id', () => {
+    const ops = createStatefulOps(new InMemoryStore()).tags;
+    expect(ops.update(scope, 'missing', { name: 'x', parent_id: '' })).to.equal(undefined);
+  });
 });
 
 describe('stateful — brand_urls ops', () => {

--- a/packages/spacecat-shared-project-engine-client/test/types/factories.type-test.ts
+++ b/packages/spacecat-shared-project-engine-client/test/types/factories.type-test.ts
@@ -27,6 +27,7 @@ import {
   createBenchmarkMock,
   createBrandUrlMock,
   createAIOTagMock,
+  createAIOTagLeafMock,
 } from '../../mock/factories.js';
 import type { components } from '../../src/index.js';
 
@@ -68,6 +69,16 @@ void aioTag.prompts_count;
 void aioTag;
 // @ts-expect-error — keyword_count is a TreeNodeResponse field, not on AIOTag.
 createAIOTagMock({ keyword_count: 0 });
+// 1e-nested: a child tag carries parent_id + a path[] of AIOTagLeaf ancestors (1-level tree).
+type AIOTagLeaf = components['schemas']['model.AIOTagLeaf'];
+const tagLeaf: AIOTagLeaf = createAIOTagLeafMock({ id: 'tag-root', name: 'category:X' });
+const childTag: AIOTag = createAIOTagMock({
+  id: 'tag-child', name: 'Trail', parent_id: 'tag-root', path: [tagLeaf],
+});
+void childTag.parent_id;
+void childTag.path;
+// @ts-expect-error — a path leaf is an AIOTagLeaf, not a bare string.
+createAIOTagMock({ path: ['tag-root'] });
 // CR10: primary_url + root_domain are added to AIOBenchmarkWithCounters by the overlay (live
 // returns them). These reads only compile while CR10 is in the schema — drop CR10 and they error.
 void benchmark.primary_url;

--- a/packages/spacecat-shared-project-engine-client/test/types/factories.type-test.ts
+++ b/packages/spacecat-shared-project-engine-client/test/types/factories.type-test.ts
@@ -77,6 +77,10 @@ const childTag: AIOTag = createAIOTagMock({
 });
 void childTag.parent_id;
 void childTag.path;
+// CR13: live returns null (not omitted/[]) for a flat root's parent_id + path — the overlay makes
+// both nullable, so these only compile while CR13 is in the schema.
+const rootTag: AIOTag = createAIOTagMock({ parent_id: null, path: null });
+void rootTag;
 // @ts-expect-error — a path leaf is an AIOTagLeaf, not a bare string.
 createAIOTagMock({ path: ['tag-root'] });
 // CR10: primary_url + root_domain are added to AIOBenchmarkWithCounters by the overlay (live


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Teaches the `@adobe/spacecat-shared-project-engine-client` Counterfact mock and its baked seeds to model 1-level nested AIO tags (parent/child via `parent_id`) — parent-aware create, tree-aware listing, a re-parent/rename endpoint, a nested baked fixture — and reconciles the mock + spec overlay to what a live prod probe (2026-07-01) confirmed.

## 2. Reasoning
The client's generated types already model tag nesting (`parent_id`, `path[]`, `children_count`), but the mock was flat and ignored `parent_id`, so nothing local could validate the nested-category feature. Consumers that write `parent_id` (the nested-category work in spacecat-api-service and the onboarding CLI) would pass against the flat mock while silently dropping hierarchy. This closes that gap and, after a live probe, corrects the places where the vendored spec/mock diverged from prod.

## 3. High-level overview of the changes
Behaviour delta in the mock's project-level AIO tag taxonomy (the Categories surface):

- `POST /aio/tags` honours `body.parent_id` (children stored under that category).
- `GET /aio/tags` is tree-aware: `parent_id=''` returns roots, a non-empty `parent_id` returns that category's children; each tag carries a derived `children_count` and, for a child, a single-leaf `path[]` breadcrumb (its root). A flat root reads back `parent_id: null` and `path: null` (matching prod), and a path leaf is `{ id, name }` (no `parent_id`).
- New `PATCH /aio/tags/{tag_id}` (`aio-update-tag`) re-parents/renames/promotes in place, returning **200** and **404 `{message:'not found'}`** for an unknown id (both prod-verified).
- The baked `workspace-with-data` seed ships a populated hierarchy (root `category:` → bare child) and the seeded prompt carries both tags.
- Spec overlay corrections from the live probe: CR11 (PATCH 200 not 201), CR12 (PATCH 404 for unknown id), CR13 (`AIOTag.parent_id`/`path` nullable). Regenerated types reflect these; no vendored-swagger edit.
- The "1-level" tree is documented as a product convention, not an API constraint — the probe showed prod accepts deeper nesting (a grandchild create returned 201).

Two edges whose live behaviour is still unconfirmed — deleting a parent that still has children (orphaning) and the mock's name-derived id making a post-rename re-create duplicate — remain documented as known limitations rather than resolved with invented behaviour.

## 4. Required information
- Jira / issue: https://github.com/adobe/spacecat-shared/issues/1756
- Spec: https://github.com/adobe/serenity-docs/issues/21
- Other: folds in https://github.com/adobe/spacecat-shared/issues/1754 (baked nested fixture) ; Postgres-seed counterpart https://github.com/adobe/mysticat-data-service/issues/757

## 5. Affected / used mysticat-workspace projects
- spacecat-api-service — consumer/contract: its serenity transport writes `parent_id` on create and reads the nested tag tree; this mock validates that path locally (tracking https://github.com/adobe/spacecat-api-service/issues/2733).
- mysticat-data-service — consumer/contract: the onboarding CLI writes nested tags via this API (https://github.com/adobe/mysticat-data-service/pull/737).
- The cross-repo e2e harness / workspace local-dev consume the mock (npm package + GHCR image) to exercise `/serenity/*` against a faithful tree.

## 6. Additional information outside the code
Live prod probe was RUN on 2026-07-01 against `adobe-hackathon.semrush.com`, test workspace `bb0f4e1c-…` (a child sub-workspace's live project) — the ACL gap noted in serenity-docs#21 §7 is resolved for the probing IMS user. Throwaway tags were created under a real category, inspected, and deleted (verified removed; `children_count` back to 0 — nothing left behind).

Findings:
- Confirmed matching the mock: create-child wire (`{names[], parent_id}` → 201 top-level array with `parent_id`), ancestors-only single-leaf `path`, `children_count`, `search` substring.
- Corrected to match prod (this PR): PATCH success is **200** not 201; PATCH unknown id is **404 `{message:'not found'}`** not 500; a flat root returns `parent_id: null` / `path: null` (not omitted / `[]`); a path leaf is `{ id, name }`; there is **no 1-level depth cap** on the wire.
- Observed but NOT modelled (surfaced separately): newly-created tags are visible only in the `?draft=true` view until the project is published; the live (non-draft) read hides them. The consumer's `listProjectTags` reads the live view with no `draft`, so a created category would not appear live until publish — worth confirming the consumer publishes before it reads categories back. Not changed here to avoid inverting the mock's deliberate "0-prompt category reads back immediately" contract without that confirmation.

## 7. Test plan
(a) Local end-to-end: booted the Counterfact mock and drove the real generated client through nested create (`POST parent_id`), child listing (`GET ?parent_id=` with `children_count` + `path`), PATCH re-parent/rename/promote, PATCH unknown-id → 404, delete-without-cascade, root `null` shape, and the baked-seed nested read. Plus the live prod probe above.
(b) Per-consumer verification (dev-tooling/mock package, not a deployed service): after publish, consumers bump the package / pull the refreshed GHCR mock image and run their serenity IT / local-dev against the nested tags — confirm a created child reads back under its parent, the Categories tree renders from the baked seed, and a re-parent reflects in the listing.

## 8. Deployment & merge order
Part of the cross-repo nested-category effort but independent to merge (additive, backward-compatible for flat callers):
- related: https://github.com/adobe/spacecat-api-service/issues/2733 — the proxy + create-tag work that writes `parent_id`.
- related: https://github.com/adobe/mysticat-data-service/pull/737 — the onboarding CLI that writes the nested tree.
- related: https://github.com/adobe/project-elmo-ui/pull/2078 — the Serenity Categories UI.

Recommended sequence: merge and publish this mock first so the consumer PRs can validate their nested behaviour locally against it; it does not depend on any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
