### PR TITLE
feat(tokowaka-client): re-export classifyProbeResponse for reuse

### DIFF
--- a/packages/spacecat-shared-tokowaka-client/src/index.js
+++ b/packages/spacecat-shared-tokowaka-client/src/index.js
@@ -50,6 +50,11 @@ import {
 
 export { FastlyKVClient } from './fastly-kv-client.js';
 export { calculateForwardedHost } from './utils/custom-html-utils.js';
+export {
+  classifyProbeResponse,
+  BOT_CHALLENGE_KEYWORDS,
+  HARD_BLOCK_STATUS_CODES,
+} from './utils/waf-probe-utils.js';
 
 const HTTP_BAD_REQUEST = 400;
 const HTTP_INTERNAL_SERVER_ERROR = 500;


### PR DESCRIPTION
## What
Re-exports `classifyProbeResponse`, `BOT_CHALLENGE_KEYWORDS`, and `HARD_BLOCK_STATUS_CODES` from `spacecat-shared-tokowaka-client`'s public entry point (previously internal to `utils/waf-probe-utils.js`).

## Why
Lets consumers apply the same WAF/bot-block classification to a response they've already fetched, without vendoring a copy of the logic. First intended consumer is spacecat-import-worker's prerender-validation.

## Note
Additive only (5 lines). The import-worker currently ships a self-contained vendored copy (its published tokowaka-client dependency predates this export, and it needs a `presetHtml` param to reuse an already-read body), so nothing consumes this export yet — it's the forward-looking path to drop that vendored copy once released and the dependency is bumped. Safe to hold/close if we prefer to keep the classifier internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)