### PR TITLE
fix(cloud-manager-client): pass ref as last pull argument

### DIFF
--- a/packages/spacecat-shared-cloud-manager-client/src/index.js
+++ b/packages/spacecat-shared-cloud-manager-client/src/index.js
@@ -909,6 +909,13 @@ export default class CloudManagerClient {
     }
 
     const pullArgs = await this.#buildAuthGitArgs('pull', programId, repositoryId, { imsOrgId, repoType, repoUrl });
+    // Explicitly pass the ref as the last argument so `git pull` fetches and
+    // merges that branch. Without it, `git pull <url>` merges the remote's
+    // default branch (its HEAD) into the checked-out branch, which can
+    // conflict with — or silently diverge from — the branch we actually want.
+    if (hasText(ref)) {
+      pullArgs.push(ref);
+    }
     // Always pull the parent only — never `--recurse-submodules` — so a
     // submodule failure can't take down the parent pull. Submodules are
     // populated below in a path whose errors are caught and logged.

--- a/packages/spacecat-shared-cloud-manager-client/test/cloud-manager-client.test.js
+++ b/packages/spacecat-shared-cloud-manager-client/test/cloud-manager-client.test.js
@@ -1393,10 +1393,74 @@ describe('CloudManagerClient', () => {
       expect(checkoutArgStr).to.include('checkout');
       expect(checkoutArgStr).to.include('feature/my-branch');
 
-      // Second call: pull
+      // Second call: pull, with the ref appended as the last argument so
+      // git pulls (fetches + merges) that branch instead of the remote's
+      // default branch.
+      const pullArgs = getGitArgs(execFileSyncStub.secondCall);
+      expect(pullArgs[pullArgs.length - 1]).to.equal('feature/my-branch');
       const pullArgStr = getGitArgsStr(execFileSyncStub.secondCall);
       expect(pullArgStr).to.include('pull');
       expect(pullArgStr).to.include(`Authorization: Bearer ${TEST_TOKEN}`);
+    });
+
+    it('appends the ref as the last pull argument for a BYOG repo', async () => {
+      const client = CloudManagerClient.createFrom(createContext());
+
+      await client.pull(
+        '/tmp/cm-repo-test',
+        TEST_PROGRAM_ID,
+        TEST_REPO_ID,
+        { imsOrgId: TEST_IMS_ORG_ID, ref: 'release/5.11' },
+      );
+
+      expect(execFileSyncStub).to.have.been.calledTwice;
+      const pullArgs = getGitArgs(execFileSyncStub.secondCall);
+      expect(pullArgs).to.deep.equal([
+        '-c', `http.${TEST_ENV.CM_REPO_URL}.extraheader=Authorization: Bearer ${TEST_TOKEN}`,
+        '-c', `http.${TEST_ENV.CM_REPO_URL}.extraheader=x-api-key: test-client-id`,
+        '-c', `http.${TEST_ENV.CM_REPO_URL}.extraheader=x-gw-ims-org-id: ${TEST_IMS_ORG_ID}`,
+        'pull',
+        `${TEST_ENV.CM_REPO_URL}/api/program/${TEST_PROGRAM_ID}/repository/${TEST_REPO_ID}.git`,
+        'release/5.11',
+      ]);
+    });
+
+    it('appends the ref as the last pull argument for a standard repo', async () => {
+      const client = CloudManagerClient.createFrom(
+        createContext({ CM_STANDARD_REPO_CREDENTIALS: TEST_STANDARD_CREDENTIALS }),
+      );
+
+      await client.pull(
+        '/tmp/cm-repo-test',
+        TEST_PROGRAM_ID,
+        TEST_REPO_ID,
+        { repoType: 'standard', repoUrl: TEST_STANDARD_REPO_URL, ref: 'main' },
+      );
+
+      expect(execFileSyncStub).to.have.been.calledTwice;
+      const pullArgs = getGitArgs(execFileSyncStub.secondCall);
+      expect(pullArgs).to.deep.equal([
+        '-c', 'http.https://git.cloudmanager.adobe.com/myorg/.extraheader=Authorization: Basic c3RkdXNlcjpzdGR0b2tlbjEyMw==',
+        'pull',
+        TEST_STANDARD_REPO_URL,
+        'main',
+      ]);
+    });
+
+    it('does not append a ref argument to pull when ref is not provided', async () => {
+      const client = CloudManagerClient.createFrom(createContext());
+
+      await client.pull(
+        '/tmp/cm-repo-test',
+        TEST_PROGRAM_ID,
+        TEST_REPO_ID,
+        { imsOrgId: TEST_IMS_ORG_ID },
+      );
+
+      expect(execFileSyncStub).to.have.been.calledOnce;
+      const pullArgs = getGitArgs(execFileSyncStub.firstCall);
+      expect(pullArgs[pullArgs.length - 1])
+        .to.equal(`${TEST_ENV.CM_REPO_URL}/api/program/${TEST_PROGRAM_ID}/repository/${TEST_REPO_ID}.git`);
     });
 
     it('skips checkout when ref is not provided', async () => {


### PR DESCRIPTION
## Summary
- `pull()` checks out the requested `ref` locally before running `git pull`, but never told `git pull` which branch to fetch/merge — so `git pull <url>` fell back to fetching and merging the remote's default branch (its HEAD) into the checked-out branch.
- This could silently diverge from, or conflict with, the branch the caller actually wanted to update.
- Fix: append `ref` as the last argument to the pull git args (mirrors how `push()` already appends `ref`), so `git pull <url> <ref>` fetches and merges the correct branch.

## Test plan
- [x] Added/updated unit tests in `packages/spacecat-shared-cloud-manager-client/test/cloud-manager-client.test.js` covering: ref appended as last arg for BYOG and standard repos, and no ref arg appended when `ref` is omitted.
- [x] `npm test -w packages/spacecat-shared-cloud-manager-client` — 87 passing, 100% coverage.
- [x] `npm run lint -w packages/spacecat-shared-cloud-manager-client` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)