### PR TITLE
feat(fix-entity): add allByOpportunityIds for site-wide fix queries

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/fix-entity/fix-entity.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/fix-entity/fix-entity.collection.js
@@ -250,9 +250,11 @@ class FixEntityCollection extends BaseCollection {
     }
 
     try {
+      const uniqueIds = [...new Set(opportunityIds)];
+
       const chunks = [];
-      for (let i = 0; i < opportunityIds.length; i += IN_FILTER_CHUNK_SIZE) {
-        chunks.push(opportunityIds.slice(i, i + IN_FILTER_CHUNK_SIZE));
+      for (let i = 0; i < uniqueIds.length; i += IN_FILTER_CHUNK_SIZE) {
+        chunks.push(uniqueIds.slice(i, i + IN_FILTER_CHUNK_SIZE));
       }
 
       const results = await Promise.all(
@@ -264,6 +266,9 @@ class FixEntityCollection extends BaseCollection {
 
       return results.flat();
     } catch (error) {
+      if (error instanceof DataAccessError) {
+        throw error;
+      }
       this.log.error('Failed to get all fixes by opportunity IDs', error);
       throw new DataAccessError('Failed to get all fixes by opportunity IDs', this, error);
     }

--- a/packages/spacecat-shared-data-access/src/models/fix-entity/fix-entity.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/fix-entity/fix-entity.collection.js
@@ -15,6 +15,11 @@ import ValidationError from '../../errors/validation.error.js';
 import { guardId, guardArray, guardString } from '../../util/guards.js';
 import { resolveUpdates } from '../../util/util.js';
 
+// PostgREST GET requests serialize IN-filters into the URL, so large ID lists must be
+// chunked to stay well under the ~8KB URL length limit (see batchGetByKeys / llmo-brand-presence
+// for the same pattern elsewhere in this package).
+const IN_FILTER_CHUNK_SIZE = 50;
+
 /**
  * FixEntityCollection - A collection class responsible for managing FixEntities.
  * Extends the BaseCollection to provide specific methods for interacting with
@@ -223,6 +228,44 @@ class FixEntityCollection extends BaseCollection {
       }
       this.log.error('Failed to get all fixes with suggestions by opportunity ID', error);
       throw new DataAccessError('Failed to get all fixes with suggestions by opportunity ID', this, error);
+    }
+  }
+
+  /**
+   * Gets all fixes across a set of opportunities (e.g. every opportunity for a site),
+   * by filtering on opportunityId IN (...). Chunks the IN-filter to stay under
+   * PostgREST's URL length limit.
+   *
+   * @async
+   * @param {string[]} opportunityIds - The IDs of the opportunities.
+   * @returns {Promise<FixEntity[]>} - A promise that resolves to an array of FixEntity models.
+   * @throws {DataAccessError} - Throws an error if the query fails.
+   * @throws {ValidationError} - Throws an error if opportunityIds is not an array of strings.
+   */
+  async allByOpportunityIds(opportunityIds) {
+    guardArray('opportunityIds', opportunityIds, 'FixEntityCollection', 'string');
+
+    if (opportunityIds.length === 0) {
+      return [];
+    }
+
+    try {
+      const chunks = [];
+      for (let i = 0; i < opportunityIds.length; i += IN_FILTER_CHUNK_SIZE) {
+        chunks.push(opportunityIds.slice(i, i + IN_FILTER_CHUNK_SIZE));
+      }
+
+      const results = await Promise.all(
+        chunks.map((chunk) => this.all(
+          {},
+          { where: (attrs, op) => op.in(attrs.opportunityId, chunk) },
+        )),
+      );
+
+      return results.flat();
+    } catch (error) {
+      this.log.error('Failed to get all fixes by opportunity IDs', error);
+      throw new DataAccessError('Failed to get all fixes by opportunity IDs', this, error);
     }
   }
 

--- a/packages/spacecat-shared-data-access/test/unit/models/fix-entity/fix-entity.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/fix-entity/fix-entity.collection.test.js
@@ -979,6 +979,73 @@ describe('FixEntityCollection', () => {
     });
   });
 
+  describe('allByOpportunityIds', () => {
+    it('should return an empty array without querying when given no ids', async () => {
+      fixEntityCollection.all = stub();
+
+      const result = await fixEntityCollection.allByOpportunityIds([]);
+
+      expect(result).to.deep.equal([]);
+      expect(fixEntityCollection.all).to.not.have.been.called;
+    });
+
+    it('should throw a validation error when opportunityIds is not an array', async () => {
+      await expect(fixEntityCollection.allByOpportunityIds('not-an-array'))
+        .to.be.rejectedWith('Validation failed in FixEntityCollection: opportunityIds must be an array');
+    });
+
+    it('should query fixes with a single IN-filter chunk when under the chunk size', async () => {
+      const opportunityIds = ['opp-1', 'opp-2', 'opp-3'];
+      const mockFixEntities = [{ getId: () => 'fix-1' }, { getId: () => 'fix-2' }];
+
+      fixEntityCollection.all = stub().resolves(mockFixEntities);
+
+      const result = await fixEntityCollection.allByOpportunityIds(opportunityIds);
+
+      expect(result).to.deep.equal(mockFixEntities);
+      expect(fixEntityCollection.all).to.have.been.calledOnce;
+
+      const [sortKeys, options] = fixEntityCollection.all.firstCall.args;
+      expect(sortKeys).to.deep.equal({});
+
+      const opStub = { in: stub().returns('IN_EXPR') };
+      const expression = options.where({ opportunityId: 'opportunityId' }, opStub);
+      expect(opStub.in).to.have.been.calledOnceWith('opportunityId', opportunityIds);
+      expect(expression).to.equal('IN_EXPR');
+    });
+
+    it('should chunk the IN-filter and merge results when over the chunk size', async () => {
+      const opportunityIds = Array.from({ length: 60 }, (_, i) => `opp-${i}`);
+      const firstChunkResults = [{ getId: () => 'fix-1' }];
+      const secondChunkResults = [{ getId: () => 'fix-2' }];
+
+      fixEntityCollection.all = stub();
+      fixEntityCollection.all.onCall(0).resolves(firstChunkResults);
+      fixEntityCollection.all.onCall(1).resolves(secondChunkResults);
+
+      const result = await fixEntityCollection.allByOpportunityIds(opportunityIds);
+
+      expect(result).to.deep.equal([...firstChunkResults, ...secondChunkResults]);
+      expect(fixEntityCollection.all).to.have.been.calledTwice;
+
+      const opStub = { in: stub().returns('IN_EXPR') };
+      fixEntityCollection.all.firstCall.args[1].where({ opportunityId: 'opportunityId' }, opStub);
+      fixEntityCollection.all.secondCall.args[1].where({ opportunityId: 'opportunityId' }, opStub);
+
+      expect(opStub.in.firstCall.args[1]).to.have.lengthOf(50);
+      expect(opStub.in.secondCall.args[1]).to.have.lengthOf(10);
+    });
+
+    it('should handle errors and throw DataAccessError', async () => {
+      const error = new Error('Database error');
+      fixEntityCollection.all = stub().rejects(error);
+
+      await expect(fixEntityCollection.allByOpportunityIds(['opp-1']))
+        .to.be.rejectedWith(DataAccessError, 'Failed to get all fixes by opportunity IDs');
+      expect(mockLogger.error).to.have.been.calledWith('Failed to get all fixes by opportunity IDs', error);
+    });
+  });
+
   describe('FixEntity model constants', () => {
     it('has ORIGINS enum with correct values', () => {
       expect(FixEntity.ORIGINS).to.be.an('object');

--- a/packages/spacecat-shared-data-access/test/unit/models/fix-entity/fix-entity.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/fix-entity/fix-entity.collection.test.js
@@ -1036,6 +1036,22 @@ describe('FixEntityCollection', () => {
       expect(opStub.in.secondCall.args[1]).to.have.lengthOf(10);
     });
 
+    it('should deduplicate opportunity IDs before chunking', async () => {
+      const opportunityIds = ['opp-1', 'opp-2', 'opp-1'];
+      const mockFixEntities = [{ getId: () => 'fix-1' }];
+
+      fixEntityCollection.all = stub().resolves(mockFixEntities);
+
+      const result = await fixEntityCollection.allByOpportunityIds(opportunityIds);
+
+      expect(result).to.deep.equal(mockFixEntities);
+      expect(fixEntityCollection.all).to.have.been.calledOnce;
+
+      const opStub = { in: stub().returns('IN_EXPR') };
+      fixEntityCollection.all.firstCall.args[1].where({ opportunityId: 'opportunityId' }, opStub);
+      expect(opStub.in).to.have.been.calledOnceWith('opportunityId', ['opp-1', 'opp-2']);
+    });
+
     it('should handle errors and throw DataAccessError', async () => {
       const error = new Error('Database error');
       fixEntityCollection.all = stub().rejects(error);
@@ -1043,6 +1059,19 @@ describe('FixEntityCollection', () => {
       await expect(fixEntityCollection.allByOpportunityIds(['opp-1']))
         .to.be.rejectedWith(DataAccessError, 'Failed to get all fixes by opportunity IDs');
       expect(mockLogger.error).to.have.been.calledWith('Failed to get all fixes by opportunity IDs', error);
+    });
+
+    it('should re-throw DataAccessError without wrapping', async () => {
+      const innerError = new DataAccessError('inner failure');
+      fixEntityCollection.all = stub().rejects(innerError);
+
+      try {
+        await fixEntityCollection.allByOpportunityIds(['opp-1']);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).to.equal(innerError);
+      }
+      expect(mockLogger.error).to.not.have.been.called;
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds `FixEntityCollection.allByOpportunityIds(opportunityIds)` so callers can fetch all fixes across a set of opportunities (e.g. every opportunity for a site) in one call, filtering on `opportunityId IN (...)`.
- Chunks the IN-filter at 50 ids to stay under PostgREST's GET URL length limit, matching the existing pattern used in `batchGetByKeys` and `llmo-brand-presence.js`.
- No schema/migration changes — `opportunityId` is already a fully indexed attribute on `FixEntity`.

This unblocks a site-wide `GET /sites/:siteId/fixes` endpoint in `spacecat-api-service` (companion PR), closing part of the gap described in SITES-47506.

## Test plan
- [x] `npm test -w packages/spacecat-shared-data-access` — full suite passes, 100% coverage
- [x] New unit tests cover: empty input, single chunk, multi-chunk (>50 ids), validation error, and DataAccessError wrapping

Part of SITES-47506 / epic SITES-47501.