### PR TITLE
feat(utils): add isPathPatternWithinSiteScope url helper

### DIFF
--- a/packages/spacecat-shared-utils/src/index.js
+++ b/packages/spacecat-shared-utils/src/index.js
@@ -79,6 +79,7 @@ export {
   toPathname,
   hasSamePathname,
   allHaveSamePathname,
+  isPathPatternWithinSiteScope,
 } from './url-helpers.js';
 
 export {

--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -595,6 +595,43 @@ export function allHaveSamePathname(urls, referenceUrl) {
   return urls.every((url) => hasSamePathname(url, referenceUrl));
 }
 
+/**
+ * A pattern is trusted as scoped to the site's base path only when it is an exact match or
+ * uses the `/*` pathname-prefix convention (see @adobe/spacecat-shared-tokowaka-client's
+ * buildUrlMatcher). Any other pattern is compiled as a regex and matched against the full
+ * URL downstream, so a literal `startsWith` check on the pattern text is not sound —
+ * e.g. `/kings/.*|/wolves/.*` starts with `/kings` but, once compiled, also matches
+ * `/wolves/...` via the `|` alternation. We fail closed for anything we cannot verify.
+ * @param {string} pathPattern - the pattern to check.
+ * @param {string} siteBaseUrl - the site's base URL defining the scope (e.g. "bulk.com/uk"),
+ * mirroring the siteBaseUrl argument of @adobe/spacecat-shared-utils's isWithinSiteScope.
+ * @returns {boolean} true if the pattern is confirmed to be within the site's scope.
+ */
+export function isPathPatternWithinSiteScope(pathPattern, siteBaseUrl) {
+  if (typeof pathPattern !== 'string') {
+    return false;
+  }
+  if (!siteBaseUrl) {
+    return true;
+  }
+
+  const siteBasePath = toPathname(siteBaseUrl);
+
+  if (siteBasePath === '/') {
+    return true;
+  }
+
+  if (pathPattern.endsWith('/*')) {
+    const prefix = pathPattern.slice(0, -2);
+    return prefix === siteBasePath || prefix.startsWith(`${siteBasePath}/`);
+  }
+  // eslint-disable-next-line no-useless-escape
+  if (/[|()\[\]^$+*?\\.]/.test(pathPattern)) {
+    return false;
+  }
+  return pathPattern === siteBasePath || pathPattern.startsWith(`${siteBasePath}/`);
+}
+
 export {
   ensureHttps,
   getSpacecatRequestHeaders,

--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -596,8 +596,9 @@ export function allHaveSamePathname(urls, referenceUrl) {
 }
 
 /**
- * A pattern is trusted as scoped to the site's base path only when it is an exact match or
- * uses the `/*` pathname-prefix convention (see @adobe/spacecat-shared-tokowaka-client's
+ * A pattern is trusted as scoped to the site's base path only when it is a literal path
+ * (no regex metacharacters) that equals or is nested under the base path, or when it uses
+ * the `/*` pathname-prefix convention (see @adobe/spacecat-shared-tokowaka-client's
  * buildUrlMatcher). Any other pattern is compiled as a regex and matched against the full
  * URL downstream, so a literal `startsWith` check on the pattern text is not sound —
  * e.g. `/kings/.*|/wolves/.*` starts with `/kings` but, once compiled, also matches

--- a/packages/spacecat-shared-utils/test/index.test.js
+++ b/packages/spacecat-shared-utils/test/index.test.js
@@ -133,6 +133,7 @@ describe('Index Exports', () => {
     'toBoolean',
     'filterBySiteScope',
     'isWithinSiteScope',
+    'isPathPatternWithinSiteScope',
     'toggleWWWHostname',
     'toPathname',
     'hasSamePathname',

--- a/packages/spacecat-shared-utils/test/url-helpers.test.js
+++ b/packages/spacecat-shared-utils/test/url-helpers.test.js
@@ -36,6 +36,7 @@ import {
   toPathname,
   hasSamePathname,
   allHaveSamePathname,
+  isPathPatternWithinSiteScope,
 } from '../src/url-helpers.js';
 
 use(sinonChai);
@@ -1489,6 +1490,48 @@ describe('URL Utility Functions', () => {
     it('matches schema-less URLs in the array against a reference URL', () => {
       const urls = ['a.com/page', 'https://b.com/page'];
       expect(allHaveSamePathname(urls, 'c.com/page')).to.be.true;
+    });
+  });
+
+  describe('isPathPatternWithinSiteScope', () => {
+    it('returns false for non-string patterns', () => {
+      expect(isPathPatternWithinSiteScope(null, 'bulk.com/uk')).to.be.false;
+      expect(isPathPatternWithinSiteScope(undefined, 'bulk.com/uk')).to.be.false;
+    });
+
+    it('returns true when no siteBaseUrl is given', () => {
+      expect(isPathPatternWithinSiteScope('/kings/.*', '')).to.be.true;
+    });
+
+    it('returns true when the site is scoped to the root path', () => {
+      expect(isPathPatternWithinSiteScope('/kings/.*', 'bulk.com')).to.be.true;
+      expect(isPathPatternWithinSiteScope('/kings/.*', 'bulk.com/')).to.be.true;
+    });
+
+    it('treats /* prefixed patterns as trusted when the prefix is or extends the base path', () => {
+      expect(isPathPatternWithinSiteScope('/uk/*', 'bulk.com/uk')).to.be.true;
+      expect(isPathPatternWithinSiteScope('/uk/kings/*', 'bulk.com/uk')).to.be.true;
+    });
+
+    it('rejects /* prefixed patterns whose prefix escapes the base path', () => {
+      expect(isPathPatternWithinSiteScope('/us/*', 'bulk.com/uk')).to.be.false;
+      expect(isPathPatternWithinSiteScope('/ukraine/*', 'bulk.com/uk')).to.be.false;
+    });
+
+    it('fails closed for patterns containing regex metacharacters', () => {
+      expect(isPathPatternWithinSiteScope('/kings/.*|/wolves/.*', 'bulk.com/kings')).to.be.false;
+      expect(isPathPatternWithinSiteScope('/uk/(a|b)', 'bulk.com/uk')).to.be.false;
+      expect(isPathPatternWithinSiteScope('/uk/[a-z]', 'bulk.com/uk')).to.be.false;
+    });
+
+    it('treats exact or extending plain-text patterns as within scope', () => {
+      expect(isPathPatternWithinSiteScope('/uk', 'bulk.com/uk')).to.be.true;
+      expect(isPathPatternWithinSiteScope('/uk/kings', 'bulk.com/uk')).to.be.true;
+    });
+
+    it('rejects plain-text patterns that escape the base path', () => {
+      expect(isPathPatternWithinSiteScope('/us', 'bulk.com/uk')).to.be.false;
+      expect(isPathPatternWithinSiteScope('/ukraine', 'bulk.com/uk')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `isPathPatternWithinSiteScope(pathPattern, siteBaseUrl)` to `spacecat-shared-utils`, mirroring `isWithinSiteScope`'s `siteBaseUrl` argument, to determine whether a path pattern is confirmed to be scoped under a site's base path.
- A pattern is trusted only when it's a literal path (no regex metacharacters) that equals or is nested under the base path, or when it uses the `/*` pathname-prefix convention (matching `@adobe/spacecat-shared-tokowaka-client`'s `buildUrlMatcher`). Anything else fails closed, since such patterns are compiled as a regex and matched against the full URL downstream, making a literal `startsWith` check on the pattern text unsound.

## Test plan
- [x] `npm test -w packages/spacecat-shared-utils` — 1254 passing, 100% line/statement coverage
- [x] `npm run lint -w packages/spacecat-shared-utils`