### PR TITLE
feat(project-engine-client): fold serenity sub-workspace fixtures into the baked mock seed

### DIFF
--- a/packages/spacecat-shared-project-engine-client/docs/mock-usage.md
+++ b/packages/spacecat-shared-project-engine-client/docs/mock-usage.md
@@ -31,7 +31,7 @@ npm run mock              # serves on http://localhost:4010
 | Env var | Default | Purpose |
 | --- | --- | --- |
 | `MOCK_PORT` | `4010` | listen port |
-| `MOCK_SEED` | `workspace-with-data` | named startup fixture (`empty-workspace` \| `workspace-with-data`); unknown → default |
+| `MOCK_SEED` | `workspace-with-data` | named startup fixture (`empty-workspace` \| `workspace-with-data` \| `two-hierarchies`); unknown → default |
 | `MOCK_SEED_FILE` | — | path to a JSON `Snapshot` to boot from; **takes precedence** over `MOCK_SEED` |
 
 ```bash
@@ -137,18 +137,25 @@ method that calls it.
 > with `live_id`/`draft_id` mirrored and `is_draft: true`/`publish_status: 'draft'` — NOT a flat
 > echo of the request body. `addAiModel` resolves the catalog model's `name` and `icon` onto the
 > response (with an empty `key`), matching the live add path; an unmodelled `model_id` keeps the
-> factory default (GPT-4o).
+> catalog-valid factory default (`search-gpt` / ChatGPT).
 
 ---
 
 ## 4. Seeds
 
-Two named seeds ship in `mock/seeds.js`:
+Three named seeds ship in `mock/seeds.js`:
 
-- **`empty-workspace`** — the seed workspace with no projects.
-- **`workspace-with-data`** (default) — one project under the seed workspace, with an AI model, a
-  prompt, an own-brand benchmark, and a brand URL. Canonical ids are exported as `SEED_IDS`
-  (`workspaceId`, `projectId`, `aiModelId`, `promptId`, `benchmarkId`, `brandUrlId`).
+- **`empty-workspace`** — the (child) seed workspace with no projects.
+- **`workspace-with-data`** (default) — one LIVE US/en market under the brand's **child**
+  sub-workspace (`SEED_IDS.workspaceId`, the id a correctly-anchored brand resolves to — NOT the org
+  parent), with a catalog-valid AI model (`search-gpt`), a `topic:`/`source:`/`intent:`/`type:`-tagged
+  prompt, `category:` project tags, an own-brand benchmark, and a brand URL. Canonical ids are
+  exported as `SEED_IDS` (`parentWorkspaceId`, `workspaceId`, `projectId`, `aiModelId`, `promptId`,
+  `benchmarkId`, `brandUrlId`).
+- **`two-hierarchies`** — a strict superset of `workspace-with-data` plus a second, fully
+  independent parent/child hierarchy with its own LIVE DE/de market (`SEED_IDS.secondWorkspaceId` /
+  `secondProjectId`), for the dual-org case where two mock-wired orgs each need a distinct
+  `semrush_workspace_id`.
 
 Boot from a custom state with `MOCK_SEED_FILE=/path/to/snapshot.json` or replace state at runtime
 with `POST /__seed` (§5). A `Snapshot` is a plain JSON object keyed `<resource>:<scope>`:
@@ -156,7 +163,7 @@ with `POST /__seed` (§5). A `Snapshot` is a plain JSON object keyed `<resource>
 ```jsonc
 {
   "projects:<ws>":            [ { "id": "<pid>", "name": "Acme" } ],
-  "ai_models:<ws>:<pid>":     [ { "id": "<id>", "model": { "id": "<mid>", "key": "gpt-4o", "name": "GPT-4o" }, "prompts_count": 0 } ],
+  "ai_models:<ws>:<pid>":     [ { "id": "<id>", "model": { "id": "eab23d14-df70-463f-8779-3f6a4ba770bc", "key": "search-gpt", "name": "ChatGPT", "icon": "openai" }, "prompts_count": 0 } ],
   "prompts:<ws>:<pid>":       [ { "id": "<id>", "name": "What is Acme?", "is_new": false, "tags": [] } ],
   "benchmarks:<ws>:<pid>":    [ { "id": "<bid>", "main_brand": true, "brand_name": "Acme", "domain": "acme.com", "brand_aliases": [], "rejected_brand_aliases": [], "color": "", "favorite": false, "products_count": 0 } ],
   "brand_urls:<ws>:<pid>:<bid>": [ { "id": "<id>", "url": "https://acme.com/about", "type": "own" } ],
@@ -245,7 +252,7 @@ const snapshot = buildSeed({
   projects: [{
     id: projectId,
     name: 'Acme',
-    aiModels: [createProjectAiModelMock({ model: createAiModelMock({ name: 'GPT-4o' }) })],
+    aiModels: [createProjectAiModelMock({ model: createAiModelMock() })], // default = catalog search-gpt
     prompts: [createPromptMock({ name: 'What is Acme?' })],
   }],
   quota: { projects: 3, prompts: 1500 }, // omit for unlimited

--- a/packages/spacecat-shared-project-engine-client/mock/ai-model-catalog.js
+++ b/packages/spacecat-shared-project-engine-client/mock/ai-model-catalog.js
@@ -111,3 +111,19 @@ export const AI_MODEL_CATALOG = Object.freeze([
     icon: 'deepseek',
   },
 ].map((entry) => Object.freeze(entry)));
+
+/**
+ * Resolves a catalog entry by its `key`, THROWING if absent — so a seeded assignment or the factory
+ * default stays catalog-valid by construction (a typo'd key fails loudly instead of silently
+ * falling back to a wrong/default model). The non-nullable return also localizes what would
+ * otherwise be a scattered `find(...)!` / `any` cast to one spot.
+ * @param {string} key
+ * @returns {AiModelCatalogEntry}
+ */
+export const findCatalogEntryByKey = (key) => {
+  const entry = AI_MODEL_CATALOG.find((m) => m.key === key);
+  if (!entry) {
+    throw new Error(`Unknown AI model catalog key: ${key}`);
+  }
+  return entry;
+};

--- a/packages/spacecat-shared-project-engine-client/mock/factories.js
+++ b/packages/spacecat-shared-project-engine-client/mock/factories.js
@@ -210,7 +210,7 @@ export const createProjectResponseFromRequest = (request = {}) => {
  * bare `createProjectMock({ id, name })` seeds an *invisible* market. This is the seed/default side
  * of adobe/spacecat-shared#1754 gap 3 (live status): it mirrors the live read-view (nested
  * `settings.ai`, like {@link createProjectResponseFromRequest}) but marks the project live
- * (`publish_status:'live'`, `is_draft:false`, `published_at`) with a caller-fixed id. Pass
+ * (`publish_status:'live'`, `published_at`) with a caller-fixed id. Pass
  * `location_id` (a positive Google geoTargetId, e.g. `2840` = US, `2276` = Germany) so the market
  * resolves without depending on api-service's ISO→geo table; `language_id` is a catalog id (→ ISO
  * via {@link isoForLanguageId}). The live create/publish path still starts drafts — only seeds use

--- a/packages/spacecat-shared-project-engine-client/mock/factories.js
+++ b/packages/spacecat-shared-project-engine-client/mock/factories.js
@@ -42,8 +42,20 @@
 /** @typedef {Schemas['model.CICompetitor']} CiCompetitor */
 
 import { isoForLanguageId } from './language-catalog.js';
+import { findCatalogEntryByKey } from './ai-model-catalog.js';
 
 const uuid = () => globalThis.crypto.randomUUID();
+
+/**
+ * The canonical default assigned model — the live catalog's "search" ChatGPT entry
+ * (`key: 'search-gpt'`). Catalog-valid by construction (id/key/name/icon come straight from the
+ * shared catalog the mock also serves at `GET /v1/ai_models`), so a seeded assignment or an
+ * add-path fallback never surfaces a model the catalog can't resolve. The prior `gpt-4o` default
+ * was NOT in the catalog, which rendered an unresolvable model chip on a seeded market
+ * (adobe/spacecat-shared#1754 gap 4). {@link findCatalogEntryByKey} throws if `search-gpt` ever
+ * leaves the catalog, so this can't silently go stale.
+ */
+const DEFAULT_AI_MODEL = findCatalogEntryByKey('search-gpt');
 
 // Built once: the locale + options are constant, so a per-call constructor would be wasteful.
 const REGION_NAMES = new Intl.DisplayNames(['en'], { type: 'region' });
@@ -83,18 +95,17 @@ const countryName = (code) => {
 };
 
 /**
- * A catalog AI model (`AIModelResponse`). Only `id` is required by the spec; `name`/`key` are
- * realistic defaults. `icon` is included because the live add path (`POST .../ai_models`) resolves
- * and returns the catalog model's `name` + `icon` (only `key` comes back empty there) — verified
- * live 2026-06-25 — so the complete shape carries `icon` and an `addAiModel` response matches live.
+ * A catalog AI model (`AIModelResponse`). Only `id` is required by the spec; the default
+ * `id`/`key`/`name`/`icon` come from the canonical catalog entry ({@link DEFAULT_AI_MODEL},
+ * `search-gpt` / ChatGPT), so the default is catalog-valid (adobe/spacecat-shared#1754 gap 4).
+ * `icon` matters because the live add path (`POST .../ai_models`) resolves and returns the catalog
+ * model's `name` + `icon` (only `key` comes back empty there) — verified live 2026-06-25 — so the
+ * complete shape carries `icon` and an `addAiModel` response matches live.
  * @param {Partial<AIModel>} [overrides]
  * @returns {AIModel}
  */
 export const createAiModelMock = (overrides = {}) => ({
-  id: uuid(),
-  key: 'gpt-4o',
-  name: 'GPT-4o',
-  icon: 'openai',
+  ...DEFAULT_AI_MODEL,
   ...overrides,
 });
 
@@ -136,6 +147,35 @@ export const createProjectMock = (overrides = {}) => ({
 });
 
 /**
+ * Builds the `settings.ai` read-view sub-object the live project GET echoes — nested
+ * brand / language / country / location plus zeroed counters. Extracted so
+ * {@link createProjectResponseFromRequest} (the draft create-response) and
+ * {@link createLiveProjectMock} (a seeded live market) build the SAME shape and can't drift.
+ *
+ * `language.name` is the ISO code resolved from the catalog id (e.g. "en"), NOT the English display
+ * name; `langOf` (api-service) reads it directly as the slice code, so resolving id → ISO is the
+ * load-bearing round-trip fix (#1745). `country.name` is the informal Intl region name, populated
+ * for fidelity. Live echoes `null` (not `[]`/`''`) for an omitted `brand_names` / `location.name`
+ * on the read-view (verified 2026-06-29); the {@link NULLABLE} casts satisfy the schema
+ * (`string[]`/`string`, no explicit null variant).
+ * @param {Partial<ProjectRequest>} [request] the create-request body
+ * @returns {NonNullable<Project['settings']>['ai']}
+ */
+const buildAiSettings = (request = {}) => ({
+  models_stats: { models: [], models_count: 0 },
+  prompts_count: 0,
+  brand_names: request.brand_names ?? NULLABLE,
+  brand_name_display: request.brand_name_display ?? '',
+  language: { id: request.language_id ?? '', name: isoForLanguageId(request.language_id) },
+  country: { code: request.country_code ?? '', name: countryName(request.country_code) },
+  location: { id: request.location_id ?? 0, name: request.location_name ?? NULLABLE },
+  primary_url: request.domain ?? '',
+  segments_count: 0,
+  benchmarks_count: 0,
+  products_count: 0,
+});
+
+/**
  * Builds the {@link Project} the live API returns from a *create request* (the
  * `POST /v1/.../projects` body, `model.ProjectRequest`). The live API does NOT echo the flat
  * request fields back: it nests `brand_*` / `language_id` / `country_code` / `location_*` under
@@ -159,29 +199,41 @@ export const createProjectResponseFromRequest = (request = {}) => {
     is_draft: true,
     publish_status: 'draft',
     shared_with: 0,
-    settings: {
-      ai: {
-        models_stats: { models: [], models_count: 0 },
-        prompts_count: 0,
-        // Live echoes `null` (not `[]`/`''`) for an omitted brand_names / location_name on the
-        // read-view (verified 2026-06-29). The consumer always sends these, so it is fidelity-only;
-        // the casts satisfy the schema (string[]/string), which has no explicit null variant.
-        brand_names: request.brand_names ?? NULLABLE,
-        brand_name_display: request.brand_name_display ?? '',
-        // Live read-view: `language.name` is the ISO code (e.g. "en"), NOT the English display
-        // name, and `language.id` is the catalog UUID sent on create. `langOf` reads
-        // `language.name` directly as the slice code, so resolving the id → ISO is the load-bearing
-        // round-trip fix (#1745). `country.name` is the informal country name; not consumed,
-        // populated for fidelity.
-        language: { id: request.language_id ?? '', name: isoForLanguageId(request.language_id) },
-        country: { code: request.country_code ?? '', name: countryName(request.country_code) },
-        location: { id: request.location_id ?? 0, name: request.location_name ?? NULLABLE },
-        primary_url: request.domain ?? '',
-        segments_count: 0,
-        benchmarks_count: 0,
-        products_count: 0,
-      },
-    },
+    settings: { ai: buildAiSettings(request) },
+  });
+};
+
+/**
+ * A seeded LIVE project (`ProjectResponse`) — a published market whose `settings.ai` carries a
+ * resolvable geo + language so api-service's `listMarkets` surfaces it. That read DROPS any project
+ * with no geo/lang (`subworkspace-projects.js` drops `geoTargetId`/`languageCode` nulls), so a
+ * bare `createProjectMock({ id, name })` seeds an *invisible* market. This is the seed/default side
+ * of adobe/spacecat-shared#1754 gap 3 (live status): it mirrors the live read-view (nested
+ * `settings.ai`, like {@link createProjectResponseFromRequest}) but marks the project live
+ * (`publish_status:'live'`, `is_draft:false`, `published_at`) with a caller-fixed id. Pass
+ * `location_id` (a positive Google geoTargetId, e.g. `2840` = US, `2276` = Germany) so the market
+ * resolves without depending on api-service's ISO→geo table; `language_id` is a catalog id (→ ISO
+ * via {@link isoForLanguageId}). The live create/publish path still starts drafts — only seeds use
+ * this. `is_draft` stays `true` even when live: the publish route flips only `publish_status` /
+ * `published_at` (verified live 2026-06-25), so a seeded live market byte-matches a create→publish
+ * one.
+ * @param {Partial<ProjectRequest> & { id?: string, published_at?: string }} [overrides]
+ * @returns {Project}
+ */
+export const createLiveProjectMock = (overrides = {}) => {
+  const { id = uuid(), published_at: publishedAt = '2026-01-01T00:00:00Z', ...request } = overrides;
+  return createProjectMock({
+    id,
+    live_id: id,
+    draft_id: id,
+    type: request.type ?? 'ai',
+    name: request.name ?? 'Seeded Project',
+    domain: request.domain ?? '',
+    is_draft: true,
+    publish_status: 'live',
+    published_at: publishedAt,
+    shared_with: 0,
+    settings: { ai: buildAiSettings(request) },
   });
 };
 

--- a/packages/spacecat-shared-project-engine-client/mock/seeds.js
+++ b/packages/spacecat-shared-project-engine-client/mock/seeds.js
@@ -65,9 +65,11 @@ const ENGLISH_LANGUAGE_ID = '5a0a33ed-7f5c-4901-befd-a042c0350da1'; // catalog "
 const US_GEO_TARGET_ID = 2840; // Google geoTargetId (United States)
 
 // --- Hierarchy 2 — a second, fully independent mock-wired org (unique `semrush_workspace_id`s),
-// present only in the `two-hierarchies` seed. A German market so the two read distinctly.
-const PARENT_WORKSPACE_ID_2 = 'a2b3c4d5-e6f7-4a8b-9c0d-1e2f3a4b5c6d';
-const CHILD_WORKSPACE_ID_2 = 'b3c4d5e6-f7a8-4b9c-8d0e-2f3a4b5c6d7e';
+// present only in the `two-hierarchies` seed. A German market so the two read distinctly. These
+// two ids are the same UUIDs as the User Manager mock's second hierarchy (UM seeds.js), so PE
+// projects and UM workspaces line up across the two packages.
+const PARENT_WORKSPACE_ID_2 = 'a2b3c4d5-e6f7-4a8b-9c0d-1e2f3a4b5c6d'; // == UM parent2
+const CHILD_WORKSPACE_ID_2 = 'b3c4d5e6-f7a8-4b9c-8d0e-2f3a4b5c6d7e'; // == UM child2
 const PROJECT_ID_2 = 'c4d5e6f7-a8b9-4c0d-8e1f-3a4b5c6d7e8f';
 const AI_MODEL_ASSIGNMENT_ID_2 = 'c5d6e7f8-a9b0-4c1d-8e2f-4a5b6c7d8e9f';
 const GERMAN_LANGUAGE_ID = 'e5282ae9-83a6-4ea3-b3cf-5e99d8f51eca'; // catalog "German" → ISO de

--- a/packages/spacecat-shared-project-engine-client/mock/seeds.js
+++ b/packages/spacecat-shared-project-engine-client/mock/seeds.js
@@ -18,107 +18,76 @@
  * via `store.load(seed)` is immediately visible to the stateful handlers. E2E selects a seed at
  * startup and restores it between tests with `store.reset()` (exposed as `POST /__reset`).
  *
- * Entities are built via the typed {@link createProjectMock} / {@link createProjectAiModelMock} /
- * {@link createPromptMock} factories, so the fixtures are spec-shaped and checked by tsc
+ * Entities are built via the typed {@link createLiveProjectMock} / {@link createProjectAiModelMock}
+ * / {@link createPromptMock} factories, so the fixtures are spec-shaped and checked by tsc
  * (`// @ts-check`). E2E flows reference the fixed UUIDs through {@link SEED_IDS}.
+ *
+ * Sub-workspace model (adobe/spacecat-shared#1754): a brand resolves to a CHILD sub-workspace (the
+ * User Manager mock's `parent-with-child`), never the org's parent workspace, so the seeded
+ * project/market/model/prompt live under the CHILD id — a brand correctly anchored to the child
+ * reads non-empty, live data. The project is built LIVE with a resolvable US/en market so
+ * api-service's `listMarkets` surfaces it (it drops projects with no geo/lang). A second, fully
+ * independent hierarchy (`two-hierarchies`) exists for the dual-org case (two mock-wired orgs need
+ * two distinct `semrush_workspace_id`s — the DB enforces uniqueness).
  */
 
 import { collectionKey } from './stateful.js';
 import { QUOTA_COLLECTION } from './quota.js';
+import { tagId } from './tag-id.js';
+import { findCatalogEntryByKey } from './ai-model-catalog.js';
 import {
   createProjectMock,
+  createLiveProjectMock,
   createProjectAiModelMock,
   createAiModelMock,
   createPromptMock,
   createBenchmarkMock,
   createBrandUrlMock,
+  createAIOTagMock,
 } from './factories.js';
 
 // Real-shaped fixtures: the Project Engine API types every id as `format: uuid`, so the seeds
 // use fixed UUIDs (not `ws-1`/`pr-1`) to mirror production data. Fixed, not generated, so
 // SEED_IDS stays stable for assertions.
-const WORKSPACE_ID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'; // workspace UUID (path {id})
-const PROJECT_ID = 'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e'; // project UUID (path {project_id})
+
+// --- Hierarchy 1 — the default single-brand world the local seed SQL + api-service IT anchor to.
+// The parent workspace is the org's `semrush_workspace_id`; the CHILD is the brand's. The project
+// lives under the CHILD (a brand must not resolve to the org parent — api-service 409s that).
+const PARENT_WORKSPACE_ID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'; // org parent (== UM parent)
+const CHILD_WORKSPACE_ID = 'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e'; // brand sub-workspace (== UM child)
+const PROJECT_ID = 'b8c9d0e1-f2a3-4b4c-8d5e-7f8091021324'; // live market under the CHILD
 const AI_MODEL_ASSIGNMENT_ID = 'c3d4e5f6-a7b8-4c9d-8e1f-2a3b4c5d6e7f'; // ProjectAIModelResponse.id
-const AI_MODEL_CATALOG_ID = 'd4e5f6a7-b8c9-4d0e-9f1a-3b4c5d6e7f80'; // AIModelResponse.id (the model_id)
+const AI_MODEL_CATALOG_ID = findCatalogEntryByKey('search-gpt').id; // catalog `search-gpt` (ChatGPT)
 const PROMPT_ID = 'e5f6a7b8-c9d0-4e1f-8a2b-4c5d6e7f8091'; // AIOPromptWithStatus.id
 const BENCHMARK_ID = 'f6a7b8c9-d0e1-4f2a-9b3c-5d6e7f809102'; // AIOBenchmarkWithCounters.id (own brand)
 const BRAND_URL_ID = 'a7b8c9d0-e1f2-4a3b-8c4d-6e7f80910213'; // BrandURL.id
+const ENGLISH_LANGUAGE_ID = '5a0a33ed-7f5c-4901-befd-a042c0350da1'; // catalog "English" → ISO en
+const US_GEO_TARGET_ID = 2840; // Google geoTargetId (United States)
+
+// --- Hierarchy 2 — a second, fully independent mock-wired org (unique `semrush_workspace_id`s),
+// present only in the `two-hierarchies` seed. A German market so the two read distinctly.
+const PARENT_WORKSPACE_ID_2 = 'a2b3c4d5-e6f7-4a8b-9c0d-1e2f3a4b5c6d';
+const CHILD_WORKSPACE_ID_2 = 'b3c4d5e6-f7a8-4b9c-8d0e-2f3a4b5c6d7e';
+const PROJECT_ID_2 = 'c4d5e6f7-a8b9-4c0d-8e1f-3a4b5c6d7e8f';
+const AI_MODEL_ASSIGNMENT_ID_2 = 'c5d6e7f8-a9b0-4c1d-8e2f-4a5b6c7d8e9f';
+const GERMAN_LANGUAGE_ID = 'e5282ae9-83a6-4ea3-b3cf-5e99d8f51eca'; // catalog "German" → ISO de
+const DE_GEO_TARGET_ID = 2276; // Google geoTargetId (Germany)
 
 /**
  * @typedef {import('./store.js').Snapshot} Snapshot
- */
-
-/** Empty workspace: no projects yet — the "create from scratch" flow starts here. */
-export const EMPTY_WORKSPACE = Object.freeze({
-  [collectionKey('projects', { workspaceId: WORKSPACE_ID })]: [],
-});
-
-/**
- * Workspace with one project that already has an ai_model and a prompt — the "read/patch/run
- * existing data" flow starts here. Entity shapes mirror the real API responses
- * (ProjectAIModelResponse, AIOPromptWithStatus) so `__dump` and GETs look like production.
- */
-export const WORKSPACE_WITH_DATA = Object.freeze({
-  [collectionKey('projects', { workspaceId: WORKSPACE_ID })]: [
-    createProjectMock({ id: PROJECT_ID, name: 'Seeded Project' }),
-  ],
-  [collectionKey('ai_models', { workspaceId: WORKSPACE_ID, projectId: PROJECT_ID })]: [
-    createProjectAiModelMock({
-      id: AI_MODEL_ASSIGNMENT_ID,
-      model: createAiModelMock({ id: AI_MODEL_CATALOG_ID, key: 'gpt-4o', name: 'GPT-4o' }),
-    }),
-  ],
-  [collectionKey('prompts', { workspaceId: WORKSPACE_ID, projectId: PROJECT_ID })]: [
-    createPromptMock({ id: PROMPT_ID, name: 'What is the best running shoe?' }),
-  ],
-  // The project's own-brand benchmark (main_brand: true) — the `benchmark_id` brand URLs attach
-  // to. Mirrors the live listBenchmarks own-brand row.
-  [collectionKey('benchmarks', { workspaceId: WORKSPACE_ID, projectId: PROJECT_ID })]: [
-    createBenchmarkMock({
-      id: BENCHMARK_ID,
-      brand_name: 'Seeded Brand',
-      domain: 'example.com',
-      main_brand: true,
-    }),
-  ],
-  // One brand URL under the own-brand benchmark.
-  [collectionKey('brand_urls', {
-    workspaceId: WORKSPACE_ID, projectId: PROJECT_ID, benchmarkId: BENCHMARK_ID,
-  })]: [
-    createBrandUrlMock({ id: BRAND_URL_ID, url: 'https://example.com/about', type: 'own' }),
-  ],
-});
-
-/**
- * All seed sets by name, for the runner to select via env/flag. Typed as a string map so a
- * runtime `MOCK_SEED` (an arbitrary string) can index it with a fallback (see {@link Context}).
- * @type {Record<string, import('./store.js').Snapshot>}
- */
-export const SEEDS = Object.freeze({
-  'empty-workspace': EMPTY_WORKSPACE,
-  'workspace-with-data': WORKSPACE_WITH_DATA,
-});
-
-/** Default seed loaded when none is specified. */
-export const DEFAULT_SEED = 'workspace-with-data';
-
-/** Ids used by the seed sets, exported so E2E flows can reference them without hardcoding. */
-export const SEED_IDS = Object.freeze({
-  workspaceId: WORKSPACE_ID,
-  projectId: PROJECT_ID,
-  aiModelId: AI_MODEL_CATALOG_ID,
-  promptId: PROMPT_ID,
-  benchmarkId: BENCHMARK_ID,
-  brandUrlId: BRAND_URL_ID,
-});
-
-/**
  * @typedef {import('../src/index.js').components['schemas']} Schemas
+ */
+
+/**
  * @typedef {object} SeedProject
  * @property {string} id project UUID (use the project / `semrush_workspace_id` UUIDs from your DB
  *   fixtures so the mock and Postgres line up)
  * @property {string} name
+ * @property {Partial<Schemas['model.ProjectRequest']> & { published_at?: string }} [market] when
+ *   present, the project is built as a LIVE market via {@link createLiveProjectMock}
+ *   (`publish_status: 'live'` + a resolvable geo/lang from `country_code`/`location_id` +
+ *   `language_id`), so api-service's `listMarkets` surfaces it. Omit for a market-less project
+ *   (built via {@link createProjectMock}) — e.g. a workspace you only exercise for models/prompts.
  * @property {Array<Schemas['model.ProjectAIModelResponse']>} [aiModels] build with
  *   {@link createProjectAiModelMock} so the shape is checked
  * @property {Array<Schemas['model.AIOPromptWithStatus']>} [prompts] build with
@@ -134,9 +103,9 @@ export const SEED_IDS = Object.freeze({
 /**
  * Authors a collection-keyed {@link Snapshot} from a friendly, DB-shaped description, so a caller
  * (the cross-repo e2e harness) can mirror the rows it inserted into Postgres without hand-writing
- * `collectionKey(...)` keys. Pass the result to `POST /__seed` or write it to a `MOCK_SEED_FILE`.
- * The project entity is built via {@link createProjectMock} (typed); pass `aiModels`/`prompts`
- * built with the factories so every row stays spec-shaped with real UUIDs.
+ * `collectionKey(...)` keys. Pass a project `market` to get a LIVE, addressable market (built via
+ * {@link createLiveProjectMock}); omit it for a bare project. Pass `aiModels`/`prompts` built with
+ * the factories so every row stays spec-shaped with real UUIDs.
  *
  * Pass `quota` to mirror the AI-unit allocation the sub-workspace was granted (via user-manager);
  * the project-engine mock then meters project/prompt creates + publish against it. Omit for the
@@ -151,9 +120,13 @@ export function buildSeed({ workspaceId, projects = [], quota }) {
   /** @type {import('./store.js').Snapshot} */
   const snapshot = { [projectsKey]: [] };
   for (const {
-    id, name, aiModels = [], prompts = [], benchmarks = [], tags = [], brandUrls = [],
+    id, name, market, aiModels = [], prompts = [], benchmarks = [], tags = [], brandUrls = [],
   } of projects) {
-    snapshot[projectsKey].push(createProjectMock({ id, name }));
+    snapshot[projectsKey].push(
+      market
+        ? createLiveProjectMock({ id, name, ...market })
+        : createProjectMock({ id, name }),
+    );
     const scope = { workspaceId, projectId: id };
     snapshot[collectionKey('ai_models', scope)] = aiModels;
     snapshot[collectionKey('prompts', scope)] = prompts;
@@ -173,3 +146,150 @@ export function buildSeed({ workspaceId, projects = [], quota }) {
   }
   return snapshot;
 }
+
+/** Builds `dimension:value` tags (`topic:`/`source:`/`intent:`/`type:` for prompts, `category:` for
+ * the Categories surface) with the mock's deterministic {@link tagId}, so a standalone category tag
+ * and the same tag inline on a prompt resolve to ONE id (#1754 gap 5).
+ * @param {string[]} names
+ * @returns {Array<Schemas['model.AIOTag']>} */
+const aioTags = (names) => names.map((name) => createAIOTagMock({ id: tagId(name), name }));
+
+/**
+ * Authors one full sub-workspace hierarchy (a live market with a model, a tagged prompt, an
+ * own-brand benchmark + URL, and standalone `category:` tags) under a CHILD workspace, via the
+ * public {@link buildSeed} recipe. Both seeded hierarchies go through here so they stay identical
+ * in shape.
+ * @param {{ childWorkspaceId: string, projectId: string, aiModelAssignmentId: string, name: string,
+ *   domain: string, brandName: string, languageId: string, countryCode: string, locationId: number,
+ *   locationName: string, modelKey: string, promptId: string, promptName: string,
+ *   promptTagNames: string[], benchmarkId: string, brandUrlId: string,
+ *   categoryTagNames: string[] }} cfg
+ * @returns {Snapshot}
+ */
+const peHierarchy = (cfg) => buildSeed({
+  workspaceId: cfg.childWorkspaceId,
+  projects: [{
+    id: cfg.projectId,
+    name: cfg.name,
+    market: {
+      domain: cfg.domain,
+      brand_names: [cfg.brandName],
+      brand_name_display: cfg.brandName,
+      language_id: cfg.languageId,
+      country_code: cfg.countryCode,
+      location_id: cfg.locationId,
+      location_name: cfg.locationName,
+    },
+    aiModels: [createProjectAiModelMock({
+      id: cfg.aiModelAssignmentId,
+      model: createAiModelMock(findCatalogEntryByKey(cfg.modelKey)),
+    })],
+    prompts: [createPromptMock({
+      id: cfg.promptId,
+      name: cfg.promptName,
+      tags: aioTags(cfg.promptTagNames),
+    })],
+    benchmarks: [createBenchmarkMock({
+      id: cfg.benchmarkId,
+      brand_name: cfg.brandName,
+      domain: cfg.domain,
+      main_brand: true,
+    })],
+    tags: aioTags(cfg.categoryTagNames),
+    brandUrls: [{
+      benchmarkId: cfg.benchmarkId,
+      urls: [createBrandUrlMock({ id: cfg.brandUrlId, url: `https://${cfg.domain}/about`, type: 'own' })],
+    }],
+  }],
+});
+
+/** Empty child workspace: no projects yet — the "create from scratch" flow starts here. */
+export const EMPTY_WORKSPACE = Object.freeze({
+  [collectionKey('projects', { workspaceId: CHILD_WORKSPACE_ID })]: [],
+});
+
+/**
+ * A brand's CHILD sub-workspace with one LIVE US/en market (a model + a tagged prompt + own-brand
+ * benchmark/URL + `category:` tags) — the "read/patch/run existing data" flow starts here. Entity
+ * shapes mirror the real API responses so `__dump` and GETs look like production.
+ */
+export const WORKSPACE_WITH_DATA = Object.freeze(peHierarchy({
+  childWorkspaceId: CHILD_WORKSPACE_ID,
+  projectId: PROJECT_ID,
+  aiModelAssignmentId: AI_MODEL_ASSIGNMENT_ID,
+  name: 'Seeded Project',
+  domain: 'example.com',
+  brandName: 'Seeded Brand',
+  languageId: ENGLISH_LANGUAGE_ID,
+  countryCode: 'us',
+  locationId: US_GEO_TARGET_ID,
+  locationName: 'United States',
+  modelKey: 'search-gpt',
+  promptId: PROMPT_ID,
+  promptName: 'What is the best running shoe?',
+  promptTagNames: ['topic:Running Shoes', 'source:blog', 'intent:commercial', 'type:branded'],
+  benchmarkId: BENCHMARK_ID,
+  brandUrlId: BRAND_URL_ID,
+  categoryTagNames: ['category:Running Shoes', 'category:Trail Running'],
+}));
+
+/**
+ * Two coexisting, fully independent hierarchies (H1 = the `workspace-with-data` US/en world, plus a
+ * second DE/de world under distinct workspace ids). For the dual-org local/e2e case where two
+ * mock-wired orgs each need their own `semrush_workspace_id` (the DB enforces uniqueness) served by
+ * ONE mock container. A strict superset of `workspace-with-data`, so anything anchored to H1 still
+ * resolves. (adobe/spacecat-shared#1754 gap 2.)
+ */
+export const TWO_HIERARCHIES = Object.freeze({
+  ...WORKSPACE_WITH_DATA,
+  ...peHierarchy({
+    childWorkspaceId: CHILD_WORKSPACE_ID_2,
+    projectId: PROJECT_ID_2,
+    aiModelAssignmentId: AI_MODEL_ASSIGNMENT_ID_2,
+    name: 'Seeded Project 2',
+    domain: 'zweite-marke.example',
+    brandName: 'Zweite Marke',
+    languageId: GERMAN_LANGUAGE_ID,
+    countryCode: 'de',
+    locationId: DE_GEO_TARGET_ID,
+    locationName: 'Germany',
+    modelKey: 'gemini-2.5-flash',
+    promptId: 'd6e7f8a9-b0c1-4d2e-8f3a-5b6c7d8e9f01',
+    promptName: 'Was ist der beste Laufschuh?',
+    promptTagNames: ['topic:Laufschuhe', 'source:forum', 'intent:informational', 'type:non-branded'],
+    benchmarkId: 'e7f8a9b0-c1d2-4e3f-8a4b-6c7d8e9f0112',
+    brandUrlId: 'f8a9b0c1-d2e3-4f4a-8b5c-7d8e9f011223',
+    categoryTagNames: ['category:Laufschuhe', 'category:Trailrunning'],
+  }),
+});
+
+/**
+ * All seed sets by name, for the runner to select via env/flag. Typed as a string map so a
+ * runtime `MOCK_SEED` (an arbitrary string) can index it with a fallback (see {@link Context}).
+ * @type {Record<string, import('./store.js').Snapshot>}
+ */
+export const SEEDS = Object.freeze({
+  'empty-workspace': EMPTY_WORKSPACE,
+  'workspace-with-data': WORKSPACE_WITH_DATA,
+  'two-hierarchies': TWO_HIERARCHIES,
+});
+
+/** Default seed loaded when none is specified. */
+export const DEFAULT_SEED = 'workspace-with-data';
+
+/** Ids used by the seed sets, exported so E2E flows can reference them without hardcoding. */
+export const SEED_IDS = Object.freeze({
+  // Hierarchy 1 (the `workspace-with-data` world). `workspaceId` is the brand's CHILD sub-workspace
+  // — the one the seeded project lives under (NOT the org parent).
+  parentWorkspaceId: PARENT_WORKSPACE_ID,
+  workspaceId: CHILD_WORKSPACE_ID,
+  projectId: PROJECT_ID,
+  aiModelId: AI_MODEL_CATALOG_ID,
+  promptId: PROMPT_ID,
+  benchmarkId: BENCHMARK_ID,
+  brandUrlId: BRAND_URL_ID,
+  // Hierarchy 2 (present only in `two-hierarchies`).
+  secondParentWorkspaceId: PARENT_WORKSPACE_ID_2,
+  secondWorkspaceId: CHILD_WORKSPACE_ID_2,
+  secondProjectId: PROJECT_ID_2,
+});

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -401,8 +401,8 @@ async function waitForReady(baseUrl, deadline, getStderr) {
       },
     );
     expect(error).to.equal(undefined);
-    // Only the 'brand'-tagged prompt matches: the seeded prompt has no tags, the 'category' one
-    // carries a different tag id.
+    // Only the 'brand'-tagged prompt matches: the seeded prompt's topic:/source:/intent:/type:
+    // tags (none is the bare 'brand' → tag-brand), and the 'category' one a different tag id.
     expect(branded.items.map((p) => p.name)).to.deep.equal(['Branded question']);
     expect(branded.total).to.equal(1);
   });
@@ -499,17 +499,21 @@ async function waitForReady(baseUrl, deadline, getStderr) {
       '/v2/workspaces/{id}/projects/{project_id}/ai_models',
       {
         params: { path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT } },
-        body: { model_id: SEED_IDS.aiModelId },
+        // A synthetic id absent from the catalog, to exercise the unmodelled fallback. (The seed's
+        // own model is now the catalog `search-gpt`, so posting SEED_IDS.aiModelId would resolve —
+        // not fall back.)
+        body: { model_id: '00000000-0000-4000-8000-000000000000' },
       },
     );
     expect(error).to.equal(undefined);
     expect(response.status).to.equal(201);
     // Live resolves the catalog model's icon onto the add response (verified 2026-06-25).
     expect(data.model).to.include.keys('id', 'icon');
-    // SEED_IDS.aiModelId is NOT a catalog id, so this exercises the unmodelled fallback:
-    // the factory default (GPT-4o) is kept, with the posted id preserved.
-    expect(data.model.name).to.equal('GPT-4o');
-    expect(data.model.key).to.equal('gpt-4o');
+    // Unmodelled id → the catalog-valid factory default (search-gpt / ChatGPT) is kept, with the
+    // posted id preserved.
+    expect(data.model.name).to.equal('ChatGPT');
+    expect(data.model.key).to.equal('search-gpt');
+    expect(data.model.id).to.equal('00000000-0000-4000-8000-000000000000');
   });
 
   // Regression: a known catalog model_id must echo THAT model's name + icon — not the
@@ -551,11 +555,13 @@ async function waitForReady(baseUrl, deadline, getStderr) {
   // optimistic add because the mock couldn't persist it). parent_id + search are spec-required
   // query params (the consumer sends them); empty search lists every stored tag.
   it('persists createProjectTags and reads the 0-prompt category back via GET /aio/tags', async () => {
+    // The seed already carries two category tags; create a NEW 0-prompt category and prove it
+    // persists + reads back (the elmo Categories surface fix).
     const { error: createError } = await client.POST(
       '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
       {
         params: { path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT } },
-        body: { names: ['category:Running Shoes'] },
+        body: { names: ['category:Hydration'] },
       },
     );
     expect(createError).to.equal(undefined);
@@ -570,10 +576,11 @@ async function waitForReady(baseUrl, deadline, getStderr) {
       },
     );
     expect(listError).to.equal(undefined);
-    expect(listed.total).to.equal(1);
-    expect(listed.items.map((t) => t.name)).to.deep.equal(['category:Running Shoes']);
+    expect(listed.total).to.equal(3); // two seeded categories + the one just created
+    const created = listed.items.find((t) => t.name === 'category:Hydration');
+    expect(created).to.not.equal(undefined);
     // The stored/listed shape is an AIOTag (prompts_count), not a TreeNodeResponse (keyword_count).
-    expect(listed.items[0]).to.include.keys('id', 'name', 'prompts_count');
+    expect(created).to.include.keys('id', 'name', 'prompts_count');
   });
 
   // Re-creating the same category name is idempotent (deterministic tag-<name> id) — no duplicate.
@@ -595,7 +602,7 @@ async function waitForReady(baseUrl, deadline, getStderr) {
         },
       },
     );
-    expect(all.total).to.equal(2); // Alpha once, Beta once
+    expect(all.total).to.equal(4); // Alpha once, Beta once + the two seeded categories
 
     const { data: filtered } = await client.GET(
       '/v2/workspaces/{id}/projects/{project_id}/aio/tags',
@@ -609,8 +616,8 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     expect(filtered.items.map((t) => t.name)).to.deep.equal(['category:Beta']);
   });
 
-  // __reset restores the boot seed (no tags), so created standalone tags are cleared — proving the
-  // tags collection rides the seed/reset lifecycle like every other stateful resource.
+  // __reset restores the boot seed (its two category tags), so created tags are cleared —
+  // proving the tags collection rides the seed/reset lifecycle like every other stateful resource.
   it('clears created tags on __reset (tags ride the seed lifecycle)', async () => {
     await client.POST('/v2/workspaces/{id}/projects/{project_id}/aio/tags', {
       params: { path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT } },
@@ -627,7 +634,8 @@ async function waitForReady(baseUrl, deadline, getStderr) {
         },
       },
     );
-    expect(listed.total).to.equal(0);
+    expect(listed.total).to.equal(2); // only the two seeded categories remain
+    expect(listed.items.map((t) => t.name)).to.not.include('category:Ephemeral');
   });
 
   // Multi-market: one category name is registered on N market projects via N createProjectTags
@@ -699,7 +707,9 @@ async function waitForReady(baseUrl, deadline, getStderr) {
         },
       },
     );
-    expect(tagsAfter.total).to.equal(0);
+    // The two seeded categories remain; only the created 'Doomed' tag is gone.
+    expect(tagsAfter.total).to.equal(2);
+    expect(tagsAfter.items.map((t) => t.name)).to.not.include('category:Doomed');
 
     // The seeded prompt is untouched — the tag delete does not cascade to the prompts collection.
     const { data: prompts } = await client.POST(

--- a/packages/spacecat-shared-project-engine-client/test/mock/ai-model-catalog.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/ai-model-catalog.test.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { AI_MODEL_CATALOG, findCatalogEntryByKey } from '../../mock/ai-model-catalog.js';
+
+describe('ai-model-catalog', () => {
+  it('findCatalogEntryByKey returns the matching catalog entry', () => {
+    const entry = findCatalogEntryByKey('search-gpt');
+    expect(entry).to.deep.equal({
+      id: 'eab23d14-df70-463f-8779-3f6a4ba770bc',
+      name: 'ChatGPT',
+      key: 'search-gpt',
+      icon: 'openai',
+    });
+    // it returns the actual frozen catalog entry (single source of truth), not a copy.
+    expect(entry).to.equal(AI_MODEL_CATALOG.find((m) => m.key === 'search-gpt'));
+  });
+
+  it('findCatalogEntryByKey throws loudly on an unknown key (fail-fast, no silent default)', () => {
+    expect(() => findCatalogEntryByKey('gpt-4o')).to.throw('Unknown AI model catalog key: gpt-4o');
+  });
+});

--- a/packages/spacecat-shared-project-engine-client/test/mock/factories.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/factories.test.js
@@ -13,6 +13,7 @@
 import { expect } from 'chai';
 import {
   createAiModelMock,
+  createLiveProjectMock,
   createProjectResponseFromRequest,
   applyProjectUpdate,
   createBenchmarkMock,
@@ -30,8 +31,13 @@ import {
 // component schema; these runtime tests cover the factory bodies (defaults + override merge) so
 // coverage stays complete and the live-verified shapes are pinned.
 describe('factories — live-shaped entities', () => {
-  it('createAiModelMock carries an icon (the live add path returns name + icon)', () => {
-    expect(createAiModelMock()).to.include({ key: 'gpt-4o', name: 'GPT-4o', icon: 'openai' });
+  it('createAiModelMock defaults to a catalog-valid model (search-gpt) with its icon', () => {
+    // The default is the live catalog's ChatGPT/search-gpt entry (id/key/name/icon all from the
+    // shared AI_MODEL_CATALOG), so a seeded assignment or add-path fallback is never an
+    // unresolvable model chip (#1754 gap 4). `icon` matters — the add path returns name + icon.
+    expect(createAiModelMock()).to.include({
+      id: 'eab23d14-df70-463f-8779-3f6a4ba770bc', key: 'search-gpt', name: 'ChatGPT', icon: 'openai',
+    });
     expect(createAiModelMock({ icon: 'claude' }).icon).to.equal('claude');
   });
 
@@ -107,6 +113,56 @@ describe('factories — live-shaped entities', () => {
     expect(p.settings.ai.country).to.deep.equal({ code: '', name: '' });
     expect(p.settings.ai.location).to.deep.equal({ id: 0, name: null });
     expect(p.settings.ai.primary_url).to.equal('');
+  });
+
+  it('createLiveProjectMock defaults to a live, market-less project (no request)', () => {
+    const p = createLiveProjectMock();
+    expect(p.id).to.match(/^[0-9a-f-]{36}$/);
+    // live, not a draft — the seed/default side of #1754 gap 3.
+    expect(p).to.include({
+      live_id: p.id,
+      draft_id: p.id,
+      type: 'ai',
+      name: 'Seeded Project',
+      domain: '',
+      // is_draft stays true even when live — the publish route flips only publish_status.
+      is_draft: true,
+      publish_status: 'live',
+      published_at: '2026-01-01T00:00:00Z',
+      shared_with: 0,
+    });
+    // empty request → empty settings.ai, so it has no resolvable geo/lang (caller supplies one).
+    expect(p.settings.ai).to.deep.include({ primary_url: '', prompts_count: 0 });
+    expect(p.settings.ai.language).to.deep.equal({ id: '', name: '' });
+  });
+
+  it('createLiveProjectMock builds a resolvable live market from a request (US/en)', () => {
+    const p = createLiveProjectMock({
+      id: 'b8c9d0e1-f2a3-4b4c-8d5e-7f8091021324',
+      type: 'ai',
+      name: 'Seeded Project',
+      domain: 'example.com',
+      brand_names: ['Seeded Brand'],
+      brand_name_display: 'Seeded Brand',
+      language_id: '5a0a33ed-7f5c-4901-befd-a042c0350da1', // catalog English → en
+      country_code: 'us',
+      location_id: 2840,
+      location_name: 'United States',
+      published_at: '2030-06-01T00:00:00Z',
+    });
+    expect(p).to.include({
+      id: 'b8c9d0e1-f2a3-4b4c-8d5e-7f8091021324',
+      live_id: 'b8c9d0e1-f2a3-4b4c-8d5e-7f8091021324',
+      publish_status: 'live',
+      is_draft: true,
+      domain: 'example.com',
+      published_at: '2030-06-01T00:00:00Z',
+    });
+    // geo (location.id) + language.name (ISO) are the load-bearing fields api-service's listMarkets
+    // reads to keep the project as an addressable market.
+    expect(p.settings.ai.location.id).to.equal(2840);
+    expect(p.settings.ai.language).to.deep.equal({ id: '5a0a33ed-7f5c-4901-befd-a042c0350da1', name: 'en' });
+    expect(p.settings.ai.country).to.deep.equal({ code: 'us', name: 'United States' });
   });
 
   it('applyProjectUpdate nests brand fields under settings.ai and keeps name/type/domain top-level', () => {

--- a/packages/spacecat-shared-project-engine-client/test/mock/seeds.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/seeds.test.js
@@ -28,7 +28,8 @@ import {
 
 describe('seeds', () => {
   it('exposes named seed sets with a valid default', () => {
-    expect(Object.keys(SEEDS)).to.include.members(['empty-workspace', 'workspace-with-data']);
+    expect(Object.keys(SEEDS))
+      .to.include.members(['empty-workspace', 'workspace-with-data', 'two-hierarchies']);
     expect(SEEDS).to.have.property(DEFAULT_SEED);
   });
 
@@ -56,6 +57,49 @@ describe('seeds', () => {
     expect(benchmarks).to.have.length(1);
     expect(benchmarks[0]).to.include({ id: benchmarkId, main_brand: true });
     expect(ops.brand_urls.list({ workspaceId, projectId, benchmarkId })).to.have.length(1);
+  });
+
+  it('workspace-with-data seeds a LIVE US/en market with a catalog model, tagged prompt + categories', () => {
+    const store = new InMemoryStore();
+    store.load(SEEDS['workspace-with-data']);
+    const ops = createStatefulOps(store);
+    const { workspaceId, projectId } = SEED_IDS;
+
+    // the project lives under the CHILD sub-workspace (not the org parent) and is live with a
+    // resolvable US/en market — else api-service's listMarkets would drop it (#1754 gaps 1 + 3).
+    expect(workspaceId).to.equal('b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e');
+    const project = ops.projects.get({ workspaceId }, projectId);
+    expect(project.publish_status).to.equal('live');
+    expect(project.settings.ai.location.id).to.equal(2840);
+    expect(project.settings.ai.language.name).to.equal('en');
+
+    // the assigned model is catalog-valid (search-gpt / ChatGPT), NOT the old non-catalog gpt-4o.
+    const [assigned] = ops.ai_models.list({ workspaceId, projectId });
+    expect(assigned.model).to.include({ key: 'search-gpt', name: 'ChatGPT' });
+
+    // the seeded prompt carries dimension:value tags; the project has category: tags (#1754 g5).
+    const [prompt] = ops.prompts.list({ workspaceId, projectId });
+    expect(prompt.tags.map((t) => t.name))
+      .to.deep.equal(['topic:Running Shoes', 'source:blog', 'intent:commercial', 'type:branded']);
+    const categories = ops.tags.list({ workspaceId, projectId }).map((t) => t.name);
+    expect(categories).to.deep.equal(['category:Running Shoes', 'category:Trail Running']);
+  });
+
+  it('two-hierarchies is a superset with a second, independent live market (DE/de)', () => {
+    const store = new InMemoryStore();
+    store.load(SEEDS['two-hierarchies']);
+    const ops = createStatefulOps(store);
+
+    // hierarchy 1 still resolves (superset of workspace-with-data)…
+    expect(ops.projects.list({ workspaceId: SEED_IDS.workspaceId })).to.have.length(1);
+    // …and a second, distinct child workspace carries its own live DE/de market (#1754 gap 2).
+    const secondWs = SEED_IDS.secondWorkspaceId;
+    const [secondProject] = ops.projects.list({ workspaceId: secondWs });
+    expect(secondProject.id).to.equal(SEED_IDS.secondProjectId);
+    expect(secondProject.publish_status).to.equal('live');
+    expect(secondProject.settings.ai.language.name).to.equal('de');
+    // distinct workspace ids (the DB enforces unique semrush_workspace_id per org/brand).
+    expect(secondWs).to.not.equal(SEED_IDS.workspaceId);
   });
 
   it('reset restores a seed after mutation', () => {

--- a/packages/spacecat-shared-user-manager-client/docs/mock-usage.md
+++ b/packages/spacecat-shared-user-manager-client/docs/mock-usage.md
@@ -62,6 +62,7 @@ State boots from a named seed (`MOCK_SEED`), or a JSON snapshot file (`MOCK_SEED
 | --- | --- |
 | `parent-with-child` (default) | the org parent + one provisioned child (`SEED_IDS.parentWorkspaceId` / `.childWorkspaceId`) |
 | `empty-parent` | the org parent only — the "create a sub-workspace from scratch" flow |
+| `two-hierarchies` | a superset of `parent-with-child` plus a second, independent parent→child family (`SEED_IDS.secondParentWorkspaceId` / `.secondChildWorkspaceId`) for the dual-org case; pairs with the Project Engine mock's `two-hierarchies` |
 
 `buildSeed({ workspaces, pools })` authors a snapshot from a DB-shaped description (use the
 `semrush_workspace_id` UUIDs from your fixtures so the mock and Postgres line up). Each workspace is

--- a/packages/spacecat-shared-user-manager-client/mock/seeds.js
+++ b/packages/spacecat-shared-user-manager-client/mock/seeds.js
@@ -33,8 +33,11 @@ import { createWorkspaceMock } from './factories.js';
 // Real-shaped fixtures: the User Manager API types every workspace id as a UUID-like string, so the
 // seeds use fixed UUIDs (not `ws-1`) to mirror production data. Fixed, not generated, so SEED_IDS
 // stays stable for assertions.
-const PARENT_WORKSPACE_ID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'; // org parent workspace (path {id})
-const CHILD_WORKSPACE_ID = 'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e'; // a brand sub-workspace under it
+// Hierarchy 1 parent/child — the same UUIDs as the Project Engine mock's first hierarchy
+// (PE seeds.js), so PE projects and UM workspaces line up across the two packages. The parent
+// is the URL path `{id}`; the child is a brand sub-workspace under it.
+const PARENT_WORKSPACE_ID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'; // == PE parent
+const CHILD_WORKSPACE_ID = 'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e'; // == PE child
 
 // A second, fully independent hierarchy (present only in `two-hierarchies`). Ids match the Project
 // Engine mock's second hierarchy so PE projects and UM workspaces line up across the two packages.

--- a/packages/spacecat-shared-user-manager-client/mock/seeds.js
+++ b/packages/spacecat-shared-user-manager-client/mock/seeds.js
@@ -36,6 +36,11 @@ import { createWorkspaceMock } from './factories.js';
 const PARENT_WORKSPACE_ID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'; // org parent workspace (path {id})
 const CHILD_WORKSPACE_ID = 'b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e'; // a brand sub-workspace under it
 
+// A second, fully independent hierarchy (present only in `two-hierarchies`). Ids match the Project
+// Engine mock's second hierarchy so PE projects and UM workspaces line up across the two packages.
+const PARENT_WORKSPACE_ID_2 = 'a2b3c4d5-e6f7-4a8b-9c0d-1e2f3a4b5c6d';
+const CHILD_WORKSPACE_ID_2 = 'b3c4d5e6-f7a8-4b9c-8d0e-2f3a4b5c6d7e';
+
 /**
  * @typedef {import('./store.js').Snapshot} Snapshot
  */
@@ -66,6 +71,31 @@ export const PARENT_WITH_CHILD = Object.freeze({
 });
 
 /**
+ * Two coexisting, independent parent→child hierarchies — the User Manager side of the Project
+ * Engine mock's `two-hierarchies` seed (matching workspace ids). For the dual-org case where two
+ * mock-wired orgs each need their own parent workspace + brand sub-workspace (the DB enforces a
+ * unique `semrush_workspace_id`). A strict superset of `parent-with-child`.
+ */
+export const TWO_HIERARCHIES = Object.freeze({
+  [WORKSPACES]: [
+    createWorkspaceMock({ id: PARENT_WORKSPACE_ID, title: 'Parent Org Workspace', parent_id: '' }),
+    createWorkspaceMock({
+      id: CHILD_WORKSPACE_ID,
+      title: 'Seeded Child [b2c3d4e5]',
+      parent_id: PARENT_WORKSPACE_ID,
+      status: 'created',
+    }),
+    createWorkspaceMock({ id: PARENT_WORKSPACE_ID_2, title: 'Second Org Workspace', parent_id: '' }),
+    createWorkspaceMock({
+      id: CHILD_WORKSPACE_ID_2,
+      title: 'Seeded Child [b3c4d5e6]',
+      parent_id: PARENT_WORKSPACE_ID_2,
+      status: 'created',
+    }),
+  ],
+});
+
+/**
  * All seed sets by name, for the runner to select via env/flag. Typed as a string map so a runtime
  * `MOCK_SEED` (an arbitrary string) can index it with a fallback (see {@link Context}).
  * @type {Record<string, import('./store.js').Snapshot>}
@@ -73,6 +103,7 @@ export const PARENT_WITH_CHILD = Object.freeze({
 export const SEEDS = Object.freeze({
   'empty-parent': EMPTY_PARENT,
   'parent-with-child': PARENT_WITH_CHILD,
+  'two-hierarchies': TWO_HIERARCHIES,
 });
 
 /** Default seed loaded when none is specified. */
@@ -82,6 +113,9 @@ export const DEFAULT_SEED = 'parent-with-child';
 export const SEED_IDS = Object.freeze({
   parentWorkspaceId: PARENT_WORKSPACE_ID,
   childWorkspaceId: CHILD_WORKSPACE_ID,
+  // Hierarchy 2 (present only in `two-hierarchies`).
+  secondParentWorkspaceId: PARENT_WORKSPACE_ID_2,
+  secondChildWorkspaceId: CHILD_WORKSPACE_ID_2,
 });
 
 /**

--- a/packages/spacecat-shared-user-manager-client/test/mock/seeds.test.js
+++ b/packages/spacecat-shared-user-manager-client/test/mock/seeds.test.js
@@ -12,16 +12,33 @@
 
 import { expect } from 'chai';
 import {
-  SEEDS, DEFAULT_SEED, SEED_IDS, EMPTY_PARENT, PARENT_WITH_CHILD, buildSeed,
+  SEEDS, DEFAULT_SEED, SEED_IDS, EMPTY_PARENT, PARENT_WITH_CHILD, TWO_HIERARCHIES, buildSeed,
 } from '../../mock/seeds.js';
 import { WORKSPACES, STATUS_CONTROL } from '../../mock/stateful.js';
 import { POOL_COLLECTION } from '../../mock/quota.js';
 
 describe('mock seeds', () => {
   it('exposes the named seed sets and the default', () => {
-    expect(Object.keys(SEEDS)).to.have.members(['empty-parent', 'parent-with-child']);
+    expect(Object.keys(SEEDS))
+      .to.have.members(['empty-parent', 'parent-with-child', 'two-hierarchies']);
     expect(DEFAULT_SEED).to.equal('parent-with-child');
     expect(SEEDS[DEFAULT_SEED]).to.equal(PARENT_WITH_CHILD);
+  });
+
+  it('TWO_HIERARCHIES links two independent parent→child families', () => {
+    const ws = TWO_HIERARCHIES[WORKSPACES];
+    expect(ws).to.have.length(4);
+    const ids = ws.map((w) => w.id);
+    expect(ids).to.deep.equal([
+      SEED_IDS.parentWorkspaceId, SEED_IDS.childWorkspaceId,
+      SEED_IDS.secondParentWorkspaceId, SEED_IDS.secondChildWorkspaceId,
+    ]);
+    // each child links to its OWN parent (never the other hierarchy's).
+    expect(ws[1].parent_id).to.equal(SEED_IDS.parentWorkspaceId);
+    expect(ws[3].parent_id).to.equal(SEED_IDS.secondParentWorkspaceId);
+    // roots have no parent.
+    expect(ws[0].parent_id).to.equal('');
+    expect(ws[2].parent_id).to.equal('');
   });
 
   it('EMPTY_PARENT has the org parent only', () => {
@@ -37,9 +54,9 @@ describe('mock seeds', () => {
     expect(child.status).to.equal('created');
   });
 
-  it('SEED_IDS is frozen and exposes both ids', () => {
+  it('SEED_IDS is frozen and exposes both hierarchies ids', () => {
     expect(Object.isFrozen(SEED_IDS)).to.equal(true);
-    expect(SEED_IDS).to.have.all.keys('parentWorkspaceId', 'childWorkspaceId');
+    expect(SEED_IDS).to.have.all.keys('parentWorkspaceId', 'childWorkspaceId', 'secondParentWorkspaceId', 'secondChildWorkspaceId');
   });
 
   describe('buildSeed', () => {


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Folds the offline-serenity sub-workspace fixtures into the published Project Engine / User Manager mock images' baked seed + factory defaults, so consumers get a faithful sub-workspace world out of the box instead of hand-authoring a `__seed` snapshot around the baked seed's gaps.

## 2. Reasoning
The baked `workspace-with-data` seed + factory defaults didn't model the sub-workspace cleanly: a brand that correctly resolves to a **child** sub-workspace found no data (the only project lived under the org's parent workspace), the seeded project wasn't `live` (and carried no resolvable geo/lang, so api-service's market read silently dropped it), the default assigned model was a non-catalog `gpt-4o` (an unresolvable model chip), and prompts had no tags. `mysticat-workspace` masked all of this locally with a workspace-owned `__seed` snapshot. This moves that fidelity upstream into the image and retires the workaround.

## 3. High-level overview of the changes
Behaviour delta — before: a brand anchored to its child sub-workspace read an empty/misconfigured market from the baked seed; after: it reads a complete, live market.

- **Project under the child.** The Project Engine seed now models parent → child and places the project under the **child** sub-workspace (with its own id), so a correctly-anchored brand returns non-empty markets. The User Manager seed already modelled parent/child; the two are now aligned on the same ids.
- **Live, addressable market.** A new `createLiveProjectMock` factory builds a `publish_status: 'live'` project with a resolvable geo + language under `settings.ai` (US/en; the second hierarchy is DE/de). Without a resolvable geo/lang, api-service's `listMarkets` drops the project — so a bare project would seed an invisible market.
- **Catalog-valid model.** The default assigned model is now a real catalog entry (`search-gpt` / ChatGPT) via a new fail-fast `findCatalogEntryByKey` helper, replacing the non-catalog `gpt-4o` that rendered an unresolvable model chip. A mistyped key now throws instead of silently falling back.
- **Tagged prompts + categories.** Seeded prompts carry `topic:`/`source:`/`intent:`/`type:` tags, and the project carries `category:` tags for the Categories surface.
- **Two hierarchies.** A new `two-hierarchies` seed (both packages) is a strict superset of the default plus a second, fully independent parent/child family — for the dual-org case where two mock-wired orgs each need a distinct `semrush_workspace_id`.

The published client surface (`src/`) is unchanged; only the mock and its fixtures/docs change.

## 4. Required information
- Other: relates to  https://github.com/adobe/spacecat-shared/issues/1754  (the tracking issue),  https://github.com/adobe/mysticat-data-service/issues/757  (the offline-seed fidelity tracker), and the already-merged tag-statefulness / add-model-fidelity work referenced there.

## 5. Affected / used mysticat-workspace projects
- spacecat-api-service — consumes these mocks over HTTPS in its serenity IT/e2e harness (contract). It currently pins the pre-change published mock image, so this PR does not regress it; its IT seed-ids adopt the child-anchored shape in lockstep when it bumps the mock version.
- mysticat-data-service — its `scripts/seed-semrush-mock.sql` aligns the org/brand `semrush_workspace_id`s to these seed ids (parent for the org, child for the brand).
- mysticat-workspace (local-dev) — boots these mock images via `make up-semrush-mocks` and now selects the `two-hierarchies` seed.

## 6. Additional information outside the code
Booted the full offline serenity stack locally end-to-end: built both mock images from this branch's source, ran them with `MOCK_SEED=two-hierarchies`, applied the aligned data-service seed to a local Postgres, and drove spacecat-api-service against them.

- Both hierarchies resolved live markets through api-service: `GET .../brands/:brand/serenity/markets` returned a `live` US/en market (hierarchy 1) and a `live` DE/de market (hierarchy 2), each with the seed's own project id.
- The brand-level prompt read surfaced the seeded prompt with all four `dimension:value` tags in its `tagMap`; the org-level catalog reads (models, languages) resolved.
- Confirmed the previously-failing states are gone: no `404` (serenity gate satisfied), no `409 workspaceMisconfigured` (brand resolves as a child, not the org parent).

## 7. Test plan
Local only — this changes a dev/test mock consumed by local-dev and the cross-repo e2e harness; it is not loaded by any deployed environment.

(a) Done this session: built the PE/UM mock images from this branch, ran them with `MOCK_SEED=two-hierarchies`, and verified through spacecat-api-service that both hierarchies resolve live markets, the assigned model is catalog-valid, and prompts carry their tags (see section 6).

(b) To reproduce: from `mysticat-workspace/local`, `make up && make db-setup`, build + run these mock images (or `make up-semrush-mocks` once a version carrying this change is published), `make db-seed-serenity-mock`, then `GET /v2/orgs/:org/brands/:brand/serenity/markets` for each seeded brand and confirm a `live` market with the expected geo/lang.

## 8. Deployment & merge order
- Related:  https://github.com/adobe/mysticat-data-service/issues/757  — the data-service seed PR (brand → child + `LLMO/serenity` flag) aligns the Postgres side to these ids.
- Related: the mysticat-workspace PR selecting `MOCK_SEED=two-hierarchies` for the local mocks.

No hard ordering (dev/test only). Once this releases a new mock image, spacecat-api-service can bump the pinned mock version and adopt the child-anchored IT seed-ids in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
