### PR TITLE
feat(project-engine-client): meter prompt units as texts × models in the mock (LLMO-5616)

### DIFF
--- a/packages/spacecat-shared-project-engine-client/CLAUDE.md
+++ b/packages/spacecat-shared-project-engine-client/CLAUDE.md
@@ -14,7 +14,9 @@ Counterfact **mock** used by local dev and the cross-repo e2e harness.
   endpoint inventory, seeds, control routes, quota, troubleshooting). AI-unit quota (the
   disguised-405 the live API returns for an over-allocation) is in `mock/quota.js`, set via the
   `POST /__quota` control route or `buildSeed({ quota })`, enforced on project create / prompt write
-  / publish. **Bearer auth** (`mock/auth.js`) is modelled like the live gateway — every real route
+  / model attach / publish. The prompt UNIT is `texts × models` per project (a model-less project's
+  texts are free), so attaching a model re-meters the project's existing texts and can itself 405.
+  **Bearer auth** (`mock/auth.js`) is modelled like the live gateway — every real route
   needs `Authorization: Bearer <token>` (presence, not validity) or returns `401 { detail: 'Not
   authenticated' }`; the `__*` control routes are exempt. The gate is injected onto every handler at
   the materialization seam by `injectAuthGuard` in `mock/run.js` (so no handler can forget it). A new

--- a/packages/spacecat-shared-project-engine-client/docs/mock-usage.md
+++ b/packages/spacecat-shared-project-engine-client/docs/mock-usage.md
@@ -94,7 +94,7 @@ method that calls it.
 | --- | --- | --- |
 | `GET /v1/workspaces/{id}/projects/{project_id}/ai_models` | `listAiModels` | list → `{ items, page, total }` |
 | `DELETE /v1/workspaces/{id}/projects/{project_id}/ai_models` | `deleteAiModelsByIds` | batch-delete (body `{ ids }`) → `204` |
-| `POST /v2/workspaces/{id}/projects/{project_id}/ai_models` | `addAiModel` | add (body `{ model_id }`) → `201`; writes the same store collection the v1 list/delete read |
+| `POST /v2/workspaces/{id}/projects/{project_id}/ai_models` | `addAiModel` | add (body `{ model_id }`) → `201`; writes the same store collection the v1 list/delete read; **metered** (405 when re-metering the project's existing texts — `texts × models` — would exceed the `prompts` allocation) |
 | `GET /v1/ai_models` | `listGlobalAiModels` | global catalog → `{ page, total, items }` |
 
 ### Benchmarks & brand URLs
@@ -215,9 +215,14 @@ provisioning reports "Quota exceeded"). The mock models this:
   never 405s. The existing seeds therefore behave normally.
 - **Grant an allocation** via `POST /__quota` (mirrors a user-manager resource transfer) or a
   `quota` row in a seed `Snapshot`. Usage is derived **live** from the store, so deleting a
-  project/prompt frees its unit.
-- **Metered ops:** project create (`projects` limit), prompt write (`prompts` limit, all-or-nothing
-  per batch), and publish (405 for an `prompts: 0` empty-units workspace).
+  project/prompt (or removing a model) frees its unit(s).
+- **The prompt UNIT is `texts × models` per project** (live-verified): `prompts.used =
+  Σ_project (prompt texts × attached models)`. A project with zero models consumes zero prompt units;
+  attaching a model re-meters that project's existing texts, and removing one frees them.
+- **Metered ops:** project create (`projects` limit); prompt write (`prompts` limit, all-or-nothing
+  per batch, each new text costing `models` units); **model attach** (`POST …/ai_models` — a new
+  model re-meters the project's existing texts, so it 405s when that would exceed the `prompts`
+  allocation); and publish (405 for a `prompts: 0` empty-units workspace).
 
 ```bash
 # grant 1 project + 2 prompts

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/ai_models.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/ai_models.js
@@ -34,6 +34,9 @@ export function POST($) {
   // A new model re-meters every one of the project's existing texts (prompt unit = texts × models),
   // so the add itself is a metered op the live API 405s when it would exceed the allocation.
   if (!context.quota.canAddModel(path.id, path.project_id)) {
+    // 405 is not a declared response for this operation (only 201/401/403/500) — the disguised
+    // quota 405 the live API returns (mock/quota.js), so this stays a raw bypass like every other
+    // quota-gated route in this package; it can't go through $.response[405].json(...).
     return {
       status: 405,
       body: { message: 'Quota exceeded: model attach exceeds prompt allocation' },

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/ai_models.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/ai_models.js
@@ -31,6 +31,15 @@
 /** POST — add an AI model to the project (body: { model_id }) → 201 (matches live). */
 export function POST($) {
   const { path, body, context } = $;
+  // A new model re-meters every one of the project's existing texts (prompt unit = texts × models),
+  // so the add itself is a metered op the live API 405s when it would exceed the allocation.
+  if (!context.quota.canAddModel(path.id, path.project_id)) {
+    return {
+      status: 405,
+      body: { message: 'Quota exceeded: model attach exceeds prompt allocation' },
+      contentType: 'application/json',
+    };
+  }
   const catalogModel = context.aiModelCatalog.find((m) => m.id === body.model_id);
   // Live echoes the catalog model's name + icon on add; only `key` comes back empty there.
   // A missing model_id can't reach here on the validated route (the request schema marks it

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/prompts.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/prompts.js
@@ -83,7 +83,7 @@ export function POST($) {
     tags,
   }));
 
-  if (!context.quota.canCreatePrompts(path.id, toCreate.length)) {
+  if (!context.quota.canCreatePrompts(path.id, path.project_id, toCreate.length)) {
     // 405 is not a declared response for this operation (only 201/401/403/500) — the disguised
     // quota 405 the live API returns (mock/quota.js), so this stays a raw bypass like every other
     // quota-gated route in this package; it can't go through $.response[405].json(...).

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/prompts/tagged.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/prompts/tagged.js
@@ -54,7 +54,7 @@ export function POST($) {
       tags: (tags ?? []).map((name) => ({ id: context.tagId(name), name })),
     }));
 
-  if (!context.quota.canCreatePrompts(path.id, toCreate.length)) {
+  if (!context.quota.canCreatePrompts(path.id, path.project_id, toCreate.length)) {
     return {
       status: 405,
       body: { message: 'Quota exceeded: prompt allocation exhausted' },

--- a/packages/spacecat-shared-project-engine-client/mock/quota.js
+++ b/packages/spacecat-shared-project-engine-client/mock/quota.js
@@ -33,6 +33,15 @@
  * `quota` collection (so it rides along in seed / `__reset` / `__dump`), while USAGE is derived
  * live from the actual `projects:{ws}` and `prompts:{ws}:*` collections — so deleting a project or
  * prompt frees its unit, matching an allocation that meters concurrent count.
+ *
+ * PROMPT UNIT = texts × models (live-verified 2026-07-02, serenity-docs#22 §2): a prompt unit is
+ * NOT one prompt text — it is one text × one attached AI model, counted PER PROJECT and summed:
+ * `promptsUsed = Σ_project ( promptTexts(project) × attachedModels(project) )`. A project with zero
+ * models therefore consumes zero prompt units, and attaching/removing a model re-meters every one
+ * of that project's texts. Because usage is derived live from the `prompts:{ws}:{proj}` and
+ * `ai_models:{ws}:{proj}` collection sizes, a model add/remove (or prompt/project delete) is
+ * reflected automatically — no incremental bookkeeping. Models are attached on the Project Engine
+ * gateway (this mock), so the multiplier is enforced here.
  */
 
 /** The store collection holding per-workspace allocations: `{ id: ws, projects, prompts }`. */
@@ -102,7 +111,20 @@ export function createQuota(store) {
     },
 
     /**
-     * Prompts currently created across ALL the workspace's projects (`prompts:{ws}:*`).
+     * Models attached to one project (`ai_models:{ws}:{proj}` collection size). A project with no
+     * models has none, so its texts consume zero prompt units.
+     * @param {string} workspaceId
+     * @param {string} projectId
+     * @returns {number}
+     */
+    modelsUsed(workspaceId, projectId) {
+      return store.size(`ai_models:${workspaceId}:${projectId}`);
+    },
+
+    /**
+     * Prompt UNITS currently consumed across ALL the workspace's projects: `Σ_project (texts ×
+     * models)` (see the module note). Each `prompts:{ws}:{proj}` collection's size is multiplied by
+     * that project's attached-model count — so a model-less project contributes 0.
      * @param {string} workspaceId
      * @returns {number}
      */
@@ -110,7 +132,10 @@ export function createQuota(store) {
       const prefix = `prompts:${workspaceId}:`;
       return store.keys()
         .filter((name) => name.startsWith(prefix))
-        .reduce((sum, name) => sum + store.size(name), 0);
+        .reduce((sum, name) => {
+          const projectId = name.slice(prefix.length);
+          return sum + store.size(name) * api.modelsUsed(workspaceId, projectId);
+        }, 0);
     },
 
     /**
@@ -128,17 +153,37 @@ export function createQuota(store) {
     },
 
     /**
-     * Whether the workspace can create `count` more prompts (all-or-nothing, as the live 405 is).
+     * Whether the workspace can create `count` more prompt texts ON `projectId` (all-or-nothing, as
+     * the live 405 is). The units the new texts consume are `count × models(projectId)` — so on a
+     * project with no attached models the texts are free (zero units).
      * @param {string} workspaceId
+     * @param {string} projectId
      * @param {number} count
      * @returns {boolean}
      */
-    canCreatePrompts(workspaceId, count) {
+    canCreatePrompts(workspaceId, projectId, count) {
       const limit = api.limits(workspaceId)?.prompts;
       if (limit == null) {
         return true;
       }
-      return api.promptsUsed(workspaceId) + count <= limit;
+      return api.promptsUsed(workspaceId) + count * api.modelsUsed(workspaceId, projectId) <= limit;
+    },
+
+    /**
+     * Whether the workspace can attach one more AI model to `projectId`. A new model re-meters
+     * every one of that project's existing texts, so it consumes `promptTexts(projectId)` more
+     * units — the live API 405s the model-add when that would exceed the allocation.
+     * @param {string} workspaceId
+     * @param {string} projectId
+     * @returns {boolean}
+     */
+    canAddModel(workspaceId, projectId) {
+      const limit = api.limits(workspaceId)?.prompts;
+      if (limit == null) {
+        return true;
+      }
+      return api.promptsUsed(workspaceId) + store.size(`prompts:${workspaceId}:${projectId}`)
+        <= limit;
     },
 
     /**

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -1694,6 +1694,7 @@ async function waitForReady(baseUrl, deadline, getStderr) {
   const PROJECTS = '/v1/workspaces/{id}/projects';
   const TAGGED = '/v2/workspaces/{id}/projects/{project_id}/aio/prompts/tagged';
   const PUBLISH = '/v1/workspaces/{id}/projects/{project_id}/publish';
+  const ADD_MODEL = '/v2/workspaces/{id}/projects/{project_id}/ai_models';
 
   async function setQuota(workspaceId, allocation) {
     const res = await fetch(`${baseUrl}/__quota`, {
@@ -1716,20 +1717,49 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     expect(error).to.not.equal(undefined);
   });
 
-  it('meters prompt create: 405 (all-or-nothing) when a batch exceeds the prompts allocation', async () => {
+  it('meters prompt create: 405 (all-or-nothing), sized texts × models', async () => {
     const id = globalThis.crypto.randomUUID();
     const projectId = globalThis.crypto.randomUUID();
     await setQuota(id, { projects: 5, prompts: 2 });
+    // Attach one model so each text costs 1 unit (prompt unit = texts × models). With zero models
+    // the texts would be free and never 405.
+    const { response: model } = await client.POST(ADD_MODEL, {
+      params: { path: { id, project_id: projectId } },
+      body: { model_id: globalThis.crypto.randomUUID() },
+    });
+    expect(model.status).to.equal(201);
     const { response: ok } = await client.POST(TAGGED, {
       params: { path: { id, project_id: projectId } },
       body: { prompts: { 'prompt one': ['t'], 'prompt two': ['t'] } },
     });
-    expect(ok.status).to.equal(201);
+    expect(ok.status).to.equal(201); // 2 texts × 1 model = 2 == limit
     const { response: over } = await client.POST(TAGGED, {
       params: { path: { id, project_id: projectId } },
       body: { prompts: { 'prompt three': ['t'] } },
     });
-    expect(over.status).to.equal(405);
+    expect(over.status).to.equal(405); // 3rd text × 1 model = 3 > 2
+  });
+
+  it('meters model attach: 405 when re-metering existing texts exceeds the allocation', async () => {
+    const id = globalThis.crypto.randomUUID();
+    const projectId = globalThis.crypto.randomUUID();
+    await setQuota(id, { projects: 5, prompts: 3 });
+    // One model + 3 texts = 3 units (== limit). Attaching a 2nd model re-meters the 3 texts (+3).
+    const { response: m1 } = await client.POST(ADD_MODEL, {
+      params: { path: { id, project_id: projectId } },
+      body: { model_id: globalThis.crypto.randomUUID() },
+    });
+    expect(m1.status).to.equal(201);
+    const { response: prompts } = await client.POST(TAGGED, {
+      params: { path: { id, project_id: projectId } },
+      body: { prompts: { a: ['t'], b: ['t'], c: ['t'] } },
+    });
+    expect(prompts.status).to.equal(201);
+    const { response: over } = await client.POST(ADD_MODEL, {
+      params: { path: { id, project_id: projectId } },
+      body: { model_id: globalThis.crypto.randomUUID() },
+    });
+    expect(over.status).to.equal(405); // 3 used + 3 texts re-metered = 6 > 3
   });
 
   it('meters publish: 405 for an empty-units workspace, 202 when unlimited', async () => {

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -1760,6 +1760,11 @@ async function waitForReady(baseUrl, deadline, getStderr) {
       body: { model_id: globalThis.crypto.randomUUID() },
     });
     expect(over.status).to.equal(405); // 3 used + 3 texts re-metered = 6 > 3
+    // The rejected model must NOT have been persisted — the project still has its single model.
+    const { data: models } = await client.GET('/v1/workspaces/{id}/projects/{project_id}/ai_models', {
+      params: { path: { id, project_id: projectId } },
+    });
+    expect(models.items).to.have.length(1);
   });
 
   it('meters publish: 405 for an empty-units workspace, 202 when unlimited', async () => {

--- a/packages/spacecat-shared-project-engine-client/test/mock/quota.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/quota.test.js
@@ -158,6 +158,20 @@ describe('quota — canAddModel (attach re-meters existing texts)', () => {
     quota.set(WS, { prompts: 6 });
     expect(quota.canAddModel(WS, 'p0')).to.equal(true); // 3 + 3 = 6 <= 6
   });
+
+  it('the add cost is the TARGET project text count (not another project\'s)', () => {
+    const store = new InMemoryStore();
+    const quota = createQuota(store);
+    // pA: 2 texts × 1 model = 2; pB: 5 texts × 1 model = 5 → workspace used 7.
+    seedUsage(store, {
+      promptsByProject: { pA: 2, pB: 5 }, modelsByProject: { pA: 1, pB: 1 },
+    });
+    quota.set(WS, { prompts: 9 });
+    // Adding a model to pA costs pA's 2 texts (7 + 2 = 9 <= 9) — NOT pB's 5 (which would be 12).
+    expect(quota.canAddModel(WS, 'pA')).to.equal(true);
+    // Adding a model to pB costs pB's 5 texts (7 + 5 = 12 > 9).
+    expect(quota.canAddModel(WS, 'pB')).to.equal(false);
+  });
 });
 
 describe('quota — canPublish', () => {

--- a/packages/spacecat-shared-project-engine-client/test/mock/quota.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/quota.test.js
@@ -16,14 +16,23 @@ import { createQuota, QUOTA_COLLECTION } from '../../mock/quota.js';
 
 const WS = 'ws-1';
 
-/** Seeds projects into the workspace + prompts per project id (ids are unique per row). */
-function seedUsage(store, { projects = 0, promptsByProject = {} } = {}) {
+/**
+ * Seeds projects into the workspace + prompts and attached models per project id (ids unique per
+ * row). Prompt UNITS are `texts × models` per project, so a project needs BOTH prompts and models
+ * seeded to consume units.
+ */
+function seedUsage(store, { projects = 0, promptsByProject = {}, modelsByProject = {} } = {}) {
   for (let i = 0; i < projects; i += 1) {
     store.create(`projects:${WS}`, { id: globalThis.crypto.randomUUID() });
   }
   for (const [pid, count] of Object.entries(promptsByProject)) {
     for (let i = 0; i < count; i += 1) {
       store.create(`prompts:${WS}:${pid}`, { id: globalThis.crypto.randomUUID() });
+    }
+  }
+  for (const [pid, count] of Object.entries(modelsByProject)) {
+    for (let i = 0; i < count; i += 1) {
+      store.create(`ai_models:${WS}:${pid}`, { id: globalThis.crypto.randomUUID() });
     }
   }
 }
@@ -56,14 +65,27 @@ describe('quota — allocation set/get', () => {
 });
 
 describe('quota — usage derived from the store', () => {
-  it('counts projects and prompts across the workspace projects only', () => {
+  it('prompt usage is Σ_project (texts × models), summed across the workspace projects only', () => {
     const store = new InMemoryStore();
     const quota = createQuota(store);
-    seedUsage(store, { projects: 2, promptsByProject: { p0: 3, p1: 1 } });
+    // p0: 3 texts × 2 models = 6; p1: 1 text × 3 models = 3 → total 9.
+    seedUsage(store, {
+      projects: 2, promptsByProject: { p0: 3, p1: 1 }, modelsByProject: { p0: 2, p1: 3 },
+    });
     // a prompt under a DIFFERENT workspace must not count
     store.create('prompts:other-ws:p0', { id: 'x' });
     expect(quota.projectsUsed(WS)).to.equal(2);
-    expect(quota.promptsUsed(WS)).to.equal(4);
+    expect(quota.modelsUsed(WS, 'p0')).to.equal(2);
+    expect(quota.promptsUsed(WS)).to.equal(9);
+  });
+
+  it('a project with texts but ZERO models consumes zero prompt units', () => {
+    const store = new InMemoryStore();
+    const quota = createQuota(store);
+    // p0: 5 texts, 0 models → 0 units; p1: 2 texts × 1 model → 2 units.
+    seedUsage(store, { promptsByProject: { p0: 5, p1: 2 }, modelsByProject: { p1: 1 } });
+    expect(quota.modelsUsed(WS, 'p0')).to.equal(0);
+    expect(quota.promptsUsed(WS)).to.equal(2);
   });
 });
 
@@ -89,22 +111,52 @@ describe('quota — canCreateProject', () => {
   });
 });
 
-describe('quota — canCreatePrompts (all-or-nothing)', () => {
+describe('quota — canCreatePrompts (all-or-nothing, texts × models)', () => {
   it('is unlimited without an allocation or with a null prompts limit', () => {
     const store = new InMemoryStore();
     const quota = createQuota(store);
-    expect(quota.canCreatePrompts(WS, 1000)).to.equal(true);
+    expect(quota.canCreatePrompts(WS, 'p0', 1000)).to.equal(true);
     quota.set(WS, { projects: 1 }); // prompts null
-    expect(quota.canCreatePrompts(WS, 1000)).to.equal(true);
+    expect(quota.canCreatePrompts(WS, 'p0', 1000)).to.equal(true);
   });
 
-  it('allows a batch that fits, rejects one that would exceed', () => {
+  it('sizes the batch by the project model count: allows what fits, rejects what exceeds', () => {
     const store = new InMemoryStore();
     const quota = createQuota(store);
-    quota.set(WS, { prompts: 3 });
-    seedUsage(store, { promptsByProject: { p0: 2 } });
-    expect(quota.canCreatePrompts(WS, 1)).to.equal(true); // 2 + 1 = 3 <= 3
-    expect(quota.canCreatePrompts(WS, 2)).to.equal(false); // 2 + 2 = 4 > 3
+    quota.set(WS, { prompts: 10 });
+    // p0: 2 texts × 2 models = 4 used. Each NEW text costs 2 units (2 models).
+    seedUsage(store, { promptsByProject: { p0: 2 }, modelsByProject: { p0: 2 } });
+    expect(quota.canCreatePrompts(WS, 'p0', 3)).to.equal(true); // 4 + 3×2 = 10 <= 10
+    expect(quota.canCreatePrompts(WS, 'p0', 4)).to.equal(false); // 4 + 4×2 = 12 > 10
+  });
+
+  it('texts on a project with zero models are free (never rejected)', () => {
+    const store = new InMemoryStore();
+    const quota = createQuota(store);
+    quota.set(WS, { prompts: 1 });
+    // p0 has no models → each text costs 0 units.
+    expect(quota.canCreatePrompts(WS, 'p0', 1000)).to.equal(true);
+  });
+});
+
+describe('quota — canAddModel (attach re-meters existing texts)', () => {
+  it('is unlimited without an allocation or with a null prompts limit', () => {
+    const store = new InMemoryStore();
+    const quota = createQuota(store);
+    expect(quota.canAddModel(WS, 'p0')).to.equal(true);
+    quota.set(WS, { projects: 1 }); // prompts null
+    expect(quota.canAddModel(WS, 'p0')).to.equal(true);
+  });
+
+  it('a new model costs the project its text count; 405s when that exceeds the allocation', () => {
+    const store = new InMemoryStore();
+    const quota = createQuota(store);
+    // p0: 3 texts × 1 model = 3 used. Adding a 2nd model re-meters the 3 texts → +3 → 6.
+    seedUsage(store, { promptsByProject: { p0: 3 }, modelsByProject: { p0: 1 } });
+    quota.set(WS, { prompts: 5 });
+    expect(quota.canAddModel(WS, 'p0')).to.equal(false); // 3 + 3 = 6 > 5
+    quota.set(WS, { prompts: 6 });
+    expect(quota.canAddModel(WS, 'p0')).to.equal(true); // 3 + 3 = 6 <= 6
   });
 });
 
@@ -124,7 +176,8 @@ describe('quota — usage()', () => {
   it('reports limits + live usage (and nulls when unallocated)', () => {
     const store = new InMemoryStore();
     const quota = createQuota(store);
-    seedUsage(store, { projects: 1, promptsByProject: { p0: 2 } });
+    // p0: 2 texts × 1 model = 2 prompt units.
+    seedUsage(store, { projects: 1, promptsByProject: { p0: 2 }, modelsByProject: { p0: 1 } });
     expect(quota.usage(WS)).to.deep.equal({
       workspaceId: WS,
       projects: { limit: null, used: 1 },


### PR DESCRIPTION
## What & why

The Project Engine mock metered prompts as a raw row count with no model factor, so the **`texts × models`** prompt-unit identity that the dynamic-allocation design rests on (serenity-docs#22 §2, live-verified 2026-07-02) was **untestable**. Per Rainer's follow-up on serenity-docs#22 ([comment](https://github.com/adobe/serenity-docs/pull/22#issuecomment-4923715505)), teach the mock the multiplier so a regression in the net-delta sizing can be caught.

## Changes (mock only; nothing published ships)

- **`mock/quota.js`**: `promptsUsed` is now `Σ_project (texts × models)` — derived live from the `prompts:{ws}:{proj}` and `ai_models:{ws}:{proj}` collection sizes, so a model add/remove (or prompt/project delete) re-meters automatically. Adds `modelsUsed(ws, projectId)` and `canAddModel(ws, projectId)`; `canCreatePrompts(ws, projectId, count)` now sizes the batch by the project's model count. A model-less project consumes zero units.
- **Routes**: the v2 model-attach route 405s when attaching a model would re-meter existing texts past the allocation; both prompt-create routes (`aio/prompts`, `aio/prompts/tagged`) pass `project_id` so the batch is sized `texts × models`.
- **Tests**: `quota.test.js` (100% branches — the package gate) covers the multiplier, zero-models-free, and `canAddModel`; the e2e adds the `texts × models` prompt-create 405 and the model-attach 405 cases.

## Pairs with
- Enables the swap (net delta 0 → zero transfers) / pure-removal (net delta < 0 → one release) integration tests on **adobe/spacecat-api-service#2764** (the net-delta sizing fix), which need this model-aware mock to exercise the multiplier.
- Sibling of the User-Manager mock work (#1767, the parent-pool side) — this is the Project-Engine (metering) side; they are separate packages.

## Gates
`test:types` clean, lint clean, unit tests 100% coverage (lines/branches/statements), e2e green (70 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)