### PR TITLE
fix(release): heal package-lock on partial semantic-release failure

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -240,7 +240,23 @@ jobs:
         # packages are already published and the Test-job drift guard is the
         # backstop — hence continue-on-error. If the push loses a race it is
         # left for the next PR's drift guard to surface.
-        if: success()
+        #
+        # Gate is `success() || failure()`, NOT `success()`: semantic-release
+        # pushes a package's release commit (the thing that drifts the lock) and
+        # can then fail LATER in the same run — e.g. a subsequent workspace in
+        # the `-ws` loop whose npm OIDC exchange 404s (a new, not-yet-published
+        # package with no trusted-publisher binding). In that case the release
+        # job fails but the lock is already drifted on main; a `success()` gate
+        # SKIPS this heal, handing every open PR a lock diff it did not author
+        # (RELEASE-RUNBOOK Failure mode 7 — "partial SR failure" variant). So the
+        # single scenario that most needs the re-sync is exactly the one a
+        # success()-gate misses. `success() || failure()` runs the heal on both a
+        # clean release and a partial failure; cancellation is intentionally
+        # excluded (a job cancelled mid-push must not race in a commit). The
+        # HEAD-is-release-commit guard in the script below keeps the failure()
+        # path from committing when no release commit was actually pushed (e.g.
+        # an early `npm ci` failure — nothing drifted, npm may not be pinned).
+        if: success() || failure()
         continue-on-error: true
         shell: bash
         env:
@@ -256,6 +272,26 @@ jobs:
           # mark instead of a false "already in sync" — the `if ! git push`
           # retry below is errexit-safe (the negated condition suppresses it).
           trap 'echo "::warning title=package-lock sync after release failed::Lockfile sync did not complete; see RELEASE-RUNBOOK Failure mode 7. The next PR drift guard will surface residual drift."; echo "package-lock.json sync after release failed — see RELEASE-RUNBOOK Failure mode 7." >> "$GITHUB_STEP_SUMMARY"' ERR
+          # Only heal when semantic-release actually pushed a release commit this
+          # run. Under `success() || failure()` this step also fires when the
+          # release job failed; guard so it acts solely on the "a release commit
+          # was pushed" case. On success HEAD is the just-created
+          # `chore(release): <version>` commit; on a partial SR failure (SR failed
+          # AFTER pushing a release commit) HEAD is still that release commit. On
+          # any failure BEFORE a release was committed (e.g. `npm ci` failed) HEAD
+          # is the triggering feat/fix commit — nothing drifted, so skip rather
+          # than regenerate + commit a spurious lock diff (the runner's npm may
+          # not even be the pinned version yet at that point). The release job's
+          # own `if` guarantees the triggering commit is never a `chore(release)`
+          # commit, so this cleanly distinguishes "release pushed" from "did not".
+          head_subject="$(git log -1 --format=%s)"
+          case "${head_subject}" in
+            'chore(release):'*)
+              echo "HEAD is a release commit (${head_subject}); verifying lock sync." ;;
+            *)
+              echo "HEAD (${head_subject}) is not a release commit; no release was pushed this run — nothing to sync."
+              exit 0 ;;
+          esac
           npm install --package-lock-only --ignore-scripts
           if git diff --quiet -- package-lock.json; then
             echo "OK: package-lock.json already in sync; nothing to commit."

--- a/docs/RELEASE-RUNBOOK.md
+++ b/docs/RELEASE-RUNBOOK.md
@@ -423,6 +423,31 @@ crosses a consumer's exact internal pin, the lock loses that resolution and
 `npm ci` fails on **every** branch (the `Missing <pkg>@<ver> from lock file`
 outage).
 
+Two things trigger this step, because a released version bump can drift the lock
+whether or not the rest of the release run succeeds. Its gate is
+`success() || failure()`, not `success()`:
+
+- **Clean release** (`success()`): the normal path — regenerate the lock against
+  the just-published versions, commit if it drifted.
+- **Partial `Semantic Release` failure** (`failure()`): semantic-release runs
+  once per workspace (`npx --no -ws semantic-release`). It can publish and push
+  package A's release commit (drifting the lock) and then fail on a *later*
+  workspace B in the same run. The release job goes red, but package A's version
+  bump is already on `main` — so the lock is drifted and the heal is exactly what
+  is needed. A `success()` gate would **skip** the one scenario that most needs
+  the re-sync, converting a release-job failure into a main-wide contributor tax.
+  (This is what #1773 hit: a `data-access@4.0.0` publish pushed its release
+  commit, then the run failed on an unrelated later package; the old `success()`
+  gate skipped the heal and left `main` drifted — every open PR went red at
+  `Verify package-lock.json is in sync`.)
+
+The step guards the `failure()` path so it only commits when a release commit was
+actually pushed this run: it checks that HEAD is a `chore(release): …` commit
+(the subject semantic-release uses) before regenerating. On a failure *before*
+any release was committed (e.g. `npm ci` failed) HEAD is the triggering
+feat/fix commit, so the step no-ops. Cancellation is excluded from the gate — a
+job cancelled mid-push must not race in a commit.
+
 The step is `continue-on-error: true` — it can never fail a release. So a
 failure here is **silent** and surfaces later as the `Verify package-lock.json
 is in sync` check going red on the next unrelated PR.
@@ -459,6 +484,41 @@ git commit -m "fix: sync package-lock.json with released workspace versions"
 
 No package is republished — this is a lockfile-only commit. The drift guard on
 the recovery PR confirms the fix (it will pass once the lock is regenerated).
+
+With the `success() || failure()` gate in place this manual recovery is only
+needed when the heal step *itself* could not run or push (e.g. the push race
+above, or a regeneration hiccup) — a plain partial-SR failure now auto-heals.
+
+### Underlying cause: a partial `Semantic Release` failure
+
+The `failure()` gate heals the lock, but the release itself still failed and no
+new versions publish until the root cause is fixed. The most common trigger is a
+**newly-added publishable package with no npm trusted-publisher binding**. Because
+`semantic-release` runs once per workspace, that package's
+`@semantic-release/npm` `verifyConditions` attempts an OIDC token exchange, npm
+returns `404 - package not found` (the package has never been published and has
+no binding), it falls back to token auth, and — with no `NPM_TOKEN` — throws
+`ENONPMTOKEN No npm token specified`, failing the whole run. If an earlier
+workspace already published, that is exactly the "release commit pushed, then SR
+failed" drift this failure mode heals.
+
+> A secondary `TypeError: Cannot read properties of undefined (reading 'map')` at
+> `semantic-release-monorepo/src/only-package-commits.js` often accompanies it —
+> that is noise from the monorepo plugin's error path (`commits` is undefined
+> because `verifyConditions` failed early), not the real cause. The real cause is
+> the `ENONPMTOKEN` above.
+
+Fix the release (so it stops half-failing on every run): register the new
+package's trusted-publisher binding and bootstrap its first publish — add it to
+`PACKAGES` in `scripts/setup-npm-trusted-publishers.sh` and re-run the script
+(see **Failure mode 1** for the OIDC binding path). Until then every release run
+fails at that package's `verifyConditions`, and this heal keeps `main`'s lock in
+sync in the meantime.
+
+Real example (#1773): `data-access@4.0.0` published and pushed its release
+commit, then the run failed at `@adobe/spacecat-shared-ticket-client` (added in
+#1701, never published, absent from the setup script's `PACKAGES`) with the
+`404` → `ENONPMTOKEN` chain above.
 
 ## Re-enabling the environment approval gate
 


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Makes the Release job's `Sync package-lock.json after release` self-heal fire on a **partial** `Semantic Release` failure, not only on a fully green release, so a release that publishes one package and then fails on a later one no longer leaves `main`'s root `package-lock.json` drifted. Also extends RELEASE-RUNBOOK Failure mode 7 with this variant and its root cause.

## 2. Reasoning
The `4.0.0` release of `spacecat-shared-data-access` published and pushed its `chore(release)` commit, then the same run failed later at `spacecat-shared-ticket-client` (`404 - package not found` on the OIDC exchange → `ENONPMTOKEN`). Because the sync step was gated `if: success()`, the upstream `Semantic Release` failure short-circuited it — the step was **skipped**, not run. So `main` was left pinning `data-access@3.81.0` in the lock while `package.json` said `4.0.0`, and every open PR went red at `Verify package-lock.json is in sync` with a diff it did not author. The single scenario that most needs the re-sync (a release commit was pushed, then SR failed) was exactly the one the `success()` gate missed.

## 3. High-level overview of the changes
Behaviour delta in `.github/workflows/main.yaml` (Release job, sync step):

- **Gate `if: success()` → `if: success() || failure()`** (keeps `continue-on-error: true`). A partial `Semantic Release` failure now still triggers the lockfile re-sync. Cancellation stays excluded (not `always()`), so a job cancelled mid-push cannot race in a commit.
- **New HEAD-is-release-commit guard.** Before regenerating, the step checks that HEAD is a `chore(release): …` commit (the subject semantic-release pushes). On the `failure()` path this ensures it only commits when a release commit was actually pushed this run; on a failure *before* any release was committed (e.g. `npm ci` failed) HEAD is the triggering feat/fix commit, so the step no-ops instead of committing a spurious lock diff. The existing `git diff --quiet` drift check is unchanged.

Net effect across cases: clean-release-with-drift still heals (unchanged); the partial-failure case from the linked issue now heals (the fix); every other case (nothing released, early failure, cancellation) safely no-ops or is skipped.

Docs (`docs/RELEASE-RUNBOOK.md`, Failure mode 7): documents the `success() || failure()` gate + HEAD guard, and adds an "Underlying cause" subsection describing the real trigger — a newly-added publishable package with no npm trusted-publisher binding (OIDC `404` → `ENONPMTOKEN`), noting the accompanying `reading 'map'` TypeError is secondary noise, and pointing to Failure mode 1 for the binding bootstrap.

## 4. Required information
- Jira / issue: https://github.com/adobe/spacecat-shared/issues/1773

## 6. Additional information outside the code
- Traced the failing release run `28669792110` (Actions logs): confirmed `data-access@4.0.0` published + pushed its release commit at 15:45, then the `-ws` loop failed at `spacecat-shared-ticket-client`'s `verifyConditions` at 15:46 with `OIDC token exchange failed: 404 - package not found` → `ENONPMTOKEN No npm token specified`. The `TypeError: ... reading 'map'` originates in `semantic-release-monorepo/src/only-package-commits.js:26` and is a secondary crash, not the cause.
- Confirmed the root cause is live and ongoing: `npm view @adobe/spacecat-shared-ticket-client` returns `E404` (never published), and it is absent from `PACKAGES` in `scripts/setup-npm-trusted-publishers.sh`. The bootstrap of that binding is deliberately **out of scope** for this PR (tracked separately); until it is done, releases keep half-failing — but with this fix `main`'s lock auto-heals each time so PRs are no longer taxed.
- Validated the edited workflow: the YAML parses and the step's gate resolves to `success() || failure()`; the embedded shell (HEAD guard + regen) was checked against the full scenario matrix (clean / no-drift / nothing-released / partial-failure / early-failure / cancelled).

## 7. Test plan
- Local: the Release job runs only on `main`, so it cannot be exercised on a branch. Verified statically instead — parsed the workflow, confirmed the resolved gate, and walked the step's guard logic through each release outcome (see section 6).
- prod (`main`, next release): on the next merge that releases a package, confirm the `Sync package-lock.json after release` step runs. To exercise the fix specifically, after any partial `Semantic Release` failure that already pushed a `chore(release)` commit, confirm the step runs (green ✓) and pushes a `chore(release): sync package-lock.json after release [skip ci]` commit, and that subsequent unrelated PRs stay green at `Verify package-lock.json is in sync` (i.e. no manual FM-7 lockfile PR needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)