### PR TITLE
[SITES-47884] fix: cover init() in variation() try/catch so LaunchDarkly outage fails open

### DIFF
--- a/packages/spacecat-shared-launchdarkly-client/src/launchdarkly-client.js
+++ b/packages/spacecat-shared-launchdarkly-client/src/launchdarkly-client.js
@@ -148,9 +148,12 @@ class LaunchDarklyClient {
    * @returns {Promise<*>} The evaluated flag value
    */
   async variation(flagKey, context, defaultValue) {
-    await this.init();
-
     try {
+      // init() is inside the try/catch so that a LaunchDarkly outage (e.g. the
+      // initialization timeout rejecting) fails open and returns defaultValue,
+      // rather than propagating and taking down callers such as /auth/login.
+      await this.init();
+
       const value = await this.client.variation(flagKey, context, defaultValue);
       this.log.debug(`Flag "${flagKey}" evaluated to:`, value);
       return value;

--- a/packages/spacecat-shared-launchdarkly-client/test/index.test.js
+++ b/packages/spacecat-shared-launchdarkly-client/test/index.test.js
@@ -434,6 +434,29 @@ describe('LaunchDarklyClient', () => {
       // Reset for other tests
       mockClient.variation.resolves(true);
     });
+
+    it('should return default value when initialization fails (LD outage)', async () => {
+      const customLog = {
+        info: sinon.stub(),
+        error: sinon.stub(),
+        debug: sinon.stub(),
+        warn: sinon.stub(),
+      };
+      const client = new LaunchDarklyClient({ sdkKey: testSdkKey }, customLog);
+      const context = { kind: 'user', key: 'test-user' };
+      const initError = new Error('Initialization failed');
+
+      mockClient.waitForInitialization.rejects(initError);
+
+      const result = await client.variation('test-flag', context, false);
+
+      expect(result).to.be.false;
+      expect(mockClient.variation).to.not.have.been.called;
+      expect(customLog.error).to.have.been.calledWith('Error evaluating flag "test-flag":', initError);
+
+      // Reset for other tests
+      mockClient.waitForInitialization.resolves();
+    });
   });
 
   describe('isFlagEnabledForIMSOrg', () => {


### PR DESCRIPTION
## Problem

[SITES-47884](https://jira.corp.adobe.com/browse/SITES-47884): During a LaunchDarkly outage, `/auth/login` fails outright for effectively all users — not degraded latency, but an outright login outage caused by a third-party dependency with no fail-open path.

Root cause: in `spacecat-shared-launchdarkly-client`, `variation()` called `await this.init()` **outside** its own try/catch:

```js
async variation(flagKey, context, defaultValue) {
  await this.init();          // NOT inside the try/catch below
  try {
    ...
  } catch (error) {
    return defaultValue;      // fallback only covered this block
  }
}
```

`init()`'s `waitForInitialization({ timeoutSeconds: 5 })` **rejects** when LD is unreachable. That rejection was not caught by `variation()`, so it propagated out of `isFlagEnabledForIMSOrg()` and up through the login path — even though `isFlagEnabledForIMSOrg` is documented/expected to fail safe.

## Fix

Move `await this.init()` **inside** `variation()`'s try/catch so any initialization error returns `defaultValue` instead of throwing. This is the root defect called out in the ticket; `isFlagEnabledForIMSOrg` now genuinely fails safe during an LD outage.

## Testing

- Added a unit test asserting `variation()` returns the default value (and never calls `client.variation`) when initialization fails.
- All 46 tests in the package pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)