### PR TITLE
fix: enable npm publishing for spacecat-shared-akamai-client

### DIFF
--- a/packages/spacecat-shared-akamai-client/package.json
+++ b/packages/spacecat-shared-akamai-client/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.1",
   "description": "Shared modules of the Spacecat Services - Akamai Client",
   "type": "module",
-  "private": true,
   "engines": {
     "node": ">=22.0.0 <25.0.0",
     "npm": ">=10.9.0 <12.0.0"

--- a/scripts/setup-npm-trusted-publishers.sh
+++ b/scripts/setup-npm-trusted-publishers.sh
@@ -253,6 +253,7 @@ echo ""
 
 PACKAGES=(
   "@adobe/mysticat-shared-seo-client"
+  "@adobe/spacecat-shared-akamai-client"
   "@adobe/spacecat-shared-athena-client"
   "@adobe/spacecat-shared-brand-client"
   "@adobe/spacecat-shared-cloud-manager-client"


### PR DESCRIPTION
## Summary
- Remove the temporary `private: true` flag from `@adobe/spacecat-shared-akamai-client` so semantic-release can publish future versions via CI.
- Register the package in `scripts/setup-npm-trusted-publishers.sh` PACKAGES array so its OIDC trusted-publisher binding is tracked/reconcilable.

## Context
- `@adobe/spacecat-shared-akamai-client@1.0.1` was published manually (first-time publish requires 2FA and cannot run through CI OIDC).
- The npm OIDC trusted-publisher binding is already configured (github / `main.yaml` / `adobe/spacecat-shared` / env `npm-publish`), matching the runbook.
- This PR hands off future releases to CI.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, a release-triggering commit publishes the next version via the `npm-publish` workflow (OIDC, no token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)