### PR TITLE
test(project-engine-client): sha256 lock + spec:verify CI gate on vendored Semrush spec (LLMO-5976)

### DIFF
--- a/packages/spacecat-shared-project-engine-client/README.md
+++ b/packages/spacecat-shared-project-engine-client/README.md
@@ -46,8 +46,11 @@ version control. Semrush only provides the file (no endpoint access in the near 
 it's **Swagger 2.0** (no v3/v3.1 on offer). The vendored file is **never edited**; where it
 diverges from the live API, a generation-time overlay corrects the converted artifact instead (see
 [Spec corrections](#spec-corrections)). Refresh is **manual**: drop in the newer file, re-run
-`npm run generate`, and review the diff. There is no automated drift detection while endpoint
-access is restricted.
+`npm run generate`, and review the diff. A committed checksum lock
+(`spec/projectengine_swagger_public.yaml.sha256`) is verified by `npm run spec:verify` (wired into
+`pretest`, so CI enforces it): any re-vendor of the spec fails the build until the hash is
+explicitly regenerated (`shasum -a 256 spec/projectengine_swagger_public.yaml > spec/projectengine_swagger_public.yaml.sha256`)
+and reviewed. A true live-drift contract test against Semrush remains blocked on endpoint access.
 
 ## Pipeline
 

--- a/packages/spacecat-shared-project-engine-client/README.md
+++ b/packages/spacecat-shared-project-engine-client/README.md
@@ -49,8 +49,15 @@ diverges from the live API, a generation-time overlay corrects the converted art
 `npm run generate`, and review the diff. A committed checksum lock
 (`spec/projectengine_swagger_public.yaml.sha256`) is verified by `npm run spec:verify` (wired into
 `pretest`, so CI enforces it): any re-vendor of the spec fails the build until the hash is
-explicitly regenerated (`shasum -a 256 spec/projectengine_swagger_public.yaml > spec/projectengine_swagger_public.yaml.sha256`)
-and reviewed. A true live-drift contract test against Semrush remains blocked on endpoint access.
+explicitly regenerated with `npm run spec:lock` and reviewed. A true live-drift contract test
+against Semrush remains blocked on endpoint access.
+
+Both scripts use a **package-root-relative** path and assume the working directory is this
+package root — always invoke them via `npm run spec:verify` / `npm run spec:lock`, which npm
+runs from the package root, rather than calling `shasum -c` by hand from the monorepo root or a
+subdirectory (that yields a confusing "no such file" error). They also assume `shasum` (Perl,
+present on macOS and the `ubuntu-latest` CI runner); minimal images such as Alpine ship
+`sha256sum` instead and would need the scripts adjusted.
 
 ## Pipeline
 

--- a/packages/spacecat-shared-project-engine-client/package.json
+++ b/packages/spacecat-shared-project-engine-client/package.json
@@ -20,12 +20,14 @@
     "npm": ">=10.9.0 <12.0.0"
   },
   "scripts": {
+    "pretest": "npm run spec:verify",
     "test": "c8 mocha",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "clean": "rm -rf node_modules build .counterfact",
     "spec:convert": "mkdir -p build && swagger2openapi spec/projectengine_swagger_public.yaml --patch --outfile build/openapi3.json",
     "spec:overlay": "node scripts/apply-overlay.mjs",
+    "spec:verify": "shasum -a 256 -c spec/projectengine_swagger_public.yaml.sha256",
     "generate:ts": "openapi-typescript build/openapi3.json --output src/generated/types.ts",
     "generate:pydantic": "datamodel-codegen --input build/openapi3.json --input-file-type openapi --output python/serenity_project_engine/ --output-model-type pydantic_v2.BaseModel",
     "generate": "npm run spec:convert && npm run spec:overlay && npm run generate:ts && npm run generate:pydantic",

--- a/packages/spacecat-shared-project-engine-client/package.json
+++ b/packages/spacecat-shared-project-engine-client/package.json
@@ -28,6 +28,7 @@
     "spec:convert": "mkdir -p build && swagger2openapi spec/projectengine_swagger_public.yaml --patch --outfile build/openapi3.json",
     "spec:overlay": "node scripts/apply-overlay.mjs",
     "spec:verify": "shasum -a 256 -c spec/projectengine_swagger_public.yaml.sha256",
+    "spec:lock": "shasum -a 256 spec/projectengine_swagger_public.yaml > spec/projectengine_swagger_public.yaml.sha256",
     "generate:ts": "openapi-typescript build/openapi3.json --output src/generated/types.ts",
     "generate:pydantic": "datamodel-codegen --input build/openapi3.json --input-file-type openapi --output python/serenity_project_engine/ --output-model-type pydantic_v2.BaseModel",
     "generate": "npm run spec:convert && npm run spec:overlay && npm run generate:ts && npm run generate:pydantic",

--- a/packages/spacecat-shared-project-engine-client/spec/projectengine_swagger_public.yaml.sha256
+++ b/packages/spacecat-shared-project-engine-client/spec/projectengine_swagger_public.yaml.sha256
@@ -1,0 +1,1 @@
+077ef60b76f876300a3a13bed584085521b5e4147e53b5fb9135d2dd1d47dacf  spec/projectengine_swagger_public.yaml


### PR DESCRIPTION
## What

Commits a checksum of the vendored Swagger file (`spec/projectengine_swagger_public.yaml.sha256`) and adds a `spec:verify` (`shasum -c`) script wired into `pretest`, so any un-reviewed re-vendor of the hand-committed Semrush spec now fails CI (`npm test -ws`) until the hash is explicitly regenerated and reviewed.

Closes LLMO-5976.

## Why

Refresh of the vendored spec was manual with no drift detection (README.md:48-49). Semrush provides only the file (no endpoint access in the near term), so a checksum lock is the available guard.

## Changes

- `spec/projectengine_swagger_public.yaml.sha256` — committed checksum lock (new).
- `package.json` — `spec:verify` script + `pretest` hook so CI enforces it.
- `README.md` — replace the now-false "no automated drift detection" sentence with the gate + regeneration command.

## Test

- `npm run spec:verify` → `spec/projectengine_swagger_public.yaml: OK`.
- Tamper the spec → gate fails (`shasum: command failed`); restore → `OK` again.

## Out of scope

A true live-drift contract test against Semrush remains blocked on external endpoint access (Rainer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)