### PR TITLE
feat(project-engine-client): add requestTimeoutMs per-attempt request deadline (LLMO-5979)

### DIFF
--- a/packages/spacecat-shared-project-engine-client/README.md
+++ b/packages/spacecat-shared-project-engine-client/README.md
@@ -36,7 +36,8 @@ const { data, error } = await client.GET('/v1/countries');
   capped at 20s/attempt. Pass `onRetry` to observe the loop.
 - **Timeouts:** pass `requestTimeoutMs` to bound each attempt — a stalled attempt is aborted via
   `AbortSignal.timeout` (a per-attempt deadline, combined with any caller `signal`, never
-  replacing it) and, for idempotent methods, retried. Unset (default) ⇒ no client-imposed deadline.
+  replacing it) and, for idempotent methods, retried. Unset (default) ⇒ no client-imposed deadline,
+  so a hung socket blocks until the platform's own limit; set this to bound it.
 - **Shape:** this is a thin factory function rather than the `CLAUDE.md` "class + factory" client
   pattern — the wrapper has no per-instance state or behaviour beyond what `openapi-fetch` already
   provides, so a class would add ceremony without value. The typed surface IS the `openapi-fetch`

--- a/packages/spacecat-shared-project-engine-client/README.md
+++ b/packages/spacecat-shared-project-engine-client/README.md
@@ -34,6 +34,9 @@ const { data, error } = await client.GET('/v1/countries');
 - **Retries:** `429` is retried for any method; `5xx`/network errors only for idempotent methods
   (so a POST is never replayed). Backoff is exponential with jitter, honours `Retry-After`, and is
   capped at 20s/attempt. Pass `onRetry` to observe the loop.
+- **Timeouts:** pass `requestTimeoutMs` to bound each attempt — a stalled attempt is aborted via
+  `AbortSignal.timeout` (a per-attempt deadline, combined with any caller `signal`, never
+  replacing it) and, for idempotent methods, retried. Unset (default) ⇒ no client-imposed deadline.
 - **Shape:** this is a thin factory function rather than the `CLAUDE.md` "class + factory" client
   pattern — the wrapper has no per-instance state or behaviour beyond what `openapi-fetch` already
   provides, so a class would add ceremony without value. The typed surface IS the `openapi-fetch`

--- a/packages/spacecat-shared-project-engine-client/src/client.js
+++ b/packages/spacecat-shared-project-engine-client/src/client.js
@@ -44,6 +44,11 @@ import { createRetryingFetch, toTokenGetter } from './internal.js';
  *   retry sleep (`{ attempt, delayMs, method, status?, error? }`), for logging/metrics. A retry
  *   loop is otherwise silent — an operator can't tell "slow upstream" from "stuck in backoff". A
  *   throwing or rejecting hook is swallowed and never affects the request.
+ * @property {number} [requestTimeoutMs] Per-attempt request deadline in ms. When set (> 0), each
+ *   fetch attempt is aborted via `AbortSignal.timeout` after this many ms and — for an idempotent
+ *   method — retried under the retry budget; a caller-supplied `signal` is still honoured
+ *   (combined, not replaced). Unset (the default) ⇒ no client-imposed deadline, so a hung socket
+ *   blocks until the platform's own limit; set this to bound it.
  * @property {typeof globalThis.fetch} [fetch] Injectable fetch (tests, custom agents).
  *   Defaults to the global fetch.
  */
@@ -120,12 +125,19 @@ export function createSerenityProjectEngineApiClient(options) {
     maxRetries = 2,
     retryBaseDelayMs = 200,
     onRetry,
+    requestTimeoutMs,
     fetch: injectedFetch = globalThis.fetch,
   } = options;
 
   const client = createClient({
     baseUrl: resolveBaseUrl(baseUrl),
-    fetch: createRetryingFetch(injectedFetch, maxRetries, retryBaseDelayMs, onRetry),
+    fetch: createRetryingFetch(
+      injectedFetch,
+      maxRetries,
+      retryBaseDelayMs,
+      onRetry,
+      requestTimeoutMs,
+    ),
   });
   // Auth runs as openapi-fetch middleware, so the token getter resolves once per logical request
   // and that token is reused across the request's retries (the retry layer clones the same Request

--- a/packages/spacecat-shared-project-engine-client/src/client.js
+++ b/packages/spacecat-shared-project-engine-client/src/client.js
@@ -139,7 +139,11 @@ export function createSerenityProjectEngineApiClient(options) {
       || requestTimeoutMs <= 0)
   ) {
     throw new Error(
-      `Project Engine client: requestTimeoutMs must be a positive finite number of ms, got ${JSON.stringify(requestTimeoutMs)}`,
+      // Report numbers verbatim so NaN/Infinity read as themselves (JSON.stringify would render
+      // both as "null"); stringify other types so a bad string is visibly quoted.
+      `Project Engine client: requestTimeoutMs must be a positive finite number of ms, got ${
+        typeof requestTimeoutMs === 'number' ? requestTimeoutMs : JSON.stringify(requestTimeoutMs)
+      }`,
     );
   }
 

--- a/packages/spacecat-shared-project-engine-client/src/client.js
+++ b/packages/spacecat-shared-project-engine-client/src/client.js
@@ -129,6 +129,20 @@ export function createSerenityProjectEngineApiClient(options) {
     fetch: injectedFetch = globalThis.fetch,
   } = options;
 
+  // Fail fast on a misconfigured timeout rather than silently disabling it: a NaN/negative value
+  // would no-op in withDeadline (leaving the caller unprotected), and Infinity would reach
+  // AbortSignal.timeout. Mirrors the defensive toTokenGetter/resolveBaseUrl guards below.
+  if (
+    requestTimeoutMs !== undefined
+    && (typeof requestTimeoutMs !== 'number'
+      || !Number.isFinite(requestTimeoutMs)
+      || requestTimeoutMs <= 0)
+  ) {
+    throw new Error(
+      `Project Engine client: requestTimeoutMs must be a positive finite number of ms, got ${JSON.stringify(requestTimeoutMs)}`,
+    );
+  }
+
   const client = createClient({
     baseUrl: resolveBaseUrl(baseUrl),
     fetch: createRetryingFetch(

--- a/packages/spacecat-shared-project-engine-client/src/index.d.ts
+++ b/packages/spacecat-shared-project-engine-client/src/index.d.ts
@@ -52,6 +52,13 @@ export interface SerenityProjectEngineApiClientOptions {
     status?: number;
     error?: Error;
   }) => void | Promise<void>;
+  /**
+   * Per-attempt request deadline in ms. When set (> 0), each fetch attempt is aborted via
+   * `AbortSignal.timeout` after this many ms (and retried for idempotent methods under the retry
+   * budget); any caller-supplied `signal` is combined with it, never replaced. Unset ⇒ no
+   * client-imposed deadline.
+   */
+  requestTimeoutMs?: number;
   /** Injectable fetch (tests, custom agents). Defaults to the global fetch. */
   fetch?: typeof globalThis.fetch;
 }

--- a/packages/spacecat-shared-project-engine-client/src/internal.js
+++ b/packages/spacecat-shared-project-engine-client/src/internal.js
@@ -130,7 +130,8 @@ export function nextRetryDelayMs(completedAttempt, baseDelayMs, response) {
  * @property {number} delayMs the wait before this retry
  * @property {string} method the HTTP method
  * @property {number} [status] the retryable response status that triggered the retry, if any
- * @property {Error} [error] the network error that triggered the retry, if any
+ * @property {Error} [error] the error that triggered the retry, if any — a network error, or a
+ *   per-attempt `AbortSignal.timeout` `TimeoutError` (both are `instanceof Error`)
  */
 
 /**
@@ -188,7 +189,8 @@ export function withDeadline(init, callerSignal, requestTimeoutMs) {
 
 /**
  * Wraps a fetch with bounded exponential-backoff retries. Retryable statuses follow
- * {@link isRetryableStatus}; thrown network errors are retried only for idempotent methods.
+ * {@link isRetryableStatus}; thrown errors (a network error, or a per-attempt timeout) are
+ * retried only for idempotent methods.
  * The wait between attempts is {@link nextRetryDelayMs} — jittered exponential backoff that also
  * honours a `Retry-After` header. After exhausting retries it returns the last retryable response
  * (so the caller still sees e.g. the final 503) or rethrows the last network error.

--- a/packages/spacecat-shared-project-engine-client/src/internal.js
+++ b/packages/spacecat-shared-project-engine-client/src/internal.js
@@ -165,6 +165,28 @@ function notifyRetry(onRetry, info) {
  */
 
 /**
+ * Builds the per-attempt fetch `init` for {@link createRetryingFetch}. When `requestTimeoutMs`
+ * is a positive number, each attempt gets a FRESH `AbortSignal.timeout(requestTimeoutMs)` (the
+ * retry layer calls the underlying fetch once per attempt, so this is a per-attempt deadline, not
+ * a single budget spanning the whole retry loop) — combined with, never replacing, any
+ * caller-supplied signal via `AbortSignal.any`, so a caller abort and the deadline each still
+ * cancel the request. With no timeout configured the caller's `init` is returned untouched, so a
+ * caller signal continues to flow through natively.
+ * @param {RequestInit} [init]
+ * @param {AbortSignal} [callerSignal]
+ * @param {number} [requestTimeoutMs]
+ * @returns {RequestInit | undefined}
+ */
+export function withDeadline(init, callerSignal, requestTimeoutMs) {
+  if (!requestTimeoutMs || requestTimeoutMs <= 0) {
+    return init;
+  }
+  const timeoutSignal = AbortSignal.timeout(requestTimeoutMs);
+  const signal = callerSignal ? AbortSignal.any([callerSignal, timeoutSignal]) : timeoutSignal;
+  return { ...init, signal };
+}
+
+/**
  * Wraps a fetch with bounded exponential-backoff retries. Retryable statuses follow
  * {@link isRetryableStatus}; thrown network errors are retried only for idempotent methods.
  * The wait between attempts is {@link nextRetryDelayMs} — jittered exponential backoff that also
@@ -180,9 +202,12 @@ function notifyRetry(onRetry, info) {
  * @param {number} maxRetries
  * @param {number} baseDelayMs
  * @param {OnRetry} [onRetry] optional best-effort retry-observability hook
+ * @param {number} [requestTimeoutMs] optional per-attempt deadline in ms; when > 0 each attempt is
+ *   aborted via `AbortSignal.timeout` (combined with any caller signal) and, for idempotent
+ *   methods, retried under the retry budget. Unset ⇒ no client-imposed deadline.
  * @returns {typeof globalThis.fetch}
  */
-export function createRetryingFetch(baseFetch, maxRetries, baseDelayMs, onRetry) {
+export function createRetryingFetch(baseFetch, maxRetries, baseDelayMs, onRetry, requestTimeoutMs) {
   return async function retryingFetch(input, init) {
     const method = methodOf(input, init);
     // Floor at 0: a negative maxRetries would skip the loop entirely, leaving both lastResponse
@@ -196,6 +221,9 @@ export function createRetryingFetch(baseFetch, maxRetries, baseDelayMs, onRetry)
     // token is resolved per request, not per attempt; with the ceiling above the whole loop is
     // bounded well under an IMS token's lifetime, so mid-loop expiry is a non-issue.
     const forAttempt = () => (input instanceof Request ? input.clone() : input);
+    // Resolve any caller-supplied AbortSignal once. openapi-fetch calls us with a Request whose
+    // own `.signal` reflects a caller `signal` option; a bare-URL fetch may carry it on `init`.
+    const callerSignal = init?.signal ?? (input instanceof Request ? input.signal : undefined);
     let lastResponse;
     let lastError;
     let nextDelayMs = 0;
@@ -215,8 +243,9 @@ export function createRetryingFetch(baseFetch, maxRetries, baseDelayMs, onRetry)
         await sleep(nextDelayMs);
       }
       try {
+        const attemptInit = withDeadline(init, callerSignal, requestTimeoutMs);
         // eslint-disable-next-line no-await-in-loop
-        const response = await baseFetch(forAttempt(), init);
+        const response = await baseFetch(forAttempt(), attemptInit);
         if (!isRetryableStatus(method, response.status)) {
           return response;
         }

--- a/packages/spacecat-shared-project-engine-client/test/client.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/client.test.js
@@ -237,4 +237,19 @@ describe('createSerenityProjectEngineApiClient', () => {
     expect(thrown).to.be.an.instanceOf(Error);
     expect(thrown.name).to.equal('TimeoutError');
   });
+
+  it('throws at construction when requestTimeoutMs is not a positive finite number', () => {
+    const make = (requestTimeoutMs) => () => createSerenityProjectEngineApiClient({
+      baseUrl: 'https://serenity.example',
+      authToken: 'raw-ims-jwt',
+      requestTimeoutMs,
+    });
+    expect(make(0)).to.throw(/requestTimeoutMs must be a positive finite number/);
+    expect(make(-5)).to.throw(/requestTimeoutMs must be a positive finite number/);
+    expect(make(NaN)).to.throw(/requestTimeoutMs must be a positive finite number/);
+    expect(make(Infinity)).to.throw(/requestTimeoutMs must be a positive finite number/);
+    expect(make('5000')).to.throw(/requestTimeoutMs must be a positive finite number/);
+    // undefined (omitted) stays valid — the option is opt-in.
+    expect(make(undefined)).to.not.throw();
+  });
 });

--- a/packages/spacecat-shared-project-engine-client/test/client.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/client.test.js
@@ -213,4 +213,28 @@ describe('createSerenityProjectEngineApiClient', () => {
       authToken: 42,
     })).to.throw(/must be a string or a function/);
   });
+
+  it('threads requestTimeoutMs into the fetch layer (aborts a hung attempt)', async () => {
+    // A fetch that never resolves on its own — it settles only when the per-attempt deadline
+    // aborts it. With maxRetries 0 the single attempt times out and the abort propagates.
+    const fetch = (input, init) => new Promise((_, reject) => {
+      init.signal.addEventListener('abort', () => reject(init.signal.reason));
+    });
+    const client = createSerenityProjectEngineApiClient({
+      baseUrl: 'https://serenity.example',
+      authToken: 'raw-ims-jwt',
+      maxRetries: 0,
+      requestTimeoutMs: 10,
+      fetch,
+    });
+
+    let thrown;
+    try {
+      await client.GET('/v1/countries');
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).to.be.an.instanceOf(Error);
+    expect(thrown.name).to.equal('TimeoutError');
+  });
 });

--- a/packages/spacecat-shared-project-engine-client/test/internal.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/internal.test.js
@@ -303,6 +303,23 @@ describe('createRetryingFetch request timeout', () => {
     expect(calls).to.equal(2);
   });
 
+  it('does NOT retry a timed-out non-idempotent (POST) attempt — surfaces the timeout once', async () => {
+    let calls = 0;
+    const base = (input, init) => {
+      calls += 1;
+      return hangUntilAbort(input, init);
+    };
+    let thrown;
+    try {
+      await createRetryingFetch(base, 2, 0, undefined, 10)('https://x', { method: 'POST' });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown.name).to.equal('TimeoutError');
+    // A POST timeout is a thrown error; the isIdempotent gate rethrows it without a replay.
+    expect(calls).to.equal(1);
+  });
+
   it('still honours a caller-supplied signal — combined, not clobbered', async () => {
     const controller = new AbortController();
     // Large deadline so the caller abort (not the timeout) is what settles the request.

--- a/packages/spacecat-shared-project-engine-client/test/internal.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/internal.test.js
@@ -19,6 +19,7 @@ import {
   nextRetryDelayMs,
   parseRetryAfterMs,
   toTokenGetter,
+  withDeadline,
   MAX_RETRY_DELAY_MS,
 } from '../src/internal.js';
 
@@ -245,6 +246,99 @@ describe('createRetryingFetch onRetry hook', () => {
     const res = await createRetryingFetch(base, 2, 0, onRetry)('https://x', { method: 'GET' });
     expect(res.status).to.equal(200);
     expect(thenable.catch.called).to.equal(false);
+  });
+});
+
+describe('withDeadline', () => {
+  it('returns init untouched when no timeout is configured', () => {
+    const init = { method: 'GET' };
+    expect(withDeadline(init, undefined, undefined)).to.equal(init);
+    expect(withDeadline(init, undefined, 0)).to.equal(init);
+    expect(withDeadline(init, undefined, -5)).to.equal(init);
+  });
+
+  it('injects an AbortSignal deadline when requestTimeoutMs > 0 (preserving other init)', () => {
+    const out = withDeadline({ method: 'GET' }, undefined, 1000);
+    expect(out.signal).to.be.instanceOf(AbortSignal);
+    expect(out.method).to.equal('GET');
+  });
+
+  it('combines the caller signal with the timeout — a caller abort still fires', () => {
+    const controller = new AbortController();
+    const out = withDeadline(undefined, controller.signal, 10_000);
+    expect(out.signal.aborted).to.equal(false);
+    controller.abort(new Error('caller cancelled'));
+    expect(out.signal.aborted).to.equal(true);
+    expect(out.signal.reason.message).to.equal('caller cancelled');
+  });
+});
+
+describe('createRetryingFetch request timeout', () => {
+  // A base fetch that never resolves on its own — it settles only when the per-attempt signal
+  // aborts, rejecting with that signal's reason (a TimeoutError for the deadline path).
+  const hangUntilAbort = (input, init) => new Promise((_, reject) => {
+    init.signal.addEventListener('abort', () => reject(init.signal.reason));
+  });
+
+  it('aborts an attempt after requestTimeoutMs (the per-attempt deadline fires)', async () => {
+    let thrown;
+    try {
+      await createRetryingFetch(hangUntilAbort, 0, 0, undefined, 10)('https://x', { method: 'GET' });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).to.be.an.instanceOf(Error);
+    expect(thrown.name).to.equal('TimeoutError');
+  });
+
+  it('retries a timed-out idempotent attempt, then returns the eventual success', async () => {
+    let calls = 0;
+    const base = (input, init) => {
+      calls += 1;
+      // First attempt hangs until its 10ms deadline aborts it; the retry succeeds immediately.
+      return calls === 1 ? hangUntilAbort(input, init) : Promise.resolve(resp(200));
+    };
+    const res = await createRetryingFetch(base, 1, 0, undefined, 10)('https://x', { method: 'GET' });
+    expect(res.status).to.equal(200);
+    expect(calls).to.equal(2);
+  });
+
+  it('still honours a caller-supplied signal — combined, not clobbered', async () => {
+    const controller = new AbortController();
+    // Large deadline so the caller abort (not the timeout) is what settles the request.
+    const p = createRetryingFetch(hangUntilAbort, 0, 0, undefined, 10_000)(
+      'https://x',
+      { method: 'GET', signal: controller.signal },
+    );
+    controller.abort(new Error('caller cancelled'));
+    let thrown;
+    try {
+      await p;
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown.message).to.equal('caller cancelled');
+  });
+
+  it('gives each retry attempt a fresh deadline signal (per-attempt, not one total budget)', async () => {
+    const signalsSeen = [];
+    const base = sandbox.stub().callsFake((input, init) => {
+      signalsSeen.push(init.signal);
+      return Promise.resolve(resp(signalsSeen.length < 2 ? 503 : 200));
+    });
+    const res = await createRetryingFetch(base, 2, 0, undefined, 10_000)('https://x', { method: 'GET' });
+    expect(res.status).to.equal(200);
+    expect(base.callCount).to.equal(2);
+    expect(signalsSeen[0]).to.be.instanceOf(AbortSignal);
+    expect(signalsSeen[1]).to.be.instanceOf(AbortSignal);
+    expect(signalsSeen[0]).to.not.equal(signalsSeen[1]);
+  });
+
+  it('passes init through untouched when no requestTimeoutMs is set', async () => {
+    const base = sandbox.stub().resolves(resp(200));
+    const init = { method: 'GET' };
+    await createRetryingFetch(base, 0, 0)('https://x', init);
+    expect(base.firstCall.args[1]).to.equal(init);
   });
 });
 


### PR DESCRIPTION
Adds an opt-in per-attempt request timeout to the shared Semrush **Project Engine** client — closing the "hung upstream socket blocks forever, and retries multiply the exposure" gap. Client-only; no consumer changes in this PR.

## What changed
- **`requestTimeoutMs` option** on `createSerenityProjectEngineApiClient`. When set (`> 0`), each fetch attempt is aborted via `AbortSignal.timeout(ms)`.
- **Combined, never clobbered:** the deadline is merged with any caller-supplied `signal` via `AbortSignal.any`, so a caller abort *and* the deadline each still cancel the request.
- **Per-attempt deadline** (a fresh timeout each attempt), threaded through `createRetryingFetch`. A timed-out **idempotent** attempt is retried under the existing retry budget; a non-idempotent one is not replayed (unchanged retry semantics). Worst-case wall time = `(maxRetries + 1) × requestTimeoutMs + Σ backoffs`.
- **Opt-in / default unchanged:** unset ⇒ no client-imposed deadline, so existing callers are unaffected. New public `withDeadline` helper (unit-tested).
- Surfaced in `client.js` JSDoc + `index.d.ts`; one README bullet.

### Why per-attempt (not a total budget)
It matches the existing api-service `createTimeoutFetch` workaround this is designed to replace (the retry layer wraps the injected fetch and calls it once per attempt), so the follow-up consumer migration is **behaviour-preserving**.

## Tests
`c8 mocha` — **269 passing**, 100% statements/branch/funcs/lines. `test:types` (tsc) clean. 10 new tests: `withDeadline` unit (passthrough / injects deadline / combines caller signal); `createRetryingFetch` (deadline fires; **timed-out idempotent attempt is retried then succeeds**; caller signal honoured not clobbered; each attempt gets a fresh signal; no-timeout passthrough is byte-identical `init`); client integration (option threads end-to-end → `TimeoutError`).

## Follow-up (separate PR — do NOT bundle)
Consumer cleanup in **spacecat-api-service** is sequenced **after this package publishes** (publish needs adobe-bot creds / @spacecat-admins — not self-serve). Do not create a broken intermediate across the two repos. That PR must:
- delete `createTimeoutFetch` in `src/support/serenity/rest-transport.js` and pass `requestTimeoutMs: 15_000` instead, **and**
- **re-home the two consumer concerns `createTimeoutFetch` also carries, so they are not silently dropped** — they correctly stay in the consumer, not the shared client:
  - the `Accept: application/json` request header, and
  - the abort → **504 `SerenityTransportError`** mapping (the shared client surfaces a raw `TimeoutError`; error→HTTP translation is a consumer concern, tracked by LLMO-5978 typed errors).

## Related Issues
- LLMO-5979 (this change)
- Boundary per ADR-0001 (shared client owns transport/timeouts; consumers own error→HTTP translation, caching, redaction)
- Sibling follow-ups: LLMO-5977 (facade), LLMO-5978 (typed errors), LLMO-5980 (api-service / Elements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
