### PR TITLE
feat(akamai-client): OAE rule-tree helpers + updateRuleTree dryRun

### DIFF
--- a/packages/spacecat-shared-akamai-client/src/akamai-client.js
+++ b/packages/spacecat-shared-akamai-client/src/akamai-client.js
@@ -79,6 +79,42 @@ export function normalizeDomain(domain) {
 }
 
 /**
+ * True if the property's default (top-level) rule already has a Caching behavior.
+ *
+ * Cache ID Modification requires a Caching behavior to be in scope. When the default rule
+ * provides one, an Optimize-at-Edge rule must NOT add its own — an OAE-rule Caching would
+ * override the property's HTML no-store and make the optimized path cacheable. When the default
+ * rule has none, the OAE rule must add a Caching behavior so Cache ID Modification validates.
+ *
+ * @param {object} ruleTree - a PAPI rule tree ({ rules: { behaviors: [...] } })
+ * @returns {boolean}
+ */
+export function defaultRuleHasCaching(ruleTree) {
+  const behaviors = ruleTree?.rules?.behaviors;
+  return Array.isArray(behaviors) && behaviors.some((b) => b?.name === 'caching');
+}
+
+/**
+ * The default rule's Origin Server SSL verification settings.
+ *
+ * An Optimize-at-Edge origin's verificationMode must match the default rule's, otherwise PAPI
+ * rejects the tree ("Use Platform Settings ... not compatible with the custom settings"). Callers
+ * mirror these onto the OAE origin, and can gate onboarding on the mode (e.g. CUSTOM only).
+ *
+ * @param {object} ruleTree - a PAPI rule tree ({ rules: { behaviors: [...] } })
+ * @returns {{verificationMode: (string|undefined), originCertsToHonor: (string|undefined),
+ *   standardCertificateAuthorities: (string[]|undefined)}|null} null when no origin behavior exists
+ */
+export function getDefaultOriginSsl(ruleTree) {
+  const origin = (ruleTree?.rules?.behaviors || []).find((b) => b?.name === 'origin');
+  if (!origin || !origin.options) {
+    return null;
+  }
+  const { verificationMode, originCertsToHonor, standardCertificateAuthorities } = origin.options;
+  return { verificationMode, originCertsToHonor, standardCertificateAuthorities };
+}
+
+/**
  * A thin client for Akamai's Property Manager API (PAPI), authenticated with
  * the EdgeGrid (EG1-HMAC-SHA256) scheme.
  *
@@ -422,9 +458,21 @@ export default class AkamaiClient {
    * @param {string} groupId
    * @param {object} ruleTree
    * @param {string} [ruleFormat]
+   * @param {object} [options]
+   * @param {boolean} [options.dryRun] - validate the submitted tree without persisting it. PAPI
+   *   still requires an EDITABLE (inactive) version — an activation-locked version returns 403
+   *   "already-activated" even for a dry run.
    * @returns {Promise<object>}
    */
-  async updateRuleTree(propertyId, version, contractId, groupId, ruleTree, ruleFormat) {
+  async updateRuleTree(
+    propertyId,
+    version,
+    contractId,
+    groupId,
+    ruleTree,
+    ruleFormat,
+    options = {},
+  ) {
     requirePropertyRef(propertyId, contractId, groupId);
     if (!Number.isInteger(version)) {
       throw new Error('version must be an integer');
@@ -439,15 +487,15 @@ export default class AkamaiClient {
     const headers = ruleFormat
       ? { 'Content-Type': `application/vnd.akamai.papirules.${ruleFormat}+json` }
       : undefined;
-    this.log.info(`Updating rule tree for property ${propertyId} v${version}`);
+    const params = { contractId, groupId, validateRules: 'true' };
+    if (options.dryRun) {
+      params.dryRun = 'true';
+    }
+    this.log.info(`Updating rule tree for property ${propertyId} v${version}${options.dryRun ? ' (dry run)' : ''}`);
     return this.#request(
       'PUT',
       `/papi/v1/properties/${id}/versions/${version}/rules`,
-      {
-        params: { contractId, groupId, validateRules: 'true' },
-        body: ruleTree,
-        headers,
-      },
+      { params, body: ruleTree, headers },
     );
   }
 

--- a/packages/spacecat-shared-akamai-client/src/index.d.ts
+++ b/packages/spacecat-shared-akamai-client/src/index.d.ts
@@ -103,6 +103,7 @@ export default class AkamaiClient {
     groupId: string,
     ruleTree: object,
     ruleFormat?: string,
+    options?: { dryRun?: boolean },
   ): Promise<object>;
 
   patchRuleTree(

--- a/packages/spacecat-shared-akamai-client/src/index.d.ts
+++ b/packages/spacecat-shared-akamai-client/src/index.d.ts
@@ -12,6 +12,16 @@
 
 export function normalizeDomain(domain: string): string;
 
+export function defaultRuleHasCaching(ruleTree: object): boolean;
+
+export interface DefaultOriginSsl {
+  verificationMode?: string;
+  originCertsToHonor?: string;
+  standardCertificateAuthorities?: string[];
+}
+
+export function getDefaultOriginSsl(ruleTree: object): DefaultOriginSsl | null;
+
 export interface AkamaiClientConfig {
   host: string;
   clientToken: string;

--- a/packages/spacecat-shared-akamai-client/src/index.js
+++ b/packages/spacecat-shared-akamai-client/src/index.js
@@ -10,7 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
-import AkamaiClient, { normalizeDomain } from './akamai-client.js';
+import AkamaiClient, {
+  normalizeDomain,
+  defaultRuleHasCaching,
+  getDefaultOriginSsl,
+} from './akamai-client.js';
 
-export { normalizeDomain };
+export { normalizeDomain, defaultRuleHasCaching, getDefaultOriginSsl };
 export default AkamaiClient;

--- a/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
+++ b/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
@@ -16,7 +16,11 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import nock from 'nock';
 
-import AkamaiClient, { normalizeDomain } from '../src/index.js';
+import AkamaiClient, {
+  normalizeDomain,
+  defaultRuleHasCaching,
+  getDefaultOriginSsl,
+} from '../src/index.js';
 
 use(chaiAsPromised);
 use(sinonChai);
@@ -830,6 +834,55 @@ describe('AkamaiClient', () => {
 
     it('returns an empty string for a falsy input', () => {
       expect(normalizeDomain(undefined)).to.equal('');
+    });
+  });
+
+  // ─── defaultRuleHasCaching ──────────────────────────────────────────────
+
+  describe('defaultRuleHasCaching', () => {
+    it('is true when the default rule has a caching behavior', () => {
+      const tree = { rules: { behaviors: [{ name: 'origin' }, { name: 'caching' }] } };
+      expect(defaultRuleHasCaching(tree)).to.be.true;
+    });
+
+    it('is false when the default rule has no caching behavior', () => {
+      const tree = { rules: { behaviors: [{ name: 'origin' }] } };
+      expect(defaultRuleHasCaching(tree)).to.be.false;
+    });
+
+    it('is false for a malformed or empty tree', () => {
+      expect(defaultRuleHasCaching(null)).to.be.false;
+      expect(defaultRuleHasCaching({})).to.be.false;
+      expect(defaultRuleHasCaching({ rules: {} })).to.be.false;
+    });
+  });
+
+  // ─── getDefaultOriginSsl ────────────────────────────────────────────────
+
+  describe('getDefaultOriginSsl', () => {
+    it('returns the default origin SSL verification settings', () => {
+      const tree = {
+        rules: {
+          behaviors: [{
+            name: 'origin',
+            options: {
+              verificationMode: 'CUSTOM',
+              originCertsToHonor: 'STANDARD_CERTIFICATE_AUTHORITIES',
+              standardCertificateAuthorities: ['akamai-permissive', 'THIRD_PARTY_AMAZON'],
+            },
+          }],
+        },
+      };
+      expect(getDefaultOriginSsl(tree)).to.deep.equal({
+        verificationMode: 'CUSTOM',
+        originCertsToHonor: 'STANDARD_CERTIFICATE_AUTHORITIES',
+        standardCertificateAuthorities: ['akamai-permissive', 'THIRD_PARTY_AMAZON'],
+      });
+    });
+
+    it('returns null when there is no origin behavior or the tree is malformed', () => {
+      expect(getDefaultOriginSsl({ rules: { behaviors: [{ name: 'caching' }] } })).to.be.null;
+      expect(getDefaultOriginSsl(null)).to.be.null;
     });
   });
 });

--- a/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
+++ b/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
@@ -904,5 +904,10 @@ describe('AkamaiClient', () => {
       expect(getDefaultOriginSsl({ rules: { behaviors: [{ name: 'caching' }] } })).to.be.null;
       expect(getDefaultOriginSsl(null)).to.be.null;
     });
+
+    it('returns null when the origin behavior has no options key', () => {
+      // A PAPI response can carry an origin behavior with no `options` (distinct from no origin).
+      expect(getDefaultOriginSsl({ rules: { behaviors: [{ name: 'origin' }] } })).to.be.null;
+    });
   });
 });

--- a/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
+++ b/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
@@ -528,6 +528,26 @@ describe('AkamaiClient', () => {
       expect(result).to.deep.equal({ errors: [] });
     });
 
+    it('adds dryRun=true to the query when options.dryRun is set', async () => {
+      nock(API_BASE)
+        .put(`/papi/v1/properties/${PROPERTY_ID}/versions/6/rules`)
+        .query({
+          contractId: CONTRACT_ID, groupId: GROUP_ID, validateRules: 'true', dryRun: 'true',
+        })
+        .reply(200, { errors: [], warnings: [] });
+
+      const result = await client.updateRuleTree(
+        PROPERTY_ID,
+        6,
+        CONTRACT_ID,
+        GROUP_ID,
+        { rules: {} },
+        undefined,
+        { dryRun: true },
+      );
+      expect(result).to.deep.equal({ errors: [], warnings: [] });
+    });
+
     it('throws when version is not an integer', async () => {
       await expect(client.updateRuleTree(PROPERTY_ID, '6', CONTRACT_ID, GROUP_ID, { rules: {} }))
         .to.be.rejectedWith('version must be an integer');


### PR DESCRIPTION
Squash-collapses the OAE onboarding work onto a fresh `feat/akamai-oae-automation` branch (cut from `main`) so the review PR (`feat/akamai-oae-automation` → `main`) shows a single commit for senior review.

**Squash-merge** this PR — that puts one commit on `feat/akamai-oae-automation`. Full context lives in the automation → main review PR.