### PR TITLE
fix(launchdarkly-client): document fail-open contract for variation/isFlagEnabledForIMSOrg

### DIFF
--- a/packages/spacecat-shared-launchdarkly-client/src/launchdarkly-client.js
+++ b/packages/spacecat-shared-launchdarkly-client/src/launchdarkly-client.js
@@ -141,11 +141,17 @@ class LaunchDarklyClient {
   }
 
   /**
-   * Evaluates a feature flag for a given context
+   * Evaluates a feature flag for a given context.
+   *
+   * Fails open: if the LaunchDarkly client cannot be initialized (e.g. an LD
+   * outage causes the initialization timeout to reject) or flag evaluation
+   * throws, this returns {@link defaultValue} instead of propagating the error.
+   * Callers can therefore treat the SDK as a best-effort dependency.
    * @param {string} flagKey - The feature flag key
    * @param {Object} context - The LaunchDarkly context (user/application context)
-   * @param {*} defaultValue - Default value if flag evaluation fails
-   * @returns {Promise<*>} The evaluated flag value
+   * @param {*} defaultValue - Default value returned if initialization or flag
+   *   evaluation fails
+   * @returns {Promise<*>} The evaluated flag value, or defaultValue on any error
    */
   async variation(flagKey, context, defaultValue) {
     try {
@@ -164,7 +170,11 @@ class LaunchDarklyClient {
   }
 
   /**
-   * Check if a feature flag is enabled for a specific IMS organization
+   * Check if a feature flag is enabled for a specific IMS organization.
+   *
+   * Fails safe: returns false if the LaunchDarkly SDK is unavailable or flag
+   * evaluation fails (see {@link variation}), so an LD outage never blocks
+   * callers on the request path.
    * @param {string} flagKey - The feature flag key
    * @param {string} imsOrgId - The IMS organization ID
    * @param {string} [userKey='anonymous'] - Optional user key for tracking


### PR DESCRIPTION
## Why

Follow-up to #1803 (SITES-47884), which moved `init()` inside `variation()`'s try/catch so a LaunchDarkly outage fails open. That PR **merged but never released**: its squash-merge subject started with `[SITES-47884] fix: …`, and the repo's stock `conventionalcommits` analyzer requires the type at the *start* of the subject — so it concluded "no release" and npm stayed at `1.3.0`. (The same silently happened to `[AGENTCOM-1198] fix: … (#1800)`.)

## What

Expands the JSDoc on `variation()` and `isFlagEnabledForIMSOrg()` to document the fail-open / fail-safe contract that #1803 established. A real, on-topic doc change that also touches `spacecat-shared-launchdarkly-client`, so semantic-release attributes a `fix` to the package and publishes `1.3.1` — shipping the already-merged fail-open fix from current `main`.

> **Note on the title:** kept in conventional-commit format (`fix(launchdarkly-client): …`, no `[TICKET]` prefix) on purpose. Please **squash-merge preserving this title** so semantic-release actually triggers. A `[TICKET]`-prefixed subject will silently skip the release again.

## Testing

- `eslint` clean. No behavior change (docs only); the 46 package tests from #1803 remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)