### PR TITLE
fix(ticket-client): fix token refresh logic, listIssueTypes endpoint, and createTicket validation 

### DIFF
--- a/packages/spacecat-shared-ticket-client/README.md
+++ b/packages/spacecat-shared-ticket-client/README.md
@@ -63,7 +63,7 @@ const client = TicketClientFactory.create(
 ```javascript
 const result = await client.createTicket({
   projectKey: 'ASO',
-  issueType: 'Task',            // optional, defaults to 'Task'
+  issueType: 'Task',            // required — resolve a valid type via listIssueTypes()
   summary: 'Fix colour contrast on homepage hero',
   description: 'The hero banner fails WCAG AA contrast ratio.\n\nSee https://example.com/audit for details.',
   labels: ['a11y', 'mysticat'],  // optional

--- a/packages/spacecat-shared-ticket-client/src/clients/jira-cloud-client.js
+++ b/packages/spacecat-shared-ticket-client/src/clients/jira-cloud-client.js
@@ -127,7 +127,10 @@ function sanitizeFilename(filename) {
  *
  * SSRF protection: all API calls route through the fixed Atlassian gateway
  * https://api.atlassian.com/ex/jira/{cloudId}/... — cloudId is validated as UUID.
- * instance_url / siteUrl are display-only and never used as request targets.
+ * instance_url / siteUrl are display-only (used to build the browse link) and never
+ * used as request targets. siteUrl is validated as a parseable https URL but its
+ * hostname is intentionally unrestricted: Premium/Enterprise sites may use a custom
+ * domain (e.g. go.jira.acme.com) rather than *.atlassian.net.
  *
  * Content sanitization: suggestion-derived text is placed as plain-text leaf nodes only.
  * Summary is truncated to 255 chars (Jira hard limit).
@@ -140,14 +143,19 @@ export default class JiraCloudClient extends BaseTicketClient {
       throw new Error(`Invalid cloudId format: ${config.cloudId}`);
     }
 
+    // siteUrl is display-only — used to build the browse link (never an API target;
+    // API calls route through the fixed api.atlassian.com gateway). Enterprise/Premium
+    // sites may use a custom domain (e.g. go.jira.acme.com) instead of *.atlassian.net,
+    // so the hostname is not restricted here. Still require a parseable https URL to keep
+    // http:/javascript: and other unsafe schemes out of the returned ticketUrl.
     let siteUrlParsed;
     try {
       siteUrlParsed = new URL(config.siteUrl);
     } catch {
-      throw new Error(`Invalid siteUrl: must be https://*.atlassian.net, got: ${config.siteUrl}`);
+      throw new Error(`Invalid siteUrl: must be a valid https URL, got: ${config.siteUrl}`);
     }
-    if (siteUrlParsed.protocol !== 'https:' || !siteUrlParsed.hostname.endsWith('.atlassian.net')) {
-      throw new Error(`Invalid siteUrl: must be https://*.atlassian.net, got: ${config.siteUrl}`);
+    if (siteUrlParsed.protocol !== 'https:') {
+      throw new Error(`Invalid siteUrl: must be a valid https URL, got: ${config.siteUrl}`);
     }
 
     this.httpClient = httpClient;
@@ -159,7 +167,9 @@ export default class JiraCloudClient extends BaseTicketClient {
    *
    * @param {object} ticketData
    * @param {string} ticketData.projectKey - Jira project key (e.g. "ASO")
-   * @param {string} [ticketData.issueType='Task'] - Jira issue type name
+   * @param {string} ticketData.issueType - Jira issue type name (e.g. "Task", "Bug").
+   *   Required — Jira has no server-side default and not every project defines "Task".
+   *   Resolve a valid type for the project via listIssueTypes() before calling.
    * @param {string} ticketData.summary - Issue summary (truncated to 255 chars)
    * @param {string} [ticketData.description] - Plain-text description (no ADF markup).
    *   Converted to ADF internally as plain-text leaf nodes only — callers MUST NOT
@@ -386,7 +396,7 @@ export default class JiraCloudClient extends BaseTicketClient {
         // SM still holds the same revoked token — caller must trigger a refresh
         // via ensure-tokens (auth-service).
         throw Object.assign(
-          new Error('Jira rejected the access token and no refreshed token is available in SM'),
+          new Error('Jira rejected the access token'),
           { code: 'TOKEN_REFRESH_REQUIRED', status: 401 },
         );
       }
@@ -446,10 +456,18 @@ export default class JiraCloudClient extends BaseTicketClient {
    */
   // eslint-disable-next-line class-methods-use-this
   #validateTicketInput({
-    projectKey, summary, labels = [], dueDate, parent,
+    projectKey, issueType, summary, labels = [], dueDate, parent,
   }) {
     if (!projectKey || typeof projectKey !== 'string') {
       throw new Error('projectKey is required to create a ticket');
+    }
+
+    // issueType is required — Jira create needs fields.issuetype and there is no
+    // server-side default. Not every project has a "Task" type (team-managed / custom
+    // schemes), so the caller must resolve a valid type via listIssueTypes() first
+    // rather than relying on a hard-coded fallback that could 400 at create time.
+    if (!issueType || typeof issueType !== 'string' || !issueType.trim()) {
+      throw new Error('issueType is required to create a ticket');
     }
 
     if (!summary || !String(summary).trim()) {
@@ -495,7 +513,7 @@ export default class JiraCloudClient extends BaseTicketClient {
   // eslint-disable-next-line class-methods-use-this
   #buildTicketBody({
     projectKey,
-    issueType = 'Task',
+    issueType,
     summary,
     description,
     labels = [],

--- a/packages/spacecat-shared-ticket-client/src/clients/jira-cloud-client.js
+++ b/packages/spacecat-shared-ticket-client/src/clients/jira-cloud-client.js
@@ -247,6 +247,13 @@ export default class JiraCloudClient extends BaseTicketClient {
     // Jira /project/search caps maxResults at 50 per page — enterprise instances
     // routinely have 100+ projects, so pagination is required to avoid silent truncation.
     // Read auth headers once before the loop — avoids an SM round-trip per page.
+    //
+    // Note (intentional divergence from listIssueTypes): that method calls
+    // #withAuthRetry per page (mid-loop 401 recovery) whereas this hoists auth once.
+    // Accepted tradeoff — a token cannot be revoked within a single Lambda's
+    // sub-second pagination window, so hoisting trades unreachable mid-loop
+    // recovery for fewer Secrets Manager reads. A 401 here still surfaces via
+    // #requireOk; it just is not retried mid-pagination.
     const paginationAuthHeaders = await this.credentialManager.getAuthHeaders();
     for (;;) {
       // eslint-disable-next-line no-await-in-loop
@@ -293,12 +300,12 @@ export default class JiraCloudClient extends BaseTicketClient {
    * (subtask: true) are excluded; all other types (standard + Epic) are
    * returned as { id, name }.
    *
-   * @param {string} projectId - Jira project numeric ID (e.g. "10000") or key (e.g. "ASO")
+   * @param {string} projectIdOrKey - Jira project numeric ID (e.g. "10000") or key (e.g. "ASO")
    * @returns {Promise<Array<{id: string, name: string}>>}
    */
-  async listIssueTypes(projectId) {
-    if (!projectId || typeof projectId !== 'string') {
-      throw new Error('projectId is required to list issue types');
+  async listIssueTypes(projectIdOrKey) {
+    if (!projectIdOrKey || typeof projectIdOrKey !== 'string') {
+      throw new Error('projectIdOrKey is required to list issue types');
     }
 
     const pageSize = 50;
@@ -307,7 +314,7 @@ export default class JiraCloudClient extends BaseTicketClient {
     let startAt = 0;
 
     for (let page = 0; page < maxPages; page += 1) {
-      const url = `${this.baseUrl}/issue/createmeta/${encodeURIComponent(projectId)}/issuetypes`
+      const url = `${this.baseUrl}/issue/createmeta/${encodeURIComponent(projectIdOrKey)}/issuetypes`
         + `?startAt=${startAt}&maxResults=${pageSize}`;
       // eslint-disable-next-line no-await-in-loop
       const response = await this.#withAuthRetry(

--- a/packages/spacecat-shared-ticket-client/src/clients/jira-cloud-client.js
+++ b/packages/spacecat-shared-ticket-client/src/clients/jira-cloud-client.js
@@ -368,6 +368,7 @@ export default class JiraCloudClient extends BaseTicketClient {
    *   trigger ensure-tokens. The error carries `code: 'TOKEN_REFRESH_REQUIRED'` and
    *   `status: 401` (the HTTP status returned by Jira).
    * @throws {Error} REQUIRES_REAUTH - credential manager flagged the connection as revoked.
+   *   Also thrown if a concurrent caller flags the connection during the retry window.
    */
   async #withAuthRetry(requestFn) {
     const authHeaders = await this.credentialManager.getAuthHeaders();

--- a/packages/spacecat-shared-ticket-client/src/clients/jira-cloud-client.js
+++ b/packages/spacecat-shared-ticket-client/src/clients/jira-cloud-client.js
@@ -236,13 +236,13 @@ export default class JiraCloudClient extends BaseTicketClient {
     // Paginate remaining pages with standard auth (token was just validated).
     // Jira /project/search caps maxResults at 50 per page — enterprise instances
     // routinely have 100+ projects, so pagination is required to avoid silent truncation.
+    // Read auth headers once before the loop — avoids an SM round-trip per page.
+    const paginationAuthHeaders = await this.credentialManager.getAuthHeaders();
     for (;;) {
-      // eslint-disable-next-line no-await-in-loop
-      const authHeaders = await this.credentialManager.getAuthHeaders();
       // eslint-disable-next-line no-await-in-loop
       const response = await this.httpClient.fetch(
         `${this.baseUrl}/project/search?maxResults=50&orderBy=name&startAt=${startAt}`,
-        { method: 'GET', headers: { ...authHeaders, Accept: 'application/json' }, redirect: 'error' },
+        { method: 'GET', headers: { ...paginationAuthHeaders, Accept: 'application/json' }, redirect: 'error' },
       );
       // eslint-disable-next-line no-await-in-loop
       await this.#requireOk(response, 'listProjects');
@@ -364,6 +364,10 @@ export default class JiraCloudClient extends BaseTicketClient {
    *
    * @param {Function} requestFn - async (authHeaders) => Response
    * @returns {Promise<Response>}
+   * @throws {Error} TOKEN_REFRESH_REQUIRED - SM still holds the rejected token; caller must
+   *   trigger ensure-tokens. The error carries `code: 'TOKEN_REFRESH_REQUIRED'` and
+   *   `status: 401` (the HTTP status returned by Jira).
+   * @throws {Error} REQUIRES_REAUTH - credential manager flagged the connection as revoked.
    */
   async #withAuthRetry(requestFn) {
     const authHeaders = await this.credentialManager.getAuthHeaders();

--- a/packages/spacecat-shared-ticket-client/src/clients/jira-cloud-client.js
+++ b/packages/spacecat-shared-ticket-client/src/clients/jira-cloud-client.js
@@ -350,19 +350,17 @@ export default class JiraCloudClient extends BaseTicketClient {
   /**
    * Wraps a Jira API call with retry-once on 401.
    *
-   * If getAuthHeaders() throws (TOKEN_REFRESH_REQUIRED or REQUIRES_REAUTH):
-   * retries to pick up tokens written by a concurrent Lambda (e.g. auth-service
-   * ensure-tokens). If SM is also bad, the error propagates.
+   * If getAuthHeaders() throws REQUIRES_REAUTH, the error propagates
+   * immediately — no Jira call is attempted.
    *
-   * On first 401: re-reads SM via getAuthHeaders() (pure GET). If a concurrent
-   * caller already refreshed and SM holds a different valid token, retries once
-   * with it. If SM still holds the same stale token or throws (expired /
-   * requires_reauth), propagates the error so the caller can trigger a refresh.
+   * On first 401: re-reads SM via getAuthHeaders(). If a concurrent caller
+   * (e.g. auth-service ensure-tokens) already refreshed and SM holds a
+   * different valid token, retries once with it. If SM still holds the same
+   * revoked token, throws TOKEN_REFRESH_REQUIRED so the caller can trigger
+   * a refresh via ensure-tokens.
    *
-   * On second 401 or any other HTTP error: returned as-is for #requireOk to handle.
-   *
-   * NOTE: this does NOT consume a refresh token or write to SM. Token rotation is
-   * the caller's responsibility.
+   * NOTE: this does NOT consume a refresh token or write to SM. Token
+   * rotation is the auth-service's responsibility.
    *
    * @param {Function} requestFn - async (authHeaders) => Response
    * @returns {Promise<Response>}
@@ -374,8 +372,8 @@ export default class JiraCloudClient extends BaseTicketClient {
     if (response.status === 401) {
       this.log.debug('Jira API returned 401 — re-reading SM for a concurrent refresh');
       // 401 means Jira revoked the access token (refresh-token rotation window
-      // closed). Re-read SM with cache bypass to pick up tokens written by a
-      // concurrent caller (e.g. auth-service ensure-tokens).
+      // closed). Re-read SM to pick up tokens written by a concurrent caller
+      // (e.g. auth-service ensure-tokens).
       // NOTE: this Lambda does NOT refresh tokens itself — token rotation is
       // the auth-service's responsibility (it has SM PUT + Atlassian credentials).
       const freshHeaders = await this.credentialManager.getAuthHeaders();

--- a/packages/spacecat-shared-ticket-client/src/clients/jira-cloud-client.js
+++ b/packages/spacecat-shared-ticket-client/src/clients/jira-cloud-client.js
@@ -275,17 +275,25 @@ export default class JiraCloudClient extends BaseTicketClient {
   }
 
   /**
-   * Returns all non-subtask issue types for a given project.
+   * Returns the creatable non-subtask issue types for a given project.
    *
-   * Uses GET /project/{projectId}/hierarchy (REST v3) which is scoped to the
-   * project and works with read:jira-work scope. Hierarchy levels:
-   *   level -1 → Subtask (excluded)
-   *   level  0 → standard types (Story, Bug, Task, …)
-   *   level  1 → Epic
-   * All level >= 0 types are returned; the caller may further filter by level
-   * if Epic exclusion is needed.
+   * Uses GET /issue/createmeta/{projectIdOrKey}/issuetypes (REST v3). Unlike the
+   * /project/{id}/hierarchy endpoint (which Atlassian documents only for
+   * team-managed / next-gen projects), createmeta carries no project-style
+   * restriction, so it works uniformly across team-managed and company-managed
+   * projects. It is permission-filtered: it returns the issue types the calling
+   * user has the "Create issues" project permission for, so per-user differences
+   * are handled by Jira rather than by this client.
+   * (OAuth scope: read:jira-work.)
    *
-   * @param {string} projectId - Jira project numeric ID, e.g. "10000"
+   * The response is paginated ({ issueTypes, startAt, maxResults, total }) with
+   * no isLast flag, so we page until an empty batch or startAt >= total.
+   *
+   * Each issue type carries a documented `subtask` boolean. Subtask types
+   * (subtask: true) are excluded; all other types (standard + Epic) are
+   * returned as { id, name }.
+   *
+   * @param {string} projectId - Jira project numeric ID (e.g. "10000") or key (e.g. "ASO")
    * @returns {Promise<Array<{id: string, name: string}>>}
    */
   async listIssueTypes(projectId) {
@@ -293,21 +301,43 @@ export default class JiraCloudClient extends BaseTicketClient {
       throw new Error('projectId is required to list issue types');
     }
 
-    const response = await this.#withAuthRetry(
-      (authHeaders) => this.httpClient.fetch(
-        `${this.baseUrl}/project/${encodeURIComponent(projectId)}/hierarchy`,
-        { method: 'GET', headers: { ...authHeaders, Accept: 'application/json' }, redirect: 'error' },
-      ),
-    );
-    await this.#requireOk(response, 'listIssueTypes');
-    const data = await response.json();
+    const pageSize = 50;
+    const maxPages = 100;
+    const issueTypes = [];
+    let startAt = 0;
 
-    return (data.hierarchy ?? [])
-      .filter((level) => level.level >= 0)
-      .flatMap((level) => (level.issueTypes ?? []).map(({ id, name }) => ({
-        id: String(id),
-        name,
-      })));
+    for (let page = 0; page < maxPages; page += 1) {
+      const url = `${this.baseUrl}/issue/createmeta/${encodeURIComponent(projectId)}/issuetypes`
+        + `?startAt=${startAt}&maxResults=${pageSize}`;
+      // eslint-disable-next-line no-await-in-loop
+      const response = await this.#withAuthRetry(
+        (authHeaders) => this.httpClient.fetch(
+          url,
+          { method: 'GET', headers: { ...authHeaders, Accept: 'application/json' }, redirect: 'error' },
+        ),
+      );
+      // eslint-disable-next-line no-await-in-loop
+      await this.#requireOk(response, 'listIssueTypes');
+      // eslint-disable-next-line no-await-in-loop
+      const data = await response.json();
+
+      const batch = data.issueTypes ?? [];
+      for (const { id, name, subtask } of batch) {
+        // `subtask` (boolean) is the documented field on createmeta issue types;
+        // hierarchyLevel is not part of this response schema. Keep everything
+        // that is not a subtask (standard types + Epic).
+        if (!subtask) {
+          issueTypes.push({ id: String(id), name });
+        }
+      }
+
+      startAt += batch.length;
+      if (batch.length === 0 || startAt >= (data.total ?? 0)) {
+        break;
+      }
+    }
+
+    return issueTypes;
   }
 
   /**

--- a/packages/spacecat-shared-ticket-client/src/clients/jira-cloud-client.js
+++ b/packages/spacecat-shared-ticket-client/src/clients/jira-cloud-client.js
@@ -238,7 +238,7 @@ export default class JiraCloudClient extends BaseTicketClient {
     // routinely have 100+ projects, so pagination is required to avoid silent truncation.
     for (;;) {
       // eslint-disable-next-line no-await-in-loop
-      const authHeaders = await this.#getAuthHeadersWithCacheBypass();
+      const authHeaders = await this.credentialManager.getAuthHeaders();
       // eslint-disable-next-line no-await-in-loop
       const response = await this.httpClient.fetch(
         `${this.baseUrl}/project/search?maxResults=50&orderBy=name&startAt=${startAt}`,
@@ -348,31 +348,11 @@ export default class JiraCloudClient extends BaseTicketClient {
   // ── Auth retry ──────────────────────────────────────────────────────────────
 
   /**
-   * Returns auth headers, retrying with bypassCache=true when the cached token
-   * is stale (TOKEN_REFRESH_REQUIRED or REQUIRES_REAUTH). Another Lambda may
-   * have written fresh tokens to SM since the cache was populated.
-   * If the bypass call also fails, the error propagates to the caller.
-   * Non-credential errors (network, SDK, IAM) are re-thrown immediately.
-   */
-  async #getAuthHeadersWithCacheBypass() {
-    try {
-      return await this.credentialManager.getAuthHeaders();
-    } catch (err) {
-      if (err.code !== 'TOKEN_REFRESH_REQUIRED' && err.code !== 'REQUIRES_REAUTH') {
-        throw err;
-      }
-      this.log.debug(`getAuthHeaders() threw ${err.code} — bypassing cache for SM re-read`);
-      return this.credentialManager.getAuthHeaders(true);
-    }
-  }
-
-  /**
    * Wraps a Jira API call with retry-once on 401.
    *
-   * If getAuthHeaders() throws (cache stale — TOKEN_REFRESH_REQUIRED or
-   * REQUIRES_REAUTH): retries with bypassCache=true to pick up tokens written
-   * by a concurrent Lambda (e.g. auth-service ensure-tokens). If SM is also
-   * bad, the error propagates.
+   * If getAuthHeaders() throws (TOKEN_REFRESH_REQUIRED or REQUIRES_REAUTH):
+   * retries to pick up tokens written by a concurrent Lambda (e.g. auth-service
+   * ensure-tokens). If SM is also bad, the error propagates.
    *
    * On first 401: re-reads SM via getAuthHeaders() (pure GET). If a concurrent
    * caller already refreshed and SM holds a different valid token, retries once
@@ -388,21 +368,23 @@ export default class JiraCloudClient extends BaseTicketClient {
    * @returns {Promise<Response>}
    */
   async #withAuthRetry(requestFn) {
-    const authHeaders = await this.#getAuthHeadersWithCacheBypass();
+    const authHeaders = await this.credentialManager.getAuthHeaders();
     const response = await requestFn(authHeaders);
 
     if (response.status === 401) {
       this.log.debug('Jira API returned 401 — re-reading SM for a concurrent refresh');
-      // bypassCache=true: forces SM re-read, making a concurrent Lambda's refresh
-      // visible even within the 30s TTL window.
-      // getAuthHeaders() throws TOKEN_REFRESH_REQUIRED or REQUIRES_REAUTH when SM is
-      // still stale — let those propagate so the caller can trigger a refresh.
-      const freshHeaders = await this.credentialManager.getAuthHeaders(true);
+      // 401 means Jira revoked the access token (refresh-token rotation window
+      // closed). Re-read SM with cache bypass to pick up tokens written by a
+      // concurrent caller (e.g. auth-service ensure-tokens).
+      // NOTE: this Lambda does NOT refresh tokens itself — token rotation is
+      // the auth-service's responsibility (it has SM PUT + Atlassian credentials).
+      const freshHeaders = await this.credentialManager.getAuthHeaders();
       if (freshHeaders.Authorization === authHeaders.Authorization) {
-        // SM holds the same token that Jira just rejected — retrying would fail again.
+        // SM still holds the same revoked token — caller must trigger a refresh
+        // via ensure-tokens (auth-service).
         throw Object.assign(
-          new Error('OAuth token expired — caller should trigger a refresh'),
-          { code: 'TOKEN_REFRESH_REQUIRED' },
+          new Error('Jira rejected the access token and no refreshed token is available in SM'),
+          { code: 'TOKEN_REFRESH_REQUIRED', status: 401 },
         );
       }
       return requestFn(freshHeaders);

--- a/packages/spacecat-shared-ticket-client/src/credentials/oauth-credential-manager.js
+++ b/packages/spacecat-shared-ticket-client/src/credentials/oauth-credential-manager.js
@@ -35,7 +35,7 @@ const CONCURRENT_REFRESH_WAIT_MS = 200;
  * each call returns a valid access token + a NEW refresh token. After the
  * 10-minute window, the original refresh token is invalidated and only the
  * latest refresh token remains valid (for 90 days of inactivity).
- * (Ref: https://developer.atlassian.com/cloud/jira/software/oauth-2-3lo-apps/#faq-rrt-config)
+ * (Ref: https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/)
  *
  * Verified empirically: the same refresh token was exchanged 5 times within
  * 10 minutes — all calls returned 200. After 10 minutes, re-using the ORIGINAL
@@ -52,8 +52,11 @@ const CONCURRENT_REFRESH_WAIT_MS = 200;
  *   Lambda B: refresh(RT) → 200 → { AT_B, RT_B } → writes RT_B to SM (overwrites RT_A)
  *
  * Both succeed (10-minute reuse). Last writer wins in SM — RT_A is lost but
- * this is harmless: AT_A is in Lambda A's memory (valid 1 hour), and RT_B in
- * SM is valid for 90 days. No token is "consumed and lost" — both calls succeed.
+ * this is harmless: AT_A is usable in Lambda A's memory for the remainder of the
+ * 10-minute leeway window (Atlassian may revoke the companion access token earlier
+ * than its exp once RT_A is superseded outside that window), and RT_B in SM is
+ * valid for 90 days. No token is "consumed and lost" — both calls succeed, and a
+ * real 401 from Jira is handled reactively via forceRefreshAuthHeaders.
  *
  * ## Grant failure scenarios
  *

--- a/packages/spacecat-shared-ticket-client/src/credentials/oauth-credential-manager.js
+++ b/packages/spacecat-shared-ticket-client/src/credentials/oauth-credential-manager.js
@@ -128,12 +128,13 @@ export default class OAuthCredentialManager {
   // ── Public methods ────────────────────────────────────────────────────────
 
   /**
-   * Returns a valid Bearer header from the current SM state.
-   * Pure read — no SM writes, no Atlassian calls.
+   * Returns a Bearer header from the current SM state.
+   * Pure read — no SM writes, no Atlassian calls. Always reads SM fresh.
    *
-   * Throws with code TOKEN_REFRESH_REQUIRED when the token is expired so the
-   * caller can return a 401 to the UI, which then triggers a refresh
-   * before retrying.
+   * Returns the token regardless of its expiry state — Jira validates
+   * access tokens via its own revocation check (tied to the refresh-token
+   * rotation window), not the JWT exp claim. Callers should handle a real
+   * 401 from Jira reactively rather than blocking on local expiry checks.
    *
    * Throws with code REQUIRES_REAUTH when the connection is flagged for
    * re-authorization (refresh token revoked — user must reconnect).

--- a/packages/spacecat-shared-ticket-client/src/credentials/oauth-credential-manager.js
+++ b/packages/spacecat-shared-ticket-client/src/credentials/oauth-credential-manager.js
@@ -16,7 +16,6 @@ const TOKEN_EXPIRY_BUFFER_MS = 10 * 60 * 1000; // refresh 10 minutes before expi
 const SM_WRITE_ATTEMPTS = 3;
 const SM_WRITE_BASE_DELAY_MS = 100;
 const CONCURRENT_REFRESH_WAIT_MS = 200;
-const SECRET_CACHE_TTL_MS = 30_000; // cache SM reads for 30 seconds
 
 /**
  * Manages OAuth 2.0 access tokens stored in AWS Secrets Manager.
@@ -98,11 +97,6 @@ const SECRET_CACHE_TTL_MS = 30_000; // cache SM reads for 30 seconds
  * inside #fetchNewTokens — callers that only read tokens do not need them set.
  */
 export default class OAuthCredentialManager {
-  // ── In-memory TTL cache for SM reads (default/read path only) ─────────────
-  #secretCache = null;
-
-  #cacheExpiresAt = 0;
-
   // ── In-process concurrency locks ──────────────────────────────────────────
   // Serialise concurrent same-Lambda calls so only one Atlassian request fires.
   // The Promise is stored while a refresh is in flight; cleared when it settles.
@@ -146,8 +140,8 @@ export default class OAuthCredentialManager {
    *
    * @returns {Promise<{Authorization: string}>}
    */
-  async getAuthHeaders(bypassCache = false) {
-    const secret = await this.#readSecret(bypassCache);
+  async getAuthHeaders() {
+    const secret = await this.#readSecret();
 
     if (secret.requiresReauth) {
       throw Object.assign(
@@ -156,13 +150,10 @@ export default class OAuthCredentialManager {
       );
     }
 
-    if (this.#isExpired(secret)) {
-      throw Object.assign(
-        new Error('OAuth token expired — caller should trigger a refresh'),
-        { code: 'TOKEN_REFRESH_REQUIRED' },
-      );
-    }
-
+    // Return the token even if #isExpired — Jira validates access tokens via
+    // its own revocation check (tied to the refresh-token rotation window),
+    // NOT the JWT exp claim. Blocking locally causes false-positive 409s when
+    // the token is still valid at Jira. Let #withAuthRetry handle real 401s.
     return { Authorization: `Bearer ${secret.accessToken}` };
   }
 
@@ -192,7 +183,7 @@ export default class OAuthCredentialManager {
   }
 
   async #doRefreshAuthHeaders() {
-    const current = await this.#readSecret(true);
+    const current = await this.#readSecret();
 
     // Pre-read exit: concurrent caller already refreshed — use their token.
     if (!this.#isExpired(current) && !current.requiresReauth) {
@@ -269,7 +260,7 @@ export default class OAuthCredentialManager {
     const usedToken = usedAuthHeader
       ? (usedAuthHeader.replace(/^bearer\s+/i, '').trim() || null)
       : null;
-    const current = await this.#readSecret(true);
+    const current = await this.#readSecret();
 
     if (usedToken
       && current.accessToken !== usedToken
@@ -318,10 +309,7 @@ export default class OAuthCredentialManager {
 
   // ── Private utilities ──────────────────────────────────────────────────────
 
-  async #readSecret(bypassCache = false) {
-    if (!bypassCache && this.#secretCache !== null && Date.now() < this.#cacheExpiresAt) {
-      return this.#secretCache;
-    }
+  async #readSecret() {
     const result = await this.smClient.getSecretValue({ SecretId: this.secretPath });
     let parsed;
     try {
@@ -341,14 +329,7 @@ export default class OAuthCredentialManager {
       && (typeof parsed.accessToken !== 'string' || !parsed.accessToken)) {
       throw new Error(`SM secret at ${this.secretPath} is missing a valid accessToken`);
     }
-    this.#secretCache = parsed;
-    this.#cacheExpiresAt = Date.now() + SECRET_CACHE_TTL_MS;
     return parsed;
-  }
-
-  #invalidateSecretCache() {
-    this.#secretCache = null;
-    this.#cacheExpiresAt = 0;
   }
 
   // eslint-disable-next-line class-methods-use-this
@@ -437,7 +418,6 @@ export default class OAuthCredentialManager {
    * SM is still expired, writes requiresReauth: true and throws.
    */
   async #writeTokens(refreshed) {
-    this.#invalidateSecretCache();
     const idempotencyToken = createHash('sha256')
       .update(refreshed.access_token)
       .digest('hex')
@@ -483,7 +463,7 @@ export default class OAuthCredentialManager {
     this.log.debug('SM write exhausted, re-reading for concurrent writer', {
       secretPath: this.secretPath,
     });
-    const reread = await this.#readSecret(true);
+    const reread = await this.#readSecret();
     if (!this.#isExpired(reread)) {
       return;
     }
@@ -517,7 +497,7 @@ export default class OAuthCredentialManager {
    *    Both scenarios return identical HTTP 403 unauthorized_client from Atlassian.
    */
   async #recoverFromRevokedGrant() {
-    const raceCheck = await this.#readSecret(true);
+    const raceCheck = await this.#readSecret();
     if (!this.#isExpired(raceCheck) && !raceCheck.requiresReauth) {
       this.log.debug('GRANT_REVOKED — concurrent caller already refreshed, using their token');
       return { Authorization: `Bearer ${raceCheck.accessToken}` };
@@ -527,7 +507,7 @@ export default class OAuthCredentialManager {
     // its fresh tokens to SM before we conclude the grant is genuinely dead.
     // eslint-disable-next-line no-promise-executor-return
     await new Promise((resolve) => setTimeout(resolve, CONCURRENT_REFRESH_WAIT_MS));
-    const finalCheck = await this.#readSecret(true);
+    const finalCheck = await this.#readSecret();
     if (!this.#isExpired(finalCheck) && !finalCheck.requiresReauth) {
       this.log.debug('Concurrent refresh completed during wait — using their token');
       return { Authorization: `Bearer ${finalCheck.accessToken}` };
@@ -545,7 +525,6 @@ export default class OAuthCredentialManager {
    * so no ClientRequestToken is needed.
    */
   async #writeReauthFlag() {
-    this.#invalidateSecretCache();
     let lastErr;
     // eslint-disable-next-line no-plusplus
     for (let attempt = 0; attempt < SM_WRITE_ATTEMPTS; attempt++) {
@@ -554,7 +533,7 @@ export default class OAuthCredentialManager {
         // new valid tokens — merging requiresReauth: true onto the freshest snapshot avoids
         // clobbering their tokens with a stale read-modify-write.
         // eslint-disable-next-line no-await-in-loop
-        const secret = await this.#readSecret(true);
+        const secret = await this.#readSecret();
         // If a concurrent Lambda wrote valid tokens since our last check, do NOT
         // clobber them with requiresReauth: true — the connection is healthy.
         if (!this.#isExpired(secret) && !secret.requiresReauth) {

--- a/packages/spacecat-shared-ticket-client/src/http/rate-limit-aware-http-client.js
+++ b/packages/spacecat-shared-ticket-client/src/http/rate-limit-aware-http-client.js
@@ -24,10 +24,6 @@ const MAX_WAIT_MS = 30_000;
 // until the 15-minute function timeout. AbortSignal.timeout() is available in Node 18+.
 const FETCH_TIMEOUT_MS = 30_000;
 
-// Threshold below which remaining quota triggers a warning log.
-// At ~10 k remaining, ops teams have time to react before exhaustion.
-const LOW_QUOTA_THRESHOLD = 10_000;
-
 // Quota-exhaustion reasons must fail fast — retrying wastes Lambda compute
 // because quota windows last up to one hour.
 const QUOTA_REASONS = new Set([
@@ -57,9 +53,13 @@ const QUOTA_REASONS = new Set([
  * 429 rate-limit retries apply to ALL methods since Jira rejected the request
  * outright and nothing was created.
  *
- * Additionally reads `X-RateLimit-Remaining` on every response and logs a
- * warning when remaining capacity falls below LOW_QUOTA_THRESHOLD so operators
+ * Additionally reads Atlassian's `X-RateLimit-NearLimit` signal (documented as
+ * `true` when <20% of quota capacity remains) and logs a warning so operators
  * can request a Tier 2 (per-tenant) quota upgrade before exhaustion occurs.
+ * NearLimit is used instead of a fixed numeric threshold on `X-RateLimit-Remaining`
+ * because, per the Atlassian docs, Remaining is per-second for burst/request-rate
+ * scopes (a fixed threshold would false-positive there) whereas NearLimit is only
+ * emitted for the pool/quota scopes we actually want to warn on.
  */
 export default class RateLimitAwareHttpClient {
   constructor(httpClient, log) {
@@ -182,26 +182,32 @@ export default class RateLimitAwareHttpClient {
   /**
    * Reads rate-limit observation headers from every response.
    *
-   * - `X-RateLimit-Remaining`: warns when capacity is below threshold so operators
-   *   can request a Tier 2 (per-tenant) quota upgrade before exhaustion.
-   * - `X-RateLimit-Reset`: logged at debug level for diagnostics; shows when the
-   *   current quota window resets (ISO 8601 timestamp per Atlassian docs).
+   * - `X-RateLimit-NearLimit`: Atlassian's documented near-capacity signal —
+   *   `true` when <20% of quota capacity remains. Triggers a warning so operators
+   *   can request a Tier 2 (per-tenant) quota upgrade before exhaustion. Preferred
+   *   over a fixed numeric threshold on `X-RateLimit-Remaining`, whose value is
+   *   per-second for burst scopes and would otherwise false-positive constantly.
+   * - `X-RateLimit-Remaining` / `X-RateLimit-Limit`: included in the warning for
+   *   context when available.
+   * - `X-RateLimit-Reset`: per Atlassian docs, only returned on 429 responses.
+   *   Logged at debug level when present so operators can correlate quota windows.
    *
    * @param {Headers} headers
    */
   #observeQuotaHeaders(headers) {
-    const remaining = parseInt(headers?.get?.('X-RateLimit-Remaining') ?? '', 10);
-    if (Number.isFinite(remaining) && remaining < LOW_QUOTA_THRESHOLD) {
+    // X-RateLimit-Reset is only returned on 429 responses per Atlassian docs, so
+    // this is typically undefined on success paths.
+    const resetAt = headers?.get?.('X-RateLimit-Reset') ?? undefined;
+
+    if (headers?.get?.('X-RateLimit-NearLimit') === 'true') {
+      const remaining = parseInt(headers?.get?.('X-RateLimit-Remaining') ?? '', 10);
       this.log.warn('Jira quota running low', {
-        remaining,
-        threshold: LOW_QUOTA_THRESHOLD,
-        resetAt: headers?.get?.('X-RateLimit-Reset') ?? undefined,
+        remaining: Number.isFinite(remaining) ? remaining : undefined,
+        limit: headers?.get?.('X-RateLimit-Limit') ?? undefined,
+        resetAt,
       });
     }
 
-    // Log reset timestamp at debug level on every response (not just low-quota) so
-    // operators can correlate quota windows in debug traces.
-    const resetAt = headers?.get?.('X-RateLimit-Reset');
     if (resetAt) {
       this.log.debug('Jira rate-limit window', { resetAt });
     }

--- a/packages/spacecat-shared-ticket-client/src/index.d.ts
+++ b/packages/spacecat-shared-ticket-client/src/index.d.ts
@@ -73,7 +73,7 @@ export interface RequiresReauthError extends Error {
 export declare class BaseTicketClient {
   createTicket(ticketData: TicketData): Promise<TicketResult>;
   listProjects(): Promise<Project[]>;
-  listIssueTypes(projectId: string): Promise<IssueType[]>;
+  listIssueTypes(projectIdOrKey: string): Promise<IssueType[]>;
 }
 
 export declare class JiraCloudClient extends BaseTicketClient {

--- a/packages/spacecat-shared-ticket-client/src/index.d.ts
+++ b/packages/spacecat-shared-ticket-client/src/index.d.ts
@@ -46,6 +46,30 @@ export interface Attachment {
   filename: string;
 }
 
+/**
+ * Error thrown by JiraCloudClient when Jira rejects the access token and no
+ * refreshed token is available in Secrets Manager.
+ *
+ * Properties:
+ *   code:   'TOKEN_REFRESH_REQUIRED' — caller must trigger ensure-tokens via auth-service
+ *   status: 401                      — the HTTP status returned by Jira
+ */
+export interface TokenRefreshRequiredError extends Error {
+  code: 'TOKEN_REFRESH_REQUIRED';
+  status: 401;
+}
+
+/**
+ * Error thrown by JiraCloudClient / OAuthCredentialManager when the OAuth
+ * connection is flagged as requiring re-authorization (refresh token revoked).
+ *
+ * Properties:
+ *   code: 'REQUIRES_REAUTH' — user must reconnect via the OAuth consent flow
+ */
+export interface RequiresReauthError extends Error {
+  code: 'REQUIRES_REAUTH';
+}
+
 export declare class BaseTicketClient {
   createTicket(ticketData: TicketData): Promise<TicketResult>;
   listProjects(): Promise<Project[]>;

--- a/packages/spacecat-shared-ticket-client/src/index.d.ts
+++ b/packages/spacecat-shared-ticket-client/src/index.d.ts
@@ -19,7 +19,7 @@ export interface TicketResult {
 
 export interface TicketData {
   projectKey: string;
-  issueType?: string;
+  issueType: string;
   summary: string;
   description?: string;
   labels?: string[];

--- a/packages/spacecat-shared-ticket-client/src/index.d.ts
+++ b/packages/spacecat-shared-ticket-client/src/index.d.ts
@@ -57,7 +57,7 @@ export declare class JiraCloudClient extends BaseTicketClient {
 }
 
 export declare class OAuthCredentialManager {
-  getAuthHeaders(bypassCache?: boolean): Promise<Record<string, string>>;
+  getAuthHeaders(): Promise<Record<string, string>>;
   refreshAuthHeaders(): Promise<Record<string, string>>;
   forceRefreshAuthHeaders(usedAuthHeader?: string | null): Promise<Record<string, string>>;
   setRequiresReauth(): Promise<void>;

--- a/packages/spacecat-shared-ticket-client/test/jira-cloud-client.test.js
+++ b/packages/spacecat-shared-ticket-client/test/jira-cloud-client.test.js
@@ -1309,16 +1309,22 @@ describe('JiraCloudClient', () => {
   });
 
   describe('listIssueTypes', () => {
-    const hierarchyResponse = {
-      hierarchy: [
-        { level: 0, issueTypes: [{ id: 10001, name: 'Story' }, { id: 10002, name: 'Bug' }] },
-        { level: 1, issueTypes: [{ id: 10003, name: 'Epic' }] },
-        { level: -1, issueTypes: [{ id: 10004, name: 'Subtask' }] },
+    // createmeta/issuetypes response shape: flat, paginated, subtask boolean per type.
+    // Works uniformly for team-managed and company-managed projects (no style gate).
+    const createMetaResponse = {
+      startAt: 0,
+      maxResults: 50,
+      total: 4,
+      issueTypes: [
+        { id: 10001, name: 'Story', subtask: false },
+        { id: 10002, name: 'Bug', subtask: false },
+        { id: 10003, name: 'Epic', subtask: false },
+        { id: 10004, name: 'Subtask', subtask: true },
       ],
     };
 
-    it('returns non-subtask issue types from hierarchy (level >= 0)', async () => {
-      const httpClient = makeHttpClient(hierarchyResponse);
+    it('returns non-subtask issue types (subtask: false)', async () => {
+      const httpClient = makeHttpClient(createMetaResponse);
       const client = new JiraCloudClient(
         VALID_CONFIG,
         makeCredentialManager(),
@@ -1331,9 +1337,23 @@ describe('JiraCloudClient', () => {
         { id: '10002', name: 'Bug' },
         { id: '10003', name: 'Epic' },
       ]);
+      // Hits the createmeta endpoint (not the team-managed-only hierarchy endpoint)
+      expect(httpClient.fetch.firstCall.args[0]).to.include('/issue/createmeta/10000/issuetypes');
     });
 
-    it('returns empty array when hierarchy is absent', async () => {
+    it('accepts a project key (not just numeric id)', async () => {
+      const httpClient = makeHttpClient(createMetaResponse);
+      const client = new JiraCloudClient(
+        VALID_CONFIG,
+        makeCredentialManager(),
+        httpClient,
+        makeLog(),
+      );
+      await client.listIssueTypes('ASO');
+      expect(httpClient.fetch.firstCall.args[0]).to.include('/issue/createmeta/ASO/issuetypes');
+    });
+
+    it('returns empty array when issueTypes is absent', async () => {
       const httpClient = makeHttpClient({});
       const client = new JiraCloudClient(
         VALID_CONFIG,
@@ -1345,8 +1365,53 @@ describe('JiraCloudClient', () => {
       expect(issueTypes).to.deep.equal([]);
     });
 
-    it('handles hierarchy level with missing issueTypes array', async () => {
-      const httpClient = makeHttpClient({ hierarchy: [{ level: 0 }] });
+    it('paginates until startAt >= total', async () => {
+      const fetchStub = sinon.stub();
+      fetchStub.onFirstCall().resolves({
+        ok: true,
+        status: 200,
+        json: sinon.stub().resolves({
+          startAt: 0,
+          maxResults: 2,
+          total: 3,
+          issueTypes: [
+            { id: 1, name: 'Story', subtask: false },
+            { id: 2, name: 'Bug', subtask: false },
+          ],
+        }),
+      });
+      fetchStub.onSecondCall().resolves({
+        ok: true,
+        status: 200,
+        json: sinon.stub().resolves({
+          startAt: 2,
+          maxResults: 2,
+          total: 3,
+          issueTypes: [{ id: 3, name: 'Epic', subtask: false }],
+        }),
+      });
+      const client = new JiraCloudClient(
+        VALID_CONFIG,
+        makeCredentialManager(),
+        { fetch: fetchStub },
+        makeLog(),
+      );
+      const issueTypes = await client.listIssueTypes('10000');
+      expect(issueTypes).to.deep.equal([
+        { id: '1', name: 'Story' },
+        { id: '2', name: 'Bug' },
+        { id: '3', name: 'Epic' },
+      ]);
+      expect(fetchStub.callCount).to.equal(2);
+      expect(fetchStub.firstCall.args[0]).to.include('startAt=0');
+      expect(fetchStub.secondCall.args[0]).to.include('startAt=2');
+    });
+
+    it('stops when a page returns an empty batch (guards against total drift)', async () => {
+      // total claims more items than are actually returned — must not loop forever.
+      const httpClient = makeHttpClient({
+        startAt: 0, maxResults: 50, total: 10, issueTypes: [],
+      });
       const client = new JiraCloudClient(
         VALID_CONFIG,
         makeCredentialManager(),
@@ -1355,6 +1420,7 @@ describe('JiraCloudClient', () => {
       );
       const issueTypes = await client.listIssueTypes('10000');
       expect(issueTypes).to.deep.equal([]);
+      expect(httpClient.fetch.callCount).to.equal(1);
     });
 
     it('throws when projectId is missing', async () => {
@@ -1679,7 +1745,7 @@ describe('JiraCloudClient', () => {
         ok: true,
         status: 200,
         json: sinon.stub().resolves({
-          hierarchy: [{ level: 0, issueTypes: [{ id: 10, name: 'Bug' }] }],
+          issueTypes: [{ id: 10, name: 'Bug', subtask: false }],
         }),
       });
       const credMgr = makeRetryCredentialManager();
@@ -1772,7 +1838,7 @@ describe('JiraCloudClient', () => {
         ok: true,
         status: 200,
         json: sinon.stub().resolves({
-          hierarchy: [{ level: 0, issueTypes: [{ id: 10, name: 'Bug' }] }],
+          issueTypes: [{ id: 10, name: 'Bug', subtask: false }],
         }),
       });
       const client = new JiraCloudClient(VALID_CONFIG, credMgr, { fetch: fetchStub }, makeLog());

--- a/packages/spacecat-shared-ticket-client/test/jira-cloud-client.test.js
+++ b/packages/spacecat-shared-ticket-client/test/jira-cloud-client.test.js
@@ -1525,8 +1525,8 @@ describe('JiraCloudClient', () => {
     function makeRetryCredentialManager() {
       return {
         getAuthHeaders: sinon.stub()
+          .onFirstCall()
           .resolves({ Authorization: 'Bearer stale-token' })
-          .onSecondCall()
           .resolves({ Authorization: 'Bearer fresh-token' }),
       };
     }
@@ -1673,23 +1673,6 @@ describe('JiraCloudClient', () => {
       const err = await client.listIssueTypes('10000').catch((e) => e);
       expect(err.code).to.equal('REQUIRES_REAUTH');
       expect(credMgr.getAuthHeaders.callCount).to.equal(1); // no retry
-      expect(fetchStub.callCount).to.equal(0);
-    });
-
-    it('propagates REQUIRES_REAUTH without attempting Jira call', async () => {
-      const reauthErr = Object.assign(
-        new Error('OAuth connection requires re-authorization'),
-        { code: 'REQUIRES_REAUTH' },
-      );
-      const credMgr = {
-        getAuthHeaders: sinon.stub().rejects(reauthErr),
-      };
-      const fetchStub = sinon.stub();
-      const client = new JiraCloudClient(VALID_CONFIG, credMgr, { fetch: fetchStub }, makeLog());
-
-      const err = await client.listIssueTypes('10000').catch((e) => e);
-      expect(err.code).to.equal('REQUIRES_REAUTH');
-      expect(credMgr.getAuthHeaders.callCount).to.equal(1);
       expect(fetchStub.callCount).to.equal(0);
     });
 

--- a/packages/spacecat-shared-ticket-client/test/jira-cloud-client.test.js
+++ b/packages/spacecat-shared-ticket-client/test/jira-cloud-client.test.js
@@ -1519,13 +1519,12 @@ describe('JiraCloudClient', () => {
   describe('auth retry on 401', () => {
     /**
      * Credential manager that simulates a concurrent auth-service refresh:
-     * first getAuthHeaders call returns a stale token, second returns a fresh one.
-     * No forceRefreshAuthHeaders — #withAuthRetry uses getAuthHeaders (GET-only).
+     * getAuthHeaders returns a stale token on the first call; on 401,
+     * #withAuthRetry calls getAuthHeaders() again which returns a fresh token.
      */
     function makeRetryCredentialManager() {
       return {
         getAuthHeaders: sinon.stub()
-          .onFirstCall()
           .resolves({ Authorization: 'Bearer stale-token' })
           .onSecondCall()
           .resolves({ Authorization: 'Bearer fresh-token' }),
@@ -1549,11 +1548,8 @@ describe('JiraCloudClient', () => {
 
       const result = await client.listIssueTypes('10000');
       expect(result).to.deep.equal([{ id: '10', name: 'Bug' }]);
-      // getAuthHeaders called twice: before first attempt + re-read after 401
+      // getAuthHeaders called twice: (1) before first attempt, (2) re-read SM after 401
       expect(credMgr.getAuthHeaders.callCount).to.equal(2);
-      // 401 re-read must bypass the 30s TTL cache — bypassCache=true
-      expect(credMgr.getAuthHeaders.firstCall.args[0]).to.be.undefined;
-      expect(credMgr.getAuthHeaders.secondCall.args[0]).to.equal(true);
       // First attempt used stale-token; retry used fresh-token
       expect(fetchStub.firstCall.args[1].headers.Authorization).to.equal('Bearer stale-token');
       expect(fetchStub.secondCall.args[1].headers.Authorization).to.equal('Bearer fresh-token');
@@ -1600,7 +1596,7 @@ describe('JiraCloudClient', () => {
 
       const result = await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '' });
       expect(result.ticketKey).to.equal('ASO-1');
-      // 3 calls: (1) before POST, (2) re-read after 401, (3) #fetchTicketStatus after create
+      // 3 getAuthHeaders calls: (1) before POST, (2) re-read SM after 401, (3) #fetchTicketStatus
       expect(credMgr.getAuthHeaders.callCount).to.equal(3);
     });
 
@@ -1623,20 +1619,13 @@ describe('JiraCloudClient', () => {
       expect(credMgr.getAuthHeaders.callCount).to.equal(2);
     });
 
-    it('bypasses cache when getAuthHeaders throws TOKEN_REFRESH_REQUIRED (stale cache)', async () => {
-      // Simulates: auth-service refreshed SM, but api-service cache still holds
-      // the expired token. First getAuthHeaders() throws; retry with bypassCache
-      // reads fresh token from SM → Jira call succeeds.
-      const tokenRefreshErr = Object.assign(
-        new Error('OAuth token expired — caller should trigger a refresh'),
-        { code: 'TOKEN_REFRESH_REQUIRED' },
-      );
+    it('getAuthHeaders returns expired token — Jira validates via its own revocation check', async () => {
+      // getAuthHeaders no longer throws for expired tokens — it returns them.
+      // Jira validates access tokens via its own revocation check, not JWT exp.
+      // If Jira accepts the token, the call succeeds without any retry.
       const credMgr = {
         getAuthHeaders: sinon.stub()
-          .onFirstCall()
-          .rejects(tokenRefreshErr)
-          .onSecondCall()
-          .resolves({ Authorization: 'Bearer fresh-token' }),
+          .resolves({ Authorization: 'Bearer expired-but-valid-token' }),
       };
       const fetchStub = sinon.stub().resolves({
         ok: true,
@@ -1649,34 +1638,14 @@ describe('JiraCloudClient', () => {
 
       const result = await client.listIssueTypes('10000');
       expect(result).to.deep.equal([{ id: '10', name: 'Bug' }]);
-      expect(credMgr.getAuthHeaders.callCount).to.equal(2);
-      // Second call must bypass cache
-      expect(credMgr.getAuthHeaders.firstCall.args[0]).to.be.undefined;
-      expect(credMgr.getAuthHeaders.secondCall.args[0]).to.equal(true);
+      expect(credMgr.getAuthHeaders.callCount).to.equal(1);
       expect(fetchStub.callCount).to.equal(1);
-      expect(fetchStub.firstCall.args[1].headers.Authorization).to.equal('Bearer fresh-token');
-    });
-
-    it('propagates TOKEN_REFRESH_REQUIRED when SM is also expired after cache bypass', async () => {
-      // Both cache and SM hold expired tokens — error must propagate to caller.
-      const tokenRefreshErr = Object.assign(
-        new Error('OAuth token expired — caller should trigger a refresh'),
-        { code: 'TOKEN_REFRESH_REQUIRED' },
-      );
-      const credMgr = {
-        getAuthHeaders: sinon.stub().rejects(tokenRefreshErr),
-      };
-      const fetchStub = sinon.stub();
-      const client = new JiraCloudClient(VALID_CONFIG, credMgr, { fetch: fetchStub }, makeLog());
-
-      const err = await client.listIssueTypes('10000').catch((e) => e);
-      expect(err.code).to.equal('TOKEN_REFRESH_REQUIRED');
-      expect(fetchStub.callCount).to.equal(0); // never reached Jira
+      expect(fetchStub.firstCall.args[1].headers.Authorization).to.equal('Bearer expired-but-valid-token');
     });
 
     it('re-throws non-credential errors from getAuthHeaders without cache bypass', async () => {
       // Non-credential errors (network, IAM, SDK) must propagate immediately —
-      // retrying with bypassCache would mask the real failure.
+      // retrying would mask the real failure.
       const networkErr = new Error('NetworkingError: socket hang up');
       const credMgr = {
         getAuthHeaders: sinon.stub().rejects(networkErr),
@@ -1690,8 +1659,7 @@ describe('JiraCloudClient', () => {
       expect(fetchStub.callCount).to.equal(0);
     });
 
-    it('propagates REQUIRES_REAUTH after cache bypass also fails', async () => {
-      // Both cache and SM have requiresReauth — error propagates after bypass retry.
+    it('propagates REQUIRES_REAUTH immediately from getAuthHeaders', async () => {
       const reauthErr = Object.assign(
         new Error('OAuth connection requires re-authorization'),
         { code: 'REQUIRES_REAUTH' },
@@ -1704,92 +1672,69 @@ describe('JiraCloudClient', () => {
 
       const err = await client.listIssueTypes('10000').catch((e) => e);
       expect(err.code).to.equal('REQUIRES_REAUTH');
-      expect(credMgr.getAuthHeaders.callCount).to.equal(2); // cache + bypass
-      expect(credMgr.getAuthHeaders.firstCall.args[0]).to.be.undefined;
-      expect(credMgr.getAuthHeaders.secondCall.args[0]).to.equal(true);
+      expect(credMgr.getAuthHeaders.callCount).to.equal(1); // no retry
       expect(fetchStub.callCount).to.equal(0);
     });
 
-    it('handles combined cache-bypass + 401 retry (two-layer interaction)', async () => {
-      // Layer 1: getAuthHeaders() cache throws → bypass gets token-A from SM.
-      // Layer 2: Jira 401 with token-A → re-reads SM → token-B → OK.
-      const tokenRefreshErr = Object.assign(
-        new Error('OAuth token expired'),
-        { code: 'TOKEN_REFRESH_REQUIRED' },
+    it('propagates REQUIRES_REAUTH without attempting Jira call', async () => {
+      const reauthErr = Object.assign(
+        new Error('OAuth connection requires re-authorization'),
+        { code: 'REQUIRES_REAUTH' },
       );
       const credMgr = {
-        getAuthHeaders: sinon.stub()
-          // Call 1: cache → throws
-          .onCall(0)
-          .rejects(tokenRefreshErr)
-          // Call 2: bypass → token-A (Jira will reject)
-          .onCall(1)
-          .resolves({ Authorization: 'Bearer token-A' })
-          // Call 3: 401 re-read bypass → token-B (fresh)
-          .onCall(2)
-          .resolves({ Authorization: 'Bearer token-B' }),
+        getAuthHeaders: sinon.stub().rejects(reauthErr),
       };
       const fetchStub = sinon.stub();
-      fetchStub.onFirstCall().resolves({
-        ok: false,
-        status: 401,
-        json: sinon.stub().resolves({}),
-      });
-      fetchStub.onSecondCall().resolves({
-        ok: true,
-        status: 200,
-        json: sinon.stub().resolves({
-          hierarchy: [{ level: 0, issueTypes: [{ id: 10, name: 'Bug' }] }],
-        }),
-      });
       const client = new JiraCloudClient(VALID_CONFIG, credMgr, { fetch: fetchStub }, makeLog());
 
-      const result = await client.listIssueTypes('10000');
-      expect(result).to.deep.equal([{ id: '10', name: 'Bug' }]);
-      expect(credMgr.getAuthHeaders.callCount).to.equal(3);
-      expect(credMgr.getAuthHeaders.firstCall.args[0]).to.be.undefined;
-      expect(credMgr.getAuthHeaders.secondCall.args[0]).to.equal(true);
-      expect(credMgr.getAuthHeaders.thirdCall.args[0]).to.equal(true);
-      expect(fetchStub.firstCall.args[1].headers.Authorization).to.equal('Bearer token-A');
-      expect(fetchStub.secondCall.args[1].headers.Authorization).to.equal('Bearer token-B');
+      const err = await client.listIssueTypes('10000').catch((e) => e);
+      expect(err.code).to.equal('REQUIRES_REAUTH');
+      expect(credMgr.getAuthHeaders.callCount).to.equal(1);
+      expect(fetchStub.callCount).to.equal(0);
     });
 
-    it('throws TOKEN_REFRESH_REQUIRED on 401 when SM still has the same token', async () => {
-      // SM re-read returns the same stale token — retrying Jira would fail again.
-      // #withAuthRetry must signal the caller to trigger an auth-service refresh.
-      const fetchStub = sinon.stub().resolves({
+    it('throws TOKEN_REFRESH_REQUIRED when getAuthHeaders returns same token on 401', async () => {
+      // On 401, #withAuthRetry calls getAuthHeaders(). If the token is the
+      // same as the one Jira rejected, it throws TOKEN_REFRESH_REQUIRED.
+      const fetchStub = sinon.stub();
+      fetchStub.onFirstCall().resolves({
         ok: false, status: 401, json: sinon.stub().resolves({}),
       });
       const credMgr = {
-        getAuthHeaders: sinon.stub().resolves({ Authorization: 'Bearer stale-token' }),
+        getAuthHeaders: sinon.stub()
+          .resolves({ Authorization: 'Bearer same-token' }),
       };
       const client = new JiraCloudClient(VALID_CONFIG, credMgr, { fetch: fetchStub }, makeLog());
 
       const err = await client.listIssueTypes('10000').catch((e) => e);
       expect(err.code).to.equal('TOKEN_REFRESH_REQUIRED');
-      expect(fetchStub.callCount).to.equal(1); // no retry with same token
+      expect(err.status).to.equal(401);
+      expect(err.message).to.include('no refreshed token is available in SM');
+      expect(credMgr.getAuthHeaders.callCount).to.equal(2);
+      expect(fetchStub.callCount).to.equal(1);
     });
 
-    it('propagates REQUIRES_REAUTH when SM re-read shows requiresReauth', async () => {
-      // Concurrent Lambda wrote requiresReauth:true while we were in-flight.
+    it('propagates REQUIRES_REAUTH when getAuthHeaders throws on 401 retry', async () => {
+      // Concurrent Lambda wrote requiresReauth:true → getAuthHeaders()
+      // discovers the grant is revoked and throws REQUIRES_REAUTH.
       const fetchStub = sinon.stub().onFirstCall().resolves({
         ok: false, status: 401, json: sinon.stub().resolves({}),
       });
-      const reauthError = Object.assign(
+      const reauthErr = Object.assign(
         new Error('OAuth connection requires re-authorization'),
         { code: 'REQUIRES_REAUTH' },
       );
       const credMgr = {
         getAuthHeaders: sinon.stub()
-          .onFirstCall()
-          .resolves({ Authorization: 'Bearer stale-token' })
+          .onFirstCall().resolves({ Authorization: 'Bearer stale-token' })
           .onSecondCall()
-          .rejects(reauthError),
+          .rejects(reauthErr),
       };
       const client = new JiraCloudClient(VALID_CONFIG, credMgr, { fetch: fetchStub }, makeLog());
 
       const err = await client.listIssueTypes('10000').catch((e) => e);
       expect(err.code).to.equal('REQUIRES_REAUTH');
+      expect(err.message).to.include('connection requires re-authorization');
     });
 
     it('throws on 401 if retry also returns 401', async () => {
@@ -1889,7 +1834,7 @@ describe('JiraCloudClient', () => {
       expect(stub.thirdCall.args[0]).to.include('startAt=2'); // page.length = 1
     });
 
-    it('propagates REQUIRES_REAUTH from pagination after cache bypass also fails', async () => {
+    it('propagates REQUIRES_REAUTH from pagination immediately', async () => {
       const reauthErr = Object.assign(
         new Error('OAuth connection requires re-authorization'),
         { code: 'REQUIRES_REAUTH' },
@@ -1897,10 +1842,7 @@ describe('JiraCloudClient', () => {
       const credMgr = {
         getAuthHeaders: sinon.stub()
           .onCall(0).resolves({ Authorization: 'Bearer ok-token' })
-          // pagination loop: cache throw + bypass throw
           .onCall(1)
-          .rejects(reauthErr)
-          .onCall(2)
           .rejects(reauthErr),
       };
       const stub = sinon.stub();
@@ -1915,27 +1857,19 @@ describe('JiraCloudClient', () => {
 
       const err = await client.listProjects().catch((e) => e);
       expect(err.code).to.equal('REQUIRES_REAUTH');
-      expect(credMgr.getAuthHeaders.callCount).to.equal(3); // page1 + cache + bypass
-      expect(credMgr.getAuthHeaders.thirdCall.args[0]).to.equal(true);
+      expect(credMgr.getAuthHeaders.callCount).to.equal(2); // page1 + page2 throw
     });
 
-    it('bypasses cache in pagination loop when getAuthHeaders throws TOKEN_REFRESH_REQUIRED', async () => {
-      const tokenRefreshErr = Object.assign(
-        new Error('OAuth token expired'),
-        { code: 'TOKEN_REFRESH_REQUIRED' },
+    it('propagates REQUIRES_REAUTH from pagination without retrying', async () => {
+      const reauthErr = Object.assign(
+        new Error('OAuth connection requires re-authorization'),
+        { code: 'REQUIRES_REAUTH' },
       );
-      // Page 1 succeeds via #withAuthRetry; page 2 getAuthHeaders() throws from
-      // stale cache, then retry with bypassCache=true returns fresh token.
       const credMgr = {
         getAuthHeaders: sinon.stub()
-          // Call 1: #withAuthRetry page 1 (cache ok)
           .onCall(0).resolves({ Authorization: 'Bearer ok-token' })
-          // Call 2: pagination loop page 2 — cache stale → throws
           .onCall(1)
-          .rejects(tokenRefreshErr)
-          // Call 3: pagination loop retry with bypassCache=true
-          .onCall(2)
-          .resolves({ Authorization: 'Bearer fresh-token' }),
+          .rejects(reauthErr),
       };
       const stub = sinon.stub();
       stub.onCall(0).resolves({
@@ -1945,23 +1879,12 @@ describe('JiraCloudClient', () => {
           values: [{ id: '1', key: 'A', name: 'A' }], isLast: false,
         }),
       });
-      stub.onCall(1).resolves({
-        ok: true,
-        status: 200,
-        json: sinon.stub().resolves({
-          values: [{ id: '2', key: 'B', name: 'B' }], isLast: true,
-        }),
-      });
       const client = new JiraCloudClient(VALID_CONFIG, credMgr, { fetch: stub }, makeLog());
 
-      const projects = await client.listProjects();
-      expect(projects).to.deep.equal([
-        { id: '1', key: 'A', name: 'A' },
-        { id: '2', key: 'B', name: 'B' },
-      ]);
-      // bypassCache=true on the third call
-      expect(credMgr.getAuthHeaders.thirdCall.args[0]).to.equal(true);
-      expect(stub.secondCall.args[1].headers.Authorization).to.equal('Bearer fresh-token');
+      const err = await client.listProjects().catch((e) => e);
+      expect(err.code).to.equal('REQUIRES_REAUTH');
+      expect(credMgr.getAuthHeaders.callCount).to.equal(2); // page1 ok + page2 throw
+      expect(stub.callCount).to.equal(1); // only page 1 fetch
     });
 
     it('stops at MAX_PAGES (100) even when Jira keeps returning isLast: false', async () => {

--- a/packages/spacecat-shared-ticket-client/test/jira-cloud-client.test.js
+++ b/packages/spacecat-shared-ticket-client/test/jira-cloud-client.test.js
@@ -79,16 +79,13 @@ describe('JiraCloudClient', () => {
       )).to.not.throw();
     });
 
-    it('throws if siteUrl is not https://*.atlassian.net', () => {
+    it('throws if siteUrl is not a valid https URL', () => {
       const invalidUrls = [
-        'http://example.atlassian.net',
-        'https://example.atlassian.com',
-        'https://example.com',
+        'http://example.atlassian.net', // non-https scheme
+        // eslint-disable-next-line no-script-url
+        'javascript:alert(1)', // unsafe scheme
         'not-a-url',
         undefined,
-        // hostname spoofing attempts that pass naive string checks
-        'https://evil.com/https://foo.atlassian.net',
-        'https://foo.atlassian.net.evil.com',
       ];
       for (const siteUrl of invalidUrls) {
         expect(() => new JiraCloudClient(
@@ -97,6 +94,25 @@ describe('JiraCloudClient', () => {
           makeHttpClient({}),
           makeLog(),
         )).to.throw('Invalid siteUrl');
+      }
+    });
+
+    it('accepts custom (non-atlassian.net) https domains for enterprise sites', () => {
+      // Premium/Enterprise sites may use a custom domain (e.g. go.jira.acme.com).
+      // siteUrl is display-only (browse link); API traffic routes through the
+      // fixed api.atlassian.com gateway, so the hostname is not restricted.
+      const validUrls = [
+        'https://example.atlassian.net',
+        'https://go.jira.acme.com',
+        'https://example.com',
+      ];
+      for (const siteUrl of validUrls) {
+        expect(() => new JiraCloudClient(
+          { cloudId: VALID_CLOUD_ID, siteUrl },
+          makeCredentialManager(),
+          makeHttpClient({}),
+          makeLog(),
+        )).to.not.throw();
       }
     });
 
@@ -130,7 +146,7 @@ describe('JiraCloudClient', () => {
         makeHttpClient({}),
         makeLog(),
       );
-      await expect(client.createTicket({ projectKey: 'ASO' }))
+      await expect(client.createTicket({ projectKey: 'ASO', issueType: 'Task' }))
         .to.be.rejectedWith('summary is required');
     });
 
@@ -141,8 +157,30 @@ describe('JiraCloudClient', () => {
         makeHttpClient({}),
         makeLog(),
       );
-      await expect(client.createTicket({ projectKey: 'ASO', summary: '   ' }))
+      await expect(client.createTicket({ projectKey: 'ASO', issueType: 'Task', summary: '   ' }))
         .to.be.rejectedWith('summary is required');
+    });
+
+    it('throws when issueType is missing', async () => {
+      const client = new JiraCloudClient(
+        VALID_CONFIG,
+        makeCredentialManager(),
+        makeHttpClient({}),
+        makeLog(),
+      );
+      await expect(client.createTicket({ projectKey: 'ASO', summary: 'x' }))
+        .to.be.rejectedWith('issueType is required');
+    });
+
+    it('throws when issueType is blank', async () => {
+      const client = new JiraCloudClient(
+        VALID_CONFIG,
+        makeCredentialManager(),
+        makeHttpClient({}),
+        makeLog(),
+      );
+      await expect(client.createTicket({ projectKey: 'ASO', issueType: '   ', summary: 'x' }))
+        .to.be.rejectedWith('issueType is required');
     });
 
     it('throws when a label contains whitespace', async () => {
@@ -154,6 +192,7 @@ describe('JiraCloudClient', () => {
       );
       await expect(client.createTicket({
         projectKey: 'ASO',
+        issueType: 'Task',
         summary: 'test',
         labels: ['valid-label', 'has space'],
       })).to.be.rejectedWith("Label must not contain whitespace, got: 'has space'");
@@ -173,6 +212,7 @@ describe('JiraCloudClient', () => {
 
       const result = await client.createTicket({
         projectKey: 'ASO',
+        issueType: 'Task',
         summary: 'Test ticket',
         description: 'First paragraph\n\nSecond paragraph',
         labels: ['AEM-Sites-Optimizer'],
@@ -201,7 +241,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      const result = await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '' });
+      const result = await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '',
+      });
       expect(result.ticketStatus).to.be.null;
     });
 
@@ -219,7 +261,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      const result = await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '' });
+      const result = await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '',
+      });
       // Status fetch failure must not throw — ticket was already created
       expect(result.ticketStatus).to.be.null;
       expect(result.ticketKey).to.equal('ASO-1');
@@ -236,7 +280,9 @@ describe('JiraCloudClient', () => {
       );
 
       const longSummary = 'A'.repeat(300);
-      await client.createTicket({ projectKey: 'ASO', summary: longSummary, description: '' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: longSummary, description: '',
+      });
 
       const callBody = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       expect(callBody.fields.summary).to.have.length(255);
@@ -254,7 +300,9 @@ describe('JiraCloudClient', () => {
       // 254 'A' chars + 1 emoji = 255 code points but 256 UTF-16 chars.
       // slice(0,255) on the raw string would cut the emoji's surrogate pair.
       const emojiSummary = `${'A'.repeat(254)}𝌆rest`;
-      await client.createTicket({ projectKey: 'ASO', summary: emojiSummary, description: '' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: emojiSummary, description: '',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       // Must be exactly 255 code points and end with the emoji (not a broken surrogate)
       const codePoints = [...body.fields.summary];
@@ -272,7 +320,9 @@ describe('JiraCloudClient', () => {
         makeLog(),
       );
 
-      await client.createTicket({ projectKey: 'ASO', summary: 'test', description: '' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'test', description: '',
+      });
 
       const calledUrl = httpClient.fetch.firstCall.args[0];
       expect(calledUrl).to.include(`https://api.atlassian.com/ex/jira/${VALID_CLOUD_ID}`);
@@ -289,7 +339,9 @@ describe('JiraCloudClient', () => {
         makeLog(),
       );
 
-      await expect(client.createTicket({ projectKey: 'ASO', summary: 'x', description: '' }))
+      await expect(client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '',
+      }))
         .to.be.rejectedWith('Unexpected ticketKey format returned from Jira');
     });
 
@@ -301,7 +353,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      const result = await client.createTicket({ projectKey: 'ASO', summary: 'test', description: null });
+      const result = await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'test', description: null,
+      });
       expect(result.ticketKey).to.equal('ASO-1');
     });
 
@@ -313,7 +367,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       expect(body.fields).to.not.have.property('description');
     });
@@ -328,6 +384,7 @@ describe('JiraCloudClient', () => {
       );
       await client.createTicket({
         projectKey: 'ASO',
+        issueType: 'Task',
         summary: 'x',
         description: '',
         priority: 'High',
@@ -346,6 +403,7 @@ describe('JiraCloudClient', () => {
       );
       await client.createTicket({
         projectKey: 'ASO',
+        issueType: 'Task',
         summary: 'x',
         description: '',
         dueDate: '2026-12-31',
@@ -364,6 +422,7 @@ describe('JiraCloudClient', () => {
       );
       await expect(client.createTicket({
         projectKey: 'ASO',
+        issueType: 'Task',
         summary: 'x',
         description: '',
         dueDate: '31-12-2026',
@@ -380,6 +439,7 @@ describe('JiraCloudClient', () => {
       );
       await client.createTicket({
         projectKey: 'ASO',
+        issueType: 'Task',
         summary: 'x',
         description: '',
         components: ['Frontend', 'API'],
@@ -398,6 +458,7 @@ describe('JiraCloudClient', () => {
       );
       await client.createTicket({
         projectKey: 'ASO',
+        issueType: 'Task',
         summary: 'x',
         description: '',
         parent: 'ASO-42',
@@ -415,6 +476,7 @@ describe('JiraCloudClient', () => {
       );
       await expect(client.createTicket({
         projectKey: 'ASO',
+        issueType: 'Task',
         summary: 'x',
         parent: 'not-a-valid-key',
       })).to.be.rejectedWith('Invalid parent format');
@@ -429,6 +491,7 @@ describe('JiraCloudClient', () => {
       );
       await expect(client.createTicket({
         projectKey: 'ASO',
+        issueType: 'Task',
         summary: 'x',
         dueDate: '2026-02-31',
       })).to.be.rejectedWith('Invalid dueDate: not a real calendar date');
@@ -442,7 +505,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       expect(body.fields).to.not.have.property('priority');
       expect(body.fields).to.not.have.property('duedate');
@@ -463,7 +528,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      const result = await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '' });
+      const result = await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '',
+      });
       expect(result.ticketStatus).to.be.null;
       expect(result.ticketKey).to.equal('ASO-1');
     });
@@ -477,7 +544,9 @@ describe('JiraCloudClient', () => {
         makeLog(),
       );
       // Markdown hard break: two trailing spaces + newline
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: 'line1  \nline2' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: 'line1  \nline2',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
       expect(nodes.find((n) => n.type === 'hardBreak')).to.exist;
@@ -495,6 +564,7 @@ describe('JiraCloudClient', () => {
       const url = 'https://www.adobe.com/learn/firefly';
       await client.createTicket({
         projectKey: 'ASO',
+        issueType: 'Task',
         summary: 'x',
         description: `URL: ${url}`,
       });
@@ -517,7 +587,9 @@ describe('JiraCloudClient', () => {
         makeLog(),
       );
 
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: 'No links here' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: 'No links here',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
 
@@ -536,7 +608,9 @@ describe('JiraCloudClient', () => {
         makeLog(),
       );
       const description = '```html\n<div class="foo">bar</div>\n```';
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description,
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const node = body.fields.description.content[0];
       expect(node.type).to.equal('codeBlock');
@@ -553,7 +627,9 @@ describe('JiraCloudClient', () => {
         makeLog(),
       );
       const description = '```\nsome code\n```';
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description,
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const node = body.fields.description.content[0];
       expect(node.type).to.equal('codeBlock');
@@ -570,7 +646,9 @@ describe('JiraCloudClient', () => {
         makeLog(),
       );
       const description = '- item one\n- item two\n- item three';
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description,
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const node = body.fields.description.content[0];
       expect(node.type).to.equal('bulletList');
@@ -589,7 +667,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '## Accessibility Issues' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '## Accessibility Issues',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const node = body.fields.description.content[0];
       expect(node.type).to.equal('heading');
@@ -605,7 +685,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '1. First\n2. Second\n3. Third' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '1. First\n2. Second\n3. Third',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const node = body.fields.description.content[0];
       expect(node.type).to.equal('orderedList');
@@ -623,7 +705,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '> Important note here' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '> Important note here',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const node = body.fields.description.content[0];
       expect(node.type).to.equal('blockquote');
@@ -639,7 +723,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: 'Before\n\n---\n\nAfter' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: 'Before\n\n---\n\nAfter',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content;
       expect(nodes[1].type).to.equal('rule');
@@ -654,7 +740,9 @@ describe('JiraCloudClient', () => {
         makeLog(),
       );
       const description = '| Col A | Col B |\n|-------|-------|\n| data1 | data2 |';
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description,
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const table = body.fields.description.content[0];
       expect(table.type).to.equal('table');
@@ -673,7 +761,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: 'This is **bold** text' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: 'This is **bold** text',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
       const boldNode = nodes.find((n) => n.marks?.some((m) => m.type === 'strong'));
@@ -689,7 +779,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: 'This is *italic* text' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: 'This is *italic* text',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
       const emNode = nodes.find((n) => n.marks?.some((m) => m.type === 'em'));
@@ -705,7 +797,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: 'Use `aria-label` attribute' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: 'Use `aria-label` attribute',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
       const codeNode = nodes.find((n) => n.marks?.some((m) => m.type === 'code'));
@@ -721,7 +815,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: 'Visit [Adobe](https://adobe.com)' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: 'Visit [Adobe](https://adobe.com)',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
       const linkNode = nodes.find((n) => n.marks?.some((m) => m.type === 'link'));
@@ -738,7 +834,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '[no href]()' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '[no href]()',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
       expect(nodes.some((n) => n.marks?.some((m) => m.type === 'link'))).to.be.false;
@@ -750,7 +848,9 @@ describe('JiraCloudClient', () => {
       // eslint-disable-next-line max-len
       const client = new JiraCloudClient(VALID_CONFIG, makeCredentialManager(), httpClient, makeLog()); // NOSONAR
       // eslint-disable-next-line no-script-url
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '[click me](javascript:alert(1))' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '[click me](javascript:alert(1))',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
       expect(nodes.some((n) => n.marks?.some((m) => m.type === 'link'))).to.be.false;
@@ -761,7 +861,9 @@ describe('JiraCloudClient', () => {
       const httpClient = makeHttpClient({ id: '1', key: 'ASO-1' });
       // eslint-disable-next-line max-len
       const client = new JiraCloudClient(VALID_CONFIG, makeCredentialManager(), httpClient, makeLog()); // NOSONAR
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '[click me](data:text/html,xss)' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '[click me](data:text/html,xss)',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
       expect(nodes.some((n) => n.marks?.some((m) => m.type === 'link'))).to.be.false;
@@ -773,7 +875,9 @@ describe('JiraCloudClient', () => {
       // eslint-disable-next-line max-len
       const client = new JiraCloudClient(VALID_CONFIG, makeCredentialManager(), httpClient, makeLog()); // NOSONAR
       // eslint-disable-next-line no-script-url
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '[click me](JaVaScRiPt:alert(1))' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '[click me](JaVaScRiPt:alert(1))',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
       expect(nodes.some((n) => n.marks?.some((m) => m.type === 'link'))).to.be.false;
@@ -788,7 +892,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: 'This is ~~removed~~ text' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: 'This is ~~removed~~ text',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
       const strikeNode = nodes.find((n) => n.marks?.some((m) => m.type === 'strike'));
@@ -804,7 +910,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '***bold italic***' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '***bold italic***',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
       const markedNode = nodes.find((n) => n.marks?.length >= 2);
@@ -822,7 +930,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '[`code`](https://example.com)' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '[`code`](https://example.com)',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
       const codeLink = nodes.find((n) => n.marks?.some((m) => m.type === 'code') && n.marks?.some((m) => m.type === 'link'));
@@ -838,7 +948,9 @@ describe('JiraCloudClient', () => {
         makeLog(),
       );
       // Raw HTML produces an 'html' token type which hits the default branch in tokensToAdf
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '<div>custom html</div>' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '<div>custom html</div>',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content;
       // HTML token hits default branch — should produce a paragraph with raw text
@@ -854,7 +966,9 @@ describe('JiraCloudClient', () => {
         makeLog(),
       );
       // List items produce text tokens with nested .tokens containing inline marks
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '- foo **bar** baz' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '- foo **bar** baz',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const listItem = body.fields.description.content[0].content[0];
       const paragraph = listItem.content[0];
@@ -872,7 +986,9 @@ describe('JiraCloudClient', () => {
         makeLog(),
       );
       // Image token hits the default branch in inlineToAdf
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: 'text with ![alt text](img.png) inside' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: 'text with ![alt text](img.png) inside',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
       // Image token has text="alt text" which is rendered as plain text via default branch
@@ -888,7 +1004,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: 'Not \\*bold\\*' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: 'Not \\*bold\\*',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
       const boldNode = nodes.find((n) => n.marks?.some((m) => m.type === 'strong'));
@@ -903,7 +1021,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '**bold \\* star**' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '**bold \\* star**',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
       // Escape token inside bold should have strong mark
@@ -919,7 +1039,9 @@ describe('JiraCloudClient', () => {
         httpClient,
         makeLog(),
       );
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '**text ![alt](img.png) more**' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '**text ![alt](img.png) more**',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const nodes = body.fields.description.content[0].content;
       // Image alt text inside bold should get strong mark via default branch
@@ -936,7 +1058,9 @@ describe('JiraCloudClient', () => {
         makeLog(),
       );
       // Whitespace-only is trimmed to empty, returns null (omits field)
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '   ' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '   ',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       expect(body.fields).to.not.have.property('description');
     });
@@ -950,7 +1074,9 @@ describe('JiraCloudClient', () => {
         makeLog(),
       );
       // Single word list items may produce text tokens without .tokens
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '- alpha\n- beta' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '- alpha\n- beta',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const list = body.fields.description.content[0];
       expect(list.type).to.equal('bulletList');
@@ -967,7 +1093,9 @@ describe('JiraCloudClient', () => {
       );
       // Markdown table with an empty cell
       const description = '| A | B |\n|---|---|\n| data |  |';
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description,
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const dataRow = body.fields.description.content[0].content[1];
       const emptyCell = dataRow.content[1];
@@ -998,7 +1126,9 @@ describe('JiraCloudClient', () => {
         '<img src="hero.jpg">',
         '```',
       ].join('\n');
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description,
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const types = body.fields.description.content.map((n) => n.type);
       expect(types).to.include('heading');
@@ -1014,7 +1144,9 @@ describe('JiraCloudClient', () => {
 
       const client = new JiraCloudClient(VALID_CONFIG, makeCredentialManager(), httpClient, log);
 
-      await expect(client.createTicket({ projectKey: 'ASO', summary: 'x', description: '' }))
+      await expect(client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '',
+      }))
         .to.be.rejectedWith('Jira API error: 404');
 
       // Must not log response body (may contain PII/tokens)
@@ -1027,7 +1159,9 @@ describe('JiraCloudClient', () => {
       // 3000 nested blockquotes — would blow the call stack without depth limit
       const deepQuote = `${'> '.repeat(3000)}deep`;
       await expect(
-        client.createTicket({ projectKey: 'ASO', summary: 'x', description: deepQuote }),
+        client.createTicket({
+          projectKey: 'ASO', issueType: 'Task', summary: 'x', description: deepQuote,
+        }),
       ).to.not.be.rejected;
       // Must produce valid ADF (not null, has content)
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
@@ -1040,7 +1174,9 @@ describe('JiraCloudClient', () => {
       const client = new JiraCloudClient(VALID_CONFIG, makeCredentialManager(), httpClient, makeLog()); // eslint-disable-line max-len
       const massive = 'word '.repeat(240000); // ~1.2 MB
       await expect(
-        client.createTicket({ projectKey: 'ASO', summary: 'x', description: massive }),
+        client.createTicket({
+          projectKey: 'ASO', issueType: 'Task', summary: 'x', description: massive,
+        }),
       ).to.not.be.rejected;
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       expect(body.fields.description).to.exist;
@@ -1055,7 +1191,9 @@ describe('JiraCloudClient', () => {
         makeLog(),
       );
       // Empty fenced code block — token.text would be ''
-      await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '```\n```' });
+      await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '```\n```',
+      });
       const body = JSON.parse(httpClient.fetch.firstCall.args[1].body);
       const node = body.fields.description.content[0];
       expect(node.type).to.equal('codeBlock');
@@ -1073,6 +1211,7 @@ describe('JiraCloudClient', () => {
       );
       await client.createTicket({
         projectKey: 'ASO',
+        issueType: 'Task',
         summary: 'x',
         description: '<script>alert("xss")</script>',
       });
@@ -1594,7 +1733,9 @@ describe('JiraCloudClient', () => {
       const credMgr = makeRetryCredentialManager();
       const client = new JiraCloudClient(VALID_CONFIG, credMgr, { fetch: fetchStub }, makeLog());
 
-      const result = await client.createTicket({ projectKey: 'ASO', summary: 'x', description: '' });
+      const result = await client.createTicket({
+        projectKey: 'ASO', issueType: 'Task', summary: 'x', description: '',
+      });
       expect(result.ticketKey).to.equal('ASO-1');
       // 3 getAuthHeaders calls: (1) before POST, (2) re-read SM after 401, (3) #fetchTicketStatus
       expect(credMgr.getAuthHeaders.callCount).to.equal(3);
@@ -1692,7 +1833,7 @@ describe('JiraCloudClient', () => {
       const err = await client.listIssueTypes('10000').catch((e) => e);
       expect(err.code).to.equal('TOKEN_REFRESH_REQUIRED');
       expect(err.status).to.equal(401);
-      expect(err.message).to.include('no refreshed token is available in SM');
+      expect(err.message).to.include('Jira rejected the access token');
       expect(credMgr.getAuthHeaders.callCount).to.equal(2);
       expect(fetchStub.callCount).to.equal(1);
     });

--- a/packages/spacecat-shared-ticket-client/test/jira-cloud-client.test.js
+++ b/packages/spacecat-shared-ticket-client/test/jira-cloud-client.test.js
@@ -1430,7 +1430,7 @@ describe('JiraCloudClient', () => {
         makeHttpClient({}),
         makeLog(),
       );
-      await expect(client.listIssueTypes('')).to.be.rejectedWith('projectId is required');
+      await expect(client.listIssueTypes('')).to.be.rejectedWith('projectIdOrKey is required');
     });
 
     it('throws on non-2xx response without leaking response body', async () => {

--- a/packages/spacecat-shared-ticket-client/test/oauth-credential-manager.test.js
+++ b/packages/spacecat-shared-ticket-client/test/oauth-credential-manager.test.js
@@ -133,7 +133,7 @@ describe('OAuthCredentialManager', () => {
       expect(err.code).to.equal('REQUIRES_REAUTH');
     });
 
-    it('throws TOKEN_REFRESH_REQUIRED when token is expired — no Atlassian call', async () => {
+    it('returns Bearer header even when token is expired — no Atlassian call', async () => {
       const httpClient = makeHttpClient({});
       const manager = new OAuthCredentialManager(
         makeSmClient(EXPIRED_SECRET),
@@ -141,9 +141,8 @@ describe('OAuthCredentialManager', () => {
         httpClient,
         makeLog(),
       );
-      const err = await manager.getAuthHeaders().catch((e) => e);
-      expect(err.code).to.equal('TOKEN_REFRESH_REQUIRED');
-      expect(err.message).to.include('OAuth token expired');
+      const headers = await manager.getAuthHeaders();
+      expect(headers).to.deep.equal({ Authorization: `Bearer ${EXPIRED_SECRET.accessToken}` });
       expect(httpClient.fetch.called).to.be.false;
     });
 
@@ -184,7 +183,7 @@ describe('OAuthCredentialManager', () => {
       );
     });
 
-    it('treats missing expiresAt as expired — throws TOKEN_REFRESH_REQUIRED', async () => {
+    it('treats missing expiresAt as expired — still returns Bearer header', async () => {
       const noExpirySecret = { ...VALID_SECRET, expiresAt: undefined };
       const manager = new OAuthCredentialManager(
         makeSmClient(noExpirySecret),
@@ -192,11 +191,11 @@ describe('OAuthCredentialManager', () => {
         makeHttpClient({}),
         makeLog(),
       );
-      const err = await manager.getAuthHeaders().catch((e) => e);
-      expect(err.code).to.equal('TOKEN_REFRESH_REQUIRED');
+      const headers = await manager.getAuthHeaders();
+      expect(headers).to.deep.equal({ Authorization: `Bearer ${VALID_SECRET.accessToken}` });
     });
 
-    it('treats NaN expiresAt as expired — throws TOKEN_REFRESH_REQUIRED', async () => {
+    it('treats NaN expiresAt as expired — still returns Bearer header', async () => {
       const nanExpirySecret = { ...VALID_SECRET, expiresAt: NaN };
       const manager = new OAuthCredentialManager(
         makeSmClient(nanExpirySecret),
@@ -204,11 +203,11 @@ describe('OAuthCredentialManager', () => {
         makeHttpClient({}),
         makeLog(),
       );
-      const err = await manager.getAuthHeaders().catch((e) => e);
-      expect(err.code).to.equal('TOKEN_REFRESH_REQUIRED');
+      const headers = await manager.getAuthHeaders();
+      expect(headers).to.deep.equal({ Authorization: `Bearer ${VALID_SECRET.accessToken}` });
     });
 
-    it('treats null expiresAt as expired — throws TOKEN_REFRESH_REQUIRED', async () => {
+    it('treats null expiresAt as expired — still returns Bearer header', async () => {
       const nullExpirySecret = { ...VALID_SECRET, expiresAt: null };
       const manager = new OAuthCredentialManager(
         makeSmClient(nullExpirySecret),
@@ -216,11 +215,11 @@ describe('OAuthCredentialManager', () => {
         makeHttpClient({}),
         makeLog(),
       );
-      const err = await manager.getAuthHeaders().catch((e) => e);
-      expect(err.code).to.equal('TOKEN_REFRESH_REQUIRED');
+      const headers = await manager.getAuthHeaders();
+      expect(headers).to.deep.equal({ Authorization: `Bearer ${VALID_SECRET.accessToken}` });
     });
 
-    it('reads SM only once across 3 sequential getAuthHeaders calls (cache hit)', async () => {
+    it('re-reads SM on every getAuthHeaders call (no cache)', async () => {
       const smClient = makeSmClient(VALID_SECRET);
       const manager = new OAuthCredentialManager(smClient, '/test/secret', makeHttpClient({}), makeLog());
 
@@ -228,27 +227,10 @@ describe('OAuthCredentialManager', () => {
       await manager.getAuthHeaders();
       await manager.getAuthHeaders();
 
-      expect(smClient.getSecretValue.callCount).to.equal(1);
+      expect(smClient.getSecretValue.callCount).to.equal(3);
     });
 
-    it('bypasses TTL cache when bypassCache=true — reads SM even within the cache window', async () => {
-      const smClient = makeSmClient(VALID_SECRET);
-      const manager = new OAuthCredentialManager(smClient, '/test/secret', makeHttpClient({}), makeLog());
-
-      // First call — populates cache
-      await manager.getAuthHeaders();
-      expect(smClient.getSecretValue.callCount).to.equal(1);
-
-      // Second call within TTL — normally served from cache (no SM call)
-      await manager.getAuthHeaders();
-      expect(smClient.getSecretValue.callCount).to.equal(1);
-
-      // Third call with bypassCache=true — forces SM re-read despite live cache
-      await manager.getAuthHeaders(true);
-      expect(smClient.getSecretValue.callCount).to.equal(2);
-    });
-
-    it('re-reads SM after a write path (refreshAuthHeaders) invalidates the cache', async () => {
+    it('re-reads SM after a write path (refreshAuthHeaders)', async () => {
       const smClient = {
         getSecretValue: sinon.stub()
           .onFirstCall()
@@ -266,14 +248,14 @@ describe('OAuthCredentialManager', () => {
       });
       const manager = new OAuthCredentialManager(smClient, '/test/secret', httpClient, makeLog());
 
-      // First getAuthHeaders — populates cache (SM call #1)
+      // First getAuthHeaders — reads SM (call #1)
       await manager.getAuthHeaders();
       expect(smClient.getSecretValue.callCount).to.equal(1);
 
-      // refreshAuthHeaders — write path, must bypass and then invalidate cache (SM call #2)
+      // refreshAuthHeaders — reads SM to check freshness (call #2)
       await manager.refreshAuthHeaders();
 
-      // Second getAuthHeaders after cache invalidation — must re-read SM (SM call #3)
+      // Second getAuthHeaders — reads SM again (call #3)
       await manager.getAuthHeaders();
       expect(smClient.getSecretValue.callCount).to.equal(3);
     });
@@ -313,6 +295,21 @@ describe('OAuthCredentialManager', () => {
       expect(headers).to.deep.equal({ Authorization: 'Bearer new-access-token' });
       expect(httpClient.fetch.calledOnce).to.be.true;
       expect(smClient.putSecretValue.calledOnce).to.be.true;
+    });
+
+    it('treats non-finite expiresAt as expired and refreshes via Atlassian', async () => {
+      const noExpirySecret = { ...VALID_SECRET, expiresAt: undefined };
+      const smClient = makeSmClient(noExpirySecret);
+      const httpClient = makeHttpClient({
+        access_token: 'refreshed-token',
+        refresh_token: 'refreshed-rt',
+        expires_in: 3600,
+      });
+      const manager = new OAuthCredentialManager(smClient, '/test/secret', httpClient, makeLog());
+
+      const headers = await manager.refreshAuthHeaders();
+      expect(headers).to.deep.equal({ Authorization: 'Bearer refreshed-token' });
+      expect(httpClient.fetch.calledOnce).to.be.true;
     });
 
     it('calls Atlassian even when requiresReauth is set (auth-service clearing revoked state)', async () => {

--- a/packages/spacecat-shared-ticket-client/test/rate-limit-aware-http-client.test.js
+++ b/packages/spacecat-shared-ticket-client/test/rate-limit-aware-http-client.test.js
@@ -368,9 +368,13 @@ describe('RateLimitAwareHttpClient', () => {
   });
 
   describe('X-RateLimit quota headers', () => {
-    it('logs a warning when X-RateLimit-Remaining is below threshold', async () => {
+    it('logs a warning when X-RateLimit-NearLimit is true, including remaining and limit', async () => {
       const inner = {
-        fetch: sinon.stub().resolves(makeResponse(200, { 'X-RateLimit-Remaining': '500' })),
+        fetch: sinon.stub().resolves(makeResponse(200, {
+          'X-RateLimit-NearLimit': 'true',
+          'X-RateLimit-Remaining': '500',
+          'X-RateLimit-Limit': '65000',
+        })),
       };
       const log = makeLog();
       const client = new RateLimitAwareHttpClient(inner, log);
@@ -379,11 +383,28 @@ describe('RateLimitAwareHttpClient', () => {
 
       expect(log.warn.calledOnce).to.be.true;
       expect(log.warn.firstCall.args[0]).to.include('quota running low');
+      expect(log.warn.firstCall.args[1]).to.deep.include({ remaining: 500, limit: '65000' });
     });
 
-    it('does not warn when X-RateLimit-Remaining is above threshold', async () => {
+    it('warns with undefined remaining/limit when NearLimit is true but those headers are absent', async () => {
       const inner = {
-        fetch: sinon.stub().resolves(makeResponse(200, { 'X-RateLimit-Remaining': '50000' })),
+        fetch: sinon.stub().resolves(makeResponse(200, { 'X-RateLimit-NearLimit': 'true' })),
+      };
+      const log = makeLog();
+      const client = new RateLimitAwareHttpClient(inner, log);
+
+      await client.fetch('https://api.atlassian.com/issue', {});
+
+      expect(log.warn.calledOnce).to.be.true;
+      expect(log.warn.firstCall.args[1]).to.deep.include({
+        remaining: undefined,
+        limit: undefined,
+      });
+    });
+
+    it('does not warn when X-RateLimit-NearLimit is absent', async () => {
+      const inner = {
+        fetch: sinon.stub().resolves(makeResponse(200, { 'X-RateLimit-Remaining': '500' })),
       };
       const log = makeLog();
       const client = new RateLimitAwareHttpClient(inner, log);
@@ -408,10 +429,11 @@ describe('RateLimitAwareHttpClient', () => {
       expect(log.debug.firstCall.args[1]).to.deep.include({ resetAt });
     });
 
-    it('includes resetAt in the low-quota warning when both headers are present', async () => {
+    it('includes resetAt in the low-quota warning when NearLimit and Reset are present', async () => {
       const resetAt = '2026-06-23T10:00:00Z';
       const inner = {
         fetch: sinon.stub().resolves(makeResponse(200, {
+          'X-RateLimit-NearLimit': 'true',
           'X-RateLimit-Remaining': '100',
           'X-RateLimit-Reset': resetAt,
         })),


### PR DESCRIPTION
## Summary
                                                                                               
  ### Token refresh / auth fixes                                                             
  - **Stop preemptive token blocking**: `getAuthHeaders()` no longer throws                  
  `TOKEN_REFRESH_REQUIRED` within the 10-minute expiry buffer. Jira validates access tokens via
   its own revocation check (tied to RT rotation window), not just the JWT `exp` claim. The
  buffer created a 10-min dead zone where valid tokens were rejected locally, causing          
  false-positive 409 loops.                                                                  
  - **Remove SM secret cache**: Eliminated the 30-second `SECRET_CACHE_TTL_MS` in-memory cache
  and `bypassCache` parameter — every `getAuthHeaders()` call reads SM fresh.                  
  - **Simplify auth retry**: Removed `#getAuthHeadersWithCacheBypass` wrapper. `#withAuthRetry`
   still handles real 401s from Jira (re-reads SM, retries, throws on same token).             
  - **Hoist `getAuthHeaders()` before pagination loops**: avoids one SM read per page.       
  - **Export error interfaces**: `TokenRefreshRequiredError` and `RequiresReauthError` now     
  exported from `index.d.ts` with `@throws` JSDoc.                                             
  - **Clarify `REQUIRES_REAUTH` throw path**: can be thrown from the retry path, not just the 
  initial call.                                                                                
                                                                                             
  ### `listIssueTypes` — fix endpoint                                                          
  - Switch from `GET /project/{id}/hierarchy` (team-managed only) to `GET 
  /issue/createmeta/{projectIdOrKey}/issuetypes`, which works uniformly across team-managed and
   company-managed projects and is permission-filtered per user.                             
  - Exclude subtasks via the `subtask` boolean (hierarchyLevel not present in this response    
  schema).                                                                                   
  - Paginate until empty batch or `startAt >= total`.                                        

  ### `createTicket` — `issueType` required + custom domains
  - `issueType` is now a required field. Jira has no server-side default; callers resolve a 
  valid type via `listIssueTypes()` first.                                                     
  - Relax `siteUrl` validation to accept any parseable `https://` URL instead of 
  `*.atlassian.net` only — Premium/Enterprise sites use custom domains. `https` scheme still   
  enforced.                                                                                  
  - Simplify the misleading `TOKEN_REFRESH_REQUIRED` error message.                            
                                                                                             
  ### Rate-limit header fix                                                                  
  - Align quota warnings with `X-RateLimit-NearLimit` (correct Atlassian header name).
  - Correct stale OAuth/rate-limit JSDoc.                                                      
  
  ## Evidence                                                                                  
                                                                                             
  Verified via live Atlassian API experiments (3 rounds):                                    

  | Finding | Data |                                                                           
  |---------|------|
  | AT survives ~600s after RT consumed | 601s, 601s, 602s across 3 experiments |              
  | Jira grants ~30s grace past JWT `exp` then returns 401 | Last 200 at exp-1s, first 401 at 
  exp+32s |                                                                                    
  | Garbage/malformed tokens → 200 with 0 results | Unauthenticated treatment |
  | Real expired JWT (past grace) → 401 | Jira enforces JWT exp after ~30s |                   
  | Revoked AT → 401 | Tied to RT rotation 10-min window |                                     
  | Expired RT → 403 `unauthorized_client` | From `auth.atlassian.com` |                     
                                                                                               
       
