### PR TITLE
feat(tier-client): emit entitlement.tier_changed event (best-effort, opt-in)

### DIFF
--- a/docs/adr/0002-entitlement-tier-changed-event.md
+++ b/docs/adr/0002-entitlement-tier-changed-event.md
@@ -1,0 +1,107 @@
+# ADR-0002: `entitlement.tier_changed` as the target-architecture seam for tier transitions
+
+- **Status:** Accepted (groundwork — no live consumer yet)
+- **Date:** 2026-07-17
+- **Package:** `@adobe/spacecat-shared-tier-client`
+- **Relates to:** the FREE_TRIAL→PAID provisioning flow (api-service endpoint + spacecat-fulfillment-worker)
+
+## Context
+
+Entitlement tier transitions (most importantly FREE_TRIAL→PAID, but also fresh
+entitlement creation and other non-PAID transitions) are the trigger for downstream
+provisioning work — e.g. standing up the prompt-suggestion schedule when an org goes PAID,
+and, eventually, tearing that provisioning down on a PAID→trial transition.
+
+Today that reaction is driven imperatively: an `spacecat-api-service` endpoint performs the
+tier change via `TierClient.createEntitlement(tier)` and the caller (or the
+`spacecat-fulfillment-worker`) then does the provisioning. There is a single choke point
+where a tier actually changes — `TierClient.createEntitlement` in this package — but nothing
+is emitted from it, so every reaction has to be wired to the specific call site that happened
+to perform the change.
+
+The architecture review recommended writing down a domain event, `entitlement.tier_changed`,
+as the **target architecture**: the eventual replacement for the endpoint/reaction approach,
+emitted from the choke point so consumers can subscribe instead of being coupled to call
+sites. This ADR records that decision and the groundwork implementation.
+
+## Decision
+
+### The event
+
+Introduce a domain event **`entitlement.tier_changed`**, emitted from the single choke point
+where a tier changes: `TierClient.createEntitlement(tier)`.
+
+- **Constant:** `ENTITLEMENT_TIER_CHANGED = 'entitlement.tier_changed'`, exported from the
+  package (with a typed `EntitlementTierChangedEvent` payload in `index.d.ts`).
+- **Emitted on an actual change only:**
+  - Fresh entitlement create → `{ from: null, to: tier }`.
+  - Existing entitlement, tier transition (`setTier`+`save`) → `{ from: prevTier, to: tier }`.
+  - No change (tier unchanged, or existing entitlement is already PAID and is not
+    downgraded) → **no event**. Creating only a site enrollment on an existing entitlement is
+    not a tier change and emits nothing.
+- **Payload:**
+
+  ```jsonc
+  {
+    "type": "entitlement.tier_changed",
+    "entitlementId": "…",
+    "organizationId": "…",
+    "productCode": "LLMO",
+    "siteId": "…|null",        // null for org-only scope
+    "enrollmentId": "…|null",  // null when no enrollment is in scope
+    "from": "FREE_TRIAL|null", // null on a fresh create
+    "to": "PAID",
+    "occurredAt": "2026-07-17T00:00:00.000Z"
+  }
+  ```
+
+### Emission mechanism: opt-in, best-effort, non-breaking
+
+`tier-client` is a shared library with 6+ consumers (api-service tier-provisioning,
+access-control, entitlement controller, several Slack actions/commands, etc.). The emission
+must not force any of them to configure new infrastructure and must never change the
+`createEntitlement` return contract.
+
+We use the **ecosystem's idiomatic publish path — the shared SQS helper on the request
+context** (`context.sqs`, provided by `sqsWrapper` from `@adobe/spacecat-shared-utils`, which
+every SpaceCat Lambda already wires) plus an `ENTITLEMENT_EVENTS_QUEUE_URL` env var. No new
+SDK dependency is added to the package, and no factory/constructor signature changes.
+
+- **Opt-in:** emission is a no-op unless the caller's context provides **both** `context.sqs`
+  **and** `context.env.ENTITLEMENT_EVENTS_QUEUE_URL`. Existing consumers configure neither, so
+  they are entirely unaffected. This is what makes the change safe to ship ahead of any
+  consumer.
+- **Best-effort:** a publish failure is caught and logged (`log.warn`); it never propagates
+  out of `createEntitlement`/`save`. Provisioning correctness today does not depend on the
+  event, so a lost event must not fail the tier change.
+- **Additive:** additions only — the constant, the private emit method, and optional
+  `sqs`/`env` on the typed context. No behavioural change for callers that don't opt in.
+
+## Intended consumers (future)
+
+- **→PAID:** provision the prompt-suggestion schedule for the org/site (today handled by the
+  api-service endpoint + fulfillment worker).
+- **PAID→trial (future):** tear the provisioning down.
+
+When the first real consumer is built, a dedicated queue is provisioned, its URL is set as
+`ENTITLEMENT_EVENTS_QUEUE_URL` on the emitting service, and the consumer subscribes. Until
+then this is dormant groundwork.
+
+## Consequences
+
+**Good**
+
+- The event is defined and emitted from the one place tiers change, so future reactions
+  subscribe to a fact instead of being coupled to whichever call site performed the change.
+- Ships safely now with zero risk to existing consumers (no-op until a queue is configured).
+- No new dependency; uses the transport every SpaceCat service already has.
+
+**Costs / risks**
+
+- No end-to-end delivery until a queue and a consumer exist — the event is unobservable in
+  production until then (by design).
+- Best-effort delivery means an at-most-once event on the emit side; the eventual
+  provisioning consumer must remain idempotent and not treat the event as the system of
+  record. Provisioning today does not rely on it.
+- The env-var contract (`ENTITLEMENT_EVENTS_QUEUE_URL`) must be documented where the emitting
+  service's config lives when a consumer is wired.

--- a/packages/spacecat-shared-tier-client/README.md
+++ b/packages/spacecat-shared-tier-client/README.md
@@ -129,6 +129,52 @@ async function createEntitlement() {
 createEntitlement();
 ```
 
+### `entitlement.tier_changed` event (opt-in, best-effort)
+
+`createEntitlement` is the single choke point where an entitlement tier changes. It emits an
+**`entitlement.tier_changed`** domain event on an actual transition — a fresh create
+(`from: null`) or a tier change on an existing entitlement (`from: prevTier`). No event is
+emitted when the tier is unchanged (or when an existing PAID entitlement is left as-is), or
+when only a site enrollment is added to an existing entitlement.
+
+Emission is **opt-in** and **best-effort**, so existing consumers are unaffected:
+
+- It is a **no-op** unless the context provides both the shared SQS helper (`context.sqs`,
+  from `sqsWrapper`) **and** an `ENTITLEMENT_EVENTS_QUEUE_URL` env var.
+- A publish failure is logged and swallowed — it never fails `createEntitlement`/`save`.
+
+```javascript
+import TierClient, { ENTITLEMENT_TIER_CHANGED } from '@adobe/spacecat-shared-tier-client';
+
+// context.sqs is provided by sqsWrapper in every SpaceCat Lambda.
+const context = {
+  dataAccess: { /* ... */ },
+  log: { info: console.log, error: console.error, warn: console.warn },
+  sqs, // shared SQS helper
+  env: { ENTITLEMENT_EVENTS_QUEUE_URL: 'https://sqs.../entitlement-events' },
+};
+```
+
+Payload (`EntitlementTierChangedEvent`):
+
+```jsonc
+{
+  "type": "entitlement.tier_changed",
+  "entitlementId": "…",
+  "organizationId": "…",
+  "productCode": "LLMO",
+  "siteId": "…|null",
+  "enrollmentId": "…|null",
+  "from": "FREE_TRIAL|null",
+  "to": "PAID",
+  "occurredAt": "2026-07-17T00:00:00.000Z"
+}
+```
+
+This is target-architecture groundwork; there is no live consumer yet (current provisioning
+uses the api-service endpoint + fulfillment worker). See
+[docs/adr/0002-entitlement-tier-changed-event.md](../../docs/adr/0002-entitlement-tier-changed-event.md).
+
 ## API Reference
 
 ### Static Factory Methods
@@ -183,6 +229,8 @@ Creates entitlement for organization and site enrollment for site.
 - `tier` (string): Entitlement tier (must be a valid tier from EntitlementModel.TIERS)
 
 **Returns:** Promise<object> - Object with created entitlement and siteEnrollment
+
+Emits an `entitlement.tier_changed` event on an actual tier transition (opt-in, best-effort — see [above](#entitlementtier_changed-event-opt-in-best-effort)).
 
 ## Error Handling
 

--- a/packages/spacecat-shared-tier-client/src/events.js
+++ b/packages/spacecat-shared-tier-client/src/events.js
@@ -10,8 +10,16 @@
  * governing permissions and limitations under the License.
  */
 
-import TierClient from './tier-client.js';
+/**
+ * Domain event emitted when an entitlement's tier transitions (including a fresh create).
+ * See docs/adr/0002-entitlement-tier-changed-event.md for the target-architecture rationale.
+ * @type {string}
+ */
+export const ENTITLEMENT_TIER_CHANGED = 'entitlement.tier_changed';
 
-export { TierClient };
-export { ENTITLEMENT_TIER_CHANGED, ENTITLEMENT_EVENTS_QUEUE_URL_KEY } from './events.js';
-export default TierClient;
+/**
+ * Context key holding the SQS queue URL that `entitlement.tier_changed` events are published to.
+ * When this env var is absent, emission is a no-op (opt-in).
+ * @type {string}
+ */
+export const ENTITLEMENT_EVENTS_QUEUE_URL_KEY = 'ENTITLEMENT_EVENTS_QUEUE_URL';

--- a/packages/spacecat-shared-tier-client/src/index.d.ts
+++ b/packages/spacecat-shared-tier-client/src/index.d.ts
@@ -10,6 +10,41 @@
  * governing permissions and limitations under the License.
  */
 
+/**
+ * Domain event name emitted when an entitlement's tier transitions
+ * (including a fresh create). See the ADR for the target-architecture rationale.
+ */
+export declare const ENTITLEMENT_TIER_CHANGED: 'entitlement.tier_changed';
+
+/**
+ * Env key holding the SQS queue URL that `entitlement.tier_changed` events are
+ * published to. When absent, emission is a no-op (opt-in).
+ */
+export declare const ENTITLEMENT_EVENTS_QUEUE_URL_KEY: 'ENTITLEMENT_EVENTS_QUEUE_URL';
+
+/**
+ * Payload published for the `entitlement.tier_changed` event.
+ * `from` is null on a fresh create; `siteId`/`enrollmentId` are null for org-only scope.
+ */
+export interface EntitlementTierChangedEvent {
+  type: typeof ENTITLEMENT_TIER_CHANGED;
+  entitlementId: string;
+  organizationId: string;
+  productCode: string;
+  siteId: string | null;
+  enrollmentId: string | null;
+  from: string | null;
+  to: string;
+  occurredAt: string;
+}
+
+/**
+ * Minimal shape of the shared SQS helper (`context.sqs`) used to publish events.
+ */
+export interface TierClientSqs {
+  sendMessage(queueUrl: string, message: object): Promise<void>;
+}
+
 export interface TierClientContext {
   dataAccess: {
     Entitlement: any;
@@ -21,7 +56,16 @@ export interface TierClientContext {
   log: {
     info: (message: string) => void;
     error: (message: string) => void;
+    warn?: (message: string) => void;
   };
+  /**
+   * Optional shared SQS helper. When present together with the
+   * `ENTITLEMENT_EVENTS_QUEUE_URL` env var, `entitlement.tier_changed` events are published
+   * best-effort. Absent → emission is a no-op.
+   */
+  sqs?: TierClientSqs;
+  /** Optional env bag; `ENTITLEMENT_EVENTS_QUEUE_URL` opts into event emission. */
+  env?: Record<string, string | undefined>;
 }
 
 export interface TierClientResult {

--- a/packages/spacecat-shared-tier-client/src/tier-client.js
+++ b/packages/spacecat-shared-tier-client/src/tier-client.js
@@ -12,6 +12,7 @@
 
 import { isNonEmptyObject, hasText } from '@adobe/spacecat-shared-utils';
 import { MYSTICAT_ENUMS_BY_TYPE } from '@mysticat/data-service-types';
+import { ENTITLEMENT_TIER_CHANGED, ENTITLEMENT_EVENTS_QUEUE_URL_KEY } from './events.js';
 
 const ENTITLEMENT_TIERS = MYSTICAT_ENUMS_BY_TYPE.ENTITLEMENT_TIER;
 /**
@@ -129,6 +130,57 @@ class TierClient {
   }
 
   /**
+   * Best-effort emission of the `entitlement.tier_changed` domain event.
+   *
+   * This is the target-architecture seam for reacting to tier transitions (see
+   * docs/adr/0002-entitlement-tier-changed-event.md). It is deliberately opt-in and
+   * best-effort:
+   * - Opt-in: it is a no-op unless the caller's context provides both `sqs` (the shared
+   *   SQS helper) and an `ENTITLEMENT_EVENTS_QUEUE_URL` env var. Existing consumers that
+   *   configure neither are unaffected.
+   * - Best-effort: a publish failure is logged and swallowed — it must never fail the
+   *   `createEntitlement`/`save` that triggered it.
+   *
+   * @param {object} params - Emission parameters.
+   * @param {object} params.entitlement - The created/updated entitlement entity.
+   * @param {string|null} params.from - Previous tier (null on a fresh create).
+   * @param {string} params.to - New tier.
+   * @param {object} [params.siteEnrollment] - Site enrollment entity, if in scope.
+   * @returns {Promise<void>}
+   */
+  async #emitTierChangedEvent({
+    entitlement, from, to, siteEnrollment,
+  }) {
+    const { sqs, env } = this.context;
+    const queueUrl = env?.[ENTITLEMENT_EVENTS_QUEUE_URL_KEY];
+
+    // Opt-in: no destination configured → no-op, keeping existing consumers unaffected.
+    if (!sqs || !hasText(queueUrl)) {
+      return;
+    }
+
+    const event = {
+      type: ENTITLEMENT_TIER_CHANGED,
+      entitlementId: entitlement.getId(),
+      organizationId: this.organization.getId(),
+      productCode: this.productCode,
+      siteId: this.site ? this.site.getId() : null,
+      enrollmentId: siteEnrollment ? siteEnrollment.getId() : null,
+      from,
+      to,
+      occurredAt: new Date().toISOString(),
+    };
+
+    try {
+      await sqs.sendMessage(queueUrl, event);
+      this.log.info(`[TierClient] Emitted ${ENTITLEMENT_TIER_CHANGED} for entitlement ${event.entitlementId} (${from} -> ${to})`);
+    } catch (error) {
+      // Best-effort: an emit failure must never fail createEntitlement/save.
+      this.log.warn(`[TierClient] Failed to emit ${ENTITLEMENT_TIER_CHANGED} for entitlement ${event.entitlementId}: ${error.message}`);
+    }
+  }
+
+  /**
    * Creates entitlement for organization and site enrollment for site.
    * If entitlement exists with different tier, updates the tier.
    * @param {string} tier - Entitlement tier.
@@ -149,25 +201,40 @@ class TierClient {
         const currentTier = existing.entitlement.getTier();
 
         // If currentTier doesn't match with given tier and is not PAID, update it
+        let tierChanged = false;
         if (currentTier !== tier && currentTier !== ENTITLEMENT_TIERS.PAID) {
           existing.entitlement.setTier(tier);
           await existing.entitlement.save();
+          tierChanged = true;
         }
 
         // If site provided but no site enrollment, create it
+        let result;
         if (this.site && !existing.siteEnrollment) {
           const siteId = this.site.getId();
           const siteEnrollment = await this.SiteEnrollment.create({
             siteId,
             entitlementId: existing.entitlement.getId(),
           });
-          return {
+          result = {
             entitlement: existing.entitlement,
             siteEnrollment,
           };
+        } else {
+          result = existing;
         }
 
-        return existing;
+        // Only emit on an actual tier transition, never on an unchanged tier.
+        if (tierChanged) {
+          await this.#emitTierChangedEvent({
+            entitlement: existing.entitlement,
+            from: currentTier,
+            to: tier,
+            siteEnrollment: result.siteEnrollment,
+          });
+        }
+
+        return result;
       }
 
       // No existing entitlement, create new one
@@ -183,6 +250,8 @@ class TierClient {
 
       // If no site provided, return entitlement only
       if (!this.site) {
+        // Fresh create is a transition from no entitlement (null) to the new tier.
+        await this.#emitTierChangedEvent({ entitlement, from: null, to: tier });
         return { entitlement };
       }
 
@@ -191,6 +260,11 @@ class TierClient {
       const siteEnrollment = await this.SiteEnrollment.create({
         siteId,
         entitlementId: entitlement.getId(),
+      });
+
+      // Fresh create is a transition from no entitlement (null) to the new tier.
+      await this.#emitTierChangedEvent({
+        entitlement, from: null, to: tier, siteEnrollment,
       });
 
       return {

--- a/packages/spacecat-shared-tier-client/test/tier-client.test.js
+++ b/packages/spacecat-shared-tier-client/test/tier-client.test.js
@@ -595,6 +595,232 @@ describe('TierClient', () => {
     });
   });
 
+  describe('entitlement.tier_changed event emission', () => {
+    const queueUrl = 'https://sqs.us-east-1.amazonaws.com/1234/entitlement-events';
+    let sqsStub;
+    let eventContext;
+
+    beforeEach(() => {
+      sqsStub = { sendMessage: sandbox.stub().resolves() };
+      eventContext = {
+        ...mockContext,
+        sqs: sqsStub,
+        env: { ENTITLEMENT_EVENTS_QUEUE_URL: queueUrl },
+      };
+      mockDataAccess.Organization.findById.resolves(mockOrganization);
+      mockDataAccess.Site.findById.resolves(mockSite);
+    });
+
+    it('emits on fresh create for org-only client (from null, no site/enrollment)', async () => {
+      const orgOnlyClient = new TierClient(eventContext, organizationInstance, null, productCode);
+      mockDataAccess.Entitlement.findByOrganizationIdAndProductCode.resolves(null);
+      mockDataAccess.Entitlement.create.resolves(mockEntitlement);
+
+      await orgOnlyClient.createEntitlement('FREE_TRIAL');
+
+      expect(sqsStub.sendMessage).to.have.been.calledOnce;
+      const [url, event] = sqsStub.sendMessage.firstCall.args;
+      expect(url).to.equal(queueUrl);
+      expect(event).to.include({
+        type: 'entitlement.tier_changed',
+        entitlementId: 'entitlement-123',
+        organizationId: orgId,
+        productCode,
+        siteId: null,
+        enrollmentId: null,
+        from: null,
+        to: 'FREE_TRIAL',
+      });
+      expect(event.occurredAt).to.be.a('string');
+    });
+
+    it('emits on fresh create for site client (siteId + enrollmentId populated)', async () => {
+      const siteClient = new TierClient(
+        eventContext,
+        organizationInstance,
+        siteInstance,
+        productCode,
+      );
+      mockDataAccess.Entitlement.findByOrganizationIdAndProductCode.resolves(null);
+      mockDataAccess.Entitlement.create.resolves(mockEntitlement);
+      mockDataAccess.SiteEnrollment.create.resolves(mockSiteEnrollment);
+
+      await siteClient.createEntitlement('FREE_TRIAL');
+
+      expect(sqsStub.sendMessage).to.have.been.calledOnce;
+      const [, event] = sqsStub.sendMessage.firstCall.args;
+      expect(event).to.include({
+        type: 'entitlement.tier_changed',
+        siteId,
+        enrollmentId: 'enrollment-123',
+        from: null,
+        to: 'FREE_TRIAL',
+      });
+    });
+
+    it('emits on tier transition with correct from/to', async () => {
+      const transitioningEntitlement = {
+        ...mockEntitlement,
+        getTier: () => 'FREE_TRIAL',
+        setTier: sandbox.stub().returnsThis(),
+        save: sandbox.stub().resolves(),
+      };
+      const siteClient = new TierClient(
+        eventContext,
+        organizationInstance,
+        siteInstance,
+        productCode,
+      );
+      mockDataAccess.Entitlement
+        .findByOrganizationIdAndProductCode.resolves(transitioningEntitlement);
+      mockDataAccess.SiteEnrollment.allBySiteId.resolves([mockSiteEnrollment]);
+
+      await siteClient.createEntitlement('PAID');
+
+      expect(sqsStub.sendMessage).to.have.been.calledOnce;
+      const [, event] = sqsStub.sendMessage.firstCall.args;
+      expect(event).to.include({
+        type: 'entitlement.tier_changed',
+        entitlementId: 'entitlement-123',
+        enrollmentId: 'enrollment-123',
+        from: 'FREE_TRIAL',
+        to: 'PAID',
+      });
+    });
+
+    it('emits on transition when a new site enrollment is also created', async () => {
+      const transitioningEntitlement = {
+        ...mockEntitlement,
+        getTier: () => 'FREE_TRIAL',
+        setTier: sandbox.stub().returnsThis(),
+        save: sandbox.stub().resolves(),
+      };
+      const siteClient = new TierClient(
+        eventContext,
+        organizationInstance,
+        siteInstance,
+        productCode,
+      );
+      mockDataAccess.Entitlement
+        .findByOrganizationIdAndProductCode.resolves(transitioningEntitlement);
+      mockDataAccess.SiteEnrollment.allBySiteId.resolves([]);
+      mockDataAccess.SiteEnrollment.create.resolves(mockSiteEnrollment);
+
+      await siteClient.createEntitlement('PAID');
+
+      expect(sqsStub.sendMessage).to.have.been.calledOnce;
+      const [, event] = sqsStub.sendMessage.firstCall.args;
+      expect(event).to.include({
+        from: 'FREE_TRIAL',
+        to: 'PAID',
+        enrollmentId: 'enrollment-123',
+      });
+    });
+
+    it('does NOT emit when tier is unchanged', async () => {
+      const sameTierEntitlement = {
+        ...mockEntitlement,
+        getTier: () => 'FREE_TRIAL',
+        setTier: sandbox.stub().returnsThis(),
+        save: sandbox.stub().resolves(),
+      };
+      const siteClient = new TierClient(
+        eventContext,
+        organizationInstance,
+        siteInstance,
+        productCode,
+      );
+      mockDataAccess.Entitlement
+        .findByOrganizationIdAndProductCode.resolves(sameTierEntitlement);
+      mockDataAccess.SiteEnrollment.allBySiteId.resolves([mockSiteEnrollment]);
+
+      await siteClient.createEntitlement('FREE_TRIAL');
+
+      expect(sqsStub.sendMessage).to.not.have.been.called;
+    });
+
+    it('does NOT emit when existing entitlement is PAID (no downgrade)', async () => {
+      const paidEntitlement = {
+        ...mockEntitlement,
+        getTier: () => 'PAID',
+        setTier: sandbox.stub().returnsThis(),
+        save: sandbox.stub().resolves(),
+      };
+      const siteClient = new TierClient(
+        eventContext,
+        organizationInstance,
+        siteInstance,
+        productCode,
+      );
+      mockDataAccess.Entitlement
+        .findByOrganizationIdAndProductCode.resolves(paidEntitlement);
+      mockDataAccess.SiteEnrollment.allBySiteId.resolves([mockSiteEnrollment]);
+
+      await siteClient.createEntitlement('FREE_TRIAL');
+
+      expect(sqsStub.sendMessage).to.not.have.been.called;
+    });
+
+    it('is a no-op (no throw) when no sqs is configured', async () => {
+      // mockContext has no sqs — emission must be skipped silently.
+      const siteClient = new TierClient(
+        mockContext,
+        organizationInstance,
+        siteInstance,
+        productCode,
+      );
+      mockDataAccess.Entitlement.findByOrganizationIdAndProductCode.resolves(null);
+      mockDataAccess.Entitlement.create.resolves(mockEntitlement);
+      mockDataAccess.SiteEnrollment.create.resolves(mockSiteEnrollment);
+
+      const result = await siteClient.createEntitlement('FREE_TRIAL');
+
+      expect(result).to.deep.equal({
+        entitlement: mockEntitlement,
+        siteEnrollment: mockSiteEnrollment,
+      });
+      expect(sqsStub.sendMessage).to.not.have.been.called;
+    });
+
+    it('is a no-op when sqs is present but the queue URL env var is absent', async () => {
+      const contextWithoutQueue = { ...mockContext, sqs: sqsStub, env: {} };
+      const siteClient = new TierClient(
+        contextWithoutQueue,
+        organizationInstance,
+        siteInstance,
+        productCode,
+      );
+      mockDataAccess.Entitlement.findByOrganizationIdAndProductCode.resolves(null);
+      mockDataAccess.Entitlement.create.resolves(mockEntitlement);
+      mockDataAccess.SiteEnrollment.create.resolves(mockSiteEnrollment);
+
+      await siteClient.createEntitlement('FREE_TRIAL');
+
+      expect(sqsStub.sendMessage).to.not.have.been.called;
+    });
+
+    it('does not fail createEntitlement when the publisher throws (best-effort)', async () => {
+      sqsStub.sendMessage.rejects(new Error('SQS down'));
+      const siteClient = new TierClient(
+        eventContext,
+        organizationInstance,
+        siteInstance,
+        productCode,
+      );
+      mockDataAccess.Entitlement.findByOrganizationIdAndProductCode.resolves(null);
+      mockDataAccess.Entitlement.create.resolves(mockEntitlement);
+      mockDataAccess.SiteEnrollment.create.resolves(mockSiteEnrollment);
+
+      const result = await siteClient.createEntitlement('FREE_TRIAL');
+
+      expect(result).to.deep.equal({
+        entitlement: mockEntitlement,
+        siteEnrollment: mockSiteEnrollment,
+      });
+      expect(eventContext.log.warn).to.have.been.calledWithMatch(/Failed to emit entitlement.tier_changed/);
+    });
+  });
+
   describe('Edge Cases', () => {
     it('should handle context without authInfo', async () => {
       const contextWithoutAuth = {


### PR DESCRIPTION
## What

Introduces an **`entitlement.tier_changed`** domain event, emitted from the single choke point where an entitlement tier changes — `TierClient.createEntitlement(tier)`.

### Event

- **Name / constant:** `ENTITLEMENT_TIER_CHANGED = 'entitlement.tier_changed'` (exported from the package; typed `EntitlementTierChangedEvent` in `index.d.ts`).
- **Emitted on an actual change only:**
  - Fresh create → `{ from: null, to: tier }`
  - Existing entitlement tier transition (`setTier`+`save`) → `{ from: prevTier, to: tier }`
  - **No event** when the tier is unchanged, when an existing PAID entitlement is left as-is, or when only a site enrollment is added.
- **Payload:**
  ```jsonc
  {
    "type": "entitlement.tier_changed",
    "entitlementId": "…",
    "organizationId": "…",
    "productCode": "LLMO",
    "siteId": "…|null",        // null for org-only scope
    "enrollmentId": "…|null",  // null when no enrollment is in scope
    "from": "FREE_TRIAL|null", // null on a fresh create
    "to": "PAID",
    "occurredAt": "2026-07-17T00:00:00.000Z"
  }
  ```

### Design: opt-in, best-effort, non-breaking

Uses the ecosystem's idiomatic publish path — the shared SQS helper on the request context (`context.sqs`, provided by `sqsWrapper` in every SpaceCat Lambda) plus an `ENTITLEMENT_EVENTS_QUEUE_URL` env var. No new SDK dependency, no factory/constructor signature change — additions only.

- **Opt-in:** a no-op unless the context provides **both** `context.sqs` **and** `context.env.ENTITLEMENT_EVENTS_QUEUE_URL`. The 6+ existing consumers configure neither, so they are entirely unaffected.
- **Best-effort:** a publish failure is caught and logged (`log.warn`) — it never propagates out of `createEntitlement`/`save`.

I considered a pluggable injected-publisher, but the shared `context.sqs` helper is the established convention for domain-event publishing across SpaceCat services and requires zero new infra from callers, so it wins here.

### Target-architecture groundwork

This writes the event down as the target architecture (per the review recommendation): the eventual replacement for the current endpoint/reaction approach. **There is no live consumer yet** — today's provisioning is handled by the api-service endpoint + the fulfillment worker. Intended future consumers: prompt-suggestion schedule provisioning on →PAID, and a PAID→trial teardown. See the ADR: `docs/adr/0002-entitlement-tier-changed-event.md`.

## Files changed

- `packages/spacecat-shared-tier-client/src/events.js` (new) — `ENTITLEMENT_TIER_CHANGED` + queue-url key constants
- `packages/spacecat-shared-tier-client/src/tier-client.js` — `#emitTierChangedEvent` + wiring at the create/transition points
- `packages/spacecat-shared-tier-client/src/index.js` / `index.d.ts` — export constants + typed payload/context
- `packages/spacecat-shared-tier-client/test/tier-client.test.js` — emission tests
- `packages/spacecat-shared-tier-client/README.md`, `docs/adr/0002-entitlement-tier-changed-event.md` — docs

## Tests / lint

- `npm test -w packages/spacecat-shared-tier-client` → **88 passing**, coverage **100%** lines/statements/branches/functions.
- `npm run lint -w packages/spacecat-shared-tier-client` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
