### PR TITLE
feat(akamai-client): add patchRuleTree + return etag from getRuleTree

### DIFF
--- a/packages/spacecat-shared-akamai-client/src/akamai-client.js
+++ b/packages/spacecat-shared-akamai-client/src/akamai-client.js
@@ -24,6 +24,10 @@ const ACTIVATION_NETWORKS = ['STAGING', 'PRODUCTION'];
 // allowlist keeps a caller-supplied value from injecting into the Content-Type
 // header (e.g. a CR/LF-bearing string).
 const RULE_FORMAT_RE = /^[a-z0-9-]+$/i;
+// A property version's ETag is sent verbatim in the If-Match request header, so restrict it to a
+// printable-ASCII, whitespace-free token (PAPI returns a hex etag) — this stops a malformed value
+// from injecting extra headers via CR/LF, mirroring RULE_FORMAT_RE's guard for ruleFormat.
+const ETAG_RE = /^[!-~]+$/;
 
 function requireText(name, value) {
   if (!hasText(value)) {
@@ -474,6 +478,11 @@ export default class AkamaiClient {
     }
     if (!Array.isArray(ops)) {
       throw new Error('ops must be an array of JSON Patch operations');
+    }
+    // An empty ops array is forwarded as-is (PAPI treats it as a no-op); buildRuleTreePatch always
+    // emits at least the wrapper add, so an empty patch is not special-cased here.
+    if (etag && !ETAG_RE.test(etag)) {
+      throw new Error('etag must not contain whitespace or control characters');
     }
     const { dryRun = false } = options;
     const id = encodePathSegment(propertyId);

--- a/packages/spacecat-shared-akamai-client/src/akamai-client.js
+++ b/packages/spacecat-shared-akamai-client/src/akamai-client.js
@@ -363,7 +363,7 @@ export default class AkamaiClient {
    * @param {number} version
    * @param {string} contractId
    * @param {string} groupId
-   * @returns {Promise<{ruleTree: object, ruleFormat: string|undefined}>}
+   * @returns {Promise<{ruleTree: object, ruleFormat: string|undefined, etag: string|undefined}>}
    */
   async getRuleTree(propertyId, version, contractId, groupId) {
     requirePropertyRef(propertyId, contractId, groupId);
@@ -377,7 +377,9 @@ export default class AkamaiClient {
       `/papi/v1/properties/${id}/versions/${version}/rules`,
       { params: { contractId, groupId } },
     );
-    return { ruleTree: data, ruleFormat: data.ruleFormat };
+    // `etag` is the version's optimistic-concurrency token; patchRuleTree passes it back as
+    // If-Match so a concurrent edit fails the PATCH instead of silently clobbering.
+    return { ruleTree: data, ruleFormat: data.ruleFormat, etag: data.etag };
   }
 
   /**
@@ -442,6 +444,55 @@ export default class AkamaiClient {
         body: ruleTree,
         headers,
       },
+    );
+  }
+
+  /**
+   * Applies a JSON Patch (RFC 6902) to a rule tree, with PAPI-side validation enabled. Unlike
+   * updateRuleTree (a full-tree PUT), PATCH applies the deltas to the STORED tree server-side, so
+   * behaviors we don't name in an op are never re-serialized by us — this avoids re-storing PAPI's
+   * GET-expanded projection of untouched behaviors, which is what made validateRules reject an
+   * existing "Use Platform Settings" origin. Errors/warnings, if any, come back in the response
+   * body rather than as an HTTP error (same shape as updateRuleTree).
+   *
+   * @param {string} propertyId
+   * @param {number} version - must be an editable (inactive) version for a real patch; a dry-run
+   *   only validates and never persists.
+   * @param {string} contractId
+   * @param {string} groupId
+   * @param {Array<object>} ops - JSON Patch operations (paths are rooted at the rules document,
+   *   e.g. `/rules/children/-`, `/rules/variables/-`).
+   * @param {string} [etag] - the version's ETag (from getRuleTree), sent as If-Match.
+   * @param {object} [options]
+   * @param {boolean} [options.dryRun=false] - validate without saving.
+   * @returns {Promise<object>}
+   */
+  async patchRuleTree(propertyId, version, contractId, groupId, ops, etag, options = {}) {
+    requirePropertyRef(propertyId, contractId, groupId);
+    if (!Number.isInteger(version)) {
+      throw new Error('version must be an integer');
+    }
+    if (!Array.isArray(ops)) {
+      throw new Error('ops must be an array of JSON Patch operations');
+    }
+    const { dryRun = false } = options;
+    const id = encodePathSegment(propertyId);
+    const params = { contractId, groupId, validateRules: 'true' };
+    if (dryRun) {
+      params.dryRun = 'true';
+    }
+    const headers = {
+      'Content-Type': 'application/json-patch+json',
+      ...(etag ? { 'If-Match': etag } : {}),
+    };
+    this.log.info(
+      `Patching rule tree for property ${propertyId} v${version} `
+      + `(${ops.length} op(s)${dryRun ? ', dry-run' : ''})`,
+    );
+    return this.#request(
+      'PATCH',
+      `/papi/v1/properties/${id}/versions/${version}/rules`,
+      { params, body: ops, headers },
     );
   }
 

--- a/packages/spacecat-shared-akamai-client/src/index.d.ts
+++ b/packages/spacecat-shared-akamai-client/src/index.d.ts
@@ -36,6 +36,7 @@ export interface PropertyMatch {
 export interface RuleTreeResult {
   ruleTree: object;
   ruleFormat?: string;
+  etag?: string;
 }
 
 export type Network = 'STAGING' | 'PRODUCTION';
@@ -92,6 +93,16 @@ export default class AkamaiClient {
     groupId: string,
     ruleTree: object,
     ruleFormat?: string,
+  ): Promise<object>;
+
+  patchRuleTree(
+    propertyId: string,
+    version: number,
+    contractId: string,
+    groupId: string,
+    ops: object[],
+    etag?: string,
+    options?: { dryRun?: boolean },
   ): Promise<object>;
 
   activate(

--- a/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
+++ b/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
@@ -454,6 +454,16 @@ describe('AkamaiClient', () => {
       expect(ruleTree.rules).to.deep.equal({ name: 'default' });
     });
 
+    it('returns etag undefined when the PAPI response omits it', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/versions/5/rules`)
+        .query({ contractId: CONTRACT_ID, groupId: GROUP_ID })
+        .reply(200, { ruleFormat: 'v2024-01-01', rules: { name: 'default' } });
+
+      const { etag } = await client.getRuleTree(PROPERTY_ID, 5, CONTRACT_ID, GROUP_ID);
+      expect(etag).to.equal(undefined);
+    });
+
     it('throws when version is not an integer', async () => {
       await expect(client.getRuleTree(PROPERTY_ID, '5', CONTRACT_ID, GROUP_ID))
         .to.be.rejectedWith('version must be an integer');
@@ -560,7 +570,8 @@ describe('AkamaiClient', () => {
     });
 
     it('adds dryRun=true and omits If-Match when no etag is given', async () => {
-      nock(API_BASE)
+      // badheaders: nock refuses to match if the request sends If-Match, proving it is omitted.
+      nock(API_BASE, { badheaders: ['if-match'] })
         .matchHeader('content-type', 'application/json-patch+json')
         .patch(`/papi/v1/properties/${PROPERTY_ID}/versions/6/rules`, OPS)
         .query({
@@ -588,6 +599,12 @@ describe('AkamaiClient', () => {
     it('throws when ops is not an array', async () => {
       await expect(client.patchRuleTree(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, { op: 'add' }))
         .to.be.rejectedWith('ops must be an array of JSON Patch operations');
+    });
+
+    it('rejects an etag that would inject into the If-Match header', async () => {
+      await expect(
+        client.patchRuleTree(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, OPS, 'etag\r\nX-Evil: 1'),
+      ).to.be.rejectedWith('etag must not contain whitespace or control characters');
     });
   });
 

--- a/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
+++ b/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
@@ -441,15 +441,16 @@ describe('AkamaiClient', () => {
   // ─── version + rule-tree operations ─────────────────────────────────────
 
   describe('getRuleTree', () => {
-    it('returns the rule tree and its ruleFormat', async () => {
+    it('returns the rule tree, its ruleFormat, and the version etag', async () => {
       nock(API_BASE)
         .get(`/papi/v1/properties/${PROPERTY_ID}/versions/5/rules`)
         .query({ contractId: CONTRACT_ID, groupId: GROUP_ID })
-        .reply(200, { ruleFormat: 'v2024-01-01', rules: { name: 'default' } });
+        .reply(200, { ruleFormat: 'v2024-01-01', etag: 'abc123', rules: { name: 'default' } });
 
       const result = await client.getRuleTree(PROPERTY_ID, 5, CONTRACT_ID, GROUP_ID);
-      const { ruleTree, ruleFormat } = result;
+      const { ruleTree, ruleFormat, etag } = result;
       expect(ruleFormat).to.equal('v2024-01-01');
+      expect(etag).to.equal('abc123');
       expect(ruleTree.rules).to.deep.equal({ name: 'default' });
     });
 
@@ -540,6 +541,53 @@ describe('AkamaiClient', () => {
       );
       await expect(attempt)
         .to.be.rejectedWith('ruleFormat must contain only letters, digits, and hyphens');
+    });
+  });
+
+  describe('patchRuleTree', () => {
+    const OPS = [{ op: 'add', path: '/rules/children/-', value: { name: 'X' } }];
+
+    it('sends the json-patch content-type, If-Match etag, and validateRules; returns body', async () => {
+      nock(API_BASE)
+        .matchHeader('content-type', 'application/json-patch+json')
+        .matchHeader('if-match', 'etag123')
+        .patch(`/papi/v1/properties/${PROPERTY_ID}/versions/6/rules`, OPS)
+        .query({ contractId: CONTRACT_ID, groupId: GROUP_ID, validateRules: 'true' })
+        .reply(200, { errors: [], warnings: [{ detail: 'w' }] });
+
+      const result = await client.patchRuleTree(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, OPS, 'etag123');
+      expect(result).to.deep.equal({ errors: [], warnings: [{ detail: 'w' }] });
+    });
+
+    it('adds dryRun=true and omits If-Match when no etag is given', async () => {
+      nock(API_BASE)
+        .matchHeader('content-type', 'application/json-patch+json')
+        .patch(`/papi/v1/properties/${PROPERTY_ID}/versions/6/rules`, OPS)
+        .query({
+          contractId: CONTRACT_ID, groupId: GROUP_ID, validateRules: 'true', dryRun: 'true',
+        })
+        .reply(200, { errors: [{ detail: 'e' }], warnings: [] });
+
+      const result = await client.patchRuleTree(
+        PROPERTY_ID,
+        6,
+        CONTRACT_ID,
+        GROUP_ID,
+        OPS,
+        undefined,
+        { dryRun: true },
+      );
+      expect(result.errors).to.deep.equal([{ detail: 'e' }]);
+    });
+
+    it('throws when version is not an integer', async () => {
+      await expect(client.patchRuleTree(PROPERTY_ID, '6', CONTRACT_ID, GROUP_ID, OPS))
+        .to.be.rejectedWith('version must be an integer');
+    });
+
+    it('throws when ops is not an array', async () => {
+      await expect(client.patchRuleTree(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, { op: 'add' }))
+        .to.be.rejectedWith('ops must be an array of JSON Patch operations');
     });
   });
 


### PR DESCRIPTION
## What
Adds `patchRuleTree()` to the Akamai PAPI client and returns the version `etag` from `getRuleTree()`.

- `patchRuleTree(propertyId, version, contractId, groupId, ops, etag, { dryRun })` → `PATCH /papi/v1/properties/{id}/versions/{v}/rules` with `Content-Type: application/json-patch+json`, `If-Match: <etag>`, `?validateRules=true` (+ optional `?dryRun=true`). Returns `{ errors, warnings }` (same shape as `updateRuleTree`).
- `getRuleTree` now also returns `etag` for If-Match optimistic concurrency.

## Why
The Optimize-at-Edge onboarding deploy needs to add its managed rules **without re-serializing the customer's existing rule tree**. A full-tree `GET → PUT` re-stores PAPI's GET-expanded projection of untouched behaviors and gets rejected by `validateRules` (see LLMO-6252). A server-side JSON Patch touches only the deltas; `updateRuleTree` is retained for callers that still want a full-tree PUT.

## Tests
`c8 mocha` green — added `patchRuleTree` cases (content-type, If-Match, dryRun, arg validation) + a `getRuleTree` etag assertion. 75 passing, coverage above thresholds.

LLMO-6252

🤖 Generated with [Claude Code](https://claude.com/claude-code)