### PR TITLE
feat(akamai-client): add spacecat-shared-akamai-client package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -488,6 +488,10 @@
         "node": ">=14.16"
       }
     },
+    "node_modules/@adobe/spacecat-shared-akamai-client": {
+      "resolved": "packages/spacecat-shared-akamai-client",
+      "link": true
+    },
     "node_modules/@adobe/spacecat-shared-athena-client": {
       "resolved": "packages/spacecat-shared-athena-client",
       "link": true
@@ -24335,6 +24339,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
+      }
+    },
+    "packages/spacecat-shared-akamai-client": {
+      "name": "@adobe/spacecat-shared-akamai-client",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/spacecat-shared-utils": "1.122.1"
+      },
+      "devDependencies": {
+        "chai": "6.2.2",
+        "chai-as-promised": "8.0.2",
+        "nock": "14.0.15",
+        "sinon": "22.0.0",
+        "sinon-chai": "4.0.1",
+        "typescript": "6.0.3"
+      },
+      "engines": {
+        "node": ">=22.0.0 <25.0.0",
+        "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "packages/spacecat-shared-akamai-client/node_modules/@adobe/spacecat-shared-utils": {
+      "version": "1.122.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.122.1.tgz",
+      "integrity": "sha512-MHBWdH4YPZeA+p4op3waI1xNG0Yxtoqva/B/NMuK4qPYcEeofzVHKIS/XvM1TH1z48tYd57HJOrCSqWRV7Cg4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/fetch": "4.3.0",
+        "@aws-sdk/client-s3": "3.1057.0",
+        "@aws-sdk/client-sqs": "3.1057.0",
+        "@json2csv/plainjs": "7.0.6",
+        "aws-xray-sdk": "3.12.0",
+        "cheerio": "1.2.0",
+        "date-fns": "4.4.0",
+        "franc-min": "6.2.0",
+        "ipaddr.js": "^2.2.0",
+        "iso-639-3": "3.0.1",
+        "urijs": "1.19.11",
+        "validator": "^13.15.15",
+        "world-countries": "5.1.0",
+        "zod": "^4.1.11"
+      },
+      "engines": {
+        "node": ">=22.0.0 <25.0.0",
+        "npm": ">=10.9.0 <12.0.0"
       }
     },
     "packages/spacecat-shared-athena-client": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33057,7 +33057,7 @@
     },
     "packages/spacecat-shared-project-engine-client": {
       "name": "@adobe/spacecat-shared-project-engine-client",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "0.17.0"

--- a/packages/spacecat-shared-akamai-client/.mocha-multi.json
+++ b/packages/spacecat-shared-akamai-client/.mocha-multi.json
@@ -1,0 +1,6 @@
+{
+    "reporterEnabled": "spec,xunit",
+    "xunitReporterOptions": {
+        "output": "junit/test-results.xml"
+    }
+}

--- a/packages/spacecat-shared-akamai-client/.nycrc.json
+++ b/packages/spacecat-shared-akamai-client/.nycrc.json
@@ -1,0 +1,14 @@
+{
+  "reporter": [
+    "lcov",
+    "text"
+  ],
+  "check-coverage": true,
+  "lines": 100,
+  "branches": 97,
+  "statements": 100,
+  "all": true,
+  "include": [
+    "src/**/*.js"
+  ]
+}

--- a/packages/spacecat-shared-akamai-client/.releaserc.cjs
+++ b/packages/spacecat-shared-akamai-client/.releaserc.cjs
@@ -1,0 +1,21 @@
+module.exports = {
+  extends: "semantic-release-monorepo",
+  plugins: [
+    ["@semantic-release/commit-analyzer", {
+      "preset": "conventionalcommits",
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits",
+    }],
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md",
+    }],
+    ...(process.env.SR_NO_NPM_AUTH === 'true' ? [] : ["@semantic-release/npm"]),
+    ["@semantic-release/git", {
+      "assets": ["package.json", "CHANGELOG.md"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }],
+    ["@semantic-release/github", {}],
+  ],
+  branches: ['main'],
+};

--- a/packages/spacecat-shared-akamai-client/CHANGELOG.md
+++ b/packages/spacecat-shared-akamai-client/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/spacecat-shared-akamai-client/README.md
+++ b/packages/spacecat-shared-akamai-client/README.md
@@ -34,7 +34,8 @@ const client = AkamaiClient.createFrom(context);
 ```
 
 Expects `AKAMAI_HOST`, `AKAMAI_CLIENT_TOKEN`, `AKAMAI_CLIENT_SECRET`,
-`AKAMAI_ACCESS_TOKEN`, and optionally `AKAMAI_ACCOUNT_SWITCH_KEY`.
+`AKAMAI_ACCESS_TOKEN`, and optionally `AKAMAI_ACCOUNT_SWITCH_KEY` and
+`AKAMAI_NOTIFY_EMAILS` (comma-separated; required only to call `activate()`).
 
 #### Direct constructor
 
@@ -47,6 +48,7 @@ const client = new AkamaiClient({
   clientSecret: process.env.AKAMAI_CLIENT_SECRET,
   accessToken: process.env.AKAMAI_ACCESS_TOKEN,
   accountSwitchKey: process.env.AKAMAI_ACCOUNT_SWITCH_KEY, // optional
+  notifyEmails: ['team@example.com'], // required only to call activate()
 }, log);
 ```
 
@@ -109,12 +111,13 @@ const result = await client.updateRuleTree(propertyId, version, contractId, grou
 if (result.errors?.length) { /* handle PAPI validation errors */ }
 ```
 
-### `activate(propertyId, version, contractId, groupId, network, notifyEmails, note?)`
+### `activate(propertyId, version, contractId, groupId, network, note?)`
+
+Requires the client to have been constructed with a non-empty `notifyEmails`
+(PAPI requires at least one address to notify about activation progress).
 
 ```javascript
-const activationLink = await client.activate(
-  propertyId, version, contractId, groupId, 'STAGING', ['team@example.com'],
-);
+const activationLink = await client.activate(propertyId, version, contractId, groupId, 'STAGING');
 const activationId = AkamaiClient.activationIdFromLink(activationLink);
 ```
 

--- a/packages/spacecat-shared-akamai-client/README.md
+++ b/packages/spacecat-shared-akamai-client/README.md
@@ -1,0 +1,181 @@
+# Spacecat Shared - Akamai Client
+
+## Overview
+
+`@adobe/spacecat-shared-akamai-client` is a thin client for Akamai's
+[Property Manager API (PAPI)](https://techdocs.akamai.com/property-mgr/reference/api-summary),
+authenticated with Akamai's EdgeGrid (`EG1-HMAC-SHA256`) scheme. It exposes
+operations for finding properties by site domain, reading and updating rule
+trees, creating property versions, and activating/monitoring activations —
+for use by Spacecat services that manage Akamai-fronted properties.
+
+The EdgeGrid request signing is implemented directly against Akamai's
+published algorithm (no `akamai-edgegrid` dependency), and is cross-validated
+in tests against the official `edgegrid-python` reference implementation.
+
+## Installation
+
+```bash
+npm install @adobe/spacecat-shared-akamai-client
+```
+
+## Usage
+
+### Creating a client
+
+#### From a Universal context (recommended)
+
+Reads EdgeGrid credentials from `context.env`:
+
+```javascript
+import AkamaiClient from '@adobe/spacecat-shared-akamai-client';
+
+const client = AkamaiClient.createFrom(context);
+```
+
+Expects `AKAMAI_HOST`, `AKAMAI_CLIENT_TOKEN`, `AKAMAI_CLIENT_SECRET`,
+`AKAMAI_ACCESS_TOKEN`, and optionally `AKAMAI_ACCOUNT_SWITCH_KEY`.
+
+#### Direct constructor
+
+```javascript
+import AkamaiClient from '@adobe/spacecat-shared-akamai-client';
+
+const client = new AkamaiClient({
+  host: process.env.AKAMAI_HOST, // e.g. "akab-xxxxx.luna.akamaiapis.net"
+  clientToken: process.env.AKAMAI_CLIENT_TOKEN,
+  clientSecret: process.env.AKAMAI_CLIENT_SECRET,
+  accessToken: process.env.AKAMAI_ACCESS_TOKEN,
+  accountSwitchKey: process.env.AKAMAI_ACCOUNT_SWITCH_KEY, // optional
+}, log);
+```
+
+These credentials come from an Akamai API client scoped to
+**Property Manager (PAPI) = READ-WRITE** — see
+[Create an API client](https://techdocs.akamai.com/developer/docs/set-up-authentication-credentials).
+
+## API
+
+### `findPropertiesByDomain(domain)`
+
+Finds candidate properties serving a site domain — matches the exact
+hostname (plus its apex/www variant) and, as a fallback, a property-name
+match. Returns matches deduped by `propertyId`, hostname matches ranked
+first.
+
+```javascript
+const matches = await client.findPropertiesByDomain('www.example.com');
+// [{ propertyId, propertyName, contractId, groupId, matchedOn: ['hostname'], ... }]
+```
+
+### `searchBy(key, value)`
+
+Lower-level primitive behind `findPropertiesByDomain` — a single PAPI
+find-by-value lookup.
+
+```javascript
+const results = await client.searchBy('hostname', 'www.example.com');
+```
+
+### `getLatestVersion(propertyId, contractId, groupId)`
+
+```javascript
+const version = await client.getLatestVersion(propertyId, contractId, groupId);
+```
+
+### `getRuleTree(propertyId, version, contractId, groupId)`
+
+```javascript
+const { ruleTree, ruleFormat } = await client.getRuleTree(propertyId, version, contractId, groupId);
+```
+
+### `createVersion(propertyId, baseVersion, contractId, groupId)`
+
+Creates a new property version from `baseVersion` and returns the new
+version number.
+
+```javascript
+const newVersion = await client.createVersion(propertyId, latestVersion, contractId, groupId);
+```
+
+### `updateRuleTree(propertyId, version, contractId, groupId, ruleTree, ruleFormat?)`
+
+PUTs a rule tree with PAPI-side validation (`validateRules=true`). Errors and
+warnings, if any, come back in the resolved response body rather than as a
+rejected promise.
+
+```javascript
+const result = await client.updateRuleTree(propertyId, version, contractId, groupId, ruleTree, ruleFormat);
+if (result.errors?.length) { /* handle PAPI validation errors */ }
+```
+
+### `activate(propertyId, version, contractId, groupId, network, notifyEmails, note?)`
+
+```javascript
+const activationLink = await client.activate(
+  propertyId, version, contractId, groupId, 'STAGING', ['team@example.com'],
+);
+const activationId = AkamaiClient.activationIdFromLink(activationLink);
+```
+
+### `getActivation(propertyId, activationId, contractId, groupId)`
+
+Returns one activation's details (`status`, `network`, `propertyVersion`,
+`submitDate`, `updateDate`, ...). `status` progresses through
+`PENDING` → `ZONE_1`/`ZONE_2`/`ZONE_3` → `ACTIVE` (or `ABORTED`/`FAILED`).
+
+```javascript
+const activation = await client.getActivation(propertyId, activationId, contractId, groupId);
+```
+
+### `listActivations(propertyId, contractId, groupId)`
+
+All activations (both networks, all versions) for a property.
+
+### `latestActivation(propertyId, contractId, groupId, network)`
+
+The most recently submitted activation for a network, or `undefined` if the
+property has never been activated there — useful for polling deployment
+status without having to track an `activationId` across requests/sessions.
+
+```javascript
+const activation = await client.latestActivation(propertyId, contractId, groupId, 'PRODUCTION');
+if (activation?.status === 'ACTIVE') { /* deployment complete */ }
+```
+
+### `normalizeDomain(domain)`
+
+Named export. Reduces a URL, `host:port`, or trailing-dot hostname to a bare
+lowercase hostname.
+
+```javascript
+import { normalizeDomain } from '@adobe/spacecat-shared-akamai-client';
+
+normalizeDomain('HTTPS://Example.com:8080/path'); // 'example.com'
+```
+
+## Error handling
+
+All methods reject with a descriptive `Error` when:
+
+- a required argument is missing or the wrong type (e.g. `version` must be an
+  integer, `propertyId`/`contractId`/`groupId`/`network` must be non-empty
+  strings),
+- the underlying request fails (network error),
+- PAPI responds with a non-OK HTTP status, or
+- PAPI responds with a 200 but a body that isn't valid JSON.
+
+The error message includes the targeted path and, for non-OK responses, the
+truncated response body. PAPI-level validation errors/warnings on
+`updateRuleTree` (HTTP 200 with an `errors` array) are returned in the
+resolved body, not thrown — check `result.errors` explicitly.
+
+Property/version/activation IDs are URL-encoded before being interpolated
+into request paths, and `searchBy`'s `key` argument is restricted to
+`hostname`/`edgeHostname`/`propertyName` — both defend against a caller
+accidentally (or maliciously) redirecting a request to an unintended
+endpoint.
+
+## License
+
+Apache-2.0

--- a/packages/spacecat-shared-akamai-client/package.json
+++ b/packages/spacecat-shared-akamai-client/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Shared modules of the Spacecat Services - Akamai Client",
   "type": "module",
+  "private": true,
   "engines": {
     "node": ">=22.0.0 <25.0.0",
     "npm": ">=10.9.0 <12.0.0"

--- a/packages/spacecat-shared-akamai-client/package.json
+++ b/packages/spacecat-shared-akamai-client/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@adobe/spacecat-shared-akamai-client",
+  "version": "1.0.0",
+  "description": "Shared modules of the Spacecat Services - Akamai Client",
+  "type": "module",
+  "engines": {
+    "node": ">=22.0.0 <25.0.0",
+    "npm": ">=10.9.0 <12.0.0"
+  },
+  "main": "src/index.js",
+  "types": "src/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "c8 mocha",
+    "lint": "eslint .",
+    "clean": "rm -rf package-lock.json node_modules"
+  },
+  "mocha": {
+    "require": "test/setup-env.js",
+    "reporter": "mocha-multi-reporters",
+    "reporter-options": "configFile=.mocha-multi.json",
+    "spec": "test/**/*.test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe/spacecat-shared.git"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/adobe/spacecat-shared/issues"
+  },
+  "homepage": "https://github.com/adobe/spacecat-shared#readme",
+  "dependencies": {
+    "@adobe/spacecat-shared-utils": "1.122.1"
+  },
+  "devDependencies": {
+    "chai": "6.2.2",
+    "chai-as-promised": "8.0.2",
+    "nock": "14.0.15",
+    "sinon": "22.0.0",
+    "sinon-chai": "4.0.1",
+    "typescript": "6.0.3"
+  }
+}

--- a/packages/spacecat-shared-akamai-client/src/akamai-client.js
+++ b/packages/spacecat-shared-akamai-client/src/akamai-client.js
@@ -64,7 +64,8 @@ export default class AkamaiClient {
    * Creates an AkamaiClient from a Universal context. Reads EdgeGrid
    * credentials from context.env: AKAMAI_HOST, AKAMAI_CLIENT_TOKEN,
    * AKAMAI_CLIENT_SECRET, AKAMAI_ACCESS_TOKEN, and optionally
-   * AKAMAI_ACCOUNT_SWITCH_KEY.
+   * AKAMAI_ACCOUNT_SWITCH_KEY and AKAMAI_NOTIFY_EMAILS (comma-separated,
+   * required only if you intend to call activate()).
    *
    * @param {object} context - Universal function context
    * @returns {AkamaiClient}
@@ -77,9 +78,13 @@ export default class AkamaiClient {
       AKAMAI_CLIENT_SECRET: clientSecret,
       AKAMAI_ACCESS_TOKEN: accessToken,
       AKAMAI_ACCOUNT_SWITCH_KEY: accountSwitchKey,
+      AKAMAI_NOTIFY_EMAILS: notifyEmailsCsv,
     } = env;
+    const notifyEmails = hasText(notifyEmailsCsv)
+      ? notifyEmailsCsv.split(',').map((email) => email.trim()).filter(Boolean)
+      : undefined;
     return new AkamaiClient({
-      host, clientToken, clientSecret, accessToken, accountSwitchKey,
+      host, clientToken, clientSecret, accessToken, accountSwitchKey, notifyEmails,
     }, log);
   }
 
@@ -91,6 +96,8 @@ export default class AkamaiClient {
    * @param {string} config.clientSecret
    * @param {string} config.accessToken
    * @param {string} [config.accountSwitchKey]
+   * @param {string[]} [config.notifyEmails] - Required only to call activate();
+   *   emails PAPI notifies about activation progress.
    * @param {object} [log]
    */
   constructor(config = {}, log = console) {
@@ -104,6 +111,7 @@ export default class AkamaiClient {
     this.#clientSecret = config.clientSecret;
     this.#accessToken = config.accessToken;
     this.accountSwitchKey = config.accountSwitchKey;
+    this.notifyEmails = config.notifyEmails;
     this.log = log;
   }
 
@@ -229,8 +237,12 @@ export default class AkamaiClient {
       try {
         const items = await this.searchBy('hostname', host);
         items.forEach((item) => add(item, 'hostname', host));
-      } catch {
-        // no active version on that hostname, etc. — not a hard failure
+      } catch (e) {
+        // No active version on that hostname, auth failure, rate-limiting,
+        // etc. — not a hard failure (other candidates may still match), but
+        // log it so a systemic failure (e.g. bad credentials) is observable
+        // instead of silently returning an incomplete/empty result set.
+        this.log.warn(`searchBy('hostname', '${host}') failed, continuing: ${e.message}`);
       }
     }));
 
@@ -240,8 +252,8 @@ export default class AkamaiClient {
       try {
         const items = await this.searchBy('propertyName', nameQuery);
         items.forEach((item) => add(item, 'propertyName', nameQuery));
-      } catch {
-        // no match by that name — not a hard failure
+      } catch (e) {
+        this.log.warn(`searchBy('propertyName', '${nameQuery}') failed, continuing: ${e.message}`);
       }
     }));
 
@@ -379,12 +391,15 @@ export default class AkamaiClient {
   // --- Activation --------------------------------------------------------
 
   /**
+   * Activates a property version. Requires the client to have been
+   * constructed with a non-empty `notifyEmails` list (PAPI requires at least
+   * one address to notify about activation progress).
+   *
    * @param {string} propertyId
    * @param {number} version
    * @param {string} contractId
    * @param {string} groupId
    * @param {'STAGING'|'PRODUCTION'} network
-   * @param {string[]} notifyEmails
    * @param {string} [note]
    * @returns {Promise<string>} the activationLink returned by PAPI
    */
@@ -394,7 +409,6 @@ export default class AkamaiClient {
     contractId,
     groupId,
     network,
-    notifyEmails,
     note = 'Activated via spacecat-shared-akamai-client',
   ) {
     requireText('propertyId', propertyId);
@@ -403,6 +417,11 @@ export default class AkamaiClient {
     requireText('network', network);
     if (!Number.isInteger(version)) {
       throw new Error('version must be an integer');
+    }
+    if (!Array.isArray(this.notifyEmails) || this.notifyEmails.length === 0) {
+      throw new Error(
+        'AkamaiClient must be constructed with a non-empty notifyEmails array to call activate()',
+      );
     }
     const id = encodePathSegment(propertyId);
     const upperNetwork = network.toUpperCase();
@@ -413,7 +432,7 @@ export default class AkamaiClient {
         propertyVersion: version,
         network: upperNetwork,
         note,
-        notifyEmails,
+        notifyEmails: this.notifyEmails,
         acknowledgeAllWarnings: true,
       },
     });

--- a/packages/spacecat-shared-akamai-client/src/akamai-client.js
+++ b/packages/spacecat-shared-akamai-client/src/akamai-client.js
@@ -1,0 +1,504 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { hasText, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+
+import { signRequest } from './edgegrid-auth.js';
+
+const REQUIRED_CONFIG_KEYS = ['host', 'clientToken', 'clientSecret', 'accessToken'];
+const SEARCH_KEYS = ['hostname', 'edgeHostname', 'propertyName'];
+
+function requireText(name, value) {
+  if (!hasText(value)) {
+    throw new Error(`${name} is required`);
+  }
+}
+
+// Path segments are user/caller-supplied IDs interpolated directly into PAPI
+// URLs — encode them so a stray "/", "?", "&", or "#" can't redirect the
+// request to an unintended endpoint instead of failing loudly.
+function encodePathSegment(value) {
+  return encodeURIComponent(value);
+}
+
+/**
+ * Reduces user input (a URL, a host:port, a trailing dot) to a bare,
+ * lowercase hostname.
+ *
+ * @param {string} domain
+ * @returns {string}
+ */
+export function normalizeDomain(domain) {
+  let d = String(domain || '').trim().toLowerCase();
+  if (d.includes('://')) {
+    [, d] = d.split('://');
+  }
+  [d] = d.split('/');
+  [d] = d.split(':');
+  return d.replace(/\.$/, '');
+}
+
+/**
+ * A thin client for Akamai's Property Manager API (PAPI), authenticated with
+ * the EdgeGrid (EG1-HMAC-SHA256) scheme.
+ *
+ * Docs: https://techdocs.akamai.com/property-mgr/reference/api-summary
+ */
+export default class AkamaiClient {
+  #clientToken;
+
+  #clientSecret;
+
+  #accessToken;
+
+  /**
+   * Creates an AkamaiClient from a Universal context. Reads EdgeGrid
+   * credentials from context.env: AKAMAI_HOST, AKAMAI_CLIENT_TOKEN,
+   * AKAMAI_CLIENT_SECRET, AKAMAI_ACCESS_TOKEN, and optionally
+   * AKAMAI_ACCOUNT_SWITCH_KEY.
+   *
+   * @param {object} context - Universal function context
+   * @returns {AkamaiClient}
+   */
+  static createFrom(context) {
+    const { env, log = console } = context;
+    const {
+      AKAMAI_HOST: host,
+      AKAMAI_CLIENT_TOKEN: clientToken,
+      AKAMAI_CLIENT_SECRET: clientSecret,
+      AKAMAI_ACCESS_TOKEN: accessToken,
+      AKAMAI_ACCOUNT_SWITCH_KEY: accountSwitchKey,
+    } = env;
+    return new AkamaiClient({
+      host, clientToken, clientSecret, accessToken, accountSwitchKey,
+    }, log);
+  }
+
+  /**
+   * @param {object} config
+   * @param {string} config.host - EdgeGrid host, e.g.
+   *   "akab-xxxxx.luna.akamaiapis.net" (scheme, if present, is ignored)
+   * @param {string} config.clientToken
+   * @param {string} config.clientSecret
+   * @param {string} config.accessToken
+   * @param {string} [config.accountSwitchKey]
+   * @param {object} [log]
+   */
+  constructor(config = {}, log = console) {
+    REQUIRED_CONFIG_KEYS.forEach((key) => {
+      if (!hasText(config[key])) {
+        throw new Error(`AkamaiClient requires ${key}`);
+      }
+    });
+    this.host = config.host.replace(/^https?:\/\//, '').replace(/\/+$/, '');
+    this.#clientToken = config.clientToken;
+    this.#clientSecret = config.clientSecret;
+    this.#accessToken = config.accessToken;
+    this.accountSwitchKey = config.accountSwitchKey;
+    this.log = log;
+  }
+
+  #buildUrl(path, params) {
+    const query = new URLSearchParams(params || {});
+    if (this.accountSwitchKey) {
+      query.set('accountSwitchKey', this.accountSwitchKey);
+    }
+    const qs = query.toString();
+    return `https://${this.host}${path}${qs ? `?${qs}` : ''}`;
+  }
+
+  async #request(method, path, { params, body, headers } = {}) {
+    const url = this.#buildUrl(path, params);
+    const bodyStr = body ? JSON.stringify(body) : undefined;
+    const authorization = signRequest({
+      method,
+      url,
+      body: bodyStr,
+      clientToken: this.#clientToken,
+      clientSecret: this.#clientSecret,
+      accessToken: this.#accessToken,
+    });
+
+    let res;
+    try {
+      res = await fetch(url, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          Authorization: authorization,
+          ...headers,
+        },
+        body: bodyStr,
+      });
+    } catch (e) {
+      throw new Error(`PAPI ${method} ${path} request failed: ${e.message}`);
+    }
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`PAPI ${method} ${path} -> ${res.status}: ${text.slice(0, 1000)}`);
+    }
+
+    const text = await res.text();
+    if (!text) {
+      return {};
+    }
+    try {
+      return JSON.parse(text);
+    } catch {
+      throw new Error(`PAPI ${method} ${path} returned a non-JSON response`);
+    }
+  }
+
+  // --- Find a property by the customer's site domain ------------------------
+
+  /**
+   * Searches PAPI's find-by-value endpoint for a single key.
+   *
+   * @param {'hostname'|'edgeHostname'|'propertyName'} key
+   * @param {string} value
+   * @returns {Promise<Array<object>>}
+   */
+  async searchBy(key, value) {
+    if (!SEARCH_KEYS.includes(key)) {
+      throw new Error(`searchBy key must be one of ${SEARCH_KEYS.join(', ')}, got: ${key}`);
+    }
+    requireText('value', value);
+    this.log.info(`Searching PAPI properties by ${key}: ${value}`);
+    // key is now guaranteed to be one of SEARCH_KEYS, not attacker-controlled,
+    // so this computed property can't be used to set the object's prototype.
+    const body = {};
+    body[key] = value;
+    const data = await this.#request('POST', '/papi/v1/search/find-by-value', { body });
+    return data.versions?.items ?? [];
+  }
+
+  /**
+   * Finds candidate properties serving a site domain. Searches the exact
+   * hostname (plus its apex/www variant) and a property-name match, then
+   * dedupes by propertyId, recording why each matched.
+   *
+   * @param {string} domain
+   * @returns {Promise<Array<object>>}
+   */
+  async findPropertiesByDomain(domain) {
+    requireText('domain', domain);
+    const normalized = normalizeDomain(domain);
+    const hostCandidates = new Set([normalized]);
+    if (normalized.startsWith('www.')) {
+      hostCandidates.add(normalized.slice(4));
+    } else {
+      hostCandidates.add(`www.${normalized}`);
+    }
+
+    const results = new Map();
+    const add = (item, reason, value) => {
+      const { propertyId } = item;
+      if (!propertyId) {
+        return;
+      }
+      if (!results.has(propertyId)) {
+        results.set(propertyId, {
+          propertyId,
+          propertyName: item.propertyName,
+          contractId: item.contractId,
+          groupId: item.groupId,
+          propertyVersion: item.propertyVersion,
+          productionStatus: item.productionStatus,
+          stagingStatus: item.stagingStatus,
+          matchedOn: new Set(),
+          matchedValues: new Set(),
+        });
+      }
+      const entry = results.get(propertyId);
+      entry.matchedOn.add(reason);
+      entry.matchedValues.add(value);
+    };
+
+    await Promise.all([...hostCandidates].map(async (host) => {
+      try {
+        const items = await this.searchBy('hostname', host);
+        items.forEach((item) => add(item, 'hostname', host));
+      } catch {
+        // no active version on that hostname, etc. — not a hard failure
+      }
+    }));
+
+    const label = normalized.startsWith('www.') ? normalized.slice(4) : normalized;
+    const nameQueries = new Set([label, label.split('.')[0]]);
+    await Promise.all([...nameQueries].map(async (nameQuery) => {
+      try {
+        const items = await this.searchBy('propertyName', nameQuery);
+        items.forEach((item) => add(item, 'propertyName', nameQuery));
+      } catch {
+        // no match by that name — not a hard failure
+      }
+    }));
+
+    return [...results.values()]
+      .map((entry) => ({
+        ...entry,
+        matchedOn: [...entry.matchedOn].sort(),
+        matchedValues: [...entry.matchedValues].sort(),
+      }))
+      // Hostname matches are a stronger signal than name matches.
+      .sort((a, b) => {
+        const aHost = a.matchedOn.includes('hostname') ? 0 : 1;
+        const bHost = b.matchedOn.includes('hostname') ? 0 : 1;
+        if (aHost !== bHost) {
+          return aHost - bHost;
+        }
+        return (a.propertyName || '').localeCompare(b.propertyName || '');
+      });
+  }
+
+  // --- Version + rule-tree operations ----------------------------------------
+
+  /**
+   * @param {string} propertyId
+   * @param {string} contractId
+   * @param {string} groupId
+   * @returns {Promise<number>} the latest property version
+   */
+  async getLatestVersion(propertyId, contractId, groupId) {
+    requireText('propertyId', propertyId);
+    requireText('contractId', contractId);
+    requireText('groupId', groupId);
+    const id = encodePathSegment(propertyId);
+    this.log.info(`Fetching latest version for property ${propertyId}`);
+    const data = await this.#request('GET', `/papi/v1/properties/${id}/versions/latest`, {
+      params: { contractId, groupId },
+    });
+    const version = data.versions?.items?.[0]?.propertyVersion;
+    if (version === undefined) {
+      throw new Error(`PAPI returned no versions for property ${propertyId}`);
+    }
+    return version;
+  }
+
+  /**
+   * @param {string} propertyId
+   * @param {number} version
+   * @param {string} contractId
+   * @param {string} groupId
+   * @returns {Promise<{ruleTree: object, ruleFormat: string|undefined}>}
+   */
+  async getRuleTree(propertyId, version, contractId, groupId) {
+    requireText('propertyId', propertyId);
+    requireText('contractId', contractId);
+    requireText('groupId', groupId);
+    if (!Number.isInteger(version)) {
+      throw new Error('version must be an integer');
+    }
+    const id = encodePathSegment(propertyId);
+    this.log.info(`Fetching rule tree for property ${propertyId} v${version}`);
+    const data = await this.#request(
+      'GET',
+      `/papi/v1/properties/${id}/versions/${version}/rules`,
+      { params: { contractId, groupId } },
+    );
+    return { ruleTree: data, ruleFormat: data.ruleFormat };
+  }
+
+  /**
+   * @param {string} propertyId
+   * @param {number} baseVersion
+   * @param {string} contractId
+   * @param {string} groupId
+   * @returns {Promise<number>} the newly created version number
+   */
+  async createVersion(propertyId, baseVersion, contractId, groupId) {
+    requireText('propertyId', propertyId);
+    requireText('contractId', contractId);
+    requireText('groupId', groupId);
+    if (!Number.isInteger(baseVersion)) {
+      throw new Error('baseVersion must be an integer');
+    }
+    const id = encodePathSegment(propertyId);
+    this.log.info(`Creating new version of property ${propertyId} from v${baseVersion}`);
+    const data = await this.#request('POST', `/papi/v1/properties/${id}/versions`, {
+      params: { contractId, groupId },
+      body: { createFromVersion: baseVersion },
+    });
+    // versionLink looks like ".../versions/{N}{?query}"
+    const match = typeof data.versionLink === 'string' ? data.versionLink.match(/\/versions\/(\d+)/) : null;
+    if (!match) {
+      throw new Error(`PAPI response did not include a parseable versionLink for property ${propertyId}`);
+    }
+    return Number(match[1]);
+  }
+
+  /**
+   * PUTs a rule tree, with PAPI-side validation enabled. Errors/warnings, if
+   * any, come back in the response body rather than as an HTTP error.
+   *
+   * @param {string} propertyId
+   * @param {number} version
+   * @param {string} contractId
+   * @param {string} groupId
+   * @param {object} ruleTree
+   * @param {string} [ruleFormat]
+   * @returns {Promise<object>}
+   */
+  async updateRuleTree(propertyId, version, contractId, groupId, ruleTree, ruleFormat) {
+    requireText('propertyId', propertyId);
+    requireText('contractId', contractId);
+    requireText('groupId', groupId);
+    if (!Number.isInteger(version)) {
+      throw new Error('version must be an integer');
+    }
+    if (ruleTree === null || typeof ruleTree !== 'object') {
+      throw new Error('ruleTree must be an object');
+    }
+    const id = encodePathSegment(propertyId);
+    const headers = ruleFormat
+      ? { 'Content-Type': `application/vnd.akamai.papirules.${ruleFormat}+json` }
+      : undefined;
+    this.log.info(`Updating rule tree for property ${propertyId} v${version}`);
+    return this.#request(
+      'PUT',
+      `/papi/v1/properties/${id}/versions/${version}/rules`,
+      {
+        params: { contractId, groupId, validateRules: 'true' },
+        body: ruleTree,
+        headers,
+      },
+    );
+  }
+
+  // --- Activation --------------------------------------------------------
+
+  /**
+   * @param {string} propertyId
+   * @param {number} version
+   * @param {string} contractId
+   * @param {string} groupId
+   * @param {'STAGING'|'PRODUCTION'} network
+   * @param {string[]} notifyEmails
+   * @param {string} [note]
+   * @returns {Promise<string>} the activationLink returned by PAPI
+   */
+  async activate(
+    propertyId,
+    version,
+    contractId,
+    groupId,
+    network,
+    notifyEmails,
+    note = 'Activated via spacecat-shared-akamai-client',
+  ) {
+    requireText('propertyId', propertyId);
+    requireText('contractId', contractId);
+    requireText('groupId', groupId);
+    requireText('network', network);
+    if (!Number.isInteger(version)) {
+      throw new Error('version must be an integer');
+    }
+    const id = encodePathSegment(propertyId);
+    const upperNetwork = network.toUpperCase();
+    this.log.info(`Activating property ${propertyId} v${version} to ${upperNetwork}`);
+    const data = await this.#request('POST', `/papi/v1/properties/${id}/activations`, {
+      params: { contractId, groupId },
+      body: {
+        propertyVersion: version,
+        network: upperNetwork,
+        note,
+        notifyEmails,
+        acknowledgeAllWarnings: true,
+      },
+    });
+    return data.activationLink ?? '';
+  }
+
+  /**
+   * Extracts the activation ID from an activationLink URL/path.
+   *
+   * @param {string} link
+   * @returns {string}
+   */
+  static activationIdFromLink(link) {
+    const withoutQuery = (link || '').split('?')[0];
+    return withoutQuery.replace(/\/+$/, '').split('/').pop();
+  }
+
+  /**
+   * Details for one activation: status (PENDING/ZONE_1/ZONE_2/ZONE_3/ACTIVE/
+   * ABORTED/FAILED/DEACTIVATED/...), network, propertyVersion, submitDate,
+   * updateDate, note.
+   *
+   * @param {string} propertyId
+   * @param {string} activationId
+   * @param {string} contractId
+   * @param {string} groupId
+   * @returns {Promise<object|undefined>}
+   */
+  async getActivation(propertyId, activationId, contractId, groupId) {
+    requireText('propertyId', propertyId);
+    requireText('activationId', activationId);
+    requireText('contractId', contractId);
+    requireText('groupId', groupId);
+    const id = encodePathSegment(propertyId);
+    const actId = encodePathSegment(activationId);
+    const data = await this.#request(
+      'GET',
+      `/papi/v1/properties/${id}/activations/${actId}`,
+      { params: { contractId, groupId } },
+    );
+    return data.activations?.items?.[0];
+  }
+
+  /**
+   * All activations (both networks, all versions) for a property.
+   *
+   * @param {string} propertyId
+   * @param {string} contractId
+   * @param {string} groupId
+   * @returns {Promise<Array<object>>}
+   */
+  async listActivations(propertyId, contractId, groupId) {
+    requireText('propertyId', propertyId);
+    requireText('contractId', contractId);
+    requireText('groupId', groupId);
+    const id = encodePathSegment(propertyId);
+    const data = await this.#request('GET', `/papi/v1/properties/${id}/activations`, {
+      params: { contractId, groupId },
+    });
+    return data.activations?.items ?? [];
+  }
+
+  /**
+   * The most recently submitted activation for a given network, or undefined
+   * if the property has never been activated there.
+   *
+   * @param {string} propertyId
+   * @param {string} contractId
+   * @param {string} groupId
+   * @param {'STAGING'|'PRODUCTION'} network
+   * @returns {Promise<object|undefined>}
+   */
+  async latestActivation(propertyId, contractId, groupId, network) {
+    requireText('network', network);
+    const upperNetwork = network.toUpperCase();
+    const activations = await this.listActivations(propertyId, contractId, groupId);
+    const candidates = activations.filter(
+      (a) => (a.network || '').toUpperCase() === upperNetwork,
+    );
+    if (candidates.length === 0) {
+      return undefined;
+    }
+    candidates.sort(
+      (a, b) => (a.updateDate ?? a.submitDate ?? '').localeCompare(b.updateDate ?? b.submitDate ?? ''),
+    );
+    return candidates[candidates.length - 1];
+  }
+}

--- a/packages/spacecat-shared-akamai-client/src/akamai-client.js
+++ b/packages/spacecat-shared-akamai-client/src/akamai-client.js
@@ -16,6 +16,11 @@ import { signRequest } from './edgegrid-auth.js';
 
 const REQUIRED_CONFIG_KEYS = ['host', 'clientToken', 'clientSecret', 'accessToken'];
 const SEARCH_KEYS = ['hostname', 'edgeHostname', 'propertyName'];
+const ACTIVATION_NETWORKS = ['STAGING', 'PRODUCTION'];
+// Akamai rule formats are "latest" or a dated token like "v2024-01-01". A strict
+// allowlist keeps a caller-supplied value from injecting into the Content-Type
+// header (e.g. a CR/LF-bearing string).
+const RULE_FORMAT_RE = /^[a-z0-9-]+$/i;
 
 function requireText(name, value) {
   if (!hasText(value)) {
@@ -372,6 +377,9 @@ export default class AkamaiClient {
     if (ruleTree === null || typeof ruleTree !== 'object') {
       throw new Error('ruleTree must be an object');
     }
+    if (ruleFormat && !RULE_FORMAT_RE.test(ruleFormat)) {
+      throw new Error('ruleFormat must contain only letters, digits, and hyphens');
+    }
     const id = encodePathSegment(propertyId);
     const headers = ruleFormat
       ? { 'Content-Type': `application/vnd.akamai.papirules.${ruleFormat}+json` }
@@ -423,8 +431,11 @@ export default class AkamaiClient {
         'AkamaiClient must be constructed with a non-empty notifyEmails array to call activate()',
       );
     }
-    const id = encodePathSegment(propertyId);
     const upperNetwork = network.toUpperCase();
+    if (!ACTIVATION_NETWORKS.includes(upperNetwork)) {
+      throw new Error(`network must be one of ${ACTIVATION_NETWORKS.join(', ')}, got: ${network}`);
+    }
+    const id = encodePathSegment(propertyId);
     this.log.info(`Activating property ${propertyId} v${version} to ${upperNetwork}`);
     const data = await this.#request('POST', `/papi/v1/properties/${id}/activations`, {
       params: { contractId, groupId },
@@ -508,6 +519,9 @@ export default class AkamaiClient {
   async latestActivation(propertyId, contractId, groupId, network) {
     requireText('network', network);
     const upperNetwork = network.toUpperCase();
+    if (!ACTIVATION_NETWORKS.includes(upperNetwork)) {
+      throw new Error(`network must be one of ${ACTIVATION_NETWORKS.join(', ')}, got: ${network}`);
+    }
     const activations = await this.listActivations(propertyId, contractId, groupId);
     const candidates = activations.filter(
       (a) => (a.network || '').toUpperCase() === upperNetwork,

--- a/packages/spacecat-shared-akamai-client/src/akamai-client.js
+++ b/packages/spacecat-shared-akamai-client/src/akamai-client.js
@@ -28,6 +28,25 @@ function requireText(name, value) {
   }
 }
 
+// Every property-scoped PAPI call needs the same (propertyId, contractId,
+// groupId) triple present — validate them in one place.
+function requirePropertyRef(propertyId, contractId, groupId) {
+  requireText('propertyId', propertyId);
+  requireText('contractId', contractId);
+  requireText('groupId', groupId);
+}
+
+// Validates a network argument against PAPI's two networks and returns the
+// canonical upper-cased form.
+function assertNetwork(network) {
+  requireText('network', network);
+  const upper = network.toUpperCase();
+  if (!ACTIVATION_NETWORKS.includes(upper)) {
+    throw new Error(`network must be one of ${ACTIVATION_NETWORKS.join(', ')}, got: ${network}`);
+  }
+  return upper;
+}
+
 // Path segments are user/caller-supplied IDs interpolated directly into PAPI
 // URLs — encode them so a stray "/", "?", "&", or "#" can't redirect the
 // request to an unintended endpoint instead of failing loudly.
@@ -288,9 +307,7 @@ export default class AkamaiClient {
    * @returns {Promise<number>} the latest property version
    */
   async getLatestVersion(propertyId, contractId, groupId) {
-    requireText('propertyId', propertyId);
-    requireText('contractId', contractId);
-    requireText('groupId', groupId);
+    requirePropertyRef(propertyId, contractId, groupId);
     const id = encodePathSegment(propertyId);
     this.log.info(`Fetching latest version for property ${propertyId}`);
     const data = await this.#request('GET', `/papi/v1/properties/${id}/versions/latest`, {
@@ -311,9 +328,7 @@ export default class AkamaiClient {
    * @returns {Promise<{ruleTree: object, ruleFormat: string|undefined}>}
    */
   async getRuleTree(propertyId, version, contractId, groupId) {
-    requireText('propertyId', propertyId);
-    requireText('contractId', contractId);
-    requireText('groupId', groupId);
+    requirePropertyRef(propertyId, contractId, groupId);
     if (!Number.isInteger(version)) {
       throw new Error('version must be an integer');
     }
@@ -335,9 +350,7 @@ export default class AkamaiClient {
    * @returns {Promise<number>} the newly created version number
    */
   async createVersion(propertyId, baseVersion, contractId, groupId) {
-    requireText('propertyId', propertyId);
-    requireText('contractId', contractId);
-    requireText('groupId', groupId);
+    requirePropertyRef(propertyId, contractId, groupId);
     if (!Number.isInteger(baseVersion)) {
       throw new Error('baseVersion must be an integer');
     }
@@ -368,9 +381,7 @@ export default class AkamaiClient {
    * @returns {Promise<object>}
    */
   async updateRuleTree(propertyId, version, contractId, groupId, ruleTree, ruleFormat) {
-    requireText('propertyId', propertyId);
-    requireText('contractId', contractId);
-    requireText('groupId', groupId);
+    requirePropertyRef(propertyId, contractId, groupId);
     if (!Number.isInteger(version)) {
       throw new Error('version must be an integer');
     }
@@ -419,10 +430,8 @@ export default class AkamaiClient {
     network,
     note = 'Activated via spacecat-shared-akamai-client',
   ) {
-    requireText('propertyId', propertyId);
-    requireText('contractId', contractId);
-    requireText('groupId', groupId);
-    requireText('network', network);
+    requirePropertyRef(propertyId, contractId, groupId);
+    const upperNetwork = assertNetwork(network);
     if (!Number.isInteger(version)) {
       throw new Error('version must be an integer');
     }
@@ -430,10 +439,6 @@ export default class AkamaiClient {
       throw new Error(
         'AkamaiClient must be constructed with a non-empty notifyEmails array to call activate()',
       );
-    }
-    const upperNetwork = network.toUpperCase();
-    if (!ACTIVATION_NETWORKS.includes(upperNetwork)) {
-      throw new Error(`network must be one of ${ACTIVATION_NETWORKS.join(', ')}, got: ${network}`);
     }
     const id = encodePathSegment(propertyId);
     this.log.info(`Activating property ${propertyId} v${version} to ${upperNetwork}`);
@@ -473,10 +478,8 @@ export default class AkamaiClient {
    * @returns {Promise<object|undefined>}
    */
   async getActivation(propertyId, activationId, contractId, groupId) {
-    requireText('propertyId', propertyId);
+    requirePropertyRef(propertyId, contractId, groupId);
     requireText('activationId', activationId);
-    requireText('contractId', contractId);
-    requireText('groupId', groupId);
     const id = encodePathSegment(propertyId);
     const actId = encodePathSegment(activationId);
     const data = await this.#request(
@@ -496,9 +499,7 @@ export default class AkamaiClient {
    * @returns {Promise<Array<object>>}
    */
   async listActivations(propertyId, contractId, groupId) {
-    requireText('propertyId', propertyId);
-    requireText('contractId', contractId);
-    requireText('groupId', groupId);
+    requirePropertyRef(propertyId, contractId, groupId);
     const id = encodePathSegment(propertyId);
     const data = await this.#request('GET', `/papi/v1/properties/${id}/activations`, {
       params: { contractId, groupId },
@@ -517,11 +518,7 @@ export default class AkamaiClient {
    * @returns {Promise<object|undefined>}
    */
   async latestActivation(propertyId, contractId, groupId, network) {
-    requireText('network', network);
-    const upperNetwork = network.toUpperCase();
-    if (!ACTIVATION_NETWORKS.includes(upperNetwork)) {
-      throw new Error(`network must be one of ${ACTIVATION_NETWORKS.join(', ')}, got: ${network}`);
-    }
+    const upperNetwork = assertNetwork(network);
     const activations = await this.listActivations(propertyId, contractId, groupId);
     const candidates = activations.filter(
       (a) => (a.network || '').toUpperCase() === upperNetwork,

--- a/packages/spacecat-shared-akamai-client/src/edgegrid-auth.js
+++ b/packages/spacecat-shared-akamai-client/src/edgegrid-auth.js
@@ -40,15 +40,6 @@ export function edgeGridTimestamp(date = new Date()) {
   return `${year}${month}${day}T${hours}:${minutes}:${seconds}+0000`;
 }
 
-function canonicalizeHeaders(headers) {
-  if (!headers) {
-    return '';
-  }
-  return Object.entries(headers)
-    .map(([name, value]) => `${name.toLowerCase()}:${String(value).trim().replace(/\s+/g, ' ')}`)
-    .join('\t');
-}
-
 // The EdgeGrid spec only signs the body for POST requests — PUT (used by PAPI
 // to write rule trees) is intentionally left unsigned here too, matching the
 // official akamai-edgegrid and edgegrid-python reference implementations.
@@ -71,8 +62,6 @@ function contentHash(method, body) {
  * @param {string} params.clientSecret
  * @param {string} params.accessToken
  * @param {string} [params.body] - Request body, if any (only signed for POST)
- * @param {Record<string,string>} [params.headersToSign] - Headers to include
- *   in the signature, keyed by header name (rarely needed for PAPI)
  * @param {string} [params.timestamp] - Overrides the generated timestamp
  *   (mainly for tests)
  * @param {string} [params.nonce] - Overrides the generated nonce (mainly for
@@ -86,7 +75,6 @@ export function signRequest({
   clientSecret,
   accessToken,
   body,
-  headersToSign,
   timestamp = edgeGridTimestamp(),
   nonce = randomUUID(),
 }) {
@@ -101,7 +89,9 @@ export function signRequest({
     parsedUrl.protocol.replace(':', ''),
     parsedUrl.host,
     parsedUrl.pathname + parsedUrl.search,
-    canonicalizeHeaders(headersToSign),
+    // Canonicalized signed-headers field — always empty: PAPI does not require
+    // signing any request headers, so the client never supplies them.
+    '',
     contentHash(upperMethod, body),
     unsignedAuthHeader,
   ].join('\t');

--- a/packages/spacecat-shared-akamai-client/src/edgegrid-auth.js
+++ b/packages/spacecat-shared-akamai-client/src/edgegrid-auth.js
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { createHash, createHmac, randomUUID } from 'crypto';
+
+// PAPI never signs a request body over this size — matches the reference
+// Akamai EdgeGrid clients (akamai-edgegrid, edgegrid-python).
+const MAX_BODY_BYTES = 131072;
+
+function base64Sha256(data) {
+  return createHash('sha256').update(data).digest('base64');
+}
+
+function base64HmacSha256(data, key) {
+  return createHmac('sha256', key).update(data).digest('base64');
+}
+
+/**
+ * EdgeGrid-compatible timestamp: "yyyyMMddTHH:mm:ss+0000" (UTC).
+ * @param {Date} [date]
+ * @returns {string}
+ */
+export function edgeGridTimestamp(date = new Date()) {
+  const pad = (n) => String(n).padStart(2, '0');
+  const year = date.getUTCFullYear();
+  const month = pad(date.getUTCMonth() + 1);
+  const day = pad(date.getUTCDate());
+  const hours = pad(date.getUTCHours());
+  const minutes = pad(date.getUTCMinutes());
+  const seconds = pad(date.getUTCSeconds());
+  return `${year}${month}${day}T${hours}:${minutes}:${seconds}+0000`;
+}
+
+function canonicalizeHeaders(headers) {
+  if (!headers) {
+    return '';
+  }
+  return Object.entries(headers)
+    .map(([name, value]) => `${name.toLowerCase()}:${String(value).trim().replace(/\s+/g, ' ')}`)
+    .join('\t');
+}
+
+// The EdgeGrid spec only signs the body for POST requests — PUT (used by PAPI
+// to write rule trees) is intentionally left unsigned here too, matching the
+// official akamai-edgegrid and edgegrid-python reference implementations.
+function contentHash(method, body) {
+  if (method !== 'POST' || !body) {
+    return '';
+  }
+  const truncated = Buffer.from(body, 'utf8').subarray(0, MAX_BODY_BYTES);
+  return base64Sha256(truncated);
+}
+
+/**
+ * Signs a request using Akamai's EG1-HMAC-SHA256 EdgeGrid authentication
+ * scheme and returns the value for the `Authorization` header.
+ *
+ * @param {object} params
+ * @param {string} params.method - HTTP method
+ * @param {string} params.url - Full request URL, including query string
+ * @param {string} params.clientToken
+ * @param {string} params.clientSecret
+ * @param {string} params.accessToken
+ * @param {string} [params.body] - Request body, if any (only signed for POST)
+ * @param {Record<string,string>} [params.headersToSign] - Headers to include
+ *   in the signature, keyed by header name (rarely needed for PAPI)
+ * @param {string} [params.timestamp] - Overrides the generated timestamp
+ *   (mainly for tests)
+ * @param {string} [params.nonce] - Overrides the generated nonce (mainly for
+ *   tests)
+ * @returns {string} the `Authorization` header value
+ */
+export function signRequest({
+  method,
+  url,
+  clientToken,
+  clientSecret,
+  accessToken,
+  body,
+  headersToSign,
+  timestamp = edgeGridTimestamp(),
+  nonce = randomUUID(),
+}) {
+  const upperMethod = method.toUpperCase();
+  const authHeaderData = `client_token=${clientToken};access_token=${accessToken};`
+    + `timestamp=${timestamp};nonce=${nonce};`;
+  const unsignedAuthHeader = `EG1-HMAC-SHA256 ${authHeaderData}`;
+
+  const parsedUrl = new URL(url);
+  const dataToSign = [
+    upperMethod,
+    parsedUrl.protocol.replace(':', ''),
+    parsedUrl.host,
+    parsedUrl.pathname + parsedUrl.search,
+    canonicalizeHeaders(headersToSign),
+    contentHash(upperMethod, body),
+    unsignedAuthHeader,
+  ].join('\t');
+
+  const signingKey = base64HmacSha256(timestamp, clientSecret);
+  const signature = base64HmacSha256(dataToSign, signingKey);
+
+  return `${unsignedAuthHeader}signature=${signature}`;
+}

--- a/packages/spacecat-shared-akamai-client/src/index.d.ts
+++ b/packages/spacecat-shared-akamai-client/src/index.d.ts
@@ -18,6 +18,7 @@ export interface AkamaiClientConfig {
   clientSecret: string;
   accessToken: string;
   accountSwitchKey?: string;
+  notifyEmails?: string[];
 }
 
 export interface PropertyMatch {
@@ -62,6 +63,8 @@ export default class AkamaiClient {
 
   accountSwitchKey?: string;
 
+  notifyEmails?: string[];
+
   searchBy(key: 'hostname' | 'edgeHostname' | 'propertyName', value: string): Promise<object[]>;
 
   findPropertiesByDomain(domain: string): Promise<PropertyMatch[]>;
@@ -97,7 +100,6 @@ export default class AkamaiClient {
     contractId: string,
     groupId: string,
     network: Network,
-    notifyEmails: string[],
     note?: string,
   ): Promise<string>;
 

--- a/packages/spacecat-shared-akamai-client/src/index.d.ts
+++ b/packages/spacecat-shared-akamai-client/src/index.d.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export function normalizeDomain(domain: string): string;
+
+export interface AkamaiClientConfig {
+  host: string;
+  clientToken: string;
+  clientSecret: string;
+  accessToken: string;
+  accountSwitchKey?: string;
+}
+
+export interface PropertyMatch {
+  propertyId: string;
+  propertyName?: string;
+  contractId?: string;
+  groupId?: string;
+  propertyVersion?: number;
+  productionStatus?: string;
+  stagingStatus?: string;
+  matchedOn: string[];
+  matchedValues: string[];
+}
+
+export interface RuleTreeResult {
+  ruleTree: object;
+  ruleFormat?: string;
+}
+
+export type Network = 'STAGING' | 'PRODUCTION';
+
+export interface Activation {
+  activationId: string;
+  network: Network;
+  propertyVersion: number;
+  status: string;
+  submitDate?: string;
+  updateDate?: string;
+  note?: string;
+  notifyEmails?: string[];
+  [key: string]: unknown;
+}
+
+export default class AkamaiClient {
+  static createFrom(context: object): AkamaiClient;
+
+  static activationIdFromLink(link: string): string;
+
+  constructor(config: AkamaiClientConfig, log?: object);
+
+  host: string;
+
+  accountSwitchKey?: string;
+
+  searchBy(key: 'hostname' | 'edgeHostname' | 'propertyName', value: string): Promise<object[]>;
+
+  findPropertiesByDomain(domain: string): Promise<PropertyMatch[]>;
+
+  getLatestVersion(propertyId: string, contractId: string, groupId: string): Promise<number>;
+
+  getRuleTree(
+    propertyId: string,
+    version: number,
+    contractId: string,
+    groupId: string,
+  ): Promise<RuleTreeResult>;
+
+  createVersion(
+    propertyId: string,
+    baseVersion: number,
+    contractId: string,
+    groupId: string,
+  ): Promise<number>;
+
+  updateRuleTree(
+    propertyId: string,
+    version: number,
+    contractId: string,
+    groupId: string,
+    ruleTree: object,
+    ruleFormat?: string,
+  ): Promise<object>;
+
+  activate(
+    propertyId: string,
+    version: number,
+    contractId: string,
+    groupId: string,
+    network: Network,
+    notifyEmails: string[],
+    note?: string,
+  ): Promise<string>;
+
+  getActivation(
+    propertyId: string,
+    activationId: string,
+    contractId: string,
+    groupId: string,
+  ): Promise<Activation | undefined>;
+
+  listActivations(
+    propertyId: string,
+    contractId: string,
+    groupId: string,
+  ): Promise<Activation[]>;
+
+  latestActivation(
+    propertyId: string,
+    contractId: string,
+    groupId: string,
+    network: Network,
+  ): Promise<Activation | undefined>;
+}

--- a/packages/spacecat-shared-akamai-client/src/index.js
+++ b/packages/spacecat-shared-akamai-client/src/index.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import AkamaiClient, { normalizeDomain } from './akamai-client.js';
+
+export { normalizeDomain };
+export default AkamaiClient;

--- a/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
+++ b/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
@@ -1,0 +1,656 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import nock from 'nock';
+
+import AkamaiClient, { normalizeDomain } from '../src/index.js';
+
+use(chaiAsPromised);
+use(sinonChai);
+
+const HOST = 'akab-xxxxx.luna.akamaiapis.net';
+const API_BASE = `https://${HOST}`;
+const CREDS = {
+  host: HOST,
+  clientToken: 'test-client-token',
+  clientSecret: 'test-client-secret',
+  accessToken: 'test-access-token',
+};
+const CONTRACT_ID = 'ctr_1';
+const GROUP_ID = 'grp_1';
+const PROPERTY_ID = 'prp_123';
+
+function makeLog() {
+  return {
+    info: sinon.stub(),
+    debug: sinon.stub(),
+    warn: sinon.stub(),
+    error: sinon.stub(),
+  };
+}
+
+// Any request through AkamaiClient carries a valid EdgeGrid Authorization
+// header — this matcher just asserts its presence/shape without re-deriving
+// the exact signature (that's edgegrid-auth.test.js's job). nock's
+// matchHeader() calls this with the raw header value, not a headers object.
+function hasEdgeGridAuth(value) {
+  return /^EG1-HMAC-SHA256 client_token=.*signature=.+$/.test(value || '');
+}
+
+describe('AkamaiClient', () => {
+  let client;
+  let log;
+
+  beforeEach(() => {
+    log = makeLog();
+    client = new AkamaiClient(CREDS, log);
+    nock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+
+  // ─── createFrom ────────────────────────────────────────────────────────
+
+  describe('createFrom', () => {
+    it('creates a client from context.env', () => {
+      const c = AkamaiClient.createFrom({
+        env: {
+          AKAMAI_HOST: HOST,
+          AKAMAI_CLIENT_TOKEN: 'ct',
+          AKAMAI_CLIENT_SECRET: 'cs',
+          AKAMAI_ACCESS_TOKEN: 'at',
+          AKAMAI_ACCOUNT_SWITCH_KEY: 'ask',
+        },
+        log,
+      });
+      expect(c).to.be.instanceOf(AkamaiClient);
+      expect(c.accountSwitchKey).to.equal('ask');
+    });
+
+    it('uses console as the default log', () => {
+      const c = AkamaiClient.createFrom({
+        env: {
+          AKAMAI_HOST: HOST,
+          AKAMAI_CLIENT_TOKEN: 'ct',
+          AKAMAI_CLIENT_SECRET: 'cs',
+          AKAMAI_ACCESS_TOKEN: 'at',
+        },
+      });
+      expect(c).to.be.instanceOf(AkamaiClient);
+    });
+
+    it('throws when a required env var is missing', () => {
+      expect(() => AkamaiClient.createFrom({ env: { AKAMAI_HOST: HOST }, log }))
+        .to.throw('AkamaiClient requires clientToken');
+    });
+  });
+
+  // ─── constructor ───────────────────────────────────────────────────────
+
+  describe('constructor', () => {
+    it('throws when host is missing', () => {
+      expect(() => new AkamaiClient({ ...CREDS, host: '' }))
+        .to.throw('AkamaiClient requires host');
+    });
+
+    it('throws when clientSecret is missing', () => {
+      expect(() => new AkamaiClient({ ...CREDS, clientSecret: undefined }))
+        .to.throw('AkamaiClient requires clientSecret');
+    });
+
+    it('strips a scheme and trailing slashes from the host', () => {
+      const c = new AkamaiClient({ ...CREDS, host: 'https://akab-xxxxx.luna.akamaiapis.net/' }, log);
+      expect(c.host).to.equal(HOST);
+    });
+
+    it('defaults to console when no log is given', () => {
+      const c = new AkamaiClient(CREDS);
+      expect(c).to.be.instanceOf(AkamaiClient);
+    });
+  });
+
+  // ─── low-level request behavior (via getLatestVersion) ────────────────
+
+  describe('request handling', () => {
+    it('signs requests with a valid EdgeGrid Authorization header', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/versions/latest`)
+        .query({ contractId: CONTRACT_ID, groupId: GROUP_ID })
+        .matchHeader('Authorization', hasEdgeGridAuth)
+        .reply(200, { versions: { items: [{ propertyVersion: 7 }] } });
+
+      const version = await client.getLatestVersion(PROPERTY_ID, CONTRACT_ID, GROUP_ID);
+      expect(version).to.equal(7);
+    });
+
+    it('appends accountSwitchKey to the query string when configured', async () => {
+      const c = new AkamaiClient({ ...CREDS, accountSwitchKey: 'ask123' }, log);
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/versions/latest`)
+        .query({ contractId: CONTRACT_ID, groupId: GROUP_ID, accountSwitchKey: 'ask123' })
+        .reply(200, { versions: { items: [{ propertyVersion: 1 }] } });
+
+      const version = await c.getLatestVersion(PROPERTY_ID, CONTRACT_ID, GROUP_ID);
+      expect(version).to.equal(1);
+    });
+
+    it('throws a contextual error when the underlying fetch fails', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/versions/latest`)
+        .query(true)
+        .replyWithError('socket hang up');
+
+      await expect(client.getLatestVersion(PROPERTY_ID, CONTRACT_ID, GROUP_ID))
+        .to.be.rejectedWith(/request failed/);
+    });
+
+    it('throws a contextual error on a non-OK response', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/versions/latest`)
+        .query(true)
+        .reply(403, 'forbidden');
+
+      await expect(client.getLatestVersion(PROPERTY_ID, CONTRACT_ID, GROUP_ID))
+        .to.be.rejectedWith(/-> 403: forbidden/);
+    });
+
+    it('returns an empty object for an empty response body', async () => {
+      nock(API_BASE)
+        .post(`/papi/v1/properties/${PROPERTY_ID}/activations`)
+        .query(true)
+        .reply(200, '');
+
+      const link = await client.activate(PROPERTY_ID, 5, CONTRACT_ID, GROUP_ID, 'STAGING', ['a@example.com']);
+      expect(link).to.equal('');
+    });
+
+    it('throws a contextual error on a non-JSON 200 response', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/versions/latest`)
+        .query(true)
+        .reply(200, '<html>not json</html>');
+
+      await expect(client.getLatestVersion(PROPERTY_ID, CONTRACT_ID, GROUP_ID))
+        .to.be.rejectedWith(/returned a non-JSON response/);
+    });
+
+    it('throws when a required argument is missing', async () => {
+      await expect(client.getLatestVersion('', CONTRACT_ID, GROUP_ID))
+        .to.be.rejectedWith('propertyId is required');
+    });
+
+    it('throws a contextual error when the property has no versions', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/versions/latest`)
+        .query(true)
+        .reply(200, { versions: { items: [] } });
+
+      await expect(client.getLatestVersion(PROPERTY_ID, CONTRACT_ID, GROUP_ID))
+        .to.be.rejectedWith(/no versions/);
+    });
+  });
+
+  // ─── searchBy / findPropertiesByDomain ─────────────────────────────────
+
+  describe('searchBy', () => {
+    it('returns matching versions', async () => {
+      nock(API_BASE)
+        .post('/papi/v1/search/find-by-value', { hostname: 'example.com' })
+        .reply(200, { versions: { items: [{ propertyId: PROPERTY_ID }] } });
+
+      const items = await client.searchBy('hostname', 'example.com');
+      expect(items).to.deep.equal([{ propertyId: PROPERTY_ID }]);
+    });
+
+    it('returns an empty array when versions are absent', async () => {
+      nock(API_BASE)
+        .post('/papi/v1/search/find-by-value', { hostname: 'nomatch.com' })
+        .reply(200, {});
+
+      const items = await client.searchBy('hostname', 'nomatch.com');
+      expect(items).to.deep.equal([]);
+    });
+
+    it('rejects a key that is not on the allowlist', async () => {
+      await expect(client.searchBy('__proto__', 'x'))
+        .to.be.rejectedWith(/searchBy key must be one of/);
+    });
+
+    it('throws when value is missing', async () => {
+      await expect(client.searchBy('hostname', ''))
+        .to.be.rejectedWith('value is required');
+    });
+  });
+
+  describe('findPropertiesByDomain', () => {
+    it('matches by hostname and de-dupes across the www/apex variant', async () => {
+      nock(API_BASE)
+        .post('/papi/v1/search/find-by-value', { hostname: 'example.com' })
+        .reply(200, {
+          versions: {
+            items: [{
+              propertyId: PROPERTY_ID,
+              propertyName: 'my-property',
+              contractId: CONTRACT_ID,
+              groupId: GROUP_ID,
+              propertyVersion: 3,
+              productionStatus: 'ACTIVE',
+              stagingStatus: 'ACTIVE',
+            }],
+          },
+        })
+        .post('/papi/v1/search/find-by-value', { hostname: 'www.example.com' })
+        .reply(200, { versions: { items: [{ propertyId: PROPERTY_ID }] } })
+        .post('/papi/v1/search/find-by-value', { propertyName: 'example.com' })
+        .reply(404)
+        .post('/papi/v1/search/find-by-value', { propertyName: 'example' })
+        .reply(404);
+
+      const matches = await client.findPropertiesByDomain('example.com');
+      expect(matches).to.have.lengthOf(1);
+      expect(matches[0]).to.include({ propertyId: PROPERTY_ID, propertyName: 'my-property' });
+      expect(matches[0].matchedOn).to.deep.equal(['hostname']);
+      expect(matches[0].matchedValues).to.deep.equal(['example.com', 'www.example.com']);
+    });
+
+    it('adds the bare apex when given a www. domain', async () => {
+      nock(API_BASE)
+        .post('/papi/v1/search/find-by-value', { hostname: 'www.example.com' })
+        .reply(200, { versions: { items: [{ propertyId: PROPERTY_ID }] } })
+        .post('/papi/v1/search/find-by-value', { hostname: 'example.com' })
+        .reply(404)
+        .post('/papi/v1/search/find-by-value', { propertyName: 'example.com' })
+        .reply(404)
+        .post('/papi/v1/search/find-by-value', { propertyName: 'example' })
+        .reply(404);
+
+      const matches = await client.findPropertiesByDomain('www.example.com');
+      expect(matches).to.have.lengthOf(1);
+    });
+
+    it('ranks a hostname match ahead of a name-only match, and name-only matches alphabetically', async () => {
+      nock(API_BASE)
+        .post('/papi/v1/search/find-by-value', { hostname: 'example.com' })
+        .reply(200, {
+          versions: { items: [{ propertyId: 'prp_by_hostname', propertyName: 'zzz-hostname' }] },
+        })
+        .post('/papi/v1/search/find-by-value', { hostname: 'www.example.com' })
+        .reply(404)
+        .post('/papi/v1/search/find-by-value', { propertyName: 'example.com' })
+        .reply(200, {
+          versions: {
+            items: [
+              { propertyId: 'prp_by_name_2', propertyName: 'bbb-name' },
+              { propertyId: 'prp_by_name_1', propertyName: 'aaa-name' },
+            ],
+          },
+        })
+        .post('/papi/v1/search/find-by-value', { propertyName: 'example' })
+        .reply(404);
+
+      const matches = await client.findPropertiesByDomain('example.com');
+      expect(matches.map((m) => m.propertyId)).to.deep.equal([
+        'prp_by_hostname', 'prp_by_name_1', 'prp_by_name_2',
+      ]);
+    });
+
+    it('ignores entries with no propertyId', async () => {
+      nock(API_BASE)
+        .post('/papi/v1/search/find-by-value', { hostname: 'example.com' })
+        .reply(200, { versions: { items: [{ propertyName: 'no-id' }] } })
+        .post('/papi/v1/search/find-by-value', { hostname: 'www.example.com' })
+        .reply(404)
+        .post('/papi/v1/search/find-by-value', { propertyName: 'example.com' })
+        .reply(404)
+        .post('/papi/v1/search/find-by-value', { propertyName: 'example' })
+        .reply(404);
+
+      const matches = await client.findPropertiesByDomain('example.com');
+      expect(matches).to.deep.equal([]);
+    });
+
+    it('swallows errors from individual lookups and still returns other matches', async () => {
+      nock(API_BASE)
+        .post('/papi/v1/search/find-by-value', { hostname: 'example.com' })
+        .replyWithError('boom')
+        .post('/papi/v1/search/find-by-value', { hostname: 'www.example.com' })
+        .reply(200, { versions: { items: [{ propertyId: PROPERTY_ID }] } })
+        .post('/papi/v1/search/find-by-value', { propertyName: 'example.com' })
+        .replyWithError('boom')
+        .post('/papi/v1/search/find-by-value', { propertyName: 'example' })
+        .reply(404);
+
+      const matches = await client.findPropertiesByDomain('example.com');
+      expect(matches).to.have.lengthOf(1);
+      expect(matches[0].propertyId).to.equal(PROPERTY_ID);
+    });
+
+    it('tie-breaks two hostname matches without a propertyName without throwing', async () => {
+      nock(API_BASE)
+        .post('/papi/v1/search/find-by-value', { hostname: 'example.com' })
+        .reply(200, {
+          versions: {
+            items: [
+              { propertyId: 'prp_1' },
+              { propertyId: 'prp_2' },
+            ],
+          },
+        })
+        .post('/papi/v1/search/find-by-value', { hostname: 'www.example.com' })
+        .reply(404)
+        .post('/papi/v1/search/find-by-value', { propertyName: 'example.com' })
+        .reply(404)
+        .post('/papi/v1/search/find-by-value', { propertyName: 'example' })
+        .reply(404);
+
+      const matches = await client.findPropertiesByDomain('example.com');
+      expect(matches.map((m) => m.propertyId).sort()).to.deep.equal(['prp_1', 'prp_2']);
+      matches.forEach((m) => expect(m.matchedOn).to.deep.equal(['hostname']));
+    });
+  });
+
+  // ─── version + rule-tree operations ─────────────────────────────────────
+
+  describe('getRuleTree', () => {
+    it('returns the rule tree and its ruleFormat', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/versions/5/rules`)
+        .query({ contractId: CONTRACT_ID, groupId: GROUP_ID })
+        .reply(200, { ruleFormat: 'v2024-01-01', rules: { name: 'default' } });
+
+      const result = await client.getRuleTree(PROPERTY_ID, 5, CONTRACT_ID, GROUP_ID);
+      const { ruleTree, ruleFormat } = result;
+      expect(ruleFormat).to.equal('v2024-01-01');
+      expect(ruleTree.rules).to.deep.equal({ name: 'default' });
+    });
+
+    it('throws when version is not an integer', async () => {
+      await expect(client.getRuleTree(PROPERTY_ID, '5', CONTRACT_ID, GROUP_ID))
+        .to.be.rejectedWith('version must be an integer');
+    });
+  });
+
+  describe('createVersion', () => {
+    it('returns the new version number parsed from versionLink', async () => {
+      nock(API_BASE)
+        .post(`/papi/v1/properties/${PROPERTY_ID}/versions`, { createFromVersion: 5 })
+        .query({ contractId: CONTRACT_ID, groupId: GROUP_ID })
+        .reply(201, {
+          versionLink: `/papi/v1/properties/${PROPERTY_ID}/versions/6?contractId=${CONTRACT_ID}`,
+        });
+
+      const version = await client.createVersion(PROPERTY_ID, 5, CONTRACT_ID, GROUP_ID);
+      expect(version).to.equal(6);
+    });
+
+    it('throws when baseVersion is not an integer', async () => {
+      await expect(client.createVersion(PROPERTY_ID, 'latest', CONTRACT_ID, GROUP_ID))
+        .to.be.rejectedWith('baseVersion must be an integer');
+    });
+
+    it('throws a contextual error when versionLink is missing or unparseable', async () => {
+      nock(API_BASE)
+        .post(`/papi/v1/properties/${PROPERTY_ID}/versions`, { createFromVersion: 5 })
+        .query(true)
+        .reply(201, {});
+
+      await expect(client.createVersion(PROPERTY_ID, 5, CONTRACT_ID, GROUP_ID))
+        .to.be.rejectedWith(/parseable versionLink/);
+    });
+  });
+
+  describe('updateRuleTree', () => {
+    it('sends the rule-format content-type header when ruleFormat is given', async () => {
+      nock(API_BASE)
+        .matchHeader('content-type', 'application/vnd.akamai.papirules.v2024-01-01+json')
+        .put(`/papi/v1/properties/${PROPERTY_ID}/versions/6/rules`)
+        .query({ contractId: CONTRACT_ID, groupId: GROUP_ID, validateRules: 'true' })
+        .reply(200, { errors: [], warnings: [] });
+
+      const tree = { rules: {} };
+      const result = await client.updateRuleTree(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, tree, 'v2024-01-01');
+      expect(result).to.deep.equal({ errors: [], warnings: [] });
+    });
+
+    it('omits the rule-format content-type header when ruleFormat is not given', async () => {
+      nock(API_BASE)
+        .matchHeader('content-type', 'application/json')
+        .put(`/papi/v1/properties/${PROPERTY_ID}/versions/6/rules`)
+        .query(true)
+        .reply(200, { errors: [] });
+
+      const tree = { rules: {} };
+      const result = await client.updateRuleTree(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, tree);
+      expect(result).to.deep.equal({ errors: [] });
+    });
+
+    it('throws when version is not an integer', async () => {
+      await expect(client.updateRuleTree(PROPERTY_ID, '6', CONTRACT_ID, GROUP_ID, { rules: {} }))
+        .to.be.rejectedWith('version must be an integer');
+    });
+
+    it('throws when ruleTree is not an object', async () => {
+      await expect(client.updateRuleTree(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, 'not-an-object'))
+        .to.be.rejectedWith('ruleTree must be an object');
+    });
+
+    it('throws when ruleTree is null', async () => {
+      await expect(client.updateRuleTree(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, null))
+        .to.be.rejectedWith('ruleTree must be an object');
+    });
+  });
+
+  // ─── activation ─────────────────────────────────────────────────────────
+
+  describe('activate', () => {
+    it('activates with a default note and returns the activation link', async () => {
+      nock(API_BASE)
+        .post(
+          `/papi/v1/properties/${PROPERTY_ID}/activations`,
+          (body) => body.note === 'Activated via spacecat-shared-akamai-client'
+            && body.network === 'STAGING'
+            && body.acknowledgeAllWarnings === true,
+        )
+        .query({ contractId: CONTRACT_ID, groupId: GROUP_ID })
+        .reply(201, { activationLink: '/papi/v1/properties/prp_123/activations/atv_1' });
+
+      const link = await client.activate(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, 'staging', ['a@example.com']);
+      expect(link).to.equal('/papi/v1/properties/prp_123/activations/atv_1');
+    });
+
+    it('accepts a custom note', async () => {
+      nock(API_BASE)
+        .post(
+          `/papi/v1/properties/${PROPERTY_ID}/activations`,
+          (body) => body.note === 'custom note',
+        )
+        .query(true)
+        .reply(201, { activationLink: '/link' });
+
+      const link = await client.activate(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, 'PRODUCTION', [], 'custom note');
+      expect(link).to.equal('/link');
+    });
+
+    it('throws when version is not an integer', async () => {
+      await expect(client.activate(PROPERTY_ID, '6', CONTRACT_ID, GROUP_ID, 'STAGING', []))
+        .to.be.rejectedWith('version must be an integer');
+    });
+
+    it('throws when network is missing', async () => {
+      await expect(client.activate(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, '', []))
+        .to.be.rejectedWith('network is required');
+    });
+  });
+
+  describe('AkamaiClient.activationIdFromLink', () => {
+    it('extracts the id from a link with a query string and trailing slash', () => {
+      expect(AkamaiClient.activationIdFromLink('/papi/v1/properties/prp_1/activations/atv_9/?contractId=ctr_1'))
+        .to.equal('atv_9');
+    });
+
+    it('returns an empty string for a falsy link', () => {
+      expect(AkamaiClient.activationIdFromLink(undefined)).to.equal('');
+    });
+  });
+
+  describe('getActivation', () => {
+    it('returns the first matching activation item', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/activations/atv_1`)
+        .query({ contractId: CONTRACT_ID, groupId: GROUP_ID })
+        .reply(200, { activations: { items: [{ activationId: 'atv_1', status: 'ACTIVE' }] } });
+
+      const activation = await client.getActivation(PROPERTY_ID, 'atv_1', CONTRACT_ID, GROUP_ID);
+      expect(activation).to.deep.equal({ activationId: 'atv_1', status: 'ACTIVE' });
+    });
+
+    it('returns undefined when there is no matching activation', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/activations/atv_1`)
+        .query(true)
+        .reply(200, {});
+
+      const activation = await client.getActivation(PROPERTY_ID, 'atv_1', CONTRACT_ID, GROUP_ID);
+      expect(activation).to.be.undefined;
+    });
+  });
+
+  describe('listActivations', () => {
+    it('returns all activations for the property', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/activations`)
+        .query({ contractId: CONTRACT_ID, groupId: GROUP_ID })
+        .reply(200, { activations: { items: [{ activationId: 'atv_1' }, { activationId: 'atv_2' }] } });
+
+      const activations = await client.listActivations(PROPERTY_ID, CONTRACT_ID, GROUP_ID);
+      expect(activations).to.have.lengthOf(2);
+    });
+
+    it('returns an empty array when activations are absent', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/activations`)
+        .query(true)
+        .reply(200, {});
+
+      const activations = await client.listActivations(PROPERTY_ID, CONTRACT_ID, GROUP_ID);
+      expect(activations).to.deep.equal([]);
+    });
+  });
+
+  describe('latestActivation', () => {
+    it('returns undefined when the property was never activated on that network', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/activations`)
+        .query(true)
+        .reply(200, { activations: { items: [{ network: 'STAGING', updateDate: '2026-01-01' }] } });
+
+      const activation = await client.latestActivation(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'PRODUCTION');
+      expect(activation).to.be.undefined;
+    });
+
+    it('returns the most recently updated activation for the network (case-insensitive)', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/activations`)
+        .query(true)
+        .reply(200, {
+          activations: {
+            items: [
+              {
+                network: 'STAGING', activationId: 'atv_old', updateDate: '2026-01-01T00:00:00Z',
+              },
+              {
+                network: 'staging', activationId: 'atv_new', updateDate: '2026-02-01T00:00:00Z',
+              },
+              { network: 'PRODUCTION', activationId: 'atv_prod', updateDate: '2026-03-01T00:00:00Z' },
+            ],
+          },
+        });
+
+      const activation = await client.latestActivation(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'STAGING');
+      expect(activation.activationId).to.equal('atv_new');
+    });
+
+    it('falls back to submitDate when updateDate is absent', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/activations`)
+        .query(true)
+        .reply(200, {
+          activations: {
+            items: [
+              { network: 'STAGING', activationId: 'atv_a', submitDate: '2026-01-01T00:00:00Z' },
+              { network: 'STAGING', activationId: 'atv_b', submitDate: '2026-05-01T00:00:00Z' },
+            ],
+          },
+        });
+
+      const activation = await client.latestActivation(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'STAGING');
+      expect(activation.activationId).to.equal('atv_b');
+    });
+
+    it('treats an activation with neither updateDate nor submitDate as sorting first', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/activations`)
+        .query(true)
+        .reply(200, {
+          activations: {
+            items: [
+              { network: 'STAGING', activationId: 'atv_undated' },
+              { network: 'STAGING', activationId: 'atv_dated', updateDate: '2026-01-01T00:00:00Z' },
+            ],
+          },
+        });
+
+      const activation = await client.latestActivation(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'STAGING');
+      expect(activation.activationId).to.equal('atv_dated');
+    });
+
+    it('ignores activation entries with no network field', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/activations`)
+        .query(true)
+        .reply(200, {
+          activations: {
+            items: [
+              { activationId: 'atv_no_network', updateDate: '2026-01-01T00:00:00Z' },
+              { network: 'STAGING', activationId: 'atv_staging', updateDate: '2026-02-01T00:00:00Z' },
+            ],
+          },
+        });
+
+      const activation = await client.latestActivation(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'STAGING');
+      expect(activation.activationId).to.equal('atv_staging');
+    });
+  });
+
+  // ─── normalizeDomain ────────────────────────────────────────────────────
+
+  describe('normalizeDomain', () => {
+    it('strips scheme, path, port, and a trailing dot', () => {
+      expect(normalizeDomain('HTTPS://Example.com:8080/some/path.')).to.equal('example.com');
+    });
+
+    it('passes through an already-bare hostname', () => {
+      expect(normalizeDomain('example.com')).to.equal('example.com');
+    });
+
+    it('returns an empty string for a falsy input', () => {
+      expect(normalizeDomain(undefined)).to.equal('');
+    });
+  });
+});

--- a/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
+++ b/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
@@ -28,17 +28,20 @@ const CREDS = {
   clientToken: 'test-client-token',
   clientSecret: 'test-client-secret',
   accessToken: 'test-access-token',
+  notifyEmails: ['a@example.com'],
 };
 const CONTRACT_ID = 'ctr_1';
 const GROUP_ID = 'grp_1';
 const PROPERTY_ID = 'prp_123';
 
+const sandbox = sinon.createSandbox();
+
 function makeLog() {
   return {
-    info: sinon.stub(),
-    debug: sinon.stub(),
-    warn: sinon.stub(),
-    error: sinon.stub(),
+    info: sandbox.stub(),
+    debug: sandbox.stub(),
+    warn: sandbox.stub(),
+    error: sandbox.stub(),
   };
 }
 
@@ -61,6 +64,7 @@ describe('AkamaiClient', () => {
   });
 
   afterEach(() => {
+    sandbox.restore();
     nock.cleanAll();
     nock.enableNetConnect();
   });
@@ -68,7 +72,7 @@ describe('AkamaiClient', () => {
   // ─── createFrom ────────────────────────────────────────────────────────
 
   describe('createFrom', () => {
-    it('creates a client from context.env', () => {
+    it('creates a client from context.env, parsing comma-separated notify emails', () => {
       const c = AkamaiClient.createFrom({
         env: {
           AKAMAI_HOST: HOST,
@@ -76,14 +80,16 @@ describe('AkamaiClient', () => {
           AKAMAI_CLIENT_SECRET: 'cs',
           AKAMAI_ACCESS_TOKEN: 'at',
           AKAMAI_ACCOUNT_SWITCH_KEY: 'ask',
+          AKAMAI_NOTIFY_EMAILS: 'a@example.com, b@example.com',
         },
         log,
       });
       expect(c).to.be.instanceOf(AkamaiClient);
       expect(c.accountSwitchKey).to.equal('ask');
+      expect(c.notifyEmails).to.deep.equal(['a@example.com', 'b@example.com']);
     });
 
-    it('uses console as the default log', () => {
+    it('uses console as the default log and leaves notifyEmails undefined when not set', () => {
       const c = AkamaiClient.createFrom({
         env: {
           AKAMAI_HOST: HOST,
@@ -93,6 +99,7 @@ describe('AkamaiClient', () => {
         },
       });
       expect(c).to.be.instanceOf(AkamaiClient);
+      expect(c.notifyEmails).to.be.undefined;
     });
 
     it('throws when a required env var is missing', () => {
@@ -176,7 +183,7 @@ describe('AkamaiClient', () => {
         .query(true)
         .reply(200, '');
 
-      const link = await client.activate(PROPERTY_ID, 5, CONTRACT_ID, GROUP_ID, 'STAGING', ['a@example.com']);
+      const link = await client.activate(PROPERTY_ID, 5, CONTRACT_ID, GROUP_ID, 'STAGING');
       expect(link).to.equal('');
     });
 
@@ -465,12 +472,13 @@ describe('AkamaiClient', () => {
           `/papi/v1/properties/${PROPERTY_ID}/activations`,
           (body) => body.note === 'Activated via spacecat-shared-akamai-client'
             && body.network === 'STAGING'
-            && body.acknowledgeAllWarnings === true,
+            && body.acknowledgeAllWarnings === true
+            && JSON.stringify(body.notifyEmails) === JSON.stringify(CREDS.notifyEmails),
         )
         .query({ contractId: CONTRACT_ID, groupId: GROUP_ID })
         .reply(201, { activationLink: '/papi/v1/properties/prp_123/activations/atv_1' });
 
-      const link = await client.activate(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, 'staging', ['a@example.com']);
+      const link = await client.activate(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, 'staging');
       expect(link).to.equal('/papi/v1/properties/prp_123/activations/atv_1');
     });
 
@@ -483,18 +491,30 @@ describe('AkamaiClient', () => {
         .query(true)
         .reply(201, { activationLink: '/link' });
 
-      const link = await client.activate(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, 'PRODUCTION', [], 'custom note');
+      const link = await client.activate(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, 'PRODUCTION', 'custom note');
       expect(link).to.equal('/link');
     });
 
     it('throws when version is not an integer', async () => {
-      await expect(client.activate(PROPERTY_ID, '6', CONTRACT_ID, GROUP_ID, 'STAGING', []))
+      await expect(client.activate(PROPERTY_ID, '6', CONTRACT_ID, GROUP_ID, 'STAGING'))
         .to.be.rejectedWith('version must be an integer');
     });
 
     it('throws when network is missing', async () => {
-      await expect(client.activate(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, '', []))
+      await expect(client.activate(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, ''))
         .to.be.rejectedWith('network is required');
+    });
+
+    it('throws when the client was constructed without notifyEmails', async () => {
+      const c = new AkamaiClient({ ...CREDS, notifyEmails: undefined }, log);
+      await expect(c.activate(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, 'STAGING'))
+        .to.be.rejectedWith(/notifyEmails/);
+    });
+
+    it('throws when the client was constructed with an empty notifyEmails array', async () => {
+      const c = new AkamaiClient({ ...CREDS, notifyEmails: [] }, log);
+      await expect(c.activate(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, 'STAGING'))
+        .to.be.rejectedWith(/notifyEmails/);
     });
   });
 

--- a/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
+++ b/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
@@ -346,6 +346,10 @@ describe('AkamaiClient', () => {
       const matches = await client.findPropertiesByDomain('example.com');
       expect(matches).to.have.lengthOf(1);
       expect(matches[0].propertyId).to.equal(PROPERTY_ID);
+      // The whole point of catching each lookup is to keep partial failures
+      // observable rather than silent — assert they were actually logged.
+      expect(log.warn).to.have.been.called;
+      expect(log.warn).to.have.been.calledWithMatch(/failed, continuing/);
     });
 
     it('tie-breaks two hostname matches without a propertyName without throwing', async () => {
@@ -461,6 +465,20 @@ describe('AkamaiClient', () => {
       await expect(client.updateRuleTree(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, null))
         .to.be.rejectedWith('ruleTree must be an object');
     });
+
+    it('rejects a ruleFormat that would inject into the Content-Type header', async () => {
+      const evil = 'v2024-01-01\r\nX-Evil: 1';
+      const attempt = client.updateRuleTree(
+        PROPERTY_ID,
+        6,
+        CONTRACT_ID,
+        GROUP_ID,
+        { rules: {} },
+        evil,
+      );
+      await expect(attempt)
+        .to.be.rejectedWith('ruleFormat must contain only letters, digits, and hyphens');
+    });
   });
 
   // ─── activation ─────────────────────────────────────────────────────────
@@ -503,6 +521,11 @@ describe('AkamaiClient', () => {
     it('throws when network is missing', async () => {
       await expect(client.activate(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, ''))
         .to.be.rejectedWith('network is required');
+    });
+
+    it('throws when network is not STAGING or PRODUCTION', async () => {
+      await expect(client.activate(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, 'sandbox'))
+        .to.be.rejectedWith('network must be one of STAGING, PRODUCTION, got: sandbox');
     });
 
     it('throws when the client was constructed without notifyEmails', async () => {
@@ -574,6 +597,11 @@ describe('AkamaiClient', () => {
   });
 
   describe('latestActivation', () => {
+    it('throws when network is not STAGING or PRODUCTION', async () => {
+      await expect(client.latestActivation(PROPERTY_ID, CONTRACT_ID, GROUP_ID, 'sandbox'))
+        .to.be.rejectedWith('network must be one of STAGING, PRODUCTION, got: sandbox');
+    });
+
     it('returns undefined when the property was never activated on that network', async () => {
       nock(API_BASE)
         .get(`/papi/v1/properties/${PROPERTY_ID}/activations`)
@@ -667,6 +695,10 @@ describe('AkamaiClient', () => {
 
     it('passes through an already-bare hostname', () => {
       expect(normalizeDomain('example.com')).to.equal('example.com');
+    });
+
+    it('strips a bare FQDN trailing dot with no scheme, port, or path', () => {
+      expect(normalizeDomain('example.com.')).to.equal('example.com');
     });
 
     it('returns an empty string for a falsy input', () => {

--- a/packages/spacecat-shared-akamai-client/test/edgegrid-auth.test.js
+++ b/packages/spacecat-shared-akamai-client/test/edgegrid-auth.test.js
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+
+import { edgeGridTimestamp, signRequest } from '../src/edgegrid-auth.js';
+
+const FIXED_TS = '20260702T12:00:00+0000';
+const FIXED_NONCE = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const CREDS = {
+  clientToken: 'test-client-token',
+  clientSecret: 'test-client-secret',
+  accessToken: 'test-access-token',
+};
+
+describe('edgegrid-auth', () => {
+  describe('edgeGridTimestamp', () => {
+    it('formats a given date as yyyyMMddTHH:mm:ss+0000 (UTC)', () => {
+      const date = new Date(Date.UTC(2026, 6, 2, 9, 5, 3));
+      expect(edgeGridTimestamp(date)).to.equal('20260702T09:05:03+0000');
+    });
+
+    it('defaults to the current time when no date is given', () => {
+      const before = Date.now();
+      const ts = edgeGridTimestamp();
+      const after = Date.now();
+      expect(ts).to.match(/^\d{8}T\d{2}:\d{2}:\d{2}\+0000$/);
+      const parsedYear = Number(ts.slice(0, 4));
+      expect(parsedYear).to.equal(new Date(before).getUTCFullYear());
+      expect(after - before).to.be.lessThan(5000);
+    });
+  });
+
+  describe('signRequest', () => {
+    // Cross-validated byte-for-byte against Python's official edgegrid-python
+    // EdgeGridAuth for the same fixed timestamp/nonce/credentials/URL/body.
+    it('matches the reference EdgeGrid signature for a GET request (no body)', () => {
+      const header = signRequest({
+        method: 'GET',
+        url: 'https://akab-xxxxx.luna.akamaiapis.net/papi/v1/properties/prp_123/versions/latest?contractId=ctr_1&groupId=grp_1',
+        timestamp: FIXED_TS,
+        nonce: FIXED_NONCE,
+        ...CREDS,
+      });
+      expect(header).to.equal(
+        'EG1-HMAC-SHA256 client_token=test-client-token;access_token=test-access-token;'
+        + 'timestamp=20260702T12:00:00+0000;nonce=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee;'
+        + 'signature=kvFG+F7VJ8crdI/AD1vsECVGekF+w/Mrh13y8cGkYUY=',
+      );
+    });
+
+    it('matches the reference EdgeGrid signature for a PUT request with a JSON body', () => {
+      const header = signRequest({
+        method: 'PUT',
+        url: 'https://akab-xxxxx.luna.akamaiapis.net/papi/v1/properties/prp_123/versions/5/rules?contractId=ctr_1&groupId=grp_1&validateRules=true',
+        body: '{"rules":{"name":"default"}}',
+        timestamp: FIXED_TS,
+        nonce: FIXED_NONCE,
+        ...CREDS,
+      });
+      expect(header).to.equal(
+        'EG1-HMAC-SHA256 client_token=test-client-token;access_token=test-access-token;'
+        + 'timestamp=20260702T12:00:00+0000;nonce=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee;'
+        + 'signature=CaDSAfv27qDVchPAgEg+KxJgOaqPPdiJmkb1JCDsVE8=',
+      );
+    });
+
+    it('produces a different signature for a POST body than for the same body on PUT', () => {
+      const base = {
+        url: 'https://akab-xxxxx.luna.akamaiapis.net/papi/v1/some/path',
+        body: '{"a":1}',
+        timestamp: FIXED_TS,
+        nonce: FIXED_NONCE,
+        ...CREDS,
+      };
+      const post = signRequest({ ...base, method: 'POST' });
+      const put = signRequest({ ...base, method: 'PUT' });
+      expect(post).to.not.equal(put);
+    });
+
+    it('ignores an empty POST body the same as no body at all', () => {
+      const base = {
+        url: 'https://akab-xxxxx.luna.akamaiapis.net/papi/v1/some/path',
+        method: 'POST',
+        timestamp: FIXED_TS,
+        nonce: FIXED_NONCE,
+        ...CREDS,
+      };
+      expect(signRequest({ ...base, body: '' })).to.equal(signRequest(base));
+    });
+
+    it('includes canonicalized headersToSign in the signature when provided', () => {
+      const base = {
+        url: 'https://akab-xxxxx.luna.akamaiapis.net/papi/v1/some/path',
+        method: 'GET',
+        timestamp: FIXED_TS,
+        nonce: FIXED_NONCE,
+        ...CREDS,
+      };
+      const withHeaders = signRequest({
+        ...base,
+        headersToSign: { 'X-Custom': '  multiple   spaces  ' },
+      });
+      const withoutHeaders = signRequest(base);
+      expect(withHeaders).to.not.equal(withoutHeaders);
+    });
+
+    it('generates a timestamp and nonce when not provided', () => {
+      const header = signRequest({
+        method: 'GET',
+        url: 'https://akab-xxxxx.luna.akamaiapis.net/papi/v1/some/path',
+        ...CREDS,
+      });
+      expect(header).to.match(
+        /^EG1-HMAC-SHA256 client_token=test-client-token;access_token=test-access-token;timestamp=\d{8}T\d{2}:\d{2}:\d{2}\+0000;nonce=[0-9a-f-]{36};signature=.+$/,
+      );
+    });
+  });
+});

--- a/packages/spacecat-shared-akamai-client/test/edgegrid-auth.test.js
+++ b/packages/spacecat-shared-akamai-client/test/edgegrid-auth.test.js
@@ -114,6 +114,24 @@ describe('edgegrid-auth', () => {
       expect(withHeaders).to.not.equal(withoutHeaders);
     });
 
+    it('truncates the POST body at MAX_BODY_BYTES so trailing bytes do not affect the signature', () => {
+      // MAX_BODY_BYTES is 131072; a body at exactly the limit and the same body
+      // with extra bytes appended must sign identically. Guards against the
+      // subarray(0, MAX_BODY_BYTES) truncation being removed or the constant
+      // changed — the reference-vector tests use small bodies and wouldn't catch it.
+      const base = {
+        method: 'POST',
+        url: 'https://akab-xxxxx.luna.akamaiapis.net/papi/v1/some/path',
+        timestamp: FIXED_TS,
+        nonce: FIXED_NONCE,
+        ...CREDS,
+      };
+      const exactBody = 'x'.repeat(131072);
+      const overBody = `${exactBody}EXTRA_BYTES_BEYOND_LIMIT`;
+      expect(signRequest({ ...base, body: exactBody }))
+        .to.equal(signRequest({ ...base, body: overBody }));
+    });
+
     it('generates a timestamp and nonce when not provided', () => {
       const header = signRequest({
         method: 'GET',

--- a/packages/spacecat-shared-akamai-client/test/edgegrid-auth.test.js
+++ b/packages/spacecat-shared-akamai-client/test/edgegrid-auth.test.js
@@ -98,22 +98,6 @@ describe('edgegrid-auth', () => {
       expect(signRequest({ ...base, body: '' })).to.equal(signRequest(base));
     });
 
-    it('includes canonicalized headersToSign in the signature when provided', () => {
-      const base = {
-        url: 'https://akab-xxxxx.luna.akamaiapis.net/papi/v1/some/path',
-        method: 'GET',
-        timestamp: FIXED_TS,
-        nonce: FIXED_NONCE,
-        ...CREDS,
-      };
-      const withHeaders = signRequest({
-        ...base,
-        headersToSign: { 'X-Custom': '  multiple   spaces  ' },
-      });
-      const withoutHeaders = signRequest(base);
-      expect(withHeaders).to.not.equal(withoutHeaders);
-    });
-
     it('truncates the POST body at MAX_BODY_BYTES so trailing bytes do not affect the signature', () => {
       // MAX_BODY_BYTES is 131072; a body at exactly the limit and the same body
       // with extra bytes appended must sign identically. Guards against the

--- a/packages/spacecat-shared-akamai-client/test/setup-env.js
+++ b/packages/spacecat-shared-akamai-client/test/setup-env.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+// eslint-disable-next-line no-console
+console.log('Forcing HTTP/1.1 for Adobe Fetch');
+process.env.HELIX_FETCH_FORCE_HTTP1 = 'true';


### PR DESCRIPTION
## Summary
- New `@adobe/spacecat-shared-akamai-client` package: a thin client for Akamai's Property Manager API (PAPI), authenticated with EdgeGrid (EG1-HMAC-SHA256), based on the `akamai-api` POC.
- Exposes `findPropertiesByDomain`, `getLatestVersion`, `getRuleTree`, `createVersion`, `updateRuleTree`, `activate`, `getActivation`, `listActivations`, `latestActivation`.
- EdgeGrid signing is implemented directly (no `akamai-edgegrid` dependency, keeping this monorepo's `fetch`-based client pattern) and cross-validated in tests against the official `edgegrid-python` reference implementation for byte-identical signatures.
- Every public method validates required args, URL-encodes path segments before interpolation, and `searchBy`'s `key` is restricted to an allowlist (avoids a `{ [key]: value }` prototype-pollution-via-`__proto__` gotcha).

## Test plan
- [x] `npm test -w packages/spacecat-shared-akamai-client` — 61 passing, 100% statements/lines/functions, 99.15% branches
- [x] `npm run lint -w packages/spacecat-shared-akamai-client` — clean
- [x] EdgeGrid signature cross-validated against Python's `edgegrid-python` for both a GET (no body) and PUT (with JSON body) request, fixed timestamp/nonce, byte-for-byte match
- [ ] Review by a maintainer familiar with the PAPI integration patterns used elsewhere in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)