### PR TITLE
fix(utils): fail closed in site-scope checks when siteBaseUrl is missing

### DIFF
--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -498,7 +498,7 @@ function isWithinSiteScope(url, siteBaseUrl) {
     return false;
   }
   if (!siteBaseUrl) {
-    return true;
+    return false;
   }
 
   try {
@@ -613,7 +613,7 @@ export function isPathPatternWithinSiteScope(pathPattern, siteBaseUrl) {
     return false;
   }
   if (!siteBaseUrl) {
-    return true;
+    return false;
   }
 
   const siteBasePath = toPathname(siteBaseUrl);

--- a/packages/spacecat-shared-utils/test/url-helpers.test.js
+++ b/packages/spacecat-shared-utils/test/url-helpers.test.js
@@ -1253,9 +1253,9 @@ describe('URL Utility Functions', () => {
       expect(isWithinSiteScope('', 'bulk.com/uk')).to.be.false;
     });
 
-    it('returns true when siteBaseUrl is null or empty (no restriction)', () => {
-      expect(isWithinSiteScope('https://bulk.com/uk/page', null)).to.be.true;
-      expect(isWithinSiteScope('https://bulk.com/uk/page', '')).to.be.true;
+    it('returns false when siteBaseUrl is null or empty (fails closed)', () => {
+      expect(isWithinSiteScope('https://bulk.com/uk/page', null)).to.be.false;
+      expect(isWithinSiteScope('https://bulk.com/uk/page', '')).to.be.false;
     });
 
     it('returns true for all URLs when siteBaseUrl has no subpath', () => {
@@ -1351,9 +1351,9 @@ describe('URL Utility Functions', () => {
       expect(filterBySiteScope(urls, 'bulk.com')).to.deep.equal(urls);
     });
 
-    it('returns all URLs when siteBaseUrl is null', () => {
+    it('returns no URLs when siteBaseUrl is null (fails closed)', () => {
       const urls = ['https://bulk.com/a', 'https://bulk.com/b'];
-      expect(filterBySiteScope(urls, null)).to.deep.equal(urls);
+      expect(filterBySiteScope(urls, null)).to.deep.equal([]);
     });
 
     it('returns empty array when no URLs are in scope', () => {
@@ -1499,8 +1499,8 @@ describe('URL Utility Functions', () => {
       expect(isPathPatternWithinSiteScope(undefined, 'bulk.com/uk')).to.be.false;
     });
 
-    it('returns true when no siteBaseUrl is given', () => {
-      expect(isPathPatternWithinSiteScope('/kings/.*', '')).to.be.true;
+    it('returns false when no siteBaseUrl is given (fails closed)', () => {
+      expect(isPathPatternWithinSiteScope('/kings/.*', '')).to.be.false;
     });
 
     it('returns true when the site is scoped to the root path', () => {


### PR DESCRIPTION
## What

`isWithinSiteScope` and `isPathPatternWithinSiteScope` in `spacecat-shared-utils/src/url-helpers.js` previously returned `true` (allow everything) when `siteBaseUrl` was `null`/empty. These functions are used as deploy-authorization gates in `spacecat-api-service` (the `edge-deploy` endpoint's `isSuggestionInScope`), so returning `true` on a missing scope is **fail-open**.

This PR flips both to **fail-closed** — a missing/empty `siteBaseUrl` now returns `false`, denying rather than permitting. `filterBySiteScope` inherits the new behavior since it delegates to `isWithinSiteScope`.

## Why

Defense-in-depth for the subpath deploy-scope guards. In practice `site.getBaseURL()` is effectively always truthy on a loaded Site, so production behavior is unchanged — this hardens the unreachable-in-normal-flow branch and makes the two sibling scope functions behave consistently (previously only one was going to be hardened, leaving them asymmetric).

## Changes

- `isWithinSiteScope`: `!siteBaseUrl` → `return false`
- `isPathPatternWithinSiteScope`: `!siteBaseUrl` → `return false`
- Updated three tests to assert fail-closed behavior:
  - `isWithinSiteScope` with null/empty base URL
  - `isPathPatternWithinSiteScope` with empty base URL
  - `filterBySiteScope` with null base URL (delegates to `isWithinSiteScope`)

## Testing

`npm test -w packages/spacecat-shared-utils` → **1254 passing, 0 failing**, `url-helpers.js` at 100% statements/branches/functions/lines (meets the 100%/97% coverage gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)