### PR TITLE
feat(data-access): guidance + feedback_subject_id + code-patch export gate for feedback

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/feedback-event/feedback-event.constants.js
+++ b/packages/spacecat-shared-data-access/src/models/feedback-event/feedback-event.constants.js
@@ -79,16 +79,19 @@ export const EXPORT_EXCLUDED_REJECTION_CATEGORIES = Object.freeze([
 ]);
 
 /**
- * Customer-derived fields stripped from the JSONL export for organizations with
- * `training_opt_in = false`. Verdict / signal / category / identity metadata
- * still ship. snake_case to match the JSONL row shape (and the feedback_event
- * DB columns) — {@link toJsonlRow} uses this list to do the stripping, so the
- * opt-out boundary is single-sourced here.
+ * HUMAN-authored fields stripped from the JSONL export for organizations with
+ * `training_opt_in = false`: the reviewer's written feedback (`detail_markdown`)
+ * and their hand-corrected patch (`edited_fix`). The AI-generated fields — the
+ * issue context (`guidance_markdown`) and the generated patch (`previous_fix`) —
+ * are ALWAYS exported (the Learning Agent needs the issue + generated patch to
+ * map a verdict to what was generated), as are verdict / signal / category /
+ * identity metadata. snake_case to match the JSONL row shape (and the
+ * feedback_event DB columns) — {@link toJsonlRow} uses this list to do the
+ * stripping, so the opt-out boundary is single-sourced here (SITES-43974).
  */
 export const OPT_OUT_STRIPPED_FIELDS = Object.freeze([
-  'previous_fix',
-  'edited_fix',
   'detail_markdown',
+  'edited_fix',
 ]);
 
 /**
@@ -163,11 +166,17 @@ export function toReviewView(row, { includePatches = false } = {}) {
     rejectionCategory: row.rejection_category ?? null,
     stateTransition: row.state_transition ?? null,
     tier: row.tier,
+    // Sub-item id (e.g. a CWV issue) this review is about; the Backoffice groups
+    // its per-issue "previous feedback" table on it. Always in the base view (the
+    // UI filters on it) — not gated behind includePatches. Null for
+    // whole-suggestion reviews.
+    feedbackSubjectId: row.feedback_subject_id ?? null,
   };
 
   if (includePatches) {
     view.previousFix = row.previous_fix ?? null;
     view.editedFix = row.edited_fix ?? null;
+    view.guidanceMarkdown = row.guidance_markdown ?? null;
   }
 
   return view;
@@ -175,14 +184,21 @@ export function toReviewView(row, { includePatches = false } = {}) {
 
 /**
  * Whether a raw `feedback_event` row should be exported to the Learning Agent
- * corpus. `product_bug` rejections are excluded (routed to Jira); NULL-category
- * rows ARE exported. See {@link EXPORT_EXCLUDED_REJECTION_CATEGORIES}.
+ * corpus. Two gates (SITES-43974):
+ *   1. It must carry a generated code patch (`previous_fix`). The corpus is
+ *      code-patch feedback; text-guidance-only reviews (no patch) are retained
+ *      in Postgres but NOT exported — reserved for a future text-guidance corpus.
+ *   2. `product_bug` rejections are excluded (routed to Jira). NULL-category rows
+ *      (approvals / uncategorised) ARE exported. See
+ *      {@link EXPORT_EXCLUDED_REJECTION_CATEGORIES}.
  *
  * @param {object} row - a raw feedback_event row from PostgREST.
  * @returns {boolean} true if the row should be exported.
  */
 export function shouldExport(row) {
-  return !EXPORT_EXCLUDED_REJECTION_CATEGORIES.includes(row.rejection_category);
+  const hasCodePatch = row.previous_fix != null;
+  return hasCodePatch
+    && !EXPORT_EXCLUDED_REJECTION_CATEGORIES.includes(row.rejection_category);
 }
 
 /**
@@ -190,8 +206,10 @@ export function shouldExport(row) {
  * object — the canonical Learning Agent export contract. The row mirrors the
  * feedback_event columns (snake_case), stamped with {@link SCHEMA_VERSION} and
  * the derived `verdict`. For organizations that have NOT opted into training,
- * the customer-derived fields in {@link OPT_OUT_STRIPPED_FIELDS} are nulled;
- * verdict / signal / category / identity metadata still ship (§10.5.7).
+ * the HUMAN-authored fields in {@link OPT_OUT_STRIPPED_FIELDS} are nulled; the
+ * AI-generated issue context (`guidance_markdown`) + generated patch
+ * (`previous_fix`) and the verdict / signal / category / identity metadata still
+ * ship (§10.5.7).
  *
  * This is the single source of truth for the JSONL row shape — the exporter
  * (spacecat-jobs-dispatcher) calls it rather than re-deriving the contract.
@@ -218,6 +236,7 @@ export function toJsonlRow(row, { optedIn = false } = {}) {
     state_transition: row.state_transition ?? null,
     tier: row.tier,
     detail_markdown: row.detail_markdown ?? null,
+    guidance_markdown: row.guidance_markdown ?? null,
     previous_fix: row.previous_fix ?? null,
     edited_fix: row.edited_fix ?? null,
   };

--- a/packages/spacecat-shared-data-access/src/models/feedback-event/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/feedback-event/index.d.ts
@@ -53,8 +53,10 @@ export interface ReviewView {
   rejectionCategory: string | null;
   stateTransition: string | null;
   tier: string;
+  feedbackSubjectId: string | null;
   previousFix?: unknown;
   editedFix?: unknown;
+  guidanceMarkdown?: string | null;
 }
 
 /**

--- a/packages/spacecat-shared-data-access/test/unit/models/feedback-event/feedback-event.constants.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/feedback-event/feedback-event.constants.test.js
@@ -70,8 +70,10 @@ describe('feedback-event constants', () => {
     expect(Object.isFrozen(EXPORT_EXCLUDED_REJECTION_CATEGORIES)).to.equal(true);
   });
 
-  it('lists the opt-out stripped fields (snake_case, matching the JSONL/DB columns)', () => {
-    expect(OPT_OUT_STRIPPED_FIELDS).to.deep.equal(['previous_fix', 'edited_fix', 'detail_markdown']);
+  it('lists only the HUMAN-authored opt-out stripped fields (AI-generated guidance + generated patch are always exported)', () => {
+    expect(OPT_OUT_STRIPPED_FIELDS).to.deep.equal(['detail_markdown', 'edited_fix']);
+    expect(OPT_OUT_STRIPPED_FIELDS).to.not.include('previous_fix');
+    expect(OPT_OUT_STRIPPED_FIELDS).to.not.include('guidance_markdown');
     expect(Object.isFrozen(OPT_OUT_STRIPPED_FIELDS)).to.equal(true);
   });
 
@@ -119,8 +121,10 @@ describe('toReviewView', () => {
     rejection_category: 'bad_recommendation',
     state_transition: 'PENDING_VALIDATION->REJECTED',
     tier: 'paid',
+    feedback_subject_id: 'issue-42',
     previous_fix: { patch: 'before' },
     edited_fix: { patch: 'after' },
+    guidance_markdown: '# Slow hero image\n\nLCP element is a 1.2 MB PNG.',
   };
 
   it('maps a full row to the review view, omitting patches by default', () => {
@@ -136,15 +140,18 @@ describe('toReviewView', () => {
       rejectionCategory: 'bad_recommendation',
       stateTransition: 'PENDING_VALIDATION->REJECTED',
       tier: 'paid',
+      // feedbackSubjectId is in the base view (the UI filters on it)
+      feedbackSubjectId: 'issue-42',
     });
     expect(view).to.not.have.property('previousFix');
     expect(view).to.not.have.property('editedFix');
   });
 
-  it('includes patch fields when includePatches is set', () => {
+  it('includes patch fields + guidance when includePatches is set', () => {
     const view = toReviewView(fullRow, { includePatches: true });
     expect(view.previousFix).to.deep.equal({ patch: 'before' });
     expect(view.editedFix).to.deep.equal({ patch: 'after' });
+    expect(view.guidanceMarkdown).to.equal('# Slow hero image\n\nLCP element is a 1.2 MB PNG.');
   });
 
   it('defaults missing optional fields to null (incl. absent patches when requested)', () => {
@@ -162,6 +169,8 @@ describe('toReviewView', () => {
     expect(view.stateTransition).to.equal(null);
     expect(view.previousFix).to.equal(null);
     expect(view.editedFix).to.equal(null);
+    expect(view.guidanceMarkdown).to.equal(null);
+    expect(view.feedbackSubjectId).to.equal(null);
   });
 
   it('returns null when no row is given', () => {
@@ -171,16 +180,23 @@ describe('toReviewView', () => {
 });
 
 describe('shouldExport', () => {
-  it('excludes product_bug rows', () => {
-    expect(shouldExport({ rejection_category: 'product_bug' })).to.equal(false);
+  const patch = { content: 'diff --git a/x b/x' };
+
+  it('excludes product_bug rows (even with a patch)', () => {
+    expect(shouldExport({ rejection_category: 'product_bug', previous_fix: patch })).to.equal(false);
   });
 
-  it('includes bad_recommendation rows', () => {
-    expect(shouldExport({ rejection_category: 'bad_recommendation' })).to.equal(true);
+  it('includes bad_recommendation rows that have a code patch', () => {
+    expect(shouldExport({ rejection_category: 'bad_recommendation', previous_fix: patch })).to.equal(true);
   });
 
-  it('includes NULL-category rows', () => {
-    expect(shouldExport({ rejection_category: null })).to.equal(true);
+  it('includes NULL-category rows (approvals) that have a code patch', () => {
+    expect(shouldExport({ rejection_category: null, previous_fix: patch })).to.equal(true);
+  });
+
+  it('excludes rows with no code patch (text-guidance-only feedback stays in Postgres)', () => {
+    expect(shouldExport({ rejection_category: 'bad_recommendation', previous_fix: null })).to.equal(false);
+    expect(shouldExport({ rejection_category: null })).to.equal(false);
   });
 });
 
@@ -199,6 +215,7 @@ describe('toJsonlRow', () => {
     state_transition: 'PENDING_VALIDATION->REJECTED',
     tier: 'paid',
     detail_markdown: 'rationale',
+    guidance_markdown: '# Slow hero image\n\nLCP element is a 1.2 MB PNG.',
     previous_fix: { patch: 'before' },
     edited_fix: { patch: 'after' },
   };
@@ -209,15 +226,19 @@ describe('toJsonlRow', () => {
     expect(out.verdict).to.equal('down');
     expect(out.signal).to.equal('negative');
     expect(out.detail_markdown).to.equal('rationale');
+    expect(out.guidance_markdown).to.equal('# Slow hero image\n\nLCP element is a 1.2 MB PNG.');
     expect(out.previous_fix).to.deep.equal({ patch: 'before' });
     expect(out.edited_fix).to.deep.equal({ patch: 'after' });
   });
 
-  it('strips the opt-out fields when the org is opted out', () => {
+  it('strips only the human-authored fields on opt-out; guidance + generated patch still ship', () => {
     const out = toJsonlRow(fullRow, { optedIn: false });
+    // human-authored → stripped
     expect(out.detail_markdown).to.equal(null);
-    expect(out.previous_fix).to.equal(null);
     expect(out.edited_fix).to.equal(null);
+    // AI-generated → always exported (the LA needs the issue + generated patch)
+    expect(out.guidance_markdown).to.equal('# Slow hero image\n\nLCP element is a 1.2 MB PNG.');
+    expect(out.previous_fix).to.deep.equal({ patch: 'before' });
     // metadata still ships
     expect(out.signal).to.equal('negative');
     expect(out.rejection_category).to.equal('bad_recommendation');
@@ -241,6 +262,7 @@ describe('toJsonlRow', () => {
     expect(out.rejection_category).to.equal(null);
     expect(out.state_transition).to.equal(null);
     expect(out.detail_markdown).to.equal(null);
+    expect(out.guidance_markdown).to.equal(null);
     expect(out.previous_fix).to.equal(null);
     expect(out.edited_fix).to.equal(null);
   });
@@ -257,6 +279,8 @@ describe('buildJsonl', () => {
     source: 'backoffice',
     signal: 'positive',
     tier: 'free',
+    // exportable rows carry a generated code patch by default
+    previous_fix: { content: 'diff --git a/x b/x' },
     ...overrides,
   });
 
@@ -269,6 +293,15 @@ describe('buildJsonl', () => {
     const lines = jsonl.split('\n').map((l) => JSON.parse(l));
     expect(lines).to.have.length(2);
     expect(lines.map((l) => l.event_id)).to.deep.equal(['a', 'c']);
+  });
+
+  it('filters out text-guidance-only rows (no code patch)', () => {
+    const jsonl = buildJsonl([
+      row({ event_id: 'a', rejection_category: 'bad_recommendation' }),
+      row({ event_id: 'b', previous_fix: null }), // text-guidance only → not exported
+    ], { optedIn: true });
+    const lines = jsonl.split('\n').map((l) => JSON.parse(l));
+    expect(lines.map((l) => l.event_id)).to.deep.equal(['a']);
   });
 
   it('returns an empty string when every row is filtered out', () => {


### PR DESCRIPTION
## Summary
Feedback-event model changes for the Learning Agent loop (SITES-43974).

- **`toJsonlRow`** now emits `guidance_markdown`.
- **Opt-out** (`OPT_OUT_STRIPPED_FIELDS`) now strips only the **human-authored** fields (`detail_markdown`, `edited_fix`). The AI-generated `guidance_markdown` + `previous_fix` and all metadata **always ship**.
- **`shouldExport`** now requires a **code patch** (`previous_fix` present) **and** not `product_bug`. Text-guidance-only feedback stays in Postgres and is **not** exported (reserved for a future text-guidance corpus).
- **`toReviewView`** returns `feedbackSubjectId` (base view, for per-issue grouping) and `guidanceMarkdown` (with patches).
- `.d.ts` updated.

## Testing
- 28 unit tests pass; lint clean; 100% coverage maintained.

## Downstream
bump `@adobe/spacecat-shared-data-access` after release: **spacecat-jobs-dispatcher** (export gate + guidance in JSONL) and **spacecat-api-service** (read view returns the new fields).



Please ensure your pull request adheres to the following guidelines:
- [X] make sure to link the related issues in this description
- [X] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
Jira: https://jira.corp.adobe.com/browse/SITES-43974

Thanks for contributing!
