### PR TITLE
fix(facs): bypass FACS enforcement for IMS auth channel

### DIFF
--- a/packages/spacecat-shared-http-utils/src/auth/facs-wrapper.js
+++ b/packages/spacecat-shared-http-utils/src/auth/facs-wrapper.js
@@ -126,6 +126,12 @@ function routeMatchesAnyProductMap(context, productsRoutes) {
  *
  *   0. CORS preflight (`OPTIONS`) → bypass.
  *   1. Internal identities (admin, S2S, read-only admin, api-key) → bypass.
+ *   1b. IMS auth channel (`authInfo.getType() === 'ims'`) → bypass. Direct IMS
+ *      tokens are a deprecating channel that never carry `facs_permissions` and
+ *      may not resolve a tenant `orgId`, so FACS cannot evaluate them; forcing
+ *      them through the ladder would 403 every org request. IMS orgs that ARE
+ *      FACS/RBAC-enabled are gated ahead of this wrapper, so this bypass only
+ *      admits the not-yet-enrolled IMS traffic that must keep working for now.
  *   2. Adobe internal IMS orgs (`FACS_EXCEPTION_INTERNAL_ORGS`) → bypass.
  *   3. Route NOT in any product map → bypass.
  *      Route IS in some product map but `x-product` is missing / mismatched
@@ -234,6 +240,19 @@ export function facsWrapper(fn, { routeFacsCapabilities } = {}) {
         isS2SConsumer: !!authInfo?.isS2SConsumer?.(),
         isReadOnlyAdmin: !!authInfo?.isReadOnlyAdmin?.(),
       }, 'FACS bypass: internal identity');
+      return fn(request, context);
+    }
+
+    // (1b) IMS auth channel bypass. Direct IMS tokens are a deprecating channel
+    // that never carry `facs_permissions` and may not resolve a tenant `orgId`,
+    // so FACS cannot meaningfully evaluate them — pushing them through the ladder
+    // would 403 every org request at the tenant gate. IMS orgs that ARE
+    // FACS/RBAC-enabled are gated ahead of this wrapper; this bypass only admits
+    // the not-yet-enrolled IMS traffic that must keep working for now.
+    if (authType === 'ims') {
+      log.info({
+        tag: 'facs', bypass: 'ims-auth-channel', method, suffix, authType,
+      }, 'FACS bypass: IMS auth channel');
       return fn(request, context);
     }
 

--- a/packages/spacecat-shared-http-utils/src/auth/facs-wrapper.js
+++ b/packages/spacecat-shared-http-utils/src/auth/facs-wrapper.js
@@ -126,12 +126,15 @@ function routeMatchesAnyProductMap(context, productsRoutes) {
  *
  *   0. CORS preflight (`OPTIONS`) → bypass.
  *   1. Internal identities (admin, S2S, read-only admin, api-key) → bypass.
- *   1b. IMS auth channel (`authInfo.getType() === 'ims'`) → bypass. Direct IMS
- *      tokens are a deprecating channel that never carry `facs_permissions` and
- *      may not resolve a tenant `orgId`, so FACS cannot evaluate them; forcing
- *      them through the ladder would 403 every org request. IMS orgs that ARE
- *      FACS/RBAC-enabled are gated ahead of this wrapper, so this bypass only
- *      admits the not-yet-enrolled IMS traffic that must keep working for now.
+ *   1b. IMS auth channel (`authInfo.getType() === 'ims'` AND no
+ *      `facs_permissions` claim) → bypass. Direct IMS tokens are a deprecating
+ *      channel that never carry `facs_permissions` and may not resolve a tenant
+ *      `orgId`, so FACS cannot evaluate them; forcing them through the ladder
+ *      would 403 every org request. IMS orgs that ARE FACS/RBAC-enabled are
+ *      gated ahead of this wrapper, so this bypass only admits the not-yet-
+ *      enrolled IMS traffic that must keep working for now. The no-claims guard
+ *      keeps the bypass self-contained: an IMS session that ever carried FACS
+ *      claims stays on the evaluation ladder rather than skipping it.
  *   2. Adobe internal IMS orgs (`FACS_EXCEPTION_INTERNAL_ORGS`) → bypass.
  *   3. Route NOT in any product map → bypass.
  *      Route IS in some product map but `x-product` is missing / mismatched
@@ -249,7 +252,12 @@ export function facsWrapper(fn, { routeFacsCapabilities } = {}) {
     // would 403 every org request at the tenant gate. IMS orgs that ARE
     // FACS/RBAC-enabled are gated ahead of this wrapper; this bypass only admits
     // the not-yet-enrolled IMS traffic that must keep working for now.
-    if (authType === 'ims') {
+    //
+    // Guard: the bypass is scoped to sessions that carry NO FACS claims (its
+    // stated intent). This keeps it self-contained rather than relying on the
+    // upstream fail-open RBAC gate holding — should an IMS session ever surface
+    // `facs_permissions`, it stays on the evaluation ladder instead of skipping it.
+    if (authType === 'ims' && !authInfo?.getFacsPermissions?.()?.length) {
       log.info({
         tag: 'facs', bypass: 'ims-auth-channel', method, suffix, authType,
       }, 'FACS bypass: IMS auth channel');

--- a/packages/spacecat-shared-http-utils/test/auth/facs-wrapper.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/facs-wrapper.test.js
@@ -235,6 +235,23 @@ describe('facsWrapper', () => {
     });
   });
 
+  describe('IMS auth channel bypass', () => {
+    it('bypasses for ims auth type before the tenant gate', async () => {
+      // No tenant on the IMS session — without the bypass this would 403 at the
+      // tenant gate for every org request.
+      context.attributes.authInfo = makeAuthInfo({
+        getType: () => 'ims',
+        getTenantIds: () => [],
+      });
+      const wrapped = facsWrapper(handler, { routeFacsCapabilities });
+      await wrapped({}, context);
+      expect(handler.calledOnce).to.be.true;
+      expect(logStub.info.calledWithMatch(
+        { tag: 'facs', bypass: 'ims-auth-channel' },
+      )).to.be.true;
+    });
+  });
+
   describe('tenant assertion', () => {
     it('returns 500 when getTenantIds() returns more than one tenant', async () => {
       context.attributes.authInfo = makeAuthInfo({

--- a/packages/spacecat-shared-http-utils/test/auth/facs-wrapper.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/facs-wrapper.test.js
@@ -242,6 +242,7 @@ describe('facsWrapper', () => {
       context.attributes.authInfo = makeAuthInfo({
         getType: () => 'ims',
         getTenantIds: () => [],
+        getFacsPermissions: () => [],
       });
       const wrapped = facsWrapper(handler, { routeFacsCapabilities });
       await wrapped({}, context);
@@ -249,6 +250,34 @@ describe('facsWrapper', () => {
       expect(logStub.info.calledWithMatch(
         { tag: 'facs', bypass: 'ims-auth-channel' },
       )).to.be.true;
+    });
+
+    it('bypasses for ims auth type even when a tenant is present (unconditional on tenant)', async () => {
+      context.attributes.authInfo = makeAuthInfo({
+        getType: () => 'ims',
+        getTenantIds: () => ['SOME-ORG@AdobeOrg'],
+        getFacsPermissions: () => [],
+      });
+      const wrapped = facsWrapper(handler, { routeFacsCapabilities });
+      await wrapped({}, context);
+      expect(handler.calledOnce).to.be.true;
+      expect(logStub.info.calledWithMatch(
+        { tag: 'facs', bypass: 'ims-auth-channel' },
+      )).to.be.true;
+    });
+
+    it('does NOT take the ims bypass when the session carries FACS claims', async () => {
+      // Guard: an IMS session that surfaces facs_permissions stays on the
+      // evaluation ladder rather than skipping it.
+      context.attributes.authInfo = makeAuthInfo({
+        getType: () => 'ims',
+        getFacsPermissions: () => ['llmo/some_capability'],
+      });
+      const wrapped = facsWrapper(handler, { routeFacsCapabilities });
+      await wrapped({}, context);
+      expect(logStub.info.calledWithMatch(
+        { tag: 'facs', bypass: 'ims-auth-channel' },
+      )).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Problem

On a FACS-governed route, an **IMS-authenticated** caller (`authInfo.getType() === 'ims'`) hit the tenant gate at step (4):

```js
if (!orgId) {
  return forbidden('Tenant required for FACS evaluation');
}
```

Direct IMS tokens are a deprecating channel — they never carry `facs_permissions` and may not resolve a tenant `orgId` from `getTenantIds()`. So FACS cannot meaningfully evaluate them, yet the ladder was 403-ing **every org request** from an IMS session on a FACS route.

## Fix

Add an explicit **step 1b** bypass, right after the internal-identity bypass: when `authType === 'ims'`, skip the wrapper and call the handler unchanged.

Rationale: IMS orgs that ARE FACS/RBAC-enabled are gated ahead of this wrapper, so this bypass only admits the not-yet-enrolled IMS traffic that must keep working for now. JWT (the recommended channel, which carries `facs_permissions`) is unaffected and still fully enforced.

## Changes

- `facs-wrapper.js` — new `(1b)` IMS bypass block + updated bypass-rules doc comment.
- `facs-wrapper.test.js` — test asserting an IMS session with no tenant bypasses (before the tenant gate) and logs `bypass: 'ims-auth-channel'`.

## Verification

- `facs-wrapper.js` coverage: **100% / 100%**.
- Package suite: **479 passing**, lint clean.

## Follow-up

Once published, bump `@adobe/spacecat-shared-http-utils` in `spacecat-api-service` to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
