### PR TITLE
feat(project-engine-client): facade with intent-named methods over the openapi-fetch client (LLMO-5977)

### DIFF
--- a/packages/spacecat-shared-project-engine-client/CLAUDE.md
+++ b/packages/spacecat-shared-project-engine-client/CLAUDE.md
@@ -3,9 +3,12 @@
 Typed client + generated types for the Semrush **Project Engine** API, plus a stateful
 Counterfact **mock** used by local dev and the cross-repo e2e harness.
 
-- `src/` — the published client (`createSerenityProjectEngineApiClient`, an `openapi-fetch`
-  client) + generated types (`src/generated/types.ts`). This is the ONLY thing that ships
-  (`files: ["src"]`).
+- `src/` — the published surface: the raw `createSerenityProjectEngineApiClient` (an
+  `openapi-fetch` client over every generated operation) **and** `createSerenityProjectEngineTransport`,
+  an intent-named facade that wraps the 28 in-spec operations spacecat-api-service consumes behind
+  verb+resource methods with a single error seam. Consumers depend on the facade; the raw client
+  stays available for the remaining operations. Plus generated types (`src/generated/types.ts`).
+  This is the ONLY thing that ships (`files: ["src"]`).
 - `mock/` — the stateful mock (store, factories, seeds, quota metering, bearer auth, Counterfact
   handlers, runner). NOT published (`files: ["src"]` ships only `src/`, so the `./mock/*` subpath
   export resolves via the in-workspace symlink only, never the published registry tarball —

--- a/packages/spacecat-shared-project-engine-client/src/index.d.ts
+++ b/packages/spacecat-shared-project-engine-client/src/index.d.ts
@@ -98,8 +98,8 @@ type TransportInit<P extends keyof paths, M extends keyof paths[P]> = MaybeOptio
  * `createProject({ params, body })` enforces its params + body at the call site.
  */
 type TransportInitParam<Init> = RequiredKeysOf<Init> extends never
-  ? [init?: Init & { [key: string]: unknown }]
-  : [init: Init & { [key: string]: unknown }];
+  ? [init?: Init]
+  : [init: Init];
 
 /**
  * The value a facade method resolves with: the parsed 2xx body for path `P` +

--- a/packages/spacecat-shared-project-engine-client/src/index.d.ts
+++ b/packages/spacecat-shared-project-engine-client/src/index.d.ts
@@ -107,7 +107,7 @@ type TransportInitParam<Init> = RequiredKeysOf<Init> extends never
  * responses never resolve — they throw at the single `unwrap` error seam.
  */
 type TransportData<P extends keyof paths, M extends keyof paths[P]> =
-  | NonNullable<FetchResponse<paths[P][M], {}, MediaType>['data']>
+  | NonNullable<FetchResponse<paths[P][M], TransportInit<P, M>, MediaType>['data']>
   | null;
 
 /**

--- a/packages/spacecat-shared-project-engine-client/src/index.d.ts
+++ b/packages/spacecat-shared-project-engine-client/src/index.d.ts
@@ -10,7 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import type { Client } from 'openapi-fetch';
+import type { Client, FetchResponse, MaybeOptionalInit, MediaType } from 'openapi-fetch';
+import type { RequiredKeysOf } from 'openapi-typescript-helpers';
 import type { paths, components } from './generated/types.js';
 
 /** Supplies the caller's IMS JWT — forwarded verbatim, never minted or exchanged. */
@@ -72,6 +73,285 @@ export interface SerenityProjectEngineApiClientOptions {
 export declare function createSerenityProjectEngineApiClient(
   options: SerenityProjectEngineApiClientOptions,
 ): SerenityProjectEngineApiClient;
+
+// ───────────────────────────────────────────────────────────────────────────
+// Intent-named facade (transport) over the raw client.
+//
+// The three helpers below derive every facade method's parameter and return type
+// straight from the generated `paths` contract, so the surface stays strictly
+// in-spec and never degrades to `any`. They are internal to this declaration.
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * The openapi-fetch `init` argument (params.path/query, body) accepted for a given
+ * path `P` + HTTP method `M`, derived from the generated contract.
+ */
+type TransportInit<P extends keyof paths, M extends keyof paths[P]> = MaybeOptionalInit<
+  paths[P],
+  M
+>;
+
+/**
+ * Mirror of openapi-fetch's own (unexported) `InitParam`: the `init` argument is
+ * OPTIONAL when nothing in it is required (no path/query params, no required body),
+ * and REQUIRED otherwise — so `listLanguages()` needs no argument while
+ * `createProject({ params, body })` enforces its params + body at the call site.
+ */
+type TransportInitParam<Init> = RequiredKeysOf<Init> extends never
+  ? [init?: Init & { [key: string]: unknown }]
+  : [init: Init & { [key: string]: unknown }];
+
+/**
+ * The value a facade method resolves with: the parsed 2xx body for path `P` +
+ * method `M`, or `null` for an empty body (e.g. a 204 / empty-body ack). Non-2xx
+ * responses never resolve — they throw at the single `unwrap` error seam.
+ */
+type TransportData<P extends keyof paths, M extends keyof paths[P]> =
+  | NonNullable<FetchResponse<paths[P][M], {}, MediaType>['data']>
+  | null;
+
+/**
+ * Intent-named facade over {@link SerenityProjectEngineApiClient}. Wraps the 28 in-spec
+ * Project Engine operations spacecat-api-service consumes behind verb+resource methods, so
+ * consumers depend on this seam rather than the raw client's literal path strings. Each method
+ * is THIN: it forwards the caller's openapi-fetch `init` to the underlying client and resolves
+ * with the unwrapped 2xx body (or throws on a non-2xx / network error at a single seam). No
+ * caching, redaction, error→HTTP translation, or composite methods — all consumer-owned per
+ * ADR-0001. The remaining generated operations stay reachable via the raw client.
+ */
+export interface SerenityProjectEngineTransport {
+  /** GET /v1/languages — projects-admin-list-languages */
+  listLanguages(
+    ...init: TransportInitParam<TransportInit<'/v1/languages', 'get'>>
+  ): Promise<TransportData<'/v1/languages', 'get'>>;
+  /** GET /v1/ai_models — ai-list-global-models */
+  listGlobalAiModels(
+    ...init: TransportInitParam<TransportInit<'/v1/ai_models', 'get'>>
+  ): Promise<TransportData<'/v1/ai_models', 'get'>>;
+
+  /** GET /v1/workspaces/{id}/projects — projects-list-projects */
+  listProjects(
+    ...init: TransportInitParam<TransportInit<'/v1/workspaces/{id}/projects', 'get'>>
+  ): Promise<TransportData<'/v1/workspaces/{id}/projects', 'get'>>;
+  /** POST /v1/workspaces/{id}/projects — projects-post-project */
+  createProject(
+    ...init: TransportInitParam<TransportInit<'/v1/workspaces/{id}/projects', 'post'>>
+  ): Promise<TransportData<'/v1/workspaces/{id}/projects', 'post'>>;
+  /** GET /v1/workspaces/{id}/projects/{project_id} — projects-get-project */
+  getProject(
+    ...init: TransportInitParam<TransportInit<'/v1/workspaces/{id}/projects/{project_id}', 'get'>>
+  ): Promise<TransportData<'/v1/workspaces/{id}/projects/{project_id}', 'get'>>;
+  /** PATCH /v1/workspaces/{id}/projects/{project_id} — projects-patch-project */
+  updateProject(
+    ...init: TransportInitParam<TransportInit<'/v1/workspaces/{id}/projects/{project_id}', 'patch'>>
+  ): Promise<TransportData<'/v1/workspaces/{id}/projects/{project_id}', 'patch'>>;
+  /** DELETE /v1/workspaces/{id}/projects/{project_id} — projects-delete-project */
+  deleteProject(
+    ...init: TransportInitParam<
+      TransportInit<'/v1/workspaces/{id}/projects/{project_id}', 'delete'>
+    >
+  ): Promise<TransportData<'/v1/workspaces/{id}/projects/{project_id}', 'delete'>>;
+  /** POST /v1/workspaces/{id}/projects/{project_id}/publish — projects-publish-project */
+  publishProject(
+    ...init: TransportInitParam<
+      TransportInit<'/v1/workspaces/{id}/projects/{project_id}/publish', 'post'>
+    >
+  ): Promise<TransportData<'/v1/workspaces/{id}/projects/{project_id}/publish', 'post'>>;
+
+  /** GET /v1/workspaces/{id}/projects/{project_id}/ai_models — ai-list-models */
+  listAiModels(
+    ...init: TransportInitParam<
+      TransportInit<'/v1/workspaces/{id}/projects/{project_id}/ai_models', 'get'>
+    >
+  ): Promise<TransportData<'/v1/workspaces/{id}/projects/{project_id}/ai_models', 'get'>>;
+  /** DELETE /v1/workspaces/{id}/projects/{project_id}/ai_models — ai-delete-models */
+  deleteAiModels(
+    ...init: TransportInitParam<
+      TransportInit<'/v1/workspaces/{id}/projects/{project_id}/ai_models', 'delete'>
+    >
+  ): Promise<TransportData<'/v1/workspaces/{id}/projects/{project_id}/ai_models', 'delete'>>;
+  /** GET /v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks — ai-list-benchmarks */
+  listBenchmarks(
+    ...init: TransportInitParam<
+      TransportInit<'/v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks', 'get'>
+    >
+  ): Promise<
+    TransportData<'/v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks', 'get'>
+  >;
+  /** DELETE /v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks — ai-delete-benchmarks */
+  deleteBenchmarks(
+    ...init: TransportInitParam<
+      TransportInit<'/v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks', 'delete'>
+    >
+  ): Promise<
+    TransportData<'/v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks', 'delete'>
+  >;
+  /**
+   * PUT /v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks/{benchmark_id}
+   * — ai-update-benchmark
+   */
+  updateBenchmark(
+    ...init: TransportInitParam<
+      TransportInit<
+        '/v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks/{benchmark_id}',
+        'put'
+      >
+    >
+  ): Promise<
+    TransportData<
+      '/v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks/{benchmark_id}',
+      'put'
+    >
+  >;
+  /** PUT /v1/workspaces/{id}/projects/{project_id}/ci/competitors — ci-update-competitors */
+  updateCompetitors(
+    ...init: TransportInitParam<
+      TransportInit<'/v1/workspaces/{id}/projects/{project_id}/ci/competitors', 'put'>
+    >
+  ): Promise<TransportData<'/v1/workspaces/{id}/projects/{project_id}/ci/competitors', 'put'>>;
+
+  /** POST /v2/workspaces/{id}/projects/{project_id}/ai_models — aio-project-create-model */
+  createAioModel(
+    ...init: TransportInitParam<
+      TransportInit<'/v2/workspaces/{id}/projects/{project_id}/ai_models', 'post'>
+    >
+  ): Promise<TransportData<'/v2/workspaces/{id}/projects/{project_id}/ai_models', 'post'>>;
+  /** POST /v2/workspaces/{id}/projects/{project_id}/ai_models/benchmarks — ai-create-benchmarks-v2 */
+  createBenchmarks(
+    ...init: TransportInitParam<
+      TransportInit<'/v2/workspaces/{id}/projects/{project_id}/ai_models/benchmarks', 'post'>
+    >
+  ): Promise<
+    TransportData<'/v2/workspaces/{id}/projects/{project_id}/ai_models/benchmarks', 'post'>
+  >;
+
+  /**
+   * GET /v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls
+   * — aio-list-brand-urls
+   */
+  listBrandUrls(
+    ...init: TransportInitParam<
+      TransportInit<
+        '/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls',
+        'get'
+      >
+    >
+  ): Promise<
+    TransportData<
+      '/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls',
+      'get'
+    >
+  >;
+  /**
+   * POST /v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls
+   * — aio-create-brand-urls
+   */
+  createBrandUrls(
+    ...init: TransportInitParam<
+      TransportInit<
+        '/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls',
+        'post'
+      >
+    >
+  ): Promise<
+    TransportData<
+      '/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls',
+      'post'
+    >
+  >;
+  /**
+   * DELETE /v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls
+   * — aio-delete-brand-urls
+   */
+  deleteBrandUrls(
+    ...init: TransportInitParam<
+      TransportInit<
+        '/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls',
+        'delete'
+      >
+    >
+  ): Promise<
+    TransportData<
+      '/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls',
+      'delete'
+    >
+  >;
+
+  /**
+   * GET /v2/workspaces/{id}/projects/{project_id}/aio/init_status
+   * — aio-get-project-init-status-v2
+   */
+  getProjectInitStatus(
+    ...init: TransportInitParam<
+      TransportInit<'/v2/workspaces/{id}/projects/{project_id}/aio/init_status', 'get'>
+    >
+  ): Promise<TransportData<'/v2/workspaces/{id}/projects/{project_id}/aio/init_status', 'get'>>;
+  /** POST /v2/workspaces/{id}/projects/{project_id}/aio/prompts — aio-create-prompt-v2 */
+  createPrompts(
+    ...init: TransportInitParam<
+      TransportInit<'/v2/workspaces/{id}/projects/{project_id}/aio/prompts', 'post'>
+    >
+  ): Promise<TransportData<'/v2/workspaces/{id}/projects/{project_id}/aio/prompts', 'post'>>;
+  /** DELETE /v2/workspaces/{id}/projects/{project_id}/aio/prompts — aio-delete-prompt-by-ids-v2 */
+  deletePromptsByIds(
+    ...init: TransportInitParam<
+      TransportInit<'/v2/workspaces/{id}/projects/{project_id}/aio/prompts', 'delete'>
+    >
+  ): Promise<TransportData<'/v2/workspaces/{id}/projects/{project_id}/aio/prompts', 'delete'>>;
+  /**
+   * POST /v2/workspaces/{id}/projects/{project_id}/aio/prompts/by_tags
+   * — aio-list-prompts-by-tag-ids
+   */
+  listPromptsByTagIds(
+    ...init: TransportInitParam<
+      TransportInit<'/v2/workspaces/{id}/projects/{project_id}/aio/prompts/by_tags', 'post'>
+    >
+  ): Promise<TransportData<'/v2/workspaces/{id}/projects/{project_id}/aio/prompts/by_tags', 'post'>>;
+  /** PUT /v2/workspaces/{id}/projects/{project_id}/aio/prompts/tags — aio-update-prompts-batch */
+  updatePromptTags(
+    ...init: TransportInitParam<
+      TransportInit<'/v2/workspaces/{id}/projects/{project_id}/aio/prompts/tags', 'put'>
+    >
+  ): Promise<TransportData<'/v2/workspaces/{id}/projects/{project_id}/aio/prompts/tags', 'put'>>;
+  /**
+   * POST /v2/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}/rename
+   * — aio-rename-prompt
+   */
+  renamePrompt(
+    ...init: TransportInitParam<
+      TransportInit<'/v2/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}/rename', 'post'>
+    >
+  ): Promise<
+    TransportData<'/v2/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}/rename', 'post'>
+  >;
+  /** GET /v2/workspaces/{id}/projects/{project_id}/aio/tags — aio-get-project-tags */
+  listProjectTags(
+    ...init: TransportInitParam<
+      TransportInit<'/v2/workspaces/{id}/projects/{project_id}/aio/tags', 'get'>
+    >
+  ): Promise<TransportData<'/v2/workspaces/{id}/projects/{project_id}/aio/tags', 'get'>>;
+  /** POST /v2/workspaces/{id}/projects/{project_id}/aio/tags — aio-create-project-tags */
+  createProjectTags(
+    ...init: TransportInitParam<
+      TransportInit<'/v2/workspaces/{id}/projects/{project_id}/aio/tags', 'post'>
+    >
+  ): Promise<TransportData<'/v2/workspaces/{id}/projects/{project_id}/aio/tags', 'post'>>;
+  /** PATCH /v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id} — aio-update-tag */
+  updateProjectTag(
+    ...init: TransportInitParam<
+      TransportInit<'/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}', 'patch'>
+    >
+  ): Promise<TransportData<'/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}', 'patch'>>;
+}
+
+/**
+ * Builds the {@link SerenityProjectEngineTransport} facade. Takes the SAME options as
+ * {@link createSerenityProjectEngineApiClient} (it builds that client internally and adds no
+ * options of its own).
+ */
+export declare function createSerenityProjectEngineTransport(
+  options: SerenityProjectEngineApiClientOptions,
+): SerenityProjectEngineTransport;
 
 // Re-export the generated contract types for consumers that want them directly.
 export type { paths, components };

--- a/packages/spacecat-shared-project-engine-client/src/index.js
+++ b/packages/spacecat-shared-project-engine-client/src/index.js
@@ -13,3 +13,4 @@
 // @ts-check
 
 export { createSerenityProjectEngineApiClient } from './client.js';
+export { createSerenityProjectEngineTransport } from './rest-transport.js';

--- a/packages/spacecat-shared-project-engine-client/src/rest-transport.js
+++ b/packages/spacecat-shared-project-engine-client/src/rest-transport.js
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// @ts-check
+
+import { createSerenityProjectEngineApiClient } from './client.js';
+
+/**
+ * @typedef {import('./client.js').SerenityProjectEngineApiClientOptions}
+ *   SerenityProjectEngineApiClientOptions
+ */
+
+/**
+ * Intent-named facade over the raw {@link createSerenityProjectEngineApiClient} openapi-fetch
+ * client. It wraps ONLY the 28 in-spec Project Engine operations that spacecat-api-service
+ * consumes, behind verb+resource method names, so consumers depend on this seam rather than the
+ * raw client and its literal path strings. Each method is THIN: it forwards the caller's
+ * openapi-fetch `init` (params.path/query, body) to `client.<METHOD>('<literal path>', init)` and
+ * routes the result through the single {@link unwrap} error seam. There is deliberately NO caching,
+ * redaction, error→HTTP translation, or composite/convenience method here — all consumer-owned per
+ * ADR-0001. The remaining generated operations stay reachable via the raw client; add a facade
+ * method only when a real second consumer needs one.
+ *
+ * @param {SerenityProjectEngineApiClientOptions} options The SAME options as the raw client — the
+ *   facade adds none of its own. Builds the underlying client via
+ *   {@link createSerenityProjectEngineApiClient}.
+ * @returns {import('./index.js').SerenityProjectEngineTransport}
+ */
+export function createSerenityProjectEngineTransport(options) {
+  const client = createSerenityProjectEngineApiClient(options);
+
+  /**
+   * The SINGLE seam where a failed call becomes a throw. It awaits the openapi-fetch result
+   * promise here (so a network/timeout rejection also flows through this one point), and on a
+   * non-2xx response throws. The typed client never throws on an HTTP error — it resolves to
+   * `{ data, error, response }` with the parsed error body in `error` — so a non-2xx is turned
+   * into a throw here; a 2xx returns the parsed body (or null for an empty body).
+   *
+   * `status`, `method`, and the normalized `body` are computed locally at this site FIRST so the
+   * follow-up ticket LLMO-5978 can swap ONLY the `new Error(...)` line below for
+   * `new ProjectEngineApiError(status, method, body)` without reshaping anything else here.
+   *
+   * @template T
+   * @param {string} method the HTTP method, for the error message
+   * @param {Promise<{ data?: T, error?: unknown, response: Response }>} resultPromise the pending
+   *   openapi-fetch result
+   * @returns {Promise<NonNullable<T> | null>} the parsed success body, or null for an empty body
+   *   (an empty-body operation resolves with null, never undefined)
+   */
+  async function unwrap(method, resultPromise) {
+    const { data, error, response } = await resultPromise;
+    if (!response.ok) {
+      const { status } = response;
+      // openapi-fetch surfaces an empty error body as '' (not undefined); normalise it to null.
+      const rawBody = error ?? data ?? null;
+      // `body` is computed here but not consumed by the plain Error below. LLMO-5978 swaps ONLY
+      // the `new Error(...)` line for `new ProjectEngineApiError(status, method, body)` — status,
+      // method, and this normalized body are all already in scope, so nothing else here changes.
+      // eslint-disable-next-line no-unused-vars
+      const body = rawBody === '' ? null : rawBody;
+      throw new Error(`Project Engine ${method} ${response.url} failed: ${status}`);
+    }
+    return data ?? null;
+  }
+
+  return {
+    // ─── /v1 catalog ────────────────────────────────────────────────────────
+    /** GET /v1/languages — projects-admin-list-languages */
+    listLanguages(init) {
+      return unwrap('GET', client.GET('/v1/languages', init));
+    },
+    /** GET /v1/ai_models — ai-list-global-models */
+    listGlobalAiModels(init) {
+      return unwrap('GET', client.GET('/v1/ai_models', init));
+    },
+
+    // ─── /v1 projects ───────────────────────────────────────────────────────
+    /** GET /v1/workspaces/{id}/projects — projects-list-projects */
+    listProjects(init) {
+      return unwrap('GET', client.GET('/v1/workspaces/{id}/projects', init));
+    },
+    /** POST /v1/workspaces/{id}/projects — projects-post-project */
+    createProject(init) {
+      return unwrap('POST', client.POST('/v1/workspaces/{id}/projects', init));
+    },
+    /** GET /v1/workspaces/{id}/projects/{project_id} — projects-get-project */
+    getProject(init) {
+      return unwrap('GET', client.GET('/v1/workspaces/{id}/projects/{project_id}', init));
+    },
+    /** PATCH /v1/workspaces/{id}/projects/{project_id} — projects-patch-project */
+    updateProject(init) {
+      return unwrap('PATCH', client.PATCH('/v1/workspaces/{id}/projects/{project_id}', init));
+    },
+    /** DELETE /v1/workspaces/{id}/projects/{project_id} — projects-delete-project */
+    deleteProject(init) {
+      return unwrap('DELETE', client.DELETE('/v1/workspaces/{id}/projects/{project_id}', init));
+    },
+    /** POST /v1/workspaces/{id}/projects/{project_id}/publish — projects-publish-project */
+    publishProject(init) {
+      return unwrap('POST', client.POST('/v1/workspaces/{id}/projects/{project_id}/publish', init));
+    },
+
+    // ─── /v1 AI models + benchmarks ───────────────────────────────────────────
+    /** GET /v1/workspaces/{id}/projects/{project_id}/ai_models — ai-list-models */
+    listAiModels(init) {
+      return unwrap('GET', client.GET('/v1/workspaces/{id}/projects/{project_id}/ai_models', init));
+    },
+    /** DELETE /v1/workspaces/{id}/projects/{project_id}/ai_models — ai-delete-models */
+    deleteAiModels(init) {
+      return unwrap('DELETE', client.DELETE('/v1/workspaces/{id}/projects/{project_id}/ai_models', init));
+    },
+    /** GET /v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks — ai-list-benchmarks */
+    listBenchmarks(init) {
+      return unwrap('GET', client.GET('/v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks', init));
+    },
+    /**
+     * DELETE /v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks — ai-delete-benchmarks
+     */
+    deleteBenchmarks(init) {
+      return unwrap('DELETE', client.DELETE('/v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks', init));
+    },
+    /**
+     * PUT /v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks/{benchmark_id}
+     * — ai-update-benchmark
+     */
+    updateBenchmark(init) {
+      return unwrap('PUT', client.PUT('/v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks/{benchmark_id}', init));
+    },
+    /** PUT /v1/workspaces/{id}/projects/{project_id}/ci/competitors — ci-update-competitors */
+    updateCompetitors(init) {
+      return unwrap('PUT', client.PUT('/v1/workspaces/{id}/projects/{project_id}/ci/competitors', init));
+    },
+
+    // ─── /v2 AI models + benchmarks ───────────────────────────────────────────
+    /** POST /v2/workspaces/{id}/projects/{project_id}/ai_models — aio-project-create-model */
+    createAioModel(init) {
+      return unwrap('POST', client.POST('/v2/workspaces/{id}/projects/{project_id}/ai_models', init));
+    },
+    /**
+     * POST /v2/workspaces/{id}/projects/{project_id}/ai_models/benchmarks — ai-create-benchmarks-v2
+     */
+    createBenchmarks(init) {
+      return unwrap('POST', client.POST('/v2/workspaces/{id}/projects/{project_id}/ai_models/benchmarks', init));
+    },
+
+    // ─── /v2 brand URLs ───────────────────────────────────────────────────────
+    /**
+     * GET /v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls
+     * — aio-list-brand-urls
+     */
+    listBrandUrls(init) {
+      return unwrap('GET', client.GET('/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls', init));
+    },
+    /**
+     * POST /v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls
+     * — aio-create-brand-urls
+     */
+    createBrandUrls(init) {
+      return unwrap('POST', client.POST('/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls', init));
+    },
+    /**
+     * DELETE /v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls
+     * — aio-delete-brand-urls
+     */
+    deleteBrandUrls(init) {
+      return unwrap('DELETE', client.DELETE('/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls', init));
+    },
+
+    // ─── /v2 AIO project state, prompts, tags ─────────────────────────────────
+    /**
+     * GET /v2/workspaces/{id}/projects/{project_id}/aio/init_status
+     * — aio-get-project-init-status-v2
+     */
+    getProjectInitStatus(init) {
+      return unwrap('GET', client.GET('/v2/workspaces/{id}/projects/{project_id}/aio/init_status', init));
+    },
+    /** POST /v2/workspaces/{id}/projects/{project_id}/aio/prompts — aio-create-prompt-v2 */
+    createPrompts(init) {
+      return unwrap('POST', client.POST('/v2/workspaces/{id}/projects/{project_id}/aio/prompts', init));
+    },
+    /**
+     * DELETE /v2/workspaces/{id}/projects/{project_id}/aio/prompts — aio-delete-prompt-by-ids-v2
+     */
+    deletePromptsByIds(init) {
+      return unwrap('DELETE', client.DELETE('/v2/workspaces/{id}/projects/{project_id}/aio/prompts', init));
+    },
+    /**
+     * POST /v2/workspaces/{id}/projects/{project_id}/aio/prompts/by_tags
+     * — aio-list-prompts-by-tag-ids
+     */
+    listPromptsByTagIds(init) {
+      return unwrap('POST', client.POST('/v2/workspaces/{id}/projects/{project_id}/aio/prompts/by_tags', init));
+    },
+    /** PUT /v2/workspaces/{id}/projects/{project_id}/aio/prompts/tags — aio-update-prompts-batch */
+    updatePromptTags(init) {
+      return unwrap('PUT', client.PUT('/v2/workspaces/{id}/projects/{project_id}/aio/prompts/tags', init));
+    },
+    /**
+     * POST /v2/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}/rename
+     * — aio-rename-prompt
+     */
+    renamePrompt(init) {
+      return unwrap('POST', client.POST('/v2/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}/rename', init));
+    },
+    /** GET /v2/workspaces/{id}/projects/{project_id}/aio/tags — aio-get-project-tags */
+    listProjectTags(init) {
+      return unwrap('GET', client.GET('/v2/workspaces/{id}/projects/{project_id}/aio/tags', init));
+    },
+    /** POST /v2/workspaces/{id}/projects/{project_id}/aio/tags — aio-create-project-tags */
+    createProjectTags(init) {
+      return unwrap('POST', client.POST('/v2/workspaces/{id}/projects/{project_id}/aio/tags', init));
+    },
+    /** PATCH /v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id} — aio-update-tag */
+    updateProjectTag(init) {
+      return unwrap('PATCH', client.PATCH('/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}', init));
+    },
+  };
+}

--- a/packages/spacecat-shared-project-engine-client/src/rest-transport.js
+++ b/packages/spacecat-shared-project-engine-client/src/rest-transport.js
@@ -67,7 +67,9 @@ export function createSerenityProjectEngineTransport(options) {
       // method, and this normalized body are all already in scope, so nothing else here changes.
       // eslint-disable-next-line no-unused-vars
       const body = rawBody === '' ? null : rawBody;
-      throw new Error(`Project Engine ${method} ${response.url} failed: ${status}`);
+      // Message deliberately omits the request URL: it embeds path-param ids (workspace/
+      // project/etc.) that error-reporter and log consumers should not receive by default.
+      throw new Error(`Project Engine ${method} failed: ${status}`);
     }
     return data ?? null;
   }

--- a/packages/spacecat-shared-project-engine-client/test/rest-transport.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/rest-transport.test.js
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { createSerenityProjectEngineTransport } from '../src/rest-transport.js';
+
+const BASE = 'https://pe.example';
+const PREFIX = '/enterprise/projects/api';
+
+const json = (body, status = 200) => new Response(JSON.stringify(body), {
+  status,
+  headers: { 'content-type': 'application/json' },
+});
+
+const sandbox = sinon.createSandbox();
+afterEach(() => sandbox.restore());
+
+const make = (fetch, opts = {}) => createSerenityProjectEngineTransport({
+  baseUrl: BASE,
+  authToken: 'ims-token',
+  // No retries/backoff in tests — every canned response is terminal.
+  maxRetries: 0,
+  retryBaseDelayMs: 0,
+  fetch,
+  ...opts,
+});
+
+// Fill every `{placeholder}` a path template declares with a stable id, so the
+// resolved URL is deterministic and every path param is supplied.
+const PARAM_VALUES = {
+  id: 'ws-1',
+  project_id: 'p-1',
+  benchmark_id: 'b-1',
+  tag_id: 't-1',
+  prompt_id: 'pr-1',
+};
+
+const pathParamsFor = (template) => {
+  const keys = [...template.matchAll(/\{(\w+)\}/g)].map((m) => m[1]);
+  return Object.fromEntries(keys.map((k) => [k, PARAM_VALUES[k]]));
+};
+
+const resolve = (template) => template.replace(/\{(\w+)\}/g, (_, k) => PARAM_VALUES[k]);
+
+// facadeMethod — HTTP method — path template. 1:1 with the 28 operations.
+const OPERATIONS = [
+  ['listLanguages', 'GET', '/v1/languages'],
+  ['listGlobalAiModels', 'GET', '/v1/ai_models'],
+  ['listProjects', 'GET', '/v1/workspaces/{id}/projects'],
+  ['createProject', 'POST', '/v1/workspaces/{id}/projects'],
+  ['getProject', 'GET', '/v1/workspaces/{id}/projects/{project_id}'],
+  ['updateProject', 'PATCH', '/v1/workspaces/{id}/projects/{project_id}'],
+  ['deleteProject', 'DELETE', '/v1/workspaces/{id}/projects/{project_id}'],
+  ['publishProject', 'POST', '/v1/workspaces/{id}/projects/{project_id}/publish'],
+  ['listAiModels', 'GET', '/v1/workspaces/{id}/projects/{project_id}/ai_models'],
+  ['deleteAiModels', 'DELETE', '/v1/workspaces/{id}/projects/{project_id}/ai_models'],
+  ['listBenchmarks', 'GET', '/v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks'],
+  ['deleteBenchmarks', 'DELETE', '/v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks'],
+  ['updateBenchmark', 'PUT', '/v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks/{benchmark_id}'],
+  ['updateCompetitors', 'PUT', '/v1/workspaces/{id}/projects/{project_id}/ci/competitors'],
+  ['createAioModel', 'POST', '/v2/workspaces/{id}/projects/{project_id}/ai_models'],
+  ['createBenchmarks', 'POST', '/v2/workspaces/{id}/projects/{project_id}/ai_models/benchmarks'],
+  ['listBrandUrls', 'GET', '/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls'],
+  ['createBrandUrls', 'POST', '/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls'],
+  ['deleteBrandUrls', 'DELETE', '/v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls'],
+  ['getProjectInitStatus', 'GET', '/v2/workspaces/{id}/projects/{project_id}/aio/init_status'],
+  ['createPrompts', 'POST', '/v2/workspaces/{id}/projects/{project_id}/aio/prompts'],
+  ['deletePromptsByIds', 'DELETE', '/v2/workspaces/{id}/projects/{project_id}/aio/prompts'],
+  ['listPromptsByTagIds', 'POST', '/v2/workspaces/{id}/projects/{project_id}/aio/prompts/by_tags'],
+  ['updatePromptTags', 'PUT', '/v2/workspaces/{id}/projects/{project_id}/aio/prompts/tags'],
+  ['renamePrompt', 'POST', '/v2/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}/rename'],
+  ['listProjectTags', 'GET', '/v2/workspaces/{id}/projects/{project_id}/aio/tags'],
+  ['createProjectTags', 'POST', '/v2/workspaces/{id}/projects/{project_id}/aio/tags'],
+  ['updateProjectTag', 'PATCH', '/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}'],
+];
+
+describe('createSerenityProjectEngineTransport', () => {
+  it('exposes exactly the 28 declared facade methods, all functions', () => {
+    const transport = make(sandbox.stub().resolves(json({})));
+    const names = Object.keys(transport);
+    expect(names).to.have.length(28);
+    expect(names.sort()).to.deep.equal(OPERATIONS.map(([n]) => n).sort());
+    names.forEach((n) => expect(transport[n]).to.be.a('function'));
+  });
+
+  describe('routes each method to the right HTTP method + path', () => {
+    OPERATIONS.forEach(([facade, httpMethod, template]) => {
+      it(`${facade} → ${httpMethod} ${template}`, async () => {
+        const fetch = sandbox.stub().resolves(json({ ok: true }));
+        const transport = make(fetch);
+
+        const init = { params: { path: pathParamsFor(template) } };
+        const result = await transport[facade](init);
+
+        expect(fetch.callCount).to.equal(1);
+        const request = fetch.firstCall.args[0];
+        expect(request.method).to.equal(httpMethod);
+        expect(new URL(request.url).pathname).to.equal(`${PREFIX}${resolve(template)}`);
+        // A 2xx JSON body is unwrapped and returned as-is.
+        expect(result).to.deep.equal({ ok: true });
+      });
+    });
+  });
+
+  describe('unwrap error seam', () => {
+    it('(a) ok + JSON data → returns the parsed body', async () => {
+      const transport = make(sandbox.stub().resolves(json({ hello: 'world' })));
+      expect(await transport.listLanguages()).to.deep.equal({ hello: 'world' });
+    });
+
+    it('(b) ok + empty body (204) → returns null', async () => {
+      const transport = make(sandbox.stub().resolves(new Response(null, { status: 204 })));
+      expect(await transport.listLanguages()).to.equal(null);
+    });
+
+    it('(c) non-2xx with a JSON error body → throws with the status message', async () => {
+      const transport = make(sandbox.stub().resolves(json({ message: 'nope' }, 404)));
+      let thrown;
+      try {
+        await transport.listLanguages();
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).to.be.an('error');
+      expect(thrown.constructor).to.equal(Error); // a plain Error for this ticket
+      expect(thrown.message).to.match(/^Project Engine GET .* failed: 404$/);
+    });
+
+    it('(d) non-2xx (5xx) with a JSON error body → throws with the status message', async () => {
+      // openapi-fetch ALWAYS routes a non-ok body into `error`, never `data` — so the
+      // `error ?? data` expression's `data` fallback operand is only reachable when `error`
+      // is nullish, which is the empty-body non-ok path exercised by case (f) below (there
+      // `data` is undefined too). This case pins the sibling 5xx path: a parseable error body.
+      const transport = make(sandbox.stub().resolves(json({ detail: 'boom' }, 500)));
+      let thrown;
+      try {
+        await transport.listLanguages();
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).to.be.an('error');
+      expect(thrown.message).to.contain('failed: 500');
+    });
+
+    it('(e) non-2xx with an empty-string body → normalized to null (no throw-shape change)', async () => {
+      // A non-ok response with NO content-length and an empty text body: openapi-fetch sets
+      // `error = ''`; unwrap normalizes '' → null.
+      const fetch = sandbox.stub().resolves({
+        ok: false,
+        status: 400,
+        url: `${BASE}${PREFIX}/v1/languages`,
+        headers: new Headers(),
+        clone() { return this; },
+        text: async () => '',
+      });
+      const transport = make(fetch);
+      let thrown;
+      try {
+        await transport.listLanguages();
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).to.be.an('error');
+      expect(thrown.message).to.contain('failed: 400');
+    });
+
+    it('(f) non-2xx with neither data nor error → null body', async () => {
+      // status 204-style empty on a non-ok path: openapi-fetch returns { error: undefined }.
+      const fetch = sandbox.stub().resolves({
+        ok: false,
+        status: 503,
+        url: `${BASE}${PREFIX}/v1/languages`,
+        headers: new Headers({ 'content-length': '0' }),
+        clone() { return this; },
+        text: async () => '',
+      });
+      const transport = make(fetch);
+      let thrown;
+      try {
+        await transport.listLanguages();
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).to.be.an('error');
+      expect(thrown.message).to.contain('failed: 503');
+    });
+
+    it('(g) a rejected fetch (network error) propagates out through unwrap', async () => {
+      const boom = new Error('network down');
+      const transport = make(sandbox.stub().rejects(boom));
+      let thrown;
+      try {
+        await transport.listLanguages();
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).to.equal(boom);
+    });
+  });
+});

--- a/packages/spacecat-shared-project-engine-client/test/rest-transport.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/rest-transport.test.js
@@ -133,7 +133,7 @@ describe('createSerenityProjectEngineTransport', () => {
       }
       expect(thrown).to.be.an('error');
       expect(thrown.constructor).to.equal(Error); // a plain Error for this ticket
-      expect(thrown.message).to.match(/^Project Engine GET .* failed: 404$/);
+      expect(thrown.message).to.match(/^Project Engine GET failed: 404$/);
     });
 
     it('(d) non-2xx (5xx) with a JSON error body → throws with the status message', async () => {
@@ -153,12 +153,13 @@ describe('createSerenityProjectEngineTransport', () => {
     });
 
     it('(e) non-2xx with an empty-string body → normalized to null (no throw-shape change)', async () => {
-      // A non-ok response with NO content-length and an empty text body: openapi-fetch sets
-      // `error = ''`; unwrap normalizes '' → null.
+      // Must stub (not a real Response) to reach the `error === ''` → null branch: a real
+      // `new Response('', …)` makes openapi-fetch skip the empty body and leave `error`
+      // undefined — that is case (f), not this one. Forcing a present, empty *text* body is
+      // the only way to make openapi-fetch surface `error = ''`.
       const fetch = sandbox.stub().resolves({
         ok: false,
         status: 400,
-        url: `${BASE}${PREFIX}/v1/languages`,
         headers: new Headers(),
         clone() { return this; },
         text: async () => '',
@@ -175,15 +176,12 @@ describe('createSerenityProjectEngineTransport', () => {
     });
 
     it('(f) non-2xx with neither data nor error → null body', async () => {
-      // status 204-style empty on a non-ok path: openapi-fetch returns { error: undefined }.
-      const fetch = sandbox.stub().resolves({
-        ok: false,
-        status: 503,
-        url: `${BASE}${PREFIX}/v1/languages`,
-        headers: new Headers({ 'content-length': '0' }),
-        clone() { return this; },
-        text: async () => '',
-      });
+      // A real non-ok Response with an explicit `content-length: 0`: openapi-fetch skips
+      // parsing (rather than reading '' from the empty body), leaving `error = undefined` — so
+      // unwrap's `error ?? data ?? null` falls through the nullish path to null.
+      const fetch = sandbox.stub().resolves(
+        new Response(null, { status: 503, headers: { 'content-length': '0' } }),
+      );
       const transport = make(fetch);
       let thrown;
       try {

--- a/packages/spacecat-shared-project-engine-client/test/types/rest-transport.type-test.ts
+++ b/packages/spacecat-shared-project-engine-client/test/types/rest-transport.type-test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Compile-only type test for the transport facade's PUBLIC surface (`src/index.d.ts`). The
+ * `.d.ts` is hand-written and derives every method's params + return from the generated `paths`,
+ * so it can silently drift into `any`. This fixture is type-checked by `npm run test:types`
+ * (tsc --noEmit); it emits nothing and is not run by mocha.
+ */
+
+import {
+  createSerenityProjectEngineTransport,
+} from '../../src/index.js';
+import type {
+  components,
+  SerenityProjectEngineTransport,
+} from '../../src/index.js';
+
+// Detects a type collapsing to `any` — `0 extends (1 & T)` is only true for `any`.
+type IsAny<T> = 0 extends (1 & T) ? true : false;
+// Compile error unless the argument is exactly `false` (i.e. the checked type is NOT `any`).
+type AssertNotAny<T> = IsAny<T> extends false ? true : false;
+
+// 1. The factory returns the declared transport type (same options as the raw client).
+const transport: SerenityProjectEngineTransport = createSerenityProjectEngineTransport({
+  baseUrl: 'http://localhost:4010',
+  authToken: 'token',
+});
+
+// 2a. A GET with path params: params are typed and the return is the operation's 2xx body | null.
+async function typedGet(): Promise<void> {
+  const project = await transport.getProject({
+    // `query.draft` is REQUIRED by the generated contract — omitting it is a compile error,
+    // which itself proves the params are precisely typed (not `any`).
+    params: { path: { id: 'ws-1', project_id: 'p-1' }, query: { draft: 'true' } },
+  });
+  // Return is precisely `model.ProjectResponse | null`, not `any`.
+  const asProject: components['schemas']['model.ProjectResponse'] | null = project;
+  void asProject;
+}
+void typedGet;
+// The return type must NOT be `any` (would erase all safety).
+type _GetNotAny = AssertNotAny<
+  Awaited<ReturnType<SerenityProjectEngineTransport['getProject']>>
+>;
+
+// 2b. A POST with a request body: body is typed, return is the 2xx body | null.
+async function typedPost(): Promise<void> {
+  const created = await transport.createProject({
+    params: { path: { id: 'ws-1' } },
+    body: { name: 'My Project' } as components['schemas']['model.ProjectRequest'],
+  });
+  const asProject: components['schemas']['model.ProjectResponse'] | null = created;
+  void asProject;
+}
+void typedPost;
+type _PostNotAny = AssertNotAny<
+  Awaited<ReturnType<SerenityProjectEngineTransport['createProject']>>
+>;
+
+// 2c. A DELETE: an empty-body op resolves with `null` (never `undefined`).
+async function typedDelete(): Promise<void> {
+  const deleted = await transport.deleteProject({
+    params: { path: { id: 'ws-1', project_id: 'p-1' } },
+  });
+  const asNull: null = deleted;
+  void asNull;
+}
+void typedDelete;
+
+// 3. Canary: a bogus method name must be rejected. If the surface degraded to `any`, this
+//    would type-check and the `@ts-expect-error` would itself error ("unused directive").
+// @ts-expect-error — `frobnicate` is not a facade method.
+void transport.frobnicate;
+
+// 4. Canary: a required path param cannot be omitted — proves params are typed, not `any`.
+// @ts-expect-error — getProject's path requires both `id` and `project_id`.
+void transport.getProject({ params: { path: { id: 'ws-1' } } });
+
+// 5. Canary: a required request body cannot be omitted on createProject.
+// @ts-expect-error — POST createProject requires a `body`.
+void transport.createProject({ params: { path: { id: 'ws-1' } } });
+
+// Reference the AssertNotAny aliases so they are not flagged as unused.
+type _Assertions = [_GetNotAny, _PostNotAny];
+const _assertionsHold: _Assertions = [true, true];
+void _assertionsHold;


### PR DESCRIPTION
## What

Adds `createSerenityProjectEngineTransport(options)` in `src/rest-transport.js` — an intent-named **facade** over the raw `createSerenityProjectEngineApiClient` openapi-fetch client. It wraps the 28 in-spec Project Engine operations that spacecat-api-service consumes behind verb+resource methods, so consumers depend on this seam rather than the raw client and its literal path strings.

- Factory takes the SAME `SerenityProjectEngineApiClientOptions` (adds none of its own) and builds the raw client internally.
- Each method is THIN: forwards the caller's openapi-fetch `init` to `client.<METHOD>('<literal path>', init)` and routes the result through a single private `unwrap(method, resultPromise)` seam.
- **Single error seam:** `unwrap` awaits the result (so network/timeout rejections flow through one point) and on `!response.ok` throws a plain `Error` (`Project Engine ${method} ${response.url} failed: ${status}`). It computes `status`, `method`, and a normalized `body` locally first so the follow-up ticket **LLMO-5978** can swap ONLY the `new Error(...)` line for `new ProjectEngineApiError(status, method, body)` (noted in a code comment). On success returns `data ?? null`.
- No caching / redaction / error→HTTP translation / composite methods (all consumer-owned per ADR-0001).
- Public types declared in `src/index.d.ts` (`interface SerenityProjectEngineTransport` + `createSerenityProjectEngineTransport`), each method's params/return derived from the generated `paths` contract (strictly typed, no `any`).

## Readback: `operationId → facade method` (28)

| facade method | HTTP | path | operationId |
|---|---|---|---|
| listLanguages | GET | /v1/languages | projects-admin-list-languages |
| listGlobalAiModels | GET | /v1/ai_models | ai-list-global-models |
| listProjects | GET | /v1/workspaces/{id}/projects | projects-list-projects |
| createProject | POST | /v1/workspaces/{id}/projects | projects-post-project |
| getProject | GET | /v1/workspaces/{id}/projects/{project_id} | projects-get-project |
| updateProject | PATCH | /v1/workspaces/{id}/projects/{project_id} | projects-patch-project |
| deleteProject | DELETE | /v1/workspaces/{id}/projects/{project_id} | projects-delete-project |
| publishProject | POST | /v1/workspaces/{id}/projects/{project_id}/publish | projects-publish-project |
| listAiModels | GET | /v1/workspaces/{id}/projects/{project_id}/ai_models | ai-list-models |
| deleteAiModels | DELETE | /v1/workspaces/{id}/projects/{project_id}/ai_models | ai-delete-models |
| listBenchmarks | GET | /v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks | ai-list-benchmarks |
| deleteBenchmarks | DELETE | /v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks | ai-delete-benchmarks |
| updateBenchmark | PUT | /v1/workspaces/{id}/projects/{project_id}/ai_models/benchmarks/{benchmark_id} | ai-update-benchmark |
| updateCompetitors | PUT | /v1/workspaces/{id}/projects/{project_id}/ci/competitors | ci-update-competitors |
| createAioModel | POST | /v2/workspaces/{id}/projects/{project_id}/ai_models | aio-project-create-model |
| createBenchmarks | POST | /v2/workspaces/{id}/projects/{project_id}/ai_models/benchmarks | ai-create-benchmarks-v2 |
| listBrandUrls | GET | /v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls | aio-list-brand-urls |
| createBrandUrls | POST | /v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls | aio-create-brand-urls |
| deleteBrandUrls | DELETE | /v2/workspaces/{id}/projects/{project_id}/aio/benchmarks/{benchmark_id}/brand_urls | aio-delete-brand-urls |
| getProjectInitStatus | GET | /v2/workspaces/{id}/projects/{project_id}/aio/init_status | aio-get-project-init-status-v2 |
| createPrompts | POST | /v2/workspaces/{id}/projects/{project_id}/aio/prompts | aio-create-prompt-v2 |
| deletePromptsByIds | DELETE | /v2/workspaces/{id}/projects/{project_id}/aio/prompts | aio-delete-prompt-by-ids-v2 |
| listPromptsByTagIds | POST | /v2/workspaces/{id}/projects/{project_id}/aio/prompts/by_tags | aio-list-prompts-by-tag-ids |
| updatePromptTags | PUT | /v2/workspaces/{id}/projects/{project_id}/aio/prompts/tags | aio-update-prompts-batch |
| renamePrompt | POST | /v2/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}/rename | aio-rename-prompt |
| listProjectTags | GET | /v2/workspaces/{id}/projects/{project_id}/aio/tags | aio-get-project-tags |
| createProjectTags | POST | /v2/workspaces/{id}/projects/{project_id}/aio/tags | aio-create-project-tags |
| updateProjectTag | PATCH | /v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id} | aio-update-tag |

## Notes

**Rationale:** Smallest-shippable: wraps only the 28 in-spec Project Engine operations spacecat-api-service actually consumes. The other ~77 generated operations remain reachable via the raw `createSerenityProjectEngineApiClient` client; add a facade method only when a real second consumer needs one. Surface is strictly typed/in-spec; pinned rules: verb+resource names, thin methods, single error seam, no composites/caching/redaction (consumer-owned per ADR-0001).

**Finding:** GET /v1/workspaces/{id}/brand-topics — called by spacecat-api-service on the PE client but absent from the generated spec; likely an overlay/spec gap (cf. prior missing-op corrections, e.g. CR-series). Tracked separately, not resolved here. No spec/overlay edits in this PR (Semrush-owned, gated).

## Gates
- lint: clean
- test: 307 passing, 100% lines/statements/branches (package pins `branches: 100`)
- test:types (tsc): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)