### PR TITLE
fix(ticket-client): preserve tokenRefreshedAt on inline token refresh

### DIFF
--- a/packages/spacecat-shared-ticket-client/src/credentials/oauth-credential-manager.js
+++ b/packages/spacecat-shared-ticket-client/src/credentials/oauth-credential-manager.js
@@ -449,7 +449,7 @@ export default class OAuthCredentialManager {
       SecretString: JSON.stringify({
         accessToken: refreshed.access_token,
         refreshToken: refreshed.refresh_token,
-        // expiresAt: epoch ms; tokenRefreshedAt: ISO 8601 — both match auth-service contract
+        // expiresAt: epoch ms (numeric comparisons); tokenRefreshedAt: ISO 8601 (audit/display)
         expiresAt: Date.now() + refreshed.expires_in * 1000,
         tokenRefreshedAt: new Date().toISOString(),
         requiresReauth: false,

--- a/packages/spacecat-shared-ticket-client/src/credentials/oauth-credential-manager.js
+++ b/packages/spacecat-shared-ticket-client/src/credentials/oauth-credential-manager.js
@@ -449,6 +449,7 @@ export default class OAuthCredentialManager {
       SecretString: JSON.stringify({
         accessToken: refreshed.access_token,
         refreshToken: refreshed.refresh_token,
+        // expiresAt: epoch ms; tokenRefreshedAt: ISO 8601 — both match auth-service contract
         expiresAt: Date.now() + refreshed.expires_in * 1000,
         tokenRefreshedAt: new Date().toISOString(),
         requiresReauth: false,

--- a/packages/spacecat-shared-ticket-client/src/credentials/oauth-credential-manager.js
+++ b/packages/spacecat-shared-ticket-client/src/credentials/oauth-credential-manager.js
@@ -450,6 +450,7 @@ export default class OAuthCredentialManager {
         accessToken: refreshed.access_token,
         refreshToken: refreshed.refresh_token,
         expiresAt: Date.now() + refreshed.expires_in * 1000,
+        tokenRefreshedAt: new Date().toISOString(),
         requiresReauth: false,
       }),
     };

--- a/packages/spacecat-shared-ticket-client/test/oauth-credential-manager.test.js
+++ b/packages/spacecat-shared-ticket-client/test/oauth-credential-manager.test.js
@@ -330,6 +330,8 @@ describe('OAuthCredentialManager', () => {
       expect(httpClient.fetch.calledOnce).to.be.true;
       const written = JSON.parse(smClient.putSecretValue.firstCall.args[0].SecretString);
       expect(written.requiresReauth).to.be.false;
+      expect(written.tokenRefreshedAt).to.be.a('string');
+      expect(new Date(written.tokenRefreshedAt).getTime()).to.be.closeTo(Date.now(), 5000);
     });
 
     it('sends client_id, client_secret, grant_type, and refresh_token in Atlassian request', async () => {


### PR DESCRIPTION
## Summary

- Adds `tokenRefreshedAt` (ISO 8601 timestamp) to the SM secret payload written by `OAuthCredentialManager#writeTokens()` on inline token refresh
- Previously, auth-service wrote this field at OAuth callback time, but ticket-client's inline refresh overwrote the secret without it — the timestamp disappeared after the first inline refresh

## Context

Found during alignment review of auth-service PR #595 against ticket-client PR #1701. The field is observability-only (not read by any code path), but ops tooling that inspects SM secrets to check token freshness loses the timestamp.

## Test plan

- [x] Existing test updated to verify `tokenRefreshedAt` is present and recent in written SM payload
- [x] 200 tests passing, 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)