### PR TITLE
fix(akamai-client): re-sign EdgeGrid requests across redirects

### DIFF
--- a/packages/spacecat-shared-akamai-client/src/akamai-client.js
+++ b/packages/spacecat-shared-akamai-client/src/akamai-client.js
@@ -15,6 +15,9 @@ import { hasText, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
 import { signRequest } from './edgegrid-auth.js';
 
 const REQUIRED_CONFIG_KEYS = ['host', 'clientToken', 'clientSecret', 'accessToken'];
+// The HTTP redirect statuses we follow manually (re-signing each hop). Excludes 300 (multiple
+// choices) and 304 (not modified), which are not location-driven redirects to follow.
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const SEARCH_KEYS = ['hostname', 'edgeHostname', 'propertyName'];
 const ACTIVATION_NETWORKS = ['STAGING', 'PRODUCTION'];
 // Akamai rule formats are "latest" or a dated token like "v2024-01-01". A strict
@@ -184,17 +187,31 @@ export default class AkamaiClient {
         throw new Error(`PAPI ${method} ${path} request failed: ${e.message}`);
       }
 
-      const isRedirect = res.status >= 300 && res.status < 400;
-      const location = isRedirect ? res.headers.get('location') : null;
+      const location = REDIRECT_STATUSES.has(res.status) ? res.headers.get('location') : null;
       if (!location) {
         break;
+      }
+      // Only safe, body-less methods are followed. PAPI only redirects idempotent GETs; replaying
+      // a POST/PUT body to a redirect target would be semantically wrong, so refuse it explicitly
+      // rather than silently re-issue the mutation elsewhere.
+      if (method !== 'GET' && method !== 'HEAD') {
+        throw new Error(`PAPI ${method} ${path} -> unexpected redirect (${res.status})`);
       }
       if (hop >= 5) {
         throw new Error(`PAPI ${method} ${path} -> too many redirects`);
       }
-      // Resolve relative Locations against the current URL, then re-sign for the new URL on the
-      // next iteration. Method and body are preserved (PAPI only redirects idempotent GETs here).
-      url = new URL(location, url).toString();
+      // Re-signing attaches the Authorization header to the redirect target, so refuse to cross to
+      // a different host (mirrors browsers stripping Authorization on cross-origin redirects) — the
+      // client only ever legitimately talks to its configured EdgeGrid host. Relative Locations
+      // resolve against the current URL and stay same-host.
+      const redirectUrl = new URL(location, url);
+      if (redirectUrl.host !== new URL(url).host) {
+        throw new Error(
+          `PAPI ${method} ${path} -> redirect to different host rejected: ${redirectUrl.host}`,
+        );
+      }
+      // Re-sign for the new URL on the next iteration.
+      url = redirectUrl.toString();
     }
 
     if (!res.ok) {

--- a/packages/spacecat-shared-akamai-client/src/akamai-client.js
+++ b/packages/spacecat-shared-akamai-client/src/akamai-client.js
@@ -149,31 +149,52 @@ export default class AkamaiClient {
   }
 
   async #request(method, path, { params, body, headers } = {}) {
-    const url = this.#buildUrl(path, params);
     const bodyStr = body ? JSON.stringify(body) : undefined;
-    const authorization = signRequest({
-      method,
-      url,
-      body: bodyStr,
-      clientToken: this.#clientToken,
-      clientSecret: this.#clientSecret,
-      accessToken: this.#accessToken,
-    });
 
+    // The EG1-HMAC-SHA256 signature is bound to the exact request URL, so a followed redirect
+    // would carry an Authorization header signed for the *previous* URL and be rejected with a
+    // 401 "signature does not match". PAPI relies on redirects for some GETs (e.g.
+    // /versions/latest 301s to /versions/{N}), so we follow them manually and RE-SIGN each hop.
+    let url = this.#buildUrl(path, params);
     let res;
-    try {
-      res = await fetch(url, {
+    for (let hop = 0; ; hop += 1) {
+      const authorization = signRequest({
         method,
-        headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
-          Authorization: authorization,
-          ...headers,
-        },
+        url,
         body: bodyStr,
+        clientToken: this.#clientToken,
+        clientSecret: this.#clientSecret,
+        accessToken: this.#accessToken,
       });
-    } catch (e) {
-      throw new Error(`PAPI ${method} ${path} request failed: ${e.message}`);
+
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        res = await fetch(url, {
+          method,
+          redirect: 'manual',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            Authorization: authorization,
+            ...headers,
+          },
+          body: bodyStr,
+        });
+      } catch (e) {
+        throw new Error(`PAPI ${method} ${path} request failed: ${e.message}`);
+      }
+
+      const isRedirect = res.status >= 300 && res.status < 400;
+      const location = isRedirect ? res.headers.get('location') : null;
+      if (!location) {
+        break;
+      }
+      if (hop >= 5) {
+        throw new Error(`PAPI ${method} ${path} -> too many redirects`);
+      }
+      // Resolve relative Locations against the current URL, then re-sign for the new URL on the
+      // next iteration. Method and body are preserved (PAPI only redirects idempotent GETs here).
+      url = new URL(location, url).toString();
     }
 
     if (!res.ok) {

--- a/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
+++ b/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
@@ -211,6 +211,42 @@ describe('AkamaiClient', () => {
       await expect(client.getLatestVersion(PROPERTY_ID, CONTRACT_ID, GROUP_ID))
         .to.be.rejectedWith(/no versions/);
     });
+
+    // PAPI 301-redirects /versions/latest to the concrete /versions/{N}. Because the EdgeGrid
+    // signature is bound to the request URL, the client must follow the redirect manually and
+    // re-sign for the new URL (a followed-and-not-re-signed request is rejected 401).
+    it('follows a redirect and re-signs the request for the new URL', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/versions/latest`)
+        .query({ contractId: CONTRACT_ID, groupId: GROUP_ID })
+        .matchHeader('Authorization', hasEdgeGridAuth)
+        .reply(301, '', {
+          Location: `${API_BASE}/papi/v1/properties/${PROPERTY_ID}/versions/7`
+            + `?contractId=${CONTRACT_ID}&groupId=${GROUP_ID}`,
+        });
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/versions/7`)
+        .query({ contractId: CONTRACT_ID, groupId: GROUP_ID })
+        .matchHeader('Authorization', hasEdgeGridAuth)
+        .reply(200, { versions: { items: [{ propertyVersion: 7 }] } });
+
+      const version = await client.getLatestVersion(PROPERTY_ID, CONTRACT_ID, GROUP_ID);
+      expect(version).to.equal(7);
+    });
+
+    it('gives up after too many redirects', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/versions/latest`)
+        .query({ contractId: CONTRACT_ID, groupId: GROUP_ID })
+        .times(6)
+        .reply(301, '', {
+          Location: `/papi/v1/properties/${PROPERTY_ID}/versions/latest`
+            + `?contractId=${CONTRACT_ID}&groupId=${GROUP_ID}`,
+        });
+
+      await expect(client.getLatestVersion(PROPERTY_ID, CONTRACT_ID, GROUP_ID))
+        .to.be.rejectedWith(/too many redirects/);
+    });
   });
 
   // ─── searchBy / findPropertiesByDomain ─────────────────────────────────

--- a/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
+++ b/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
@@ -247,6 +247,32 @@ describe('AkamaiClient', () => {
       await expect(client.getLatestVersion(PROPERTY_ID, CONTRACT_ID, GROUP_ID))
         .to.be.rejectedWith(/too many redirects/);
     });
+
+    // Re-signing re-attaches the Authorization header to the redirect target, so a cross-host
+    // Location must be refused rather than leaking EdgeGrid credentials to another origin.
+    it('refuses to follow a redirect to a different host', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/versions/latest`)
+        .query({ contractId: CONTRACT_ID, groupId: GROUP_ID })
+        .reply(301, '', { Location: 'https://evil.example.com/papi/v1/steal' });
+
+      await expect(client.getLatestVersion(PROPERTY_ID, CONTRACT_ID, GROUP_ID))
+        .to.be.rejectedWith(/redirect to different host rejected: evil\.example\.com/);
+    });
+
+    // Following a redirect only makes sense for safe, body-less methods; replaying a POST/PUT
+    // body to the redirect target would silently re-issue the mutation elsewhere.
+    it('refuses to follow a redirect on a non-GET request', async () => {
+      nock(API_BASE)
+        .post(`/papi/v1/properties/${PROPERTY_ID}/activations`)
+        .query(true)
+        .reply(307, '', {
+          Location: `${API_BASE}/papi/v1/properties/${PROPERTY_ID}/activations-elsewhere`,
+        });
+
+      await expect(client.activate(PROPERTY_ID, 5, CONTRACT_ID, GROUP_ID, 'STAGING'))
+        .to.be.rejectedWith(/unexpected redirect \(307\)/);
+    });
   });
 
   // ─── searchBy / findPropertiesByDomain ─────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes a bug in `@adobe/spacecat-shared-akamai-client` where EdgeGrid-signed requests failed with `401 "The signature does not match"` whenever PAPI returned a redirect.

PAPI 301-redirects some GETs to a concrete URL — most notably `GET /papi/v1/properties/{id}/versions/latest` → `/versions/{N}`. The `EG1-HMAC-SHA256` signature is bound to the **exact request URL**, so the transparently-followed redirect carried an `Authorization` header signed for the *previous* URL and was rejected:

```
401 pep-authn/deny  "The signature does not match"
```

This broke `getLatestVersion()` against live Akamai — and therefore any flow that starts from the latest property version.

## Fix

`#request` now uses `redirect: 'manual'`, follows 3xx responses itself, and **re-signs each hop** for the new (Location-resolved) URL, capped at 5 hops. Method/body are preserved (PAPI only redirects idempotent GETs here).

## Verification

Reproduced and fixed against a **live Akamai property** using real EdgeGrid credentials:

- Before: `getLatestVersion` → `401 signature does not match` (error `instance` pointed at the redirected `/versions/{N}` URL).
- After: `getLatestVersion` → returns the concrete version (e.g. `32`); `getRuleTree(v32)` and `listActivations` (which don't redirect) were unaffected throughout.

This unblocks the Akamai CDN-onboarding `plan`/`deploy` flow in `spacecat-api-service` (adobe/spacecat-api-service#2769), which pins this package via gitpkg and needs this commit.

## Test plan
- [x] New nock tests: redirect is followed + re-signed; too-many-redirects is capped
- [x] Full package suite green (69 passing), 100% statements/lines/functions retained
- [x] `eslint` clean
- [ ] Release a new version so downstreams (api-service) can pin it

🤖 Generated with [Claude Code](https://claude.com/claude-code)