### PR TITLE
WP-O1: rename authorship tag root from source to origin (PE-client mock)

### DIFF
--- a/packages/spacecat-shared-project-engine-client/docs/mock-usage.md
+++ b/packages/spacecat-shared-project-engine-client/docs/mock-usage.md
@@ -154,24 +154,30 @@ method that calls it.
 
 ## 4. Seeds
 
-Three named seeds ship in `mock/seeds.js`:
+Four named seeds ship in `mock/seeds.js`:
 
 - **`empty-workspace`** — the (child) seed workspace with no projects.
 - **`workspace-with-data`** (default) — one LIVE US/en market under the brand's **child**
   sub-workspace (`SEED_IDS.workspaceId`, the id a correctly-anchored brand resolves to — NOT the org
   parent), with a catalog-valid AI model (`search-gpt`), the four bare dimension roots (`category`,
-  `intent`, `source`, `type`) carrying the closed vocabularies as children plus a depth-2 category
+  `intent`, `origin`, `type`) carrying the closed vocabularies as children plus a depth-2 category
   with two depth-3 sub-categories, a prompt dual-tagged with its category and sub-category plus one
   closed value per dimension, an own-brand benchmark, and a brand URL. The sub-category `human` and
-  the `source` value `human` deliberately share a name and differ only by parent, so the
+  the `origin` value `human` deliberately share a name and differ only by parent, so the
   cross-dimension collision case stays exercised. Canonical ids are exported as `SEED_IDS`
   (`parentWorkspaceId`, `workspaceId`, `projectId`, `aiModelId`, `promptId`, `benchmarkId`,
   `brandUrlId`, the four `*RootTagId`s, `categoryTagId`, `childTagId`, `childCollidingTagId`,
-  `sourceHumanTagId`, `intentCommercialTagId`, `typeBrandedTagId`).
+  `originHumanTagId`, `intentCommercialTagId`, `typeBrandedTagId`).
 - **`two-hierarchies`** — a strict superset of `workspace-with-data` plus a second, fully
   independent parent/child hierarchy with its own LIVE DE/de market (`SEED_IDS.secondWorkspaceId` /
   `secondProjectId`), for the dual-org case where two mock-wired orgs each need a distinct
   `semrush_workspace_id`.
+- **`legacy-source-workspace`** — a workspace whose dimension-root tree still uses the PRE-rename
+  `source` root name (with `ai`/`human` children), for exercising a tolerant resolver that must
+  accept both `origin` and legacy `source` roots during the migration window
+  (adobe/spacecat-shared#1812, the origin dimension). Ids: `SEED_IDS.legacyWorkspaceId`,
+  `legacyProjectId`, `legacySourceRootTagId`, `legacySourceAiTagId`, `legacySourceHumanTagId`. This
+  snapshot is deleted in WP-O6 once every consumer only reads `origin`.
 
 Boot from a custom state with `MOCK_SEED_FILE=/path/to/snapshot.json` or replace state at runtime
 with `POST /__seed` (§5). A `Snapshot` is a plain JSON object keyed `<resource>:<scope>`:

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags.js
@@ -13,7 +13,7 @@
 /**
  * Stateful handlers for /v2/workspaces/{id}/projects/{project_id}/aio/tags — the project-level AIO
  * tag taxonomy (the Categories surface), modelled as a dimension-root tree: each DIMENSION
- * (`category`, `intent`, `source`, `type`) is a bare-named root with no `parent_id`, and every
+ * (`category`, `intent`, `origin`, `type`) is a bare-named root with no `parent_id`, and every
  * VALUE is a bare-named descendant carrying its parent's id. No tag name contains a `:`; a tag's
  * dimension is `path[0]`. Categories sit at depth 2 and sub-categories at depth 3. The per-project
  * `tags` collection (`tags:{ws}:{pid}`) is scoped so the same taxonomy registered across N market
@@ -30,7 +30,7 @@
  *   `TreeNodeResponse` `[{ id, name, parent_id?, children_count, keyword_count }]` (verified
  *   2026-06-25; overlay CR6 retypes the 201 as an array). Because the id is keyed on
  *   `(parent, name)`, two same-named children under DIFFERENT parents are two distinct tags — as
- *   live, and as the dimension-root model requires (a sub-category `human` and the source value
+ *   live, and as the dimension-root model requires (a sub-category `human` and the origin value
  *   `human` must coexist).
  * - GET (`aio-get-project-tags`): returns the project's stored tags as `AIOTagsListResponse`
  *   `{ items, page, total }`, so a 0-prompt tag created via POST reads back. The spec marks

--- a/packages/spacecat-shared-project-engine-client/mock/factories.js
+++ b/packages/spacecat-shared-project-engine-client/mock/factories.js
@@ -345,7 +345,7 @@ export const createTagNodeMock = (overrides = {}) => ({
  * the shape the mock persists in the per-project `tags` collection.
  *
  * The tag taxonomy is a dimension-root tree (see the dimension-root tag model): each **dimension**
- * — `category`, `intent`, `source`, `type` — is a bare-named ROOT with no `parent_id`, and every
+ * — `category`, `intent`, `origin`, `type` — is a bare-named ROOT with no `parent_id`, and every
  * **value** is a bare-named descendant carrying its parent's id. No name ever contains a `:`. A
  * category sits at depth 2 and a sub-category at depth 3; the API caps no depth. Because roots
  * legitimately have no parent, `parent_id` is left OUT of the defaults (optional, supplied via

--- a/packages/spacecat-shared-project-engine-client/mock/seeds.js
+++ b/packages/spacecat-shared-project-engine-client/mock/seeds.js
@@ -73,7 +73,7 @@ const US_GEO_TARGET_ID = 2840; // Google geoTargetId (United States)
 const DIMENSION_ROOTS = Object.freeze({
   category: 'category',
   intent: 'intent',
-  source: 'source',
+  origin: 'origin',
   type: 'type',
 });
 
@@ -81,16 +81,16 @@ const DIMENSION_ROOTS = Object.freeze({
 const INTENT_VALUES = Object.freeze([
   'Informational', 'Task', 'Commercial', 'Transactional', 'Navigational',
 ]);
-const SOURCE_VALUES = Object.freeze(['ai', 'human']);
+const ORIGIN_VALUES = Object.freeze(['ai', 'human']);
 const TYPE_VALUES = Object.freeze(['branded', 'non-branded']);
 
 const CATEGORY_ROOT_TAG_ID = tagId(DIMENSION_ROOTS.category);
 const INTENT_ROOT_TAG_ID = tagId(DIMENSION_ROOTS.intent);
-const SOURCE_ROOT_TAG_ID = tagId(DIMENSION_ROOTS.source);
+const ORIGIN_ROOT_TAG_ID = tagId(DIMENSION_ROOTS.origin);
 const TYPE_ROOT_TAG_ID = tagId(DIMENSION_ROOTS.type);
 
 // H1's open taxonomy: one depth-2 category with two depth-3 sub-categories. The sub-category named
-// `human` deliberately collides by NAME with the `source` value `human` — under bare names those
+// `human` deliberately collides by NAME with the `origin` value `human` — under bare names those
 // are two distinct tags only because ids are keyed on `(parent, name)`. Seeding the collision keeps
 // the cross-dimension case (model spec §7 gate 4) exercisable end-to-end rather than hypothetical.
 const CATEGORY_NAME = 'Running Shoes';
@@ -100,11 +100,21 @@ const CATEGORY_TAG_ID = tagId(CATEGORY_NAME, CATEGORY_ROOT_TAG_ID); // depth-2 c
 const CHILD_TAG_ID = tagId(CATEGORY_CHILD_NAME, CATEGORY_TAG_ID); // depth-3 sub-category
 const CHILD_COLLIDING_TAG_ID = tagId(CATEGORY_CHILD_COLLIDING_NAME, CATEGORY_TAG_ID);
 
-// The closed-dimension values H1's seeded prompt carries. `sourceHuman` shares its NAME with the
+// The closed-dimension values H1's seeded prompt carries. `originHuman` shares its NAME with the
 // sub-category above and its id with nothing.
-const SOURCE_HUMAN_TAG_ID = tagId('human', SOURCE_ROOT_TAG_ID);
+const ORIGIN_HUMAN_TAG_ID = tagId('human', ORIGIN_ROOT_TAG_ID);
 const INTENT_COMMERCIAL_TAG_ID = tagId('Commercial', INTENT_ROOT_TAG_ID);
 const TYPE_BRANDED_TAG_ID = tagId('branded', TYPE_ROOT_TAG_ID);
+
+// --- Legacy `source`-named root (pre-rename shape, adobe/spacecat-shared#1812 / the origin
+// dimension). Kept ONLY as its own `legacy-source-workspace` snapshot so downstream consumers
+// (e.g. api-service's tolerant resolver) can be tested against both root names. WP-O6 deletes this
+// snapshot once the migration completes — do not wire it into any other seed.
+const LEGACY_WORKSPACE_ID = 'c2d3e4f5-a6b7-4c8d-9e0f-1a2b3c4d5e6f';
+const LEGACY_PROJECT_ID = 'd3e4f5a6-b7c8-4d9e-8f0a-2b3c4d5e6f70';
+const LEGACY_SOURCE_ROOT_TAG_ID = tagId('source');
+const LEGACY_SOURCE_AI_TAG_ID = tagId('ai', LEGACY_SOURCE_ROOT_TAG_ID);
+const LEGACY_SOURCE_HUMAN_TAG_ID = tagId('human', LEGACY_SOURCE_ROOT_TAG_ID);
 
 // --- Hierarchy 2 — a second, fully independent mock-wired org (unique `semrush_workspace_id`s),
 // present only in the `two-hierarchies` seed. A German market so the two read distinctly. These
@@ -223,10 +233,10 @@ const childTag = (name, parentId) => createAIOTagMock({
 const dimensionRootTree = (categories = []) => [
   rootTag(DIMENSION_ROOTS.category),
   rootTag(DIMENSION_ROOTS.intent),
-  rootTag(DIMENSION_ROOTS.source),
+  rootTag(DIMENSION_ROOTS.origin),
   rootTag(DIMENSION_ROOTS.type),
   ...INTENT_VALUES.map((v) => childTag(v, INTENT_ROOT_TAG_ID)),
-  ...SOURCE_VALUES.map((v) => childTag(v, SOURCE_ROOT_TAG_ID)),
+  ...ORIGIN_VALUES.map((v) => childTag(v, ORIGIN_ROOT_TAG_ID)),
   ...TYPE_VALUES.map((v) => childTag(v, TYPE_ROOT_TAG_ID)),
   ...categories.flatMap(({ name, children = [] }) => {
     const categoryId = tagId(name, CATEGORY_ROOT_TAG_ID);
@@ -303,7 +313,7 @@ export const EMPTY_WORKSPACE = Object.freeze({
  *
  * The prompt is dual-tagged (its depth-2 category AND its depth-3 sub-category, per the id-based
  * alignment spec's delete-resilience rule) and carries one closed value per dimension. Its
- * sub-category `human` and its source value `human` share a name and nothing else.
+ * sub-category `human` and its origin value `human` share a name and nothing else.
  */
 export const WORKSPACE_WITH_DATA = Object.freeze(peHierarchy({
   childWorkspaceId: CHILD_WORKSPACE_ID,
@@ -322,7 +332,7 @@ export const WORKSPACE_WITH_DATA = Object.freeze(peHierarchy({
   promptTags: [
     childTag(CATEGORY_NAME, CATEGORY_ROOT_TAG_ID),
     childTag(CATEGORY_CHILD_COLLIDING_NAME, CATEGORY_TAG_ID),
-    childTag('human', SOURCE_ROOT_TAG_ID),
+    childTag('human', ORIGIN_ROOT_TAG_ID),
     childTag('Commercial', INTENT_ROOT_TAG_ID),
     childTag('branded', TYPE_ROOT_TAG_ID),
   ],
@@ -359,7 +369,7 @@ export const TWO_HIERARCHIES = Object.freeze({
     promptName: 'Was ist der beste Laufschuh?',
     promptTags: [
       childTag('Laufschuhe', CATEGORY_ROOT_TAG_ID),
-      childTag('ai', SOURCE_ROOT_TAG_ID),
+      childTag('ai', ORIGIN_ROOT_TAG_ID),
       childTag('Informational', INTENT_ROOT_TAG_ID),
       childTag('non-branded', TYPE_ROOT_TAG_ID),
     ],
@@ -371,6 +381,29 @@ export const TWO_HIERARCHIES = Object.freeze({
 });
 
 /**
+ * A workspace whose dimension-root tree still uses the PRE-rename `source` root (with its `ai`/
+ * `human` children), for exercising a tolerant resolver that must accept both `origin` and legacy
+ * `source` roots during the migration window (adobe/spacecat-shared#1812, the origin dimension).
+ * WP-O6 deletes this snapshot once every consumer's resolver only reads `origin`.
+ */
+export const LEGACY_SOURCE_WORKSPACE = Object.freeze(buildSeed({
+  workspaceId: LEGACY_WORKSPACE_ID,
+  projects: [{
+    id: LEGACY_PROJECT_ID,
+    name: 'Legacy Source Project',
+    tags: [
+      rootTag(DIMENSION_ROOTS.category),
+      rootTag(DIMENSION_ROOTS.intent),
+      rootTag('source'), // pre-rename root name — intentionally NOT DIMENSION_ROOTS.origin
+      rootTag(DIMENSION_ROOTS.type),
+      ...INTENT_VALUES.map((v) => childTag(v, INTENT_ROOT_TAG_ID)),
+      ...ORIGIN_VALUES.map((v) => childTag(v, LEGACY_SOURCE_ROOT_TAG_ID)),
+      ...TYPE_VALUES.map((v) => childTag(v, TYPE_ROOT_TAG_ID)),
+    ],
+  }],
+}));
+
+/**
  * All seed sets by name, for the runner to select via env/flag. Typed as a string map so a
  * runtime `MOCK_SEED` (an arbitrary string) can index it with a fallback (see {@link Context}).
  * @type {Record<string, import('./store.js').Snapshot>}
@@ -379,6 +412,7 @@ export const SEEDS = Object.freeze({
   'empty-workspace': EMPTY_WORKSPACE,
   'workspace-with-data': WORKSPACE_WITH_DATA,
   'two-hierarchies': TWO_HIERARCHIES,
+  'legacy-source-workspace': LEGACY_SOURCE_WORKSPACE,
 });
 
 /** Default seed loaded when none is specified. */
@@ -398,20 +432,26 @@ export const SEED_IDS = Object.freeze({
   // The four dimension roots — every project carries exactly these at the root level.
   categoryRootTagId: CATEGORY_ROOT_TAG_ID,
   intentRootTagId: INTENT_ROOT_TAG_ID,
-  sourceRootTagId: SOURCE_ROOT_TAG_ID,
+  originRootTagId: ORIGIN_ROOT_TAG_ID,
   typeRootTagId: TYPE_ROOT_TAG_ID,
   // H1's open taxonomy: a depth-2 category and its two depth-3 sub-categories. `childTagId` carries
   // no prompts; `childCollidingTagId` is the sub-category named `human`, whose name — and only
-  // whose name — matches the `source` value below.
+  // whose name — matches the `origin` value below.
   categoryTagId: CATEGORY_TAG_ID,
   childTagId: CHILD_TAG_ID,
   childCollidingTagId: CHILD_COLLIDING_TAG_ID,
   // H1's closed-dimension values, as carried by the seeded prompt.
-  sourceHumanTagId: SOURCE_HUMAN_TAG_ID,
+  originHumanTagId: ORIGIN_HUMAN_TAG_ID,
   intentCommercialTagId: INTENT_COMMERCIAL_TAG_ID,
   typeBrandedTagId: TYPE_BRANDED_TAG_ID,
   // Hierarchy 2 (present only in `two-hierarchies`).
   secondParentWorkspaceId: PARENT_WORKSPACE_ID_2,
   secondWorkspaceId: CHILD_WORKSPACE_ID_2,
   secondProjectId: PROJECT_ID_2,
+  // Legacy `source`-rooted world (present only in `legacy-source-workspace`; deleted in WP-O6).
+  legacyWorkspaceId: LEGACY_WORKSPACE_ID,
+  legacyProjectId: LEGACY_PROJECT_ID,
+  legacySourceRootTagId: LEGACY_SOURCE_ROOT_TAG_ID,
+  legacySourceAiTagId: LEGACY_SOURCE_AI_TAG_ID,
+  legacySourceHumanTagId: LEGACY_SOURCE_HUMAN_TAG_ID,
 });

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -41,7 +41,7 @@ const SHUTDOWN_TIMEOUT_MS = 5_000;
 const SEED_WORKSPACE = SEED_IDS.workspaceId;
 const SEED_PROJECT = SEED_IDS.projectId;
 // Every project's root level holds exactly these four dimension roots and nothing else.
-const DIMENSION_ROOT_NAMES = ['category', 'intent', 'source', 'type'];
+const DIMENSION_ROOT_NAMES = ['category', 'intent', 'origin', 'type'];
 
 function sleep(ms) {
   return new Promise((resolve) => {
@@ -482,7 +482,7 @@ async function waitForReady(baseUrl, deadline, getStderr) {
       if (t.path === undefined) {
         expect(t).to.not.have.property('parent_id');
       } else {
-        expect(t.path[0].name).to.be.oneOf(['category', 'intent', 'source', 'type']);
+        expect(t.path[0].name).to.be.oneOf(['category', 'intent', 'origin', 'type']);
         expect(t.parent_id).to.be.a('string');
       }
     });
@@ -617,7 +617,7 @@ async function waitForReady(baseUrl, deadline, getStderr) {
   // filter branch (OR semantics), not just the list-all branch. `tagged` is name-keyed and
   // ROOT-only: it derives `tagId(name)` with no parent, so a prompt tagged 'brand' is found via
   // tag_ids: [tagId('brand')]. Neither probe name is a dimension root — a bare name that IS one
-  // (`category`, `intent`, `source`, `type`) would resolve to that real root's id, which is exactly
+  // (`category`, `intent`, `origin`, `type`) would resolve to that real root's id, which is exactly
   // why no caller may reach this endpoint with dimension-root data.
   // Fresh creates are draft-gated (see the dedicated gating test above), so this read passes
   // draft:true — it's exercising the filter branch, not the publish gate.
@@ -1060,18 +1060,18 @@ async function waitForReady(baseUrl, deadline, getStderr) {
   // A sub-category and a closed-dimension value may share a bare NAME and must stay distinct tags —
   // ids are keyed on (parent, name). This is the cross-dimension collision case the dimension-root
   // model must survive; the seed bakes it so it is exercised rather than assumed.
-  it('keeps a sub-category and a same-named source value as distinct tags', async () => {
+  it('keeps a sub-category and a same-named origin value as distinct tags', async () => {
     const { data: subcategories } = await listTags(SEED_IDS.categoryTagId);
-    const { data: sources } = await listTags(SEED_IDS.sourceRootTagId);
+    const { data: origins } = await listTags(SEED_IDS.originRootTagId);
 
     const subHuman = subcategories.items.find((t) => t.name === 'human');
-    const srcHuman = sources.items.find((t) => t.name === 'human');
+    const originHuman = origins.items.find((t) => t.name === 'human');
 
     expect(subHuman.id).to.equal(SEED_IDS.childCollidingTagId);
-    expect(srcHuman.id).to.equal(SEED_IDS.sourceHumanTagId);
-    expect(subHuman.id).to.not.equal(srcHuman.id);
+    expect(originHuman.id).to.equal(SEED_IDS.originHumanTagId);
+    expect(subHuman.id).to.not.equal(originHuman.id);
     expect(subHuman.path[0].name).to.equal('category');
-    expect(srcHuman.path[0].name).to.equal('source');
+    expect(originHuman.path[0].name).to.equal('origin');
   });
 
   // __reset restores the boot seed (the four dimension roots, no ad-hoc tags), so a created
@@ -1398,11 +1398,11 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     expect(prompt.tags.map((t) => t.id)).to.have.members([
       SEED_IDS.categoryTagId,
       SEED_IDS.childCollidingTagId,
-      SEED_IDS.sourceHumanTagId,
+      SEED_IDS.originHumanTagId,
       SEED_IDS.intentCommercialTagId,
     ]);
 
-    // … and the same-named `human` sub-category is untouched by the source value's deletion.
+    // … and the same-named `human` sub-category is untouched by the origin value's deletion.
     const { data: subcategories } = await listTags(SEED_IDS.categoryTagId);
     expect(subcategories.items.map((t) => t.id)).to.include(SEED_IDS.childCollidingTagId);
   });
@@ -1419,7 +1419,7 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     const { response } = await delTags([
       SEED_IDS.categoryTagId,
       SEED_IDS.childCollidingTagId,
-      SEED_IDS.sourceHumanTagId,
+      SEED_IDS.originHumanTagId,
       SEED_IDS.intentCommercialTagId,
       SEED_IDS.typeBrandedTagId,
     ]);

--- a/packages/spacecat-shared-project-engine-client/test/mock/seeds.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/seeds.test.js
@@ -28,8 +28,9 @@ import {
 
 describe('seeds', () => {
   it('exposes named seed sets with a valid default', () => {
-    expect(Object.keys(SEEDS))
-      .to.include.members(['empty-workspace', 'workspace-with-data', 'two-hierarchies']);
+    expect(Object.keys(SEEDS)).to.include.members([
+      'empty-workspace', 'workspace-with-data', 'two-hierarchies', 'legacy-source-workspace',
+    ]);
     expect(SEEDS).to.have.property(DEFAULT_SEED);
   });
 
@@ -83,7 +84,7 @@ describe('seeds', () => {
 
     // Exactly the four dimension roots sit at the root level (model spec §7 gate 2).
     const roots = tags.filter((t) => !t.parent_id);
-    expect(roots.map((t) => t.name)).to.deep.equal(['category', 'intent', 'source', 'type']);
+    expect(roots.map((t) => t.name)).to.deep.equal(['category', 'intent', 'origin', 'type']);
 
     // The closed dimensions carry their full fixed vocabularies as bare children.
     const childNamesOf = (parentId) => tags
@@ -91,7 +92,7 @@ describe('seeds', () => {
       .map((t) => t.name);
     expect(childNamesOf(SEED_IDS.intentRootTagId))
       .to.deep.equal(['Informational', 'Task', 'Commercial', 'Transactional', 'Navigational']);
-    expect(childNamesOf(SEED_IDS.sourceRootTagId)).to.deep.equal(['ai', 'human']);
+    expect(childNamesOf(SEED_IDS.originRootTagId)).to.deep.equal(['ai', 'human']);
     expect(childNamesOf(SEED_IDS.typeRootTagId)).to.deep.equal(['branded', 'non-branded']);
 
     // The open dimension: a depth-2 category under `category`, with depth-3 sub-categories.
@@ -100,14 +101,14 @@ describe('seeds', () => {
     expect(category).to.include({ name: 'Running Shoes', parent_id: SEED_IDS.categoryRootTagId });
     expect(childNamesOf(SEED_IDS.categoryTagId)).to.deep.equal(['Trail', 'human']);
 
-    // The sub-category `human` and the source value `human` share a name and NOTHING else — the
+    // The sub-category `human` and the origin value `human` share a name and NOTHING else — the
     // cross-dimension collision the model spec §7 gate 4 requires to be survivable.
     const subcategoryHuman = tags.find((t) => t.id === SEED_IDS.childCollidingTagId);
-    const sourceHuman = tags.find((t) => t.id === SEED_IDS.sourceHumanTagId);
-    expect(subcategoryHuman.name).to.equal(sourceHuman.name);
-    expect(subcategoryHuman.id).to.not.equal(sourceHuman.id);
+    const originHuman = tags.find((t) => t.id === SEED_IDS.originHumanTagId);
+    expect(subcategoryHuman.name).to.equal(originHuman.name);
+    expect(subcategoryHuman.id).to.not.equal(originHuman.id);
     expect(subcategoryHuman.parent_id).to.equal(SEED_IDS.categoryTagId);
-    expect(sourceHuman.parent_id).to.equal(SEED_IDS.sourceRootTagId);
+    expect(originHuman.parent_id).to.equal(SEED_IDS.originRootTagId);
 
     // The seeded prompt is dual-tagged (category + sub-category) and carries one closed value per
     // dimension, reusing the ids the standalone tree registered so `by_tags` correlates.
@@ -117,7 +118,7 @@ describe('seeds', () => {
     expect(prompt.tags.map((t) => t.id)).to.deep.equal([
       SEED_IDS.categoryTagId,
       SEED_IDS.childCollidingTagId,
-      SEED_IDS.sourceHumanTagId,
+      SEED_IDS.originHumanTagId,
       SEED_IDS.intentCommercialTagId,
       SEED_IDS.typeBrandedTagId,
     ]);
@@ -138,6 +139,27 @@ describe('seeds', () => {
     expect(secondProject.settings.ai.language.name).to.equal('de');
     // distinct workspace ids (the DB enforces unique semrush_workspace_id per org/brand).
     expect(secondWs).to.not.equal(SEED_IDS.workspaceId);
+  });
+
+  it('legacy-source-workspace still roots the origin dimension under the pre-rename `source` name', () => {
+    const store = new InMemoryStore();
+    store.load(SEEDS['legacy-source-workspace']);
+    const ops = createStatefulOps(store);
+    const { legacyWorkspaceId, legacyProjectId } = SEED_IDS;
+
+    expect(ops.projects.list({ workspaceId: legacyWorkspaceId })).to.have.length(1);
+    const tags = ops.tags.list({ workspaceId: legacyWorkspaceId, projectId: legacyProjectId });
+    const roots = tags.filter((t) => !t.parent_id);
+    expect(roots.map((t) => t.name)).to.deep.equal(['category', 'intent', 'source', 'type']);
+
+    const legacySource = roots.find((t) => t.name === 'source');
+    expect(legacySource.id).to.equal(SEED_IDS.legacySourceRootTagId);
+    const originChildren = tags.filter((t) => t.parent_id === legacySource.id);
+    expect(originChildren.map((t) => t.name)).to.deep.equal(['ai', 'human']);
+    expect(originChildren.map((t) => t.id)).to.deep.equal([
+      SEED_IDS.legacySourceAiTagId,
+      SEED_IDS.legacySourceHumanTagId,
+    ]);
   });
 
   it('reset restores a seed after mutation', () => {

--- a/packages/spacecat-shared-project-engine-client/test/mock/tag-id.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/tag-id.test.js
@@ -62,10 +62,10 @@ describe('tag-id', () => {
     expect(tagId('Pricing', 'tag-electronics')).to.not.equal(tagId('Pricing', 'tag-furniture'));
   });
 
-  // A sub-category named `human` and the `source` value `human` must coexist on one prompt
+  // A sub-category named `human` and the `origin` value `human` must coexist on one prompt
   // (model spec §7 gate 4). They share a bare name and differ only by parent.
   it('separates a sub-category from a same-named closed-dimension value', () => {
-    expect(tagId('human', 'tag-running-shoes')).to.not.equal(tagId('human', 'tag-source'));
+    expect(tagId('human', 'tag-running-shoes')).to.not.equal(tagId('human', 'tag-origin'));
   });
 
   // Omitting the parent is how a ROOT id is derived — and it is what `POST /aio/prompts/tagged`
@@ -75,7 +75,7 @@ describe('tag-id', () => {
   });
 
   it('distinguishes a root from a child of the same name', () => {
-    expect(tagId('human')).to.not.equal(tagId('human', 'tag-source'));
+    expect(tagId('human')).to.not.equal(tagId('human', 'tag-origin'));
   });
 
   // The separator makes the preimage unambiguous: without it, the category `ab` under parent `c`

--- a/packages/spacecat-shared-project-engine-client/test/mock/tag-view.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/tag-view.test.js
@@ -15,22 +15,22 @@ import { expect } from 'chai';
 import { buildTagView } from '../../mock/tag-view.js';
 import * as factories from '../../mock/factories.js';
 
-// A dimension-root tree: `category` → `Running Shoes` → `human`, plus the `source` value `human`.
+// A dimension-root tree: `category` → `Running Shoes` → `human`, plus the `origin` value `human`.
 // The two `human` tags share a bare name and differ only by parent, which is the collision the
 // whole dimension-root model exists to survive.
 const CATEGORY_ROOT = 'root-category';
-const SOURCE_ROOT = 'root-source';
+const ORIGIN_ROOT = 'root-origin';
 const RUNNING_SHOES = 'cat-running-shoes';
 const SUB_HUMAN = 'sub-human';
-const SOURCE_HUMAN = 'source-human';
+const ORIGIN_HUMAN = 'origin-human';
 
 const tree = () => [
   { id: CATEGORY_ROOT, name: 'category' },
-  { id: SOURCE_ROOT, name: 'source' },
+  { id: ORIGIN_ROOT, name: 'origin' },
   { id: RUNNING_SHOES, name: 'Running Shoes', parent_id: CATEGORY_ROOT },
   { id: SUB_HUMAN, name: 'human', parent_id: RUNNING_SHOES },
   {
-    id: SOURCE_HUMAN, name: 'human', parent_id: SOURCE_ROOT, prompts_count: 3,
+    id: ORIGIN_HUMAN, name: 'human', parent_id: ORIGIN_ROOT, prompts_count: 3,
   },
 ];
 
@@ -89,7 +89,7 @@ describe('tag-view', () => {
 
     it('preserves the stored prompts_count, defaulting to 0', () => {
       const { byId } = buildTagView(tree(), factories);
-      expect(byId.get(SOURCE_HUMAN).prompts_count).to.equal(3);
+      expect(byId.get(ORIGIN_HUMAN).prompts_count).to.equal(3);
       expect(byId.get(SUB_HUMAN).prompts_count).to.equal(0);
     });
   });
@@ -97,9 +97,9 @@ describe('tag-view', () => {
   it('distinguishes two same-named tags by their dimension root', () => {
     const { byId } = buildTagView(tree(), factories);
 
-    expect(byId.get(SUB_HUMAN).name).to.equal(byId.get(SOURCE_HUMAN).name);
+    expect(byId.get(SUB_HUMAN).name).to.equal(byId.get(ORIGIN_HUMAN).name);
     expect(byId.get(SUB_HUMAN).path[0].name).to.equal('category');
-    expect(byId.get(SOURCE_HUMAN).path[0].name).to.equal('source');
+    expect(byId.get(ORIGIN_HUMAN).path[0].name).to.equal('origin');
   });
 
   it('serialize() answers the same object the byId index holds', () => {


### PR DESCRIPTION
## Summary
Part of the origin-dimension rename: adobe/serenity-docs#46. This is WP-O1 — renames the fully-populated authorship dimension root (`ai`/`human`) from `source` to `origin` in the `spacecat-shared-project-engine-client` mock, and adds a legacy pre-rename seed snapshot so downstream repos can test a tolerant resolver against a project still carrying the old name.

- `DIMENSION_ROOTS`/`SOURCE_VALUES`/`SOURCE_ROOT_TAG_ID`/`SEED_IDS` renamed to `origin` equivalents (ids re-derive automatically via the runtime `tagId(parent, name)` hash)
- Kept the `human`-under-category collision fixture
- Added `legacy-source-workspace` seed (pre-rename shape) — to be deleted in a later contract work package
- Updated `docs/mock-usage.md` and pinned test suites

## Test plan
- [x] `npm test` — 260 passing, 100% coverage
- [x] `npm run test:e2e` — 80 passing
- [x] `npm run lint` — clean
- [x] `npm run test:types` — clean

Closes #1812
Jira: SITES-48000 · Tracking: cross-repo plan in adobe/serenity-docs#46

🤖 Generated with [Claude Code](https://claude.com/claude-code)