### PR TITLE
feat(config): add excludedPathPrefixes support to handlers config (LLMO-6132)

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -495,6 +495,7 @@ export const configSchema = Joi.object({
     mentions: Joi.object().pattern(Joi.string(), Joi.array().items(Joi.string())),
     excludedURLs: Joi.array().items(Joi.string()),
     autofixExcludedURLs: Joi.array().items(Joi.string()),
+    excludedPathPrefixes: Joi.array().items(Joi.string()),
     manualOverwrites: Joi.array().items(Joi.object({
       brokenTargetURL: Joi.string().optional(),
       targetURL: Joi.string().optional(),
@@ -577,6 +578,7 @@ export const Config = (data = {}) => {
   self.getImports = () => state.imports;
   self.getExcludedURLs = (type) => state?.handlers?.[type]?.excludedURLs;
   self.getAutofixExcludedURLs = (type) => state?.handlers?.[type]?.autofixExcludedURLs;
+  self.getExcludedPathPrefixes = (type) => state?.handlers?.[type]?.excludedPathPrefixes;
   self.getManualOverwrites = (type) => state?.handlers?.[type]?.manualOverwrites;
   self.getFixedURLs = (type) => state?.handlers?.[type]?.fixedURLs;
   self.getIncludedURLs = (type) => state?.handlers?.[type]?.includedURLs;
@@ -880,6 +882,12 @@ export const Config = (data = {}) => {
     state.handlers = state.handlers || {};
     state.handlers[type] = state.handlers[type] || {};
     state.handlers[type].autofixExcludedURLs = autofixExcludedURLs;
+  };
+
+  self.updateExcludedPathPrefixes = (type, excludedPathPrefixes) => {
+    state.handlers = state.handlers || {};
+    state.handlers[type] = state.handlers[type] || {};
+    state.handlers[type].excludedPathPrefixes = excludedPathPrefixes;
   };
 
   self.updateManualOverwrites = (type, manualOverwrites) => {

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -413,6 +413,19 @@ describe('Config Tests', () => {
       expect(config.getAutofixExcludedURLs('non-existent-handler')).to.be.undefined;
     });
 
+    it('correctly updates the excluded path prefixes', () => {
+      const config = Config();
+      config.updateExcludedPathPrefixes('prerender', ['/jp/ja', '/de/de']);
+
+      const excludedPathPrefixes = config.getExcludedPathPrefixes('prerender');
+      expect(excludedPathPrefixes).to.deep.equal(['/jp/ja', '/de/de']);
+    });
+
+    it('returns undefined for excluded path prefixes when handler is not present', () => {
+      const config = Config();
+      expect(config.getExcludedPathPrefixes('non-existent-handler')).to.be.undefined;
+    });
+
     it('correctly updates the manual overrides', () => {
       const config = Config();
       const manualOverwrites = [
@@ -476,6 +489,7 @@ describe('Config Tests', () => {
       expect(config.getHandlerConfig('404')).to.be.undefined;
       expect(config.getExcludedURLs('404')).to.be.undefined;
       expect(config.getAutofixExcludedURLs('404')).to.be.undefined;
+      expect(config.getExcludedPathPrefixes('404')).to.be.undefined;
       expect(config.getManualOverwrites('404')).to.be.undefined;
       expect(config.getFixedURLs('404')).to.be.undefined;
       expect(config.getIncludedURLs('404')).to.be.undefined;


### PR DESCRIPTION
## Summary

- Adds `excludedPathPrefixes: Joi.array().items(Joi.string())` to the handlers Joi schema
- Adds `getExcludedPathPrefixes(type)` accessor
- Adds `updateExcludedPathPrefixes(type, prefixes)` setter

Allows a site to configure path prefixes excluded from audit scope (e.g. PwC GLSC excluding `/jp/ja` for PwC Japan). Consumed by spacecat-audit-worker (skips URL generation) and spacecat-api-service (hides existing suggestions).

**Jira:** [LLMO-6132](https://jira.corp.adobe.com/browse/LLMO-6132)

## Test plan
- [ ] 2675 unit tests pass
- [ ] getExcludedPathPrefixes / updateExcludedPathPrefixes work correctly
- [ ] Coverage: 100% lines/statements, ≥97% branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)