### PR TITLE
feat(project-engine-client): ProjectEngineApiError typed errors in the facade seam (LLMO-5978)

### DIFF
--- a/packages/spacecat-shared-project-engine-client/src/errors.js
+++ b/packages/spacecat-shared-project-engine-client/src/errors.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * The single typed error the transport facade throws from its `unwrap` seam. It carries the
+ * failing HTTP `method`, the response `status` (or `undefined` when there was no HTTP response —
+ * i.e. an exhausted-network / per-attempt-timeout failure), and the normalized parsed error
+ * `body`. On the network/timeout path the original thrown error is preserved as `cause`.
+ *
+ * This class does NOT translate the failure into an HTTP status for the consumer, redact the
+ * body, or map it onto a domain error — those are consumer-owned per ADR-0001. It exists only to
+ * give consumers a single `instanceof`-checkable type with the raw `{ status, method, body }`.
+ */
+export class ProjectEngineApiError extends Error {
+  /**
+   * @param {number | undefined} status the HTTP response status, or `undefined` when there was no
+   *   HTTP response (network / timeout failure)
+   * @param {string} method the HTTP method of the failing request
+   * @param {unknown | null} body the normalized parsed error body (`null` when empty/absent)
+   * @param {{ cause?: unknown }} [options] optional `{ cause }` forwarded to `super`, so a wrapped
+   *   network/timeout error keeps its original as `.cause`
+   */
+  constructor(status, method, body, options) {
+    const message = status === undefined
+      ? `Project Engine ${method} request failed`
+      : `Project Engine ${method} request failed with status ${status}`;
+    super(message, options);
+    /** @type {string} */
+    this.name = 'ProjectEngineApiError';
+    /** @type {number | undefined} */
+    this.status = status;
+    /** @type {string} */
+    this.method = method;
+    /** @type {unknown | null} */
+    this.body = body;
+  }
+}

--- a/packages/spacecat-shared-project-engine-client/src/errors.js
+++ b/packages/spacecat-shared-project-engine-client/src/errors.js
@@ -27,7 +27,7 @@ export class ProjectEngineApiError extends Error {
    * @param {number | undefined} status the HTTP response status, or `undefined` when there was no
    *   HTTP response (network / timeout failure)
    * @param {string} method the HTTP method of the failing request
-   * @param {unknown | null} body the normalized parsed error body (`null` when empty/absent)
+   * @param {unknown} body the normalized parsed error body (`null` when empty/absent)
    * @param {{ cause?: unknown }} [options] optional `{ cause }` forwarded to `super`, so a wrapped
    *   network/timeout error keeps its original as `.cause`
    */
@@ -42,7 +42,7 @@ export class ProjectEngineApiError extends Error {
     this.status = status;
     /** @type {string} */
     this.method = method;
-    /** @type {unknown | null} */
+    /** @type {unknown} */
     this.body = body;
   }
 }

--- a/packages/spacecat-shared-project-engine-client/src/index.d.ts
+++ b/packages/spacecat-shared-project-engine-client/src/index.d.ts
@@ -353,5 +353,27 @@ export declare function createSerenityProjectEngineTransport(
   options: SerenityProjectEngineApiClientOptions,
 ): SerenityProjectEngineTransport;
 
+/**
+ * The single typed error the transport facade throws from its `unwrap` seam. It carries the
+ * failing HTTP `method`, the response `status` (or `undefined` when there was no HTTP response —
+ * an exhausted-network / per-attempt-timeout failure), and the normalized parsed error `body`.
+ * On the network/timeout path the original thrown error is preserved as `cause`. No error→HTTP
+ * translation or redaction — consumer-owned per ADR-0001.
+ */
+export declare class ProjectEngineApiError extends Error {
+  /** The HTTP response status, or `undefined` when there was no HTTP response. */
+  readonly status: number | undefined;
+  /** The HTTP method of the failing request. */
+  readonly method: string;
+  /** The normalized parsed error body (`null` when empty/absent). */
+  readonly body: unknown;
+  constructor(
+    status: number | undefined,
+    method: string,
+    body: unknown,
+    options?: { cause?: unknown },
+  );
+}
+
 // Re-export the generated contract types for consumers that want them directly.
 export type { paths, components };

--- a/packages/spacecat-shared-project-engine-client/src/index.d.ts
+++ b/packages/spacecat-shared-project-engine-client/src/index.d.ts
@@ -359,6 +359,9 @@ export declare function createSerenityProjectEngineTransport(
  * an exhausted-network / per-attempt-timeout failure), and the normalized parsed error `body`.
  * On the network/timeout path the original thrown error is preserved as `cause`. No error→HTTP
  * translation or redaction — consumer-owned per ADR-0001.
+ *
+ * NOTE: the `readonly` modifiers below are a type-system-only guarantee; the runtime class
+ * (`errors.js`) sets these fields with plain assignment in the constructor.
  */
 export declare class ProjectEngineApiError extends Error {
   /** The HTTP response status, or `undefined` when there was no HTTP response. */

--- a/packages/spacecat-shared-project-engine-client/src/index.js
+++ b/packages/spacecat-shared-project-engine-client/src/index.js
@@ -14,3 +14,4 @@
 
 export { createSerenityProjectEngineApiClient } from './client.js';
 export { createSerenityProjectEngineTransport } from './rest-transport.js';
+export { ProjectEngineApiError } from './errors.js';

--- a/packages/spacecat-shared-project-engine-client/src/rest-transport.js
+++ b/packages/spacecat-shared-project-engine-client/src/rest-transport.js
@@ -13,6 +13,7 @@
 // @ts-check
 
 import { createSerenityProjectEngineApiClient } from './client.js';
+import { ProjectEngineApiError } from './errors.js';
 
 /**
  * @typedef {import('./client.js').SerenityProjectEngineApiClientOptions}
@@ -40,14 +41,17 @@ export function createSerenityProjectEngineTransport(options) {
 
   /**
    * The SINGLE seam where a failed call becomes a throw. It awaits the openapi-fetch result
-   * promise here (so a network/timeout rejection also flows through this one point), and on a
-   * non-2xx response throws. The typed client never throws on an HTTP error — it resolves to
-   * `{ data, error, response }` with the parsed error body in `error` — so a non-2xx is turned
-   * into a throw here; a 2xx returns the parsed body (or null for an empty body).
+   * promise here (so a network/timeout rejection also flows through this one point), and turns
+   * both failure paths into a {@link ProjectEngineApiError}:
    *
-   * `status`, `method`, and the normalized `body` are computed locally at this site FIRST so the
-   * follow-up ticket LLMO-5978 can swap ONLY the `new Error(...)` line below for
-   * `new ProjectEngineApiError(status, method, body)` without reshaping anything else here.
+   * - a non-2xx HTTP response: the typed client never throws on an HTTP error — it resolves to
+   *   `{ data, error, response }` with the parsed error body in `error` — so the non-2xx is turned
+   *   into a throw here carrying `response.status` + the normalized `body`;
+   * - an exhausted-network / per-attempt-timeout failure: `createRetryingFetch` rethrew the last
+   *   raw error after the retry budget, so the awaited promise rejects. There is no HTTP response
+   *   ⇒ `status` is `undefined`; the original error is preserved as `cause`.
+   *
+   * A 2xx returns the parsed body (or null for an empty body).
    *
    * @template T
    * @param {string} method the HTTP method, for the error message
@@ -57,19 +61,22 @@ export function createSerenityProjectEngineTransport(options) {
    *   (an empty-body operation resolves with null, never undefined)
    */
   async function unwrap(method, resultPromise) {
-    const { data, error, response } = await resultPromise;
+    let result;
+    try {
+      result = await resultPromise;
+    } catch (cause) {
+      // exhausted-network / per-attempt-timeout path: createRetryingFetch rethrew the last raw
+      // error after the retry budget. No HTTP response ⇒ status undefined; preserve the original
+      // as `cause`.
+      throw new ProjectEngineApiError(undefined, method, null, { cause });
+    }
+    const { data, error, response } = result;
     if (!response.ok) {
-      const { status } = response;
-      // openapi-fetch surfaces an empty error body as '' (not undefined); normalise it to null.
+      // openapi-fetch puts the parsed error body in `error`; fall back to `data`, then null.
       const rawBody = error ?? data ?? null;
-      // `body` is computed here but not consumed by the plain Error below. LLMO-5978 swaps ONLY
-      // the `new Error(...)` line for `new ProjectEngineApiError(status, method, body)` — status,
-      // method, and this normalized body are all already in scope, so nothing else here changes.
-      // eslint-disable-next-line no-unused-vars
+      // openapi-fetch surfaces an empty error body as '' (not undefined); normalise it to null.
       const body = rawBody === '' ? null : rawBody;
-      // Message deliberately omits the request URL: it embeds path-param ids (workspace/
-      // project/etc.) that error-reporter and log consumers should not receive by default.
-      throw new Error(`Project Engine ${method} failed: ${status}`);
+      throw new ProjectEngineApiError(response.status, method, body);
     }
     return data ?? null;
   }

--- a/packages/spacecat-shared-project-engine-client/src/rest-transport.js
+++ b/packages/spacecat-shared-project-engine-client/src/rest-transport.js
@@ -59,6 +59,8 @@ export function createSerenityProjectEngineTransport(options) {
    *   openapi-fetch result
    * @returns {Promise<NonNullable<T> | null>} the parsed success body, or null for an empty body
    *   (an empty-body operation resolves with null, never undefined)
+   * @throws {import('./errors.js').ProjectEngineApiError} on a non-2xx response or an
+   *   exhausted-network / per-attempt-timeout failure
    */
   async function unwrap(method, resultPromise) {
     let result;

--- a/packages/spacecat-shared-project-engine-client/test/errors.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/errors.test.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { ProjectEngineApiError } from '../src/errors.js';
+
+describe('ProjectEngineApiError', () => {
+  it('is a subclass of Error with the expected name', () => {
+    const err = new ProjectEngineApiError(404, 'GET', null);
+    expect(err).to.be.instanceOf(Error);
+    expect(err).to.be.instanceOf(ProjectEngineApiError);
+    expect(err.name).to.equal('ProjectEngineApiError');
+  });
+
+  it('with a status: message includes method + status, and carries the fields', () => {
+    const body = { detail: 'nope' };
+    const err = new ProjectEngineApiError(409, 'POST', body);
+    expect(err.message).to.equal('Project Engine POST request failed with status 409');
+    expect(err.status).to.equal(409);
+    expect(err.method).to.equal('POST');
+    expect(err.body).to.deep.equal(body);
+    expect(err.cause).to.equal(undefined);
+  });
+
+  it('without a status (network/timeout): message omits the status', () => {
+    const err = new ProjectEngineApiError(undefined, 'DELETE', null);
+    expect(err.message).to.equal('Project Engine DELETE request failed');
+    expect(err.status).to.equal(undefined);
+    expect(err.method).to.equal('DELETE');
+    expect(err.body).to.equal(null);
+  });
+
+  it('forwards options.cause to the underlying Error', () => {
+    const cause = new TypeError('socket hang up');
+    const err = new ProjectEngineApiError(undefined, 'GET', null, { cause });
+    expect(err.cause).to.equal(cause);
+  });
+});

--- a/packages/spacecat-shared-project-engine-client/test/rest-transport.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/rest-transport.test.js
@@ -13,6 +13,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { createSerenityProjectEngineTransport } from '../src/rest-transport.js';
+import { ProjectEngineApiError } from '../src/errors.js';
 
 const BASE = 'https://pe.example';
 const PREFIX = '/enterprise/projects/api';
@@ -123,8 +124,9 @@ describe('createSerenityProjectEngineTransport', () => {
       expect(await transport.listLanguages()).to.equal(null);
     });
 
-    it('(c) non-2xx with a JSON error body → throws with the status message', async () => {
-      const transport = make(sandbox.stub().resolves(json({ message: 'nope' }, 404)));
+    it('(c) non-2xx with a JSON error body → throws a ProjectEngineApiError carrying status/method/body', async () => {
+      const errBody = { message: 'nope' };
+      const transport = make(sandbox.stub().resolves(json(errBody, 404)));
       let thrown;
       try {
         await transport.listLanguages();
@@ -132,11 +134,16 @@ describe('createSerenityProjectEngineTransport', () => {
         thrown = e;
       }
       expect(thrown).to.be.an('error');
-      expect(thrown.constructor).to.equal(Error); // a plain Error for this ticket
-      expect(thrown.message).to.match(/^Project Engine GET failed: 404$/);
+      expect(thrown).to.be.instanceOf(Error);
+      expect(thrown).to.be.instanceOf(ProjectEngineApiError);
+      expect(thrown.name).to.equal('ProjectEngineApiError');
+      expect(thrown.status).to.equal(404);
+      expect(thrown.method).to.equal('GET');
+      expect(thrown.body).to.deep.equal(errBody);
+      expect(thrown.message).to.equal('Project Engine GET request failed with status 404');
     });
 
-    it('(d) non-2xx (5xx) with a JSON error body → throws with the status message', async () => {
+    it('(d) non-2xx (5xx) with a JSON error body → throws with status 500 and the parsed body', async () => {
       // openapi-fetch ALWAYS routes a non-ok body into `error`, never `data` — so the
       // `error ?? data` expression's `data` fallback operand is only reachable when `error`
       // is nullish, which is the empty-body non-ok path exercised by case (f) below (there
@@ -148,18 +155,18 @@ describe('createSerenityProjectEngineTransport', () => {
       } catch (e) {
         thrown = e;
       }
-      expect(thrown).to.be.an('error');
-      expect(thrown.message).to.contain('failed: 500');
+      expect(thrown).to.be.instanceOf(ProjectEngineApiError);
+      expect(thrown.status).to.equal(500);
+      expect(thrown.body).to.deep.equal({ detail: 'boom' });
     });
 
-    it('(e) non-2xx with an empty-string body → normalized to null (no throw-shape change)', async () => {
-      // Must stub (not a real Response) to reach the `error === ''` → null branch: a real
-      // `new Response('', …)` makes openapi-fetch skip the empty body and leave `error`
-      // undefined — that is case (f), not this one. Forcing a present, empty *text* body is
-      // the only way to make openapi-fetch surface `error = ''`.
+    it('(e) non-2xx with an empty-string error body → body normalized to null', async () => {
+      // A non-ok response with NO content-length and an empty text body: openapi-fetch sets
+      // `error = ''`; unwrap normalizes '' → null.
       const fetch = sandbox.stub().resolves({
         ok: false,
         status: 400,
+        url: `${BASE}${PREFIX}/v1/languages`,
         headers: new Headers(),
         clone() { return this; },
         text: async () => '',
@@ -171,17 +178,21 @@ describe('createSerenityProjectEngineTransport', () => {
       } catch (e) {
         thrown = e;
       }
-      expect(thrown).to.be.an('error');
-      expect(thrown.message).to.contain('failed: 400');
+      expect(thrown).to.be.instanceOf(ProjectEngineApiError);
+      expect(thrown.status).to.equal(400);
+      expect(thrown.body).to.equal(null);
     });
 
-    it('(f) non-2xx with neither data nor error → null body', async () => {
-      // A real non-ok Response with an explicit `content-length: 0`: openapi-fetch skips
-      // parsing (rather than reading '' from the empty body), leaving `error = undefined` — so
-      // unwrap's `error ?? data ?? null` falls through the nullish path to null.
-      const fetch = sandbox.stub().resolves(
-        new Response(null, { status: 503, headers: { 'content-length': '0' } }),
-      );
+    it('(f) non-2xx with neither data nor error → null body (both-absent fallback)', async () => {
+      // status 204-style empty on a non-ok path: openapi-fetch returns { error: undefined }.
+      const fetch = sandbox.stub().resolves({
+        ok: false,
+        status: 503,
+        url: `${BASE}${PREFIX}/v1/languages`,
+        headers: new Headers({ 'content-length': '0' }),
+        clone() { return this; },
+        text: async () => '',
+      });
       const transport = make(fetch);
       let thrown;
       try {
@@ -189,12 +200,15 @@ describe('createSerenityProjectEngineTransport', () => {
       } catch (e) {
         thrown = e;
       }
-      expect(thrown).to.be.an('error');
-      expect(thrown.message).to.contain('failed: 503');
+      expect(thrown).to.be.instanceOf(ProjectEngineApiError);
+      expect(thrown.status).to.equal(503);
+      expect(thrown.body).to.equal(null);
     });
 
-    it('(g) a rejected fetch (network error) propagates out through unwrap', async () => {
-      const boom = new Error('network down');
+    it('(g) an exhausted-network failure is wrapped: status undefined, body null, cause preserved', async () => {
+      // Injected fetch rejects for an idempotent GET with maxRetries: 0 → createRetryingFetch
+      // rethrows the last raw error; unwrap catches it and wraps it (no HTTP response).
+      const boom = new TypeError('network down');
       const transport = make(sandbox.stub().rejects(boom));
       let thrown;
       try {
@@ -202,7 +216,12 @@ describe('createSerenityProjectEngineTransport', () => {
       } catch (e) {
         thrown = e;
       }
-      expect(thrown).to.equal(boom);
+      expect(thrown).to.be.instanceOf(ProjectEngineApiError);
+      expect(thrown.status).to.equal(undefined);
+      expect(thrown.method).to.equal('GET');
+      expect(thrown.body).to.equal(null);
+      expect(thrown.cause).to.equal(boom);
+      expect(thrown.message).to.equal('Project Engine GET request failed');
     });
   });
 });

--- a/packages/spacecat-shared-project-engine-client/test/types/errors.type-test.ts
+++ b/packages/spacecat-shared-project-engine-client/test/types/errors.type-test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Compile-only type test for the PUBLIC `ProjectEngineApiError` surface (`src/index.d.ts`). It is
+ * type-checked by `npm run test:types` (tsc --noEmit); it emits nothing and is not run by mocha.
+ */
+
+import { ProjectEngineApiError } from '../../src/index.js';
+
+// 1. It is importable from the public entry and is an Error subclass.
+const err = new ProjectEngineApiError(404, 'GET', { detail: 'nope' });
+const asError: Error = err;
+void asError;
+
+// 2. `status` is `number | undefined` — assignable to that union, and `undefined` is a valid arg.
+const status: number | undefined = err.status;
+void status;
+const networkErr = new ProjectEngineApiError(undefined, 'GET', null, {
+  cause: new Error('down'),
+});
+void networkErr;
+
+// 3. `method` is a string.
+const method: string = err.method;
+void method;
+
+// 4. `body` is `unknown` — usable only after narrowing (so it is NOT `any`).
+const body: unknown = err.body;
+void body;
+// @ts-expect-error — `body` is `unknown`, not `any`: property access must be narrowed first.
+void err.body.detail;
+
+// 5. Canary: a bogus field must be rejected (proves the class is precisely typed, not `any`).
+// @ts-expect-error — `frobnicate` is not a field of ProjectEngineApiError.
+void err.frobnicate;


### PR DESCRIPTION
## What

Introduces a typed error `ProjectEngineApiError extends Error` carrying `{ status, method, body }`, and routes the facade's single `unwrap` seam (`src/rest-transport.js`) through it — replacing the plain `throw new Error(...)` left by the LLMO-5977 facade.

- **New `src/errors.js`** — `class ProjectEngineApiError extends Error`, constructed `(status, method, body, options)`:
  - `status`: `number | undefined` (undefined = no HTTP response, i.e. network/timeout).
  - `method`: the HTTP method string.
  - `body`: the normalized parsed error body (`unknown | null`).
  - `options`: optional `{ cause }` forwarded to `super(message, options)` so a wrapped network error keeps its `cause`.
  - Message: `Project Engine ${method} request failed with status ${status}` for an HTTP error, `Project Engine ${method} request failed` when there is no status.
  - Sets `this.name = 'ProjectEngineApiError'` and own `this.status` / `this.method` / `this.body`.

## The single seam, two paths

`unwrap` remains the ONE place a failure becomes a throw, now covering both:

- **non-2xx HTTP response** → `new ProjectEngineApiError(response.status, method, body)`, where `body = error ?? data ?? null` (openapi-fetch puts the parsed error body in `error`) and an empty-string body `''` normalizes to `null`.
- **exhausted-network / per-attempt-timeout** → the awaited result promise rejects (createRetryingFetch rethrows the last raw error after the retry budget); the seam catches it and throws `new ProjectEngineApiError(undefined, method, null, { cause })`, preserving the original as `cause`.

The 28 method bodies, names, and signatures are untouched; no second throw site was added.

## Deliberately NOT changed: `internal.js`

`src/internal.js` stays framework-agnostic and keeps rethrowing the raw last error; the facade seam wraps it. The ticket's stale `internal.js:227` reference predates the 5977 facade — the single-seam design supersedes it.

## Follow-up implication

Typed errors are a **facade guarantee**. Direct users of the raw `createSerenityProjectEngineApiClient` client (the ~77 non-facade operations) still receive raw network errors / `{ data, error, response }` — they do not flow through `unwrap`.

## Exports & types

- `ProjectEngineApiError` exported from `src/index.js`.
- Declared in `src/index.d.ts` with `readonly status: number | undefined`, `readonly method: string`, `readonly body: unknown` (no `any` on public fields).

## Tests / gates

- `test/rest-transport.test.js` — seam cases updated for the typed error (non-2xx with body / empty-string body / both-absent → null; exhausted-network → status undefined + cause).
- `test/errors.test.js` — direct construction (both message branches, `options.cause`, `instanceof`).
- `test/types/errors.type-test.ts` — public import, typed fields (`status: number | undefined`, `body: unknown`), `@ts-expect-error` canaries.
- lint ✓ · tests 311 passing, 100% lines/statements/branches ✓ · `tsc` ✓

Stacked on `llmo-5977-facade`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Design / spec (PR template §4)

Design basis: **ADR-0001 — Ownership boundary for the shared Semrush client** (`docs/adr/0001-shared-semrush-client-ownership.md`, ticket LLMO-5975, *Accepted*). This PR implements the follow-on work the ADR names for **LLMO-5978**: the shared client owns transport (auth/retry/timeout/typed-error taxonomy); consumers own error→HTTP translation, caching, redaction.



## Release note

Behavior change: transport failures now throw `ProjectEngineApiError` (with `{ status, method, body }`) instead of a plain `Error`, and the message format changed from `"... failed: <status>"` to `"... request failed with status <status>"`. Consumers should switch to `instanceof ProjectEngineApiError` rather than regex-matching the message.
