### PR TITLE
fix: enable npm publishing for spacecat-shared-ticket-client

### DIFF
--- a/packages/spacecat-shared-ticket-client/package.json
+++ b/packages/spacecat-shared-ticket-client/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@adobe/spacecat-shared-ticket-client",
   "version": "1.0.1",
-  "private": true,
   "description": "Shared modules of the SpaceCat Services - Ticket Client",
   "type": "module",
   "engines": {

--- a/scripts/setup-npm-trusted-publishers.sh
+++ b/scripts/setup-npm-trusted-publishers.sh
@@ -272,6 +272,7 @@ PACKAGES=(
   "@adobe/spacecat-shared-scrape-client"
   "@adobe/spacecat-shared-slack-client"
   "@adobe/spacecat-shared-splunk-client"
+  "@adobe/spacecat-shared-ticket-client"
   "@adobe/spacecat-shared-tier-client"
   "@adobe/spacecat-shared-tokowaka-client"
   "@adobe/spacecat-shared-user-manager-client"


### PR DESCRIPTION
## Summary
- Remove the temporary `private: true` flag from `@adobe/spacecat-shared-ticket-client` so semantic-release can publish future versions via CI.
- Register the package in `scripts/setup-npm-trusted-publishers.sh` PACKAGES array so its OIDC trusted-publisher binding is tracked/reconcilable.

## Context
- `@adobe/spacecat-shared-ticket-client@1.0.1` was published manually (first-time publish requires 2FA and cannot run through CI OIDC).
- The npm OIDC trusted-publisher binding is already configured (github / `main.yaml` / `adobe/spacecat-shared` / env `npm-publish`), matching the runbook.
- This PR hands off future releases to CI.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, a release-triggering commit publishes the next version via the `npm-publish` workflow (OIDC, no token)

Made with [Cursor](https://cursor.com)