### PR TITLE
fix(project-engine-client): enforce https:// on the brand_urls mock

### DIFF
--- a/packages/spacecat-shared-project-engine-client/mock/brand-url-validation.js
+++ b/packages/spacecat-shared-project-engine-client/mock/brand-url-validation.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * The `url` validation the live Semrush Project Engine `POST .../brand_urls` enforces on every
+ * entry — the single source of truth behind the `brand_urls.js` route's 400, exposed on the
+ * per-request context as `context.brandUrlHttpsTag` (every route reads its lib helpers through
+ * `$.context`, never an import — see {@link Context}). Kept a pure function so it is unit-tested on
+ * its own (the route handler is coverage-excluded), the same convention as {@link resolveUrl} /
+ * {@link tagId}.
+ *
+ * Live contract (write-probed 2026-07-06 against prod `adobe-hackathon.semrush.com` — a throwaway
+ * benchmark in a test workspace, serenity-docs#25): a brand URL MUST be a literal `https://` URL.
+ * The go-validator on `BrandURLRequest.URL` runs two tags in order:
+ *   - `url`: the value must be a parseable absolute URL (scheme + host). A scheme-less value
+ *     (`instagram.com/lovesac`, `lovesac.com`, `www.x.com`) fails HERE → 400 `'url' tag`.
+ *   - `startswith=https://`: a valid but non-https URL (`http://x`, `ftp://x`) passes `url` but
+ *     fails HERE → 400 `'startswith' tag`.
+ * A conforming `https://…` value returns null (accepted, stored verbatim — the API does NOT
+ * normalize scheme/`www.`). Enforcing this in the mock keeps an IT from going green over a write
+ * the live gateway would 400 (the fidelity gap that let the url/resolve mis-design ship).
+ *
+ * @param {unknown} url the raw `url` field of a brand-URL entry
+ * @returns {'url' | 'startswith' | null} the failed go-validator tag, or null when accepted
+ */
+export const brandUrlHttpsTag = (url) => {
+  const value = typeof url === 'string' ? url : '';
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    // Not a parseable absolute URL (scheme-less / garbage) — fails the `url` tag.
+    return 'url';
+  }
+  // A URL with no host (e.g. `mailto:hi@x.com`) is not a brand URL either → `url` tag.
+  if (!parsed.host) {
+    return 'url';
+  }
+  // Valid URL, but the value must literally begin with `https://` (case-insensitive scheme).
+  if (!value.toLowerCase().startsWith('https://')) {
+    return 'startswith';
+  }
+  return null;
+};

--- a/packages/spacecat-shared-project-engine-client/mock/brand-url-validation.js
+++ b/packages/spacecat-shared-project-engine-client/mock/brand-url-validation.js
@@ -13,42 +13,114 @@
 // @ts-check
 
 /**
- * The `url` validation the live Semrush Project Engine `POST .../brand_urls` enforces on every
- * entry — the single source of truth behind the `brand_urls.js` route's 400, exposed on the
- * per-request context as `context.brandUrlHttpsTag` (every route reads its lib helpers through
- * `$.context`, never an import — see {@link Context}). Kept a pure function so it is unit-tested on
- * its own (the route handler is coverage-excluded), the same convention as {@link resolveUrl} /
- * {@link tagId}.
+ * The `url` tag as the DEPLOYED gateway actually behaves — derived from the 2026-07-13 write-probe,
+ * NOT from reading go-validator's source (the two disagree; see the `file:` note below).
  *
- * Live contract (write-probed 2026-07-06 against prod `adobe-hackathon.semrush.com` — a throwaway
- * benchmark in a test workspace, serenity-docs#25): a brand URL MUST be a literal `https://` URL.
- * The go-validator on `BrandURLRequest.URL` runs two tags in order:
- *   - `url`: the value must be a parseable absolute URL (scheme + host). A scheme-less value
- *     (`instagram.com/lovesac`, `lovesac.com`, `www.x.com`) fails HERE → 400 `'url' tag`.
- *   - `startswith=https://`: a valid but non-https URL (`http://x`, `ftp://x`) passes `url` but
- *     fails HERE → 400 `'startswith' tag`.
- * A conforming `https://…` value returns null (accepted, stored verbatim — the API does NOT
- * normalize scheme/`www.`). Enforcing this in the mock keeps an IT from going green over a write
- * the live gateway would 400 (the fidelity gap that let the url/resolve mis-design ship).
+ * It lower-cases the value, runs go's `net/url.Parse`, and demands a non-empty scheme plus a
+ * non-empty **host, fragment, or opaque** part. Reproduced by hand rather than through JS's `URL`,
+ * whose WHATWG parsing differs from go's in exactly the cases that matter: it silently trims
+ * surrounding whitespace (go rejects it), and it reports no `host` for the opaque forms go accepts.
+ *
+ * The `file:` scheme is exempt from the host/fragment/opaque rule entirely: every `file:` form
+ * probed — `file:etc/passwd`, `file:/etc/passwd`, `file:///etc/passwd`, and even the empty
+ * `file://` and `file:///` — cleared this tag and went on to fail `startswith`. (go-validator's
+ * CURRENT source would instead reject `file://` and `file:///` here, on a path check the deployed
+ * version evidently predates. The probe wins over the source.)
+ *
+ * @param {string} raw the non-empty `url` value
+ * @returns {boolean} whether the live `url` tag would pass
+ */
+function isGoParseableUrl(raw) {
+  const value = raw.toLowerCase();
+  // go's parser rejects ASCII control bytes outright, and its host parser rejects a space; a
+  // leading space also stops a scheme from being recognised. So any whitespace or control
+  // character anywhere in the value means "did not parse".
+  // eslint-disable-next-line no-control-regex
+  if (/[\s\u0000-\u001F\u007F]/.test(value)) {
+    return false;
+  }
+  const match = value.match(/^([a-z][a-z0-9+\-.]*):([\s\S]*)$/);
+  if (!match) {
+    return false; // no scheme → url.Scheme == "" → fail
+  }
+  const [, scheme, rest] = match;
+  if (scheme === 'file') {
+    return true; // exempt from the host/fragment/opaque rule — see above
+  }
+
+  // Split off the fragment, then classify the remainder: an authority (`//host/…`), a rooted path
+  // (`/…`, which leaves go's Host AND Opaque empty), or opaque (`mailto:hi@x`, `https:x.com`).
+  const hash = rest.indexOf('#');
+  const fragment = hash === -1 ? '' : rest.slice(hash + 1);
+  const beforeFragment = hash === -1 ? rest : rest.slice(0, hash);
+
+  let host = '';
+  let opaque = '';
+  if (beforeFragment.startsWith('//')) {
+    [host] = beforeFragment.slice(2).split(/[/?]/, 1);
+  } else if (!beforeFragment.startsWith('/')) {
+    opaque = beforeFragment;
+  }
+  return host !== '' || fragment !== '' || opaque !== '';
+}
+
+/**
+ * The validation the live Semrush Project Engine `POST .../brand_urls` enforces on every entry —
+ * the single source of truth behind the `brand_urls.js` route's 400, exposed on the per-request
+ * context as `context.brandUrlHttpsTag` (every route reads its lib helpers through `$.context`,
+ * never an import — see {@link Context}). Kept a pure function so it is unit-tested on its own (the
+ * route handler is coverage-excluded), the same convention as {@link resolveUrl} / {@link tagId}.
+ *
+ * Live contract (write-probed 2026-07-13 against prod `adobe-hackathon.semrush.com`, throwaway
+ * benchmarks in the LLMO-Dev-2 dev sub-workspace, serenity-docs#25): a brand URL MUST be a literal,
+ * lower-case `https://` URL. `BrandURLRequest.URL` carries the go-validator tags
+ * `required,url,startswith=https://`, evaluated in that order — and each tag's semantics are go's,
+ * not JS's, which is what this helper reproduces:
+ *
+ * - `required` — the zero value fails. A missing field, `null` and `""` are all the empty string in
+ *   go, so all three report `required` (NOT `url`).
+ * - `url` — see {@link isGoParseableUrl}. A scheme-less value (`lovesac.com`, `www.x.com`,
+ *   `//x.com`), a scheme with only a rooted path (`https:/x.com`), a bare `https://` or `https://#`
+ *   (empty fragment), and anything containing whitespace all fail HERE. Note `https://#frag` PASSES
+ *   — a non-empty fragment satisfies the tag even with no host.
+ * - `startswith=https://` — `strings.HasPrefix` against the RAW value, so it is CASE-SENSITIVE, and
+ *   it is reached by anything that parsed. `http://x`, `ftp://x`, an upper/mixed-case scheme
+ *   (`HTTPS://X`, `Https://x`), every `file:` form, and the hostless-but-opaque forms
+ *   (`mailto:hi@x`, `tel:+1`, `https:x.com`) all fail HERE, on `startswith` — not on `url`.
+ *
+ * A non-string `url` (e.g. `123`) never reaches the validator: go fails to unmarshal the body and
+ * the gateway answers `400 {"message":"invalid request body"}` with no tag at all, which is what
+ * `'invalid_body'` models. The `brand_urls` ROUTE never sees that case (nor a missing `url`) — the
+ * spec marks `BrandURLRequest.url` required and typed, so Counterfact's request validation 400s
+ * both before the handler runs. It is modelled here anyway so this function stays a total, truthful
+ * record of the live contract rather than one narrowed to whatever the mock's schema layer lets
+ * through. An empty string, by contrast, DOES satisfy the schema and reach the route → `required`.
+ *
+ * A conforming value returns null (accepted, stored verbatim — the API does NOT normalize the
+ * scheme or `www.`, and it accepts an upper-case HOST, an IDN host, an IP and a port/path/query).
+ * Enforcing all of this in the mock keeps an IT from going green over a write the live gateway
+ * would 400 (the fidelity gap that let the url/resolve mis-design ship).
  *
  * @param {unknown} url the raw `url` field of a brand-URL entry
- * @returns {'url' | 'startswith' | null} the failed go-validator tag, or null when accepted
+ * @returns {'invalid_body' | 'required' | 'url' | 'startswith' | null} the failed go-validator tag,
+ *   `'invalid_body'` for a non-string value (unmarshal error, no tag), or null when accepted
  */
 export const brandUrlHttpsTag = (url) => {
+  // A present-but-non-string `url` fails go's JSON unmarshal before any tag runs.
+  if (url !== undefined && url !== null && typeof url !== 'string') {
+    return 'invalid_body';
+  }
+  // `required`: a missing field, `null` and `""` are all go's empty string.
   const value = typeof url === 'string' ? url : '';
-  let parsed;
-  try {
-    parsed = new URL(value);
-  } catch {
-    // Not a parseable absolute URL (scheme-less / garbage) — fails the `url` tag.
+  if (value === '') {
+    return 'required';
+  }
+  // `url`: lower-case, parse, then scheme + (host | fragment | opaque).
+  if (!isGoParseableUrl(value)) {
     return 'url';
   }
-  // A URL with no host (e.g. `mailto:hi@x.com`) is not a brand URL either → `url` tag.
-  if (!parsed.host) {
-    return 'url';
-  }
-  // Valid URL, but the value must literally begin with `https://` (case-insensitive scheme).
-  if (!value.toLowerCase().startsWith('https://')) {
+  // `startswith=https://`: strings.HasPrefix on the RAW value — case-sensitive.
+  if (!value.startsWith('https://')) {
     return 'startswith';
   }
   return null;

--- a/packages/spacecat-shared-project-engine-client/mock/context.js
+++ b/packages/spacecat-shared-project-engine-client/mock/context.js
@@ -48,6 +48,7 @@ import { AI_MODEL_CATALOG } from './ai-model-catalog.js';
 import { tagId } from './tag-id.js';
 import { parentIdField } from './parent-id.js';
 import { resolveUrl } from './url-resolve.js';
+import { brandUrlHttpsTag } from './brand-url-validation.js';
 import { SEEDS, DEFAULT_SEED } from './seeds.js';
 
 /**
@@ -110,6 +111,10 @@ export class Context {
     // function rather than inline in the coverage-excluded handler — same `$.context` lib-helper
     // convention as `tagId`. The consumer resolves a raw brand URL through this before writing it.
     this.resolveUrl = resolveUrl;
+    // The brand-URL `https://` validator (mock/brand-url-validation.js). Exposed so the
+    // `POST .../brand_urls` route rejects a non-https value with the live gateway's 400 through one
+    // pure, unit-tested function — same `$.context` lib-helper convention as `tagId`.
+    this.brandUrlHttpsTag = brandUrlHttpsTag;
   }
 
   /**

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls.js
@@ -34,11 +34,16 @@ export function GET($) {
 export function POST($) {
   const { path, body, context } = $;
   const entries = Array.isArray(body) ? body : [];
-  // Live requires every brand URL to be a literal https:// value (write-probed prod, #25): a
-  // scheme-less value 400s on the go-validator `url` tag, a non-https URL on `startswith`. Enforce
-  // it here so an IT can't go green over a write the live gateway would reject.
+  // Live requires every brand URL to be a literal, lower-case https:// value (write-probed prod,
+  // #25 — see mock/brand-url-validation.js for the full tag matrix). The batch is ATOMIC: the first
+  // non-conforming entry 400s the whole request and NOTHING is created. Enforced here so an IT
+  // can't go green over a write the live gateway would reject.
+  //
+  // A MISSING or non-string `url` never reaches this loop — the spec marks `BrandURLRequest.url`
+  // required and typed, so Counterfact's request validation 400s it first. An empty string does
+  // reach us (it satisfies the schema), and yields go's `required` tag, exactly as live.
   for (const entry of entries) {
-    const tag = context.brandUrlHttpsTag(entry?.url);
+    const tag = context.brandUrlHttpsTag(entry.url);
     if (tag) {
       return $.response[400].json(context.factories.createBasicResponseMock({
         message: `Key: 'BrandURLRequest.URL' Error:Field validation for 'URL' failed on the '${tag}' tag`,

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls.js
@@ -34,6 +34,17 @@ export function GET($) {
 export function POST($) {
   const { path, body, context } = $;
   const entries = Array.isArray(body) ? body : [];
+  // Live requires every brand URL to be a literal https:// value (write-probed prod, #25): a
+  // scheme-less value 400s on the go-validator `url` tag, a non-https URL on `startswith`. Enforce
+  // it here so an IT can't go green over a write the live gateway would reject.
+  for (const entry of entries) {
+    const tag = context.brandUrlHttpsTag(entry?.url);
+    if (tag) {
+      return $.response[400].json(context.factories.createBasicResponseMock({
+        message: `Key: 'BrandURLRequest.URL' Error:Field validation for 'URL' failed on the '${tag}' tag`,
+      }));
+    }
+  }
   const created = context.ops.brand_urls.createMany(
     { workspaceId: path.id, projectId: path.project_id, benchmarkId: path.benchmark_id },
     entries.map((u) => context.factories.createBrandUrlMock({

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -1644,6 +1644,30 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     expect(after.brand_urls.map((u) => u.id)).to.not.include(created.ids[0]);
   });
 
+  it('rejects a non-https brand URL with the live 400 (https:// required, #25)', async () => {
+    const { benchmarkId } = SEED_IDS;
+    const BRAND_URLS = '/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls';
+    const path = { id: SEED_WORKSPACE, project_id: SEED_PROJECT, benchmark_id: benchmarkId };
+
+    // Scheme-less (the resolve `primary_url` form) → 400 on the go-validator `url` tag, exactly
+    // as prod: the value cannot be written as a brand URL. Guards the mock against going green
+    // over a write the live gateway rejects.
+    const { response, error } = await client.POST(BRAND_URLS, {
+      params: { path },
+      body: [{ url: 'lovesac.com', type: 'website' }],
+    });
+    expect(response.status).to.equal(400);
+    expect(error.message).to.match(/failed on the 'url' tag/);
+
+    // A valid but http:// URL → 400 on `startswith`.
+    const { response: httpRes, error: httpErr } = await client.POST(BRAND_URLS, {
+      params: { path },
+      body: [{ url: 'http://lovesac.com', type: 'website' }],
+    });
+    expect(httpRes.status).to.equal(400);
+    expect(httpErr.message).to.match(/failed on the 'startswith' tag/);
+  });
+
   it('publishProject + getInitStatus respond with the intended mock contract', async () => {
     const { response: pubRes } = await client.POST(
       '/v1/workspaces/{id}/projects/{project_id}/publish',

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -1899,11 +1899,13 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     const GOOD = 'https://atomicity-probe.example.net';
 
     // Live is atomic: a good entry alongside a bad one is NOT created (verified by write-probe).
-    const { response } = await client.POST(BRAND_URLS, {
+    const { response, error } = await client.POST(BRAND_URLS, {
       params: { path },
       body: [{ url: GOOD, type: 'website' }, { url: 'lovesac.com', type: 'website' }],
     });
     expect(response.status).to.equal(400);
+    // The 400 came from the validation gate, not from some other source.
+    expect(error.message).to.match(/failed on the 'url' tag/);
 
     const { data } = await client.GET(BRAND_URLS, { params: { path } });
     expect(data.brand_urls.map((u) => u.url)).to.not.include(GOOD);

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -1856,6 +1856,57 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     });
     expect(httpRes.status).to.equal(400);
     expect(httpErr.message).to.match(/failed on the 'startswith' tag/);
+
+    // An upper-case scheme → `startswith`, not an accept: go's HasPrefix is case-SENSITIVE.
+    const { response: upRes, error: upErr } = await client.POST(BRAND_URLS, {
+      params: { path },
+      body: [{ url: 'HTTPS://LOVESAC.COM', type: 'website' }],
+    });
+    expect(upRes.status).to.equal(400);
+    expect(upErr.message).to.match(/failed on the 'startswith' tag/);
+
+    // An opaque, hostless URL clears go's `url` tag and dies on `startswith`.
+    const { response: mailRes, error: mailErr } = await client.POST(BRAND_URLS, {
+      params: { path },
+      body: [{ url: 'mailto:hi@lovesac.com', type: 'website' }],
+    });
+    expect(mailRes.status).to.equal(400);
+    expect(mailErr.message).to.match(/failed on the 'startswith' tag/);
+
+    // An empty url → `required` (go's zero value), reported before `url` is ever evaluated. This
+    // is the one empty-ish form that satisfies the request schema and so reaches the gate; a
+    // MISSING or non-string url is 400ed earlier by request validation (asserted below).
+    const { response: reqRes, error: reqErr } = await client.POST(BRAND_URLS, {
+      params: { path },
+      body: [{ url: '', type: 'website' }],
+    });
+    expect(reqRes.status).to.equal(400);
+    expect(reqErr.message).to.match(/failed on the 'required' tag/);
+
+    // A missing url is rejected by request validation (the spec marks it required) — still a 400,
+    // just not one this gate produces.
+    const { response: missingRes } = await client.POST(BRAND_URLS, {
+      params: { path },
+      body: [{ type: 'website' }],
+    });
+    expect(missingRes.status).to.equal(400);
+  });
+
+  it('rejects the whole batch atomically when one entry is non-https (#25)', async () => {
+    const { benchmarkId } = SEED_IDS;
+    const BRAND_URLS = '/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls';
+    const path = { id: SEED_WORKSPACE, project_id: SEED_PROJECT, benchmark_id: benchmarkId };
+    const GOOD = 'https://atomicity-probe.example.net';
+
+    // Live is atomic: a good entry alongside a bad one is NOT created (verified by write-probe).
+    const { response } = await client.POST(BRAND_URLS, {
+      params: { path },
+      body: [{ url: GOOD, type: 'website' }, { url: 'lovesac.com', type: 'website' }],
+    });
+    expect(response.status).to.equal(400);
+
+    const { data } = await client.GET(BRAND_URLS, { params: { path } });
+    expect(data.brand_urls.map((u) => u.url)).to.not.include(GOOD);
   });
 
   it('publishProject + getInitStatus respond with the intended mock contract', async () => {

--- a/packages/spacecat-shared-project-engine-client/test/mock/brand-url-validation.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/brand-url-validation.test.js
@@ -13,15 +13,33 @@
 import { expect } from 'chai';
 import { brandUrlHttpsTag } from '../../mock/brand-url-validation.js';
 
-// The route handler is coverage-excluded, so the https:// validation is unit-tested here against
-// the live contract write-probed 2026-07-06 (serenity-docs#25): a brand URL must be a literal
-// https:// value; a scheme-less value fails the `url` tag, a non-https URL the `startswith` tag.
+// Every value below was POSTed to the LIVE Semrush `create_brand_urls` during the 2026-07-13
+// write-probe (prod `adobe-hackathon.semrush.com`, throwaway benchmarks in the LLMO-Dev-2 dev
+// sub-workspace, serenity-docs#25), and the expectation is the tag prod actually answered with.
+// `BrandURLRequest.URL` is `required,url,startswith=https://`, evaluated in that order — so the
+// cases that matter are the ones where go's semantics differ from JS's: a case-SENSITIVE
+// `startswith`, opaque URLs, and untrimmed whitespace.
 describe('brand-url-validation', () => {
-  it('accepts an https:// URL (apex, www, path, uppercase host) → null', () => {
+  it('accepts a literal lower-case https:// URL → null', () => {
     expect(brandUrlHttpsTag('https://lovesac.com')).to.equal(null);
     expect(brandUrlHttpsTag('https://www.lovesac.com')).to.equal(null);
     expect(brandUrlHttpsTag('https://x.com/Lovesac')).to.equal(null);
-    expect(brandUrlHttpsTag('HTTPS://LOVESAC.COM')).to.equal(null);
+    expect(brandUrlHttpsTag('https://lovesac.com:8443/p?q=1#f')).to.equal(null);
+    // Only the SCHEME must be literal — an upper-case host is fine (live: 200).
+    expect(brandUrlHttpsTag('https://LOVESAC.COM')).to.equal(null);
+    // Live accepts an IP, a bare host and an IDN host too.
+    expect(brandUrlHttpsTag('https://192.168.0.1')).to.equal(null);
+    expect(brandUrlHttpsTag('https://localhost')).to.equal(null);
+    expect(brandUrlHttpsTag('https://exämple.net')).to.equal(null);
+    // No host at all, but a fragment — which satisfies go's `url` tag (live: 200).
+    expect(brandUrlHttpsTag('https://#frag')).to.equal(null);
+  });
+
+  it('rejects an upper/mixed-case scheme on `startswith` (HasPrefix is case-SENSITIVE)', () => {
+    // These parse fine, so go reaches `startswith` — which compares the RAW bytes.
+    expect(brandUrlHttpsTag('HTTPS://LOVESAC.COM')).to.equal('startswith');
+    expect(brandUrlHttpsTag('Https://lovesac.com')).to.equal('startswith');
+    expect(brandUrlHttpsTag('hTTps://lovesac.com')).to.equal('startswith');
   });
 
   it('rejects a scheme-less value on the `url` tag', () => {
@@ -29,17 +47,65 @@ describe('brand-url-validation', () => {
     expect(brandUrlHttpsTag('lovesac.com')).to.equal('url');
     expect(brandUrlHttpsTag('www.lovesac.com')).to.equal('url');
     expect(brandUrlHttpsTag('instagram.com/lovesac')).to.equal('url');
+    expect(brandUrlHttpsTag('//lovesac.com')).to.equal('url');
     expect(brandUrlHttpsTag('not a url')).to.equal('url');
-    expect(brandUrlHttpsTag('')).to.equal('url');
-    expect(brandUrlHttpsTag(undefined)).to.equal('url');
   });
 
   it('rejects a valid but non-https URL on the `startswith` tag', () => {
     expect(brandUrlHttpsTag('http://lovesac.com')).to.equal('startswith');
+    expect(brandUrlHttpsTag('HTTP://lovesac.com')).to.equal('startswith');
     expect(brandUrlHttpsTag('ftp://lovesac.com')).to.equal('startswith');
   });
 
-  it('rejects a scheme with no host (e.g. mailto:) on the `url` tag', () => {
-    expect(brandUrlHttpsTag('mailto:hi@lovesac.com')).to.equal('url');
+  it('rejects an opaque / hostless URL on `startswith`, NOT on `url`', () => {
+    // The `url` tag accepts a scheme carrying opaque content (no host), so these get PAST it and
+    // die on `startswith` — the tag a JS `URL.host` check gets wrong.
+    expect(brandUrlHttpsTag('mailto:hi@lovesac.com')).to.equal('startswith');
+    expect(brandUrlHttpsTag('tel:+41791234567')).to.equal('startswith');
+    // eslint-disable-next-line no-script-url -- a probed live input, not a URL we ever navigate to
+    expect(brandUrlHttpsTag('javascript:alert(1)')).to.equal('startswith');
+    expect(brandUrlHttpsTag('https:lovesac.com')).to.equal('startswith'); // opaque, not `https://`
+  });
+
+  it('rejects EVERY file: form on `startswith` (the scheme is exempt from the `url` tag)', () => {
+    // Probed live: all five clear `url` — even the empty ones, which go-validator's current source
+    // says should fail it. The deployed validator predates that path check.
+    expect(brandUrlHttpsTag('file:///etc/passwd')).to.equal('startswith');
+    expect(brandUrlHttpsTag('file:/etc/passwd')).to.equal('startswith');
+    expect(brandUrlHttpsTag('file:etc/passwd')).to.equal('startswith');
+    expect(brandUrlHttpsTag('file://')).to.equal('startswith');
+    expect(brandUrlHttpsTag('file:///')).to.equal('startswith');
+  });
+
+  it('rejects a degenerate URL on the `url` tag', () => {
+    expect(brandUrlHttpsTag('https:/lovesac.com')).to.equal('url'); // single slash → rooted path
+    expect(brandUrlHttpsTag('https://')).to.equal('url'); // scheme only: no host/fragment/opaque
+    expect(brandUrlHttpsTag('https://#')).to.equal('url'); // EMPTY fragment does not satisfy it
+  });
+
+  it('lets a non-empty fragment stand in for a missing host', () => {
+    // A rooted path alone fails `url`, but the same value with a fragment clears it and falls
+    // through to `startswith` — the fragment, not the path, is what the tag counts.
+    expect(brandUrlHttpsTag('https:/lovesac.com#frag')).to.equal('startswith');
+  });
+
+  it('rejects whitespace on the `url` tag (go does not trim it; JS `URL` would)', () => {
+    expect(brandUrlHttpsTag(' https://lovesac.com')).to.equal('url');
+    expect(brandUrlHttpsTag('https://lovesac.com ')).to.equal('url');
+    expect(brandUrlHttpsTag('https://love sac.com')).to.equal('url');
+  });
+
+  it('reports a missing / null / empty url on the `required` tag', () => {
+    // All three are go's empty string, so `required` fires before `url` is ever evaluated.
+    expect(brandUrlHttpsTag('')).to.equal('required');
+    expect(brandUrlHttpsTag(undefined)).to.equal('required');
+    expect(brandUrlHttpsTag(null)).to.equal('required');
+  });
+
+  it('reports a non-string url as an unmarshal failure, not a tag', () => {
+    // Live answers `400 {"message":"invalid request body"}` — go never reaches the validator.
+    expect(brandUrlHttpsTag(123)).to.equal('invalid_body');
+    expect(brandUrlHttpsTag(true)).to.equal('invalid_body');
+    expect(brandUrlHttpsTag({ url: 'https://lovesac.com' })).to.equal('invalid_body');
   });
 });

--- a/packages/spacecat-shared-project-engine-client/test/mock/brand-url-validation.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/brand-url-validation.test.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { brandUrlHttpsTag } from '../../mock/brand-url-validation.js';
+
+// The route handler is coverage-excluded, so the https:// validation is unit-tested here against
+// the live contract write-probed 2026-07-06 (serenity-docs#25): a brand URL must be a literal
+// https:// value; a scheme-less value fails the `url` tag, a non-https URL the `startswith` tag.
+describe('brand-url-validation', () => {
+  it('accepts an https:// URL (apex, www, path, uppercase host) → null', () => {
+    expect(brandUrlHttpsTag('https://lovesac.com')).to.equal(null);
+    expect(brandUrlHttpsTag('https://www.lovesac.com')).to.equal(null);
+    expect(brandUrlHttpsTag('https://x.com/Lovesac')).to.equal(null);
+    expect(brandUrlHttpsTag('HTTPS://LOVESAC.COM')).to.equal(null);
+  });
+
+  it('rejects a scheme-less value on the `url` tag', () => {
+    // The resolve `primary_url` form — cannot be written as a brand URL.
+    expect(brandUrlHttpsTag('lovesac.com')).to.equal('url');
+    expect(brandUrlHttpsTag('www.lovesac.com')).to.equal('url');
+    expect(brandUrlHttpsTag('instagram.com/lovesac')).to.equal('url');
+    expect(brandUrlHttpsTag('not a url')).to.equal('url');
+    expect(brandUrlHttpsTag('')).to.equal('url');
+    expect(brandUrlHttpsTag(undefined)).to.equal('url');
+  });
+
+  it('rejects a valid but non-https URL on the `startswith` tag', () => {
+    expect(brandUrlHttpsTag('http://lovesac.com')).to.equal('startswith');
+    expect(brandUrlHttpsTag('ftp://lovesac.com')).to.equal('startswith');
+  });
+
+  it('rejects a scheme with no host (e.g. mailto:) on the `url` tag', () => {
+    expect(brandUrlHttpsTag('mailto:hi@lovesac.com')).to.equal('url');
+  });
+});

--- a/packages/spacecat-shared-project-engine-client/test/mock/brand-url-validation.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/brand-url-validation.test.js
@@ -95,6 +95,14 @@ describe('brand-url-validation', () => {
     expect(brandUrlHttpsTag('https://love sac.com')).to.equal('url');
   });
 
+  it('rejects a control byte on the `url` tag (go refuses to parse one at all)', () => {
+    // Probed live: NUL, U+0001 and U+007F all 400 on `url`, wherever they sit in the value.
+    expect(brandUrlHttpsTag(`https://x${String.fromCharCode(0x01)}.com`)).to.equal('url');
+    expect(brandUrlHttpsTag(`https://x${String.fromCharCode(0x7f)}.com`)).to.equal('url');
+    expect(brandUrlHttpsTag(`https://x.com${String.fromCharCode(0x01)}`)).to.equal('url');
+    expect(brandUrlHttpsTag(`https://x${String.fromCharCode(0x00)}.com`)).to.equal('url');
+  });
+
   it('reports a missing / null / empty url on the `required` tag', () => {
     // All three are go's empty string, so `required` fires before `url` is ever evaluated.
     expect(brandUrlHttpsTag('')).to.equal('required');


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
The vendored Project Engine mock now enforces the live Semrush validation on `POST .../brand_urls`: a brand URL must be a literal, lower-case `https://` URL, and the mock answers a non-conforming entry with the same 400 (and the same go-validator tag) the live gateway returns, instead of silently accepting it.

## 2. Reasoning
While reworking the serenity-docs#25 brand-URL feature, a prod write-probe showed `create_brand_urls` REQUIRES a literal `https://`: a scheme-less value 400s on the go-validator `url` tag, and a valid non-https URL (`http://`, `ftp://`) 400s on the `startswith=https://` tag. The mock accepted all of these, so an integration test could go green over a write the live gateway rejects — exactly the fidelity gap that let the earlier "resolve brand URLs to their scheme-less form before writing" mis-design ship (the scheme-less resolve value cannot be written as a brand URL at all).

Because the point of this gate is fidelity, the contract was probed rather than inferred: ~40 edge cases were POSTed to the live API and the mock reproduces the observed matrix, including the places where go's semantics differ from JavaScript's and a `URL`-based check silently gets the wrong answer.

## 3. High-level overview of the changes
Before: the mock's `POST .../brand_urls` handler created a row for any `{ url, type }` entry, regardless of scheme, and always returned 200.

After: each entry's `url` is validated against the live contract before any row is created. A non-conforming entry short-circuits the whole batch with the gateway's 400 `BasicResponse`, naming the tag live names. `BrandURLRequest.URL` carries `required,url,startswith=https://`, evaluated in that order:

- `required` — an empty (or null/missing) value; reported before `url` is ever evaluated.
- `url` — the value must parse, under go's rules: a non-empty scheme plus a host, a fragment, or opaque content. A scheme-less value (`lovesac.com`, `www.x.com`, `//x.com`), a scheme with only a rooted path (`https:/x.com`), a bare `https://`, and any value containing whitespace fail here.
- `startswith=https://` — a literal, case-SENSITIVE prefix check against the raw value, reached by anything that parsed. `http://`, `ftp://`, an upper- or mixed-case scheme (`HTTPS://X`, `Https://x`), every `file:` form, and the hostless-but-opaque forms (`mailto:`, `tel:`, `https:x.com`) fail here — not on `url`.

A conforming value is accepted and stored verbatim (no scheme or `www.` normalization), unchanged from today; an upper-case host, an IDN host, an IP, and a port/path/query are all accepted, as is `https://#frag` (a non-empty fragment satisfies `url` even with no host). The batch is atomic: one bad entry creates nothing.

The check lives in a pure `brandUrlHttpsTag` helper exposed on the request context (same convention as the existing `resolveUrl` / `tagId` lib helpers), so it is unit-tested independently of the coverage-excluded route handler. It reproduces go's parse by hand rather than delegating to JavaScript's `URL`, whose WHATWG parsing disagrees with go exactly where it matters: it trims surrounding whitespace, and it reports no host for the opaque forms go accepts.

## 4. Required information
- Jira / issue: serenity-docs#25 — https://github.com/adobe/serenity-docs/issues/25
- Other: write-probe of the live `create_brand_urls` contract (2026-07-13, throwaway benchmarks in a dev workspace, cleaned up in the same run)

## 5. Affected / used mysticat-workspace projects
- spacecat-api-service (consumer) — its serenity brand-URL write path (PR #2748) writes only `https://` brand URLs after the skip-primary-domain redesign; this mock keeps its integration tests honest to the live 400.
- mysticat-data-service (consumer) — the serenity_migration CLI (PR #737) likewise writes only `https://` brand URLs; same fidelity guarantee.

## 6. Additional information outside the code
The contract was captured by a live write-probe against prod `adobe-hackathon.semrush.com` on 2026-07-13: throwaway competitor benchmarks were created in the LLMO-Dev-2 dev sub-workspace, ~40 candidate values were POSTed one per request, the accept/reject verdict and go-validator tag were recorded for each, and every benchmark and row created was deleted in the same run. No customer data was touched.

Two results are worth calling out because they contradict what the code would otherwise assume:
- go-validator's `startswith` is `strings.HasPrefix` against the raw value, so an upper-case scheme (`HTTPS://…`) is rejected, while an upper-case host (`https://EXAMPLE.NET`) is fine. Only the scheme must be literal.
- every `file:` form clears the `url` tag and fails on `startswith` — including `file://` and `file:///`, which go-validator's current source would reject on `url`. The deployed validator predates that path check, so the probed behaviour is what the mock models; the code says so at the point it matters.

## 7. Test plan
- Unit: the probed matrix is recorded case by case against the pure helper — accepts, the case-sensitivity of the scheme, scheme-less, non-https, opaque/hostless, `file:`, degenerate and whitespace forms, `required`, and the non-string unmarshal failure. The package's 100% branch-coverage gate is met.
- E2E (`test:e2e`, which boots the real mock server): the route answers the live 400 and tag over real HTTP for the scheme-less, `http://`, upper-case-scheme, `mailto:` and empty-url forms, a missing url is rejected by request validation, the batch is proven atomic (a good entry alongside a bad one is not created), and the existing create/list/delete e2e (which uses an `https://` URL) still passes through the new gate.
- No environment rollout applies — this is a test-only mock artifact in a shared package; it ships in the next `spacecat-shared-project-engine-client` release and is picked up by consumers when they bump.

## 8. Deployment & merge order
- serenity-docs#25 redesign is a coordinated set: this mock fix hardens the contract that spacecat-api-service PR #2748 (https://github.com/adobe/spacecat-api-service/pull/2748) and mysticat-data-service PR #737 (https://github.com/adobe/mysticat-data-service/pull/737) rely on. It is independent to merge (the consumers do not import it at runtime), but merging it first and cutting a release lets those PRs' integration tests run against the tightened mock. Suggested order: this PR (+ release) → then #2748 / #737.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
