### PR TITLE
feat(data-access): canonical v2 changeDetails schema + validator for FixEntity (SITES-47997)

### DIFF
--- a/packages/spacecat-shared-data-access/CLAUDE.md
+++ b/packages/spacecat-shared-data-access/CLAUDE.md
@@ -247,6 +247,43 @@ Consumer adoption (bump + route writes + warn→enforce) is tracked in SITES-472
 
 [adobe/mysticat-architecture#174]: https://github.com/adobe/mysticat-architecture/blob/main/platform/decisions/design-suggestion-fix-entity-status-lifecycle.md
 
+## Deploy-action `changeDetails` v2 (SITES-47997)
+
+`FixEntity.changeDetails` has a canonical **v2 shape** — the structured,
+validated "deploy action" record (who/when/what/which-pages/result) from ADR
+[adobe/mysticat-architecture#200]. It is defined in
+`src/models/fix-entity/change-details.schema.js` (Joi) and wired into the
+`changeDetails` attribute validator.
+
+- **Reader-tolerant / additive.** The DB column stays `type: 'any'` — no
+  migration. Records **without `schemaVersion: 2`** are legacy freeform (v1) and
+  keep the old non-empty-object guard; only `schemaVersion: 2` records are
+  schema-validated. This runs on the **create** path (`#validateItem` →
+  `collection.create`), not on `save()` updates.
+- **Shape.** `{ schemaVersion: 2, surface, actorType, target, result? }`.
+  `target` = the proposal (intent): `changeType` + `changes[{ targetPath,
+  property, intendedValue }]`. `result` = the outcome: `callStatus`
+  (`success|no_op|client_error|server_error|timeout`), `applied`
+  (**enum `ALL|PARTIAL|NONE`, not a boolean**), `changeResults[]` (key-matched to
+  `target.changes` by `(targetPath, property)`), `pre/postVerify` verdicts, and
+  `deployResponsePayload` (**≤ 4 KB cap**) + `deployResponseSha256` (hex).
+- **APIs** (exported from the package root):
+  - `validateChangeDetails(value)` — the attribute validator; `false` on a
+    non-object, `true` for legacy/valid-v2, **throws** with a descriptive message
+    on an invalid v2 record.
+  - `changeDetailsV2Schema` — the raw Joi `ObjectSchema` (strict; unknown keys
+    rejected) for consumers that want to validate directly.
+  - `FixEntity.CHANGE_DETAILS` — the enum bundle (`SURFACES`, `ACTOR_TYPES`,
+    `CALL_STATUSES`, `APPLIED`, `CHANGE_RESULT_STATUSES`, `VERIFY_VERDICTS`,
+    `SCHEMA_VERSION`, `DEPLOY_RESPONSE_PAYLOAD_MAX_BYTES`). Kept on the model
+    (not the barrel) to avoid collisions on these generic names.
+- **Not yet done** (tracked on SITES-47997): the `publishedBy` column +
+  `executedBy/At` → `deployedBy/At` rename (dual-write, needs a companion
+  mysticat-data-service migration), and gating the `DEPLOYED`/`PUBLISHED`
+  transition on `result` presence (extends the SITES-47091 guard).
+
+[adobe/mysticat-architecture#200]: https://github.com/adobe/mysticat-architecture/blob/main/platform/decisions/deploy-action-provenance-and-verify.md
+
 ## Site Config: Import Types
 
 Site configuration lives in `src/models/site/config.js` and defines the available import types, their validation schemas, and default configs. This is one of the most frequently changed files in the package.

--- a/packages/spacecat-shared-data-access/src/models/fix-entity/change-details.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/fix-entity/change-details.schema.js
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import Joi from 'joi';
+import { isNonEmptyObject } from '@adobe/spacecat-shared-utils';
+
+/**
+ * Canonical v2 shape for `FixEntity.changeDetails` — the structured, validated
+ * "deploy action" record defined by ADR
+ * adobe/mysticat-architecture#200 (platform/decisions/deploy-action-provenance-and-verify.md,
+ * SITES-47997): *who* deployed/published, *when*, *what entity/property* is
+ * proposed to change, *which pages* are affected, and *the result of the call*.
+ *
+ * The DB column stays `type: 'any'` (no destructive migration); this module is
+ * the machine-readable schema the JS write chokepoint validates against, so the
+ * freeform bag cannot silently drift across the two runtimes (autofix-worker JS
+ * + mystique Python). Records without `schemaVersion === 2` are legacy freeform
+ * (v1) and are intentionally NOT schema-validated — the migration is additive
+ * and reader-tolerant (ADR "V1 / V2 backwards compatibility").
+ */
+
+export const CHANGE_DETAILS_SCHEMA_VERSION = 2;
+
+// Deploy CHANNEL / "where" the fix went live.
+export const SURFACES = {
+  ASO: 'ASO',
+  AUTHOR_PUBLISH: 'AUTHOR_PUBLISH',
+  GIT_MERGE: 'GIT_MERGE',
+  SYSTEM: 'SYSTEM',
+};
+
+// WHO acted. Orthogonal to `surface` — DETECTOR is an actor (an audit that
+// observed a live fix), not a deploy channel, so it is an actorType not a surface.
+export const ACTOR_TYPES = {
+  IMS_USER: 'IMS_USER',
+  SERVICE: 'SERVICE',
+  GITHUB: 'GITHUB',
+  DETECTOR: 'DETECTOR',
+  UNKNOWN: 'UNKNOWN',
+};
+
+// Classified outcome of the deploy/apply call — transport-agnostic (JCR writes
+// and git ops classify the same way HTTP does). Set independently by the
+// transport adapter; NOT derived from `changeResults`. `no_op` is the case
+// SITES-47077 / SITES-47078 silently mis-read as success.
+export const CALL_STATUSES = {
+  SUCCESS: 'success',
+  NO_OP: 'no_op',
+  CLIENT_ERROR: 'client_error',
+  SERVER_ERROR: 'server_error',
+  TIMEOUT: 'timeout',
+};
+
+// Whole-action roll-up of the per-change `changeResults[].status`. NOT a boolean
+// — a deploy action may write >1 property, so "2-of-3" is first-class.
+export const APPLIED = {
+  ALL: 'ALL',
+  PARTIAL: 'PARTIAL',
+  NONE: 'NONE',
+};
+
+// Per-change outcome, key-matched to `target.changes` by (targetPath, property).
+export const CHANGE_RESULT_STATUSES = {
+  APPLIED: 'applied',
+  UNCHANGED: 'unchanged',
+  FAILED: 'failed',
+};
+
+// Verify verdict. Distinguishes NEGATIVE (`rejected` — verify ran, the change did
+// not render as expected → revert-eligible) from ERRORED (`verify_failed` —
+// verify could not complete → MUST NOT auto-revert). Mirrors the post-verify POC.
+export const VERIFY_VERDICTS = {
+  VERIFIED: 'verified',
+  REJECTED: 'rejected',
+  INCONCLUSIVE: 'inconclusive',
+  VERIFY_FAILED: 'verify_failed',
+};
+
+// `deployResponsePayload` size cap (bytes). MUST hold on a shared DB column — one
+// runaway payload degrades read latency for every consumer. Writers hash-first,
+// then cap/redact, so `deployResponseSha256` always covers the pre-redact payload.
+export const DEPLOY_RESPONSE_PAYLOAD_MAX_BYTES = 4096;
+
+const enumValues = (obj) => Object.values(obj);
+
+const byteLength = (value) => Buffer.byteLength(
+  typeof value === 'string' ? value : JSON.stringify(value ?? ''),
+  'utf8',
+);
+
+const verdictBase = {
+  verdict: Joi.string().valid(...enumValues(VERIFY_VERDICTS)).required(),
+  reasonCode: Joi.string(),
+  evidence: Joi.any(),
+};
+
+const preVerifySchema = Joi.object({
+  ...verdictBase,
+  preVerifiedAt: Joi.string().isoDate(),
+});
+
+const postVerifySchema = Joi.object({
+  ...verdictBase,
+  revert: Joi.any(),
+  postVerifiedAt: Joi.string().isoDate(),
+});
+
+// The PROPOSAL — intent only (`intendedValue`). Baseline (`previousValue`) and
+// observed outcome (`appliedValue`, `status`) live per-change in `changeResults`.
+const targetChangeSchema = Joi.object({
+  targetPath: Joi.string().required(),
+  property: Joi.string().required(),
+  intendedValue: Joi.any().required(),
+});
+
+const changeResultSchema = Joi.object({
+  targetPath: Joi.string().required(),
+  property: Joi.string().required(),
+  previousValue: Joi.any(),
+  appliedValue: Joi.any(),
+  status: Joi.string().valid(...enumValues(CHANGE_RESULT_STATUSES)).required(),
+});
+
+const targetSchema = Joi.object({
+  system: Joi.string(),
+  changeType: Joi.string().required(),
+  siteId: Joi.string(),
+  pageId: Joi.string(),
+  documentPath: Joi.string(),
+  detectedPageAuthorUrl: Joi.string(),
+  changes: Joi.array().items(targetChangeSchema).min(1).required(),
+});
+
+const resultSchema = Joi.object({
+  callStatus: Joi.string().valid(...enumValues(CALL_STATUSES)).required(),
+  applied: Joi.string().valid(...enumValues(APPLIED)).required(),
+  deployResponsePayload: Joi.any().custom((value, helpers) => {
+    let size;
+    try {
+      size = byteLength(value);
+    } catch {
+      // Un-serializable payload (e.g. a circular reference) — it must be
+      // serialized/truncated into deployResponseSha256 at the write chokepoint
+      // before persist, so reject it here rather than throw a raw TypeError.
+      return helpers.error('any.invalid');
+    }
+    if (size > DEPLOY_RESPONSE_PAYLOAD_MAX_BYTES) {
+      return helpers.error('any.invalid');
+    }
+    return value;
+  }).messages({
+    'any.invalid': `result.deployResponsePayload exceeds ${DEPLOY_RESPONSE_PAYLOAD_MAX_BYTES} bytes; hash it into deployResponseSha256 and truncate at the write chokepoint`,
+  }),
+  deployResponseSha256: Joi.string().pattern(/^[a-f0-9]{64}$/i),
+  changeResults: Joi.array().items(changeResultSchema),
+  preVerify: preVerifySchema,
+  postVerify: postVerifySchema,
+});
+
+// Composite match key for (targetPath, property). JSON.stringify gives an
+// unambiguous, collision-safe delimiter regardless of what the strings contain.
+const changeKey = (change) => JSON.stringify([change.targetPath, change.property]);
+
+/**
+ * Canonical Joi schema for a v2 `changeDetails` record. Strict (unknown keys are
+ * rejected) so v2 writers cannot re-introduce freeform drift.
+ */
+export const changeDetailsV2Schema = Joi.object({
+  schemaVersion: Joi.number().valid(CHANGE_DETAILS_SCHEMA_VERSION).required(),
+  surface: Joi.string().valid(...enumValues(SURFACES)).required(),
+  actorType: Joi.string().valid(...enumValues(ACTOR_TYPES)).required(),
+  target: targetSchema.required(),
+  result: resultSchema,
+}).custom((value, helpers) => {
+  // Blocking constraint: `result.changeResults` and `target.changes` MUST
+  // key-match by (targetPath, property) — not positional — so a writer that
+  // skips or reorders an entry cannot silently misalign the proposal (intent)
+  // against the observed outcome. When either side is absent the required-field
+  // rules already reject the record, so we only cross-check once both are arrays.
+  const changeResults = value.result?.changeResults;
+  const changes = value.target?.changes;
+  if (Array.isArray(changeResults) && Array.isArray(changes)) {
+    const intentKeys = new Set(changes.map(changeKey));
+    // (a) no orphan outcome — every changeResult maps to a proposed change.
+    if (changeResults.some((r) => !intentKeys.has(changeKey(r)))) {
+      return helpers.message('result.changeResults contains an entry with no matching target.changes (targetPath, property)');
+    }
+    // (b) completeness for a whole-action success — `applied: ALL` claims every
+    // proposed change landed, so each MUST have a recorded outcome. PARTIAL/NONE
+    // legitimately omit entries, so they are not held to this.
+    if (value.result.applied === APPLIED.ALL) {
+      const resultKeys = new Set(changeResults.map(changeKey));
+      if (changes.some((c) => !resultKeys.has(changeKey(c)))) {
+        return helpers.message('result.applied is ALL but a target.changes entry has no matching result.changeResults');
+      }
+    }
+  }
+  return value;
+});
+
+/**
+ * Validator for the `FixEntity.changeDetails` attribute. Reader-tolerant:
+ * legacy freeform records (schemaVersion absent or !== 2) keep the pre-existing
+ * non-empty-object guard; v2 records are validated against {@link changeDetailsV2Schema}.
+ *
+ * @param {*} value - the changeDetails value being persisted.
+ * @returns {boolean} true when valid (schema builders treat `false` as a failure).
+ * @throws {Error} with a descriptive message when a v2 record is invalid.
+ */
+export function validateChangeDetails(value) {
+  if (!isNonEmptyObject(value)) {
+    return false;
+  }
+  // Only an ABSENT schemaVersion (or an explicit v1) is legacy freeform, per the
+  // ADR ("absent/1 ⇒ legacy freeform"). Anything else is claiming to be
+  // structured, so it MUST run through the v2 schema — a stray `schemaVersion:
+  // '2'` (int-vs-string drift) or a future version must never silently pass.
+  const { schemaVersion } = value;
+  if (schemaVersion === undefined || schemaVersion === null
+    || schemaVersion === 1 || schemaVersion === '1') {
+    return true;
+  }
+  const { error } = changeDetailsV2Schema.validate(value, { abortEarly: false });
+  if (error) {
+    throw new Error(`changeDetails (v2) invalid: ${error.message}`);
+  }
+  return true;
+}
+
+/**
+ * Bundle of the v2 changeDetails enums + limits, attached to the FixEntity model
+ * as `FixEntity.CHANGE_DETAILS` (mirrors `FixEntity.STATUSES`). Kept off the
+ * package root barrel to avoid collisions on these generic names.
+ */
+export const CHANGE_DETAILS = {
+  SCHEMA_VERSION: CHANGE_DETAILS_SCHEMA_VERSION,
+  SURFACES,
+  ACTOR_TYPES,
+  CALL_STATUSES,
+  APPLIED,
+  CHANGE_RESULT_STATUSES,
+  VERIFY_VERDICTS,
+  DEPLOY_RESPONSE_PAYLOAD_MAX_BYTES,
+};

--- a/packages/spacecat-shared-data-access/src/models/fix-entity/change-details.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/fix-entity/change-details.schema.js
@@ -175,7 +175,11 @@ const changeKey = (change) => JSON.stringify([change.targetPath, change.property
  * rejected) so v2 writers cannot re-introduce freeform drift.
  */
 export const changeDetailsV2Schema = Joi.object({
-  schemaVersion: Joi.number().valid(CHANGE_DETAILS_SCHEMA_VERSION).required(),
+  // `.strict()` — no type coercion: writers MUST pass the integer 2, never the
+  // string '2'. A coerced-then-persisted '2' would read as legacy (!= 2) in
+  // mystique's Python runtime, the exact cross-runtime divergence this
+  // discriminator exists to prevent.
+  schemaVersion: Joi.number().valid(CHANGE_DETAILS_SCHEMA_VERSION).strict().required(),
   surface: Joi.string().valid(...enumValues(SURFACES)).required(),
   actorType: Joi.string().valid(...enumValues(ACTOR_TYPES)).required(),
   target: targetSchema.required(),
@@ -188,16 +192,21 @@ export const changeDetailsV2Schema = Joi.object({
   // rules already reject the record, so we only cross-check once both are arrays.
   const changeResults = value.result?.changeResults;
   const changes = value.target?.changes;
+  const appliedAll = value.result?.applied === APPLIED.ALL;
+  // (a) `applied: ALL` claims every proposed change landed, so it MUST carry the
+  // per-change evidence — an ALL with no changeResults is an unfalsifiable claim.
+  if (appliedAll && !Array.isArray(changeResults)) {
+    return helpers.message('result.applied is ALL but result.changeResults is missing');
+  }
   if (Array.isArray(changeResults) && Array.isArray(changes)) {
     const intentKeys = new Set(changes.map(changeKey));
-    // (a) no orphan outcome — every changeResult maps to a proposed change.
+    // (b) no orphan outcome — every changeResult maps to a proposed change.
     if (changeResults.some((r) => !intentKeys.has(changeKey(r)))) {
       return helpers.message('result.changeResults contains an entry with no matching target.changes (targetPath, property)');
     }
-    // (b) completeness for a whole-action success — `applied: ALL` claims every
-    // proposed change landed, so each MUST have a recorded outcome. PARTIAL/NONE
-    // legitimately omit entries, so they are not held to this.
-    if (value.result.applied === APPLIED.ALL) {
+    // (c) completeness for a whole-action success — every proposed change MUST
+    // have a recorded outcome. PARTIAL/NONE legitimately omit entries.
+    if (appliedAll) {
       const resultKeys = new Set(changeResults.map(changeKey));
       if (changes.some((c) => !resultKeys.has(changeKey(c)))) {
         return helpers.message('result.applied is ALL but a target.changes entry has no matching result.changeResults');

--- a/packages/spacecat-shared-data-access/src/models/fix-entity/fix-entity.model.js
+++ b/packages/spacecat-shared-data-access/src/models/fix-entity/fix-entity.model.js
@@ -12,6 +12,7 @@
 import BaseModel from '../base/base.model.js';
 import { guardTransition } from '../../util/status-transition-guard.js';
 import { isAllowedFixTransition } from './fix-entity.transitions.js';
+import { CHANGE_DETAILS } from './change-details.schema.js';
 
 /**
  * FixEntity - A class representing a FixEntity for a Suggestion.
@@ -40,6 +41,10 @@ class FixEntity extends BaseModel {
     ASO: 'aso',
     REPORTING: 'reporting',
   };
+
+  // Canonical v2 changeDetails enums + limits (SITES-47997, ADR
+  // adobe/mysticat-architecture#200). e.g. FixEntity.CHANGE_DETAILS.SURFACES.ASO.
+  static CHANGE_DETAILS = CHANGE_DETAILS;
 
   /**
    * Sets the fix status, guarding the transition against the canonical table

--- a/packages/spacecat-shared-data-access/src/models/fix-entity/fix-entity.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/fix-entity/fix-entity.schema.js
@@ -10,12 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-import { isIsoDate, isNonEmptyObject } from '@adobe/spacecat-shared-utils';
+import { isIsoDate } from '@adobe/spacecat-shared-utils';
 
 import SchemaBuilder from '../base/schema.builder.js';
 import FixEntity from './fix-entity.model.js';
 import FixEntityCollection from './fix-entity.collection.js';
 import Suggestion from '../suggestion/suggestion.model.js';
+import { validateChangeDetails } from './change-details.schema.js';
 
 const schema = new SchemaBuilder(FixEntity, FixEntityCollection)
   .addReference('has_many', 'FixEntitySuggestion', ['updatedAt'], { removeDependents: true })
@@ -39,7 +40,10 @@ const schema = new SchemaBuilder(FixEntity, FixEntityCollection)
   .addAttribute('changeDetails', {
     type: 'any',
     required: true,
-    validate: (value) => isNonEmptyObject(value),
+    // Reader-tolerant: legacy freeform (v1) records keep the non-empty guard;
+    // schemaVersion:2 records are validated against the canonical shape
+    // (SITES-47997, ADR adobe/mysticat-architecture#200).
+    validate: (value) => validateChangeDetails(value),
   })
   .addAttribute('status', {
     type: Object.values(FixEntity.STATUSES),

--- a/packages/spacecat-shared-data-access/src/models/fix-entity/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/fix-entity/index.d.ts
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import type { ObjectSchema } from 'joi';
 import type {
   BaseCollection, BaseModel, Opportunity, Suggestion, FixEntitySuggestion,
 } from '../index';
@@ -52,3 +53,9 @@ export declare function isAllowedFixTransition(
   from: string | null | undefined,
   to: string,
 ): boolean;
+
+// Canonical v2 changeDetails shape + validator (SITES-47997, ADR
+// adobe/mysticat-architecture#200).
+export declare const CHANGE_DETAILS_SCHEMA_VERSION: number;
+export declare const changeDetailsV2Schema: ObjectSchema;
+export declare function validateChangeDetails(value: unknown): boolean;

--- a/packages/spacecat-shared-data-access/src/models/fix-entity/index.js
+++ b/packages/spacecat-shared-data-access/src/models/fix-entity/index.js
@@ -24,3 +24,12 @@ export {
   FIX_ENTITY_CREATE,
   isAllowedFixTransition,
 } from './fix-entity.transitions.js';
+
+// Canonical v2 changeDetails shape + validator (SITES-47997, ADR
+// adobe/mysticat-architecture#200). The generic enum names live on
+// FixEntity.CHANGE_DETAILS to keep them off the package-root barrel.
+export {
+  CHANGE_DETAILS_SCHEMA_VERSION,
+  changeDetailsV2Schema,
+  validateChangeDetails,
+} from './change-details.schema.js';

--- a/packages/spacecat-shared-data-access/test/unit/models/fix-entity/change-details.schema.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/fix-entity/change-details.schema.test.js
@@ -1,0 +1,373 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+
+import {
+  CHANGE_DETAILS_SCHEMA_VERSION,
+  CHANGE_DETAILS,
+  SURFACES,
+  ACTOR_TYPES,
+  CALL_STATUSES,
+  APPLIED,
+  CHANGE_RESULT_STATUSES,
+  VERIFY_VERDICTS,
+  DEPLOY_RESPONSE_PAYLOAD_MAX_BYTES,
+  changeDetailsV2Schema,
+  validateChangeDetails,
+} from '../../../../src/models/fix-entity/change-details.schema.js';
+import FixEntity from '../../../../src/models/fix-entity/fix-entity.model.js';
+
+// Minimal valid v2 record (result is optional at create time).
+const minimal = () => ({
+  schemaVersion: 2,
+  surface: SURFACES.ASO,
+  actorType: ACTOR_TYPES.IMS_USER,
+  target: {
+    changeType: 'alt-text',
+    changes: [{ targetPath: '/content/p', property: 'alt', intendedValue: 'Mia, lawyer.' }],
+  },
+});
+
+// Full valid v2 record with a result block + verify verdicts.
+const full = () => ({
+  ...minimal(),
+  target: {
+    system: 'aem_cs',
+    changeType: 'alt-text',
+    siteId: 'site-1',
+    pageId: 'page-1',
+    documentPath: '/edit/p',
+    detectedPageAuthorUrl: 'https://author/p',
+    changes: [{ targetPath: '/content/p', property: 'alt', intendedValue: 'Mia, lawyer.' }],
+  },
+  result: {
+    callStatus: CALL_STATUSES.SUCCESS,
+    applied: APPLIED.ALL,
+    deployResponsePayload: { status: 200, body: 'ok' },
+    deployResponseSha256: 'a'.repeat(64),
+    changeResults: [{
+      targetPath: '/content/p',
+      property: 'alt',
+      previousValue: '',
+      appliedValue: 'Mia, lawyer.',
+      status: CHANGE_RESULT_STATUSES.APPLIED,
+    }],
+    preVerify: { verdict: VERIFY_VERDICTS.VERIFIED, reasonCode: 'ok', preVerifiedAt: new Date().toISOString() },
+    postVerify: {
+      verdict: VERIFY_VERDICTS.VERIFIED,
+      evidence: { rendered: true },
+      revert: { snapshot: 'x' },
+      postVerifiedAt: new Date().toISOString(),
+    },
+  },
+});
+
+describe('FixEntity changeDetails v2 schema', () => {
+  describe('enums + constants', () => {
+    it('exposes the schema version', () => {
+      expect(CHANGE_DETAILS_SCHEMA_VERSION).to.equal(2);
+    });
+
+    it('bundles enums + limits on CHANGE_DETAILS', () => {
+      expect(CHANGE_DETAILS).to.deep.equal({
+        SCHEMA_VERSION: CHANGE_DETAILS_SCHEMA_VERSION,
+        SURFACES,
+        ACTOR_TYPES,
+        CALL_STATUSES,
+        APPLIED,
+        CHANGE_RESULT_STATUSES,
+        VERIFY_VERDICTS,
+        DEPLOY_RESPONSE_PAYLOAD_MAX_BYTES,
+      });
+    });
+
+    it('is attached to the FixEntity model as a static', () => {
+      expect(FixEntity.CHANGE_DETAILS).to.equal(CHANGE_DETAILS);
+      expect(FixEntity.CHANGE_DETAILS.SURFACES.ASO).to.equal('ASO');
+    });
+
+    it('caps the deploy response payload at 4 KB', () => {
+      expect(DEPLOY_RESPONSE_PAYLOAD_MAX_BYTES).to.equal(4096);
+    });
+  });
+
+  describe('validateChangeDetails - reader tolerance', () => {
+    [null, undefined, '', 0, [], {}].forEach((value) => {
+      it(`returns false for non-object / empty value: ${JSON.stringify(value)}`, () => {
+        expect(validateChangeDetails(value)).to.equal(false);
+      });
+    });
+
+    it('passes a legacy freeform record (no schemaVersion) unchanged', () => {
+      expect(validateChangeDetails({ system: 'aem_cs', targetChanges: [] })).to.equal(true);
+    });
+
+    it('passes a v1 record (schemaVersion: 1) without v2 validation', () => {
+      expect(validateChangeDetails({ schemaVersion: 1, anything: 'goes' })).to.equal(true);
+    });
+
+    it('passes a v1 record with a string schemaVersion "1"', () => {
+      expect(validateChangeDetails({ schemaVersion: '1', anything: 'goes' })).to.equal(true);
+    });
+
+    it('does NOT treat a string schemaVersion "2" as legacy — it is validated as v2', () => {
+      // regression: a stray '2' (int-vs-string drift) must not silently skip validation.
+      expect(() => validateChangeDetails({ schemaVersion: '2', surface: 'BOGUS', junk: true }))
+        .to.throw(/changeDetails \(v2\) invalid/);
+      // a well-formed record with a coercible string version still validates.
+      expect(validateChangeDetails({ ...minimal(), schemaVersion: '2' })).to.equal(true);
+    });
+
+    it('rejects an unknown future schemaVersion (e.g. 3) rather than passing it', () => {
+      expect(() => validateChangeDetails({ ...minimal(), schemaVersion: 3 }))
+        .to.throw(/changeDetails \(v2\) invalid/);
+    });
+  });
+
+  describe('validateChangeDetails - v2 happy path', () => {
+    it('accepts a minimal v2 record (no result yet)', () => {
+      expect(validateChangeDetails(minimal())).to.equal(true);
+    });
+
+    it('accepts a full v2 record with result + verify verdicts', () => {
+      expect(validateChangeDetails(full())).to.equal(true);
+    });
+  });
+
+  describe('validateChangeDetails - v2 rejections', () => {
+    const rejects = (record, match) => {
+      expect(() => validateChangeDetails(record)).to.throw(/changeDetails \(v2\) invalid/);
+      expect(() => validateChangeDetails(record)).to.throw(match);
+    };
+
+    // Each case builds its own record so we never mutate a shared/param object.
+    const withResult = (result) => ({ ...minimal(), result });
+
+    it('rejects an unknown top-level key (strict)', () => {
+      rejects({ ...minimal(), bogus: true }, /bogus/);
+    });
+
+    it('rejects a bad surface', () => {
+      rejects({ ...minimal(), surface: 'NOPE' }, /surface/);
+    });
+
+    it('rejects a bad actorType', () => {
+      rejects({ ...minimal(), actorType: 'NOPE' }, /actorType/);
+    });
+
+    it('rejects a missing target', () => {
+      const record = minimal();
+      delete record.target;
+      rejects(record, /target/);
+    });
+
+    it('rejects a target with no changeType', () => {
+      rejects({
+        ...minimal(),
+        target: { changes: [{ targetPath: '/p', property: 'alt', intendedValue: 'x' }] },
+      }, /changeType/);
+    });
+
+    it('rejects an empty target.changes array', () => {
+      rejects({ ...minimal(), target: { changeType: 'alt-text', changes: [] } }, /changes/);
+    });
+
+    it('rejects a target change missing property', () => {
+      rejects({
+        ...minimal(),
+        target: { changeType: 'alt-text', changes: [{ targetPath: '/p', intendedValue: 'x' }] },
+      }, /property/);
+    });
+
+    it('rejects a target change missing intendedValue', () => {
+      rejects({
+        ...minimal(),
+        target: { changeType: 'alt-text', changes: [{ targetPath: '/p', property: 'alt' }] },
+      }, /intendedValue/);
+    });
+
+    it('rejects a bad result.callStatus', () => {
+      rejects(withResult({ callStatus: 'boom', applied: APPLIED.ALL }), /callStatus/);
+    });
+
+    it('rejects a bad result.applied value', () => {
+      rejects(withResult({ callStatus: CALL_STATUSES.SUCCESS, applied: 'MOSTLY' }), /applied/);
+    });
+
+    it('rejects a bad changeResults status', () => {
+      rejects(withResult({
+        callStatus: CALL_STATUSES.SUCCESS,
+        applied: APPLIED.ALL,
+        changeResults: [{ targetPath: '/content/p', property: 'alt', status: 'weird' }],
+      }), /status/);
+    });
+
+    it('rejects a malformed deployResponseSha256', () => {
+      rejects(withResult({
+        callStatus: CALL_STATUSES.SUCCESS,
+        applied: APPLIED.ALL,
+        deployResponseSha256: 'xyz',
+      }), /deployResponseSha256/);
+    });
+
+    it('rejects a bad preVerify verdict', () => {
+      rejects(withResult({
+        callStatus: CALL_STATUSES.SUCCESS,
+        applied: APPLIED.ALL,
+        preVerify: { verdict: 'meh' },
+      }), /verdict/);
+    });
+
+    it('rejects a non-iso postVerify timestamp', () => {
+      rejects(withResult({
+        callStatus: CALL_STATUSES.SUCCESS,
+        applied: APPLIED.ALL,
+        postVerify: { verdict: VERIFY_VERDICTS.VERIFIED, postVerifiedAt: 'yesterday' },
+      }), /postVerifiedAt/);
+    });
+
+    it('rejects a deployResponsePayload string over the 4 KB cap', () => {
+      rejects(withResult({
+        callStatus: CALL_STATUSES.SUCCESS,
+        applied: APPLIED.ALL,
+        deployResponsePayload: 'x'.repeat(DEPLOY_RESPONSE_PAYLOAD_MAX_BYTES + 1),
+      }), /deployResponsePayload/);
+    });
+
+    it('rejects a deployResponsePayload object over the 4 KB cap', () => {
+      rejects(withResult({
+        callStatus: CALL_STATUSES.SUCCESS,
+        applied: APPLIED.ALL,
+        deployResponsePayload: { blob: 'y'.repeat(DEPLOY_RESPONSE_PAYLOAD_MAX_BYTES) },
+      }), /deployResponsePayload/);
+    });
+
+    it('rejects changeResults with no matching target.changes (key mismatch)', () => {
+      rejects(withResult({
+        callStatus: CALL_STATUSES.SUCCESS,
+        applied: APPLIED.PARTIAL,
+        changeResults: [{ targetPath: '/other', property: 'title', status: CHANGE_RESULT_STATUSES.APPLIED }],
+      }), /no matching target\.changes/);
+    });
+
+    // The key-match cross-check only runs once both sides are arrays; when
+    // target.changes is absent the required-field rule rejects the record first,
+    // so a record with changeResults but no changes still throws (on `changes`).
+    it('falls back to the required-field error when changeResults exist but changes do not', () => {
+      rejects({
+        schemaVersion: 2,
+        surface: SURFACES.ASO,
+        actorType: ACTOR_TYPES.IMS_USER,
+        target: { changeType: 'alt-text' },
+        result: {
+          callStatus: CALL_STATUSES.SUCCESS,
+          applied: APPLIED.PARTIAL,
+          changeResults: [{ targetPath: '/p', property: 'alt', status: CHANGE_RESULT_STATUSES.APPLIED }],
+        },
+      }, /changes/);
+    });
+
+    it('rejects applied:ALL when a proposed change has no recorded outcome', () => {
+      rejects({
+        schemaVersion: 2,
+        surface: SURFACES.ASO,
+        actorType: ACTOR_TYPES.IMS_USER,
+        target: {
+          changeType: 'alt-text',
+          changes: [
+            { targetPath: '/a', property: 'alt', intendedValue: 'x' },
+            { targetPath: '/b', property: 'alt', intendedValue: 'y' },
+          ],
+        },
+        result: {
+          callStatus: CALL_STATUSES.SUCCESS,
+          applied: APPLIED.ALL,
+          changeResults: [{ targetPath: '/a', property: 'alt', status: CHANGE_RESULT_STATUSES.APPLIED }],
+        },
+      }, /applied is ALL/);
+    });
+  });
+
+  describe('deployResponsePayload edge cases', () => {
+    it('accepts a null payload (nullish coalesces to empty)', () => {
+      const record = minimal();
+      record.result = {
+        callStatus: CALL_STATUSES.SUCCESS,
+        applied: APPLIED.NONE,
+        deployResponsePayload: null,
+      };
+      expect(validateChangeDetails(record)).to.equal(true);
+    });
+
+    it('accepts a payload exactly at the cap', () => {
+      const record = minimal();
+      record.result = {
+        callStatus: CALL_STATUSES.SUCCESS,
+        applied: APPLIED.ALL,
+        deployResponsePayload: 'z'.repeat(DEPLOY_RESPONSE_PAYLOAD_MAX_BYTES),
+      };
+      expect(validateChangeDetails(record)).to.equal(true);
+    });
+
+    it('rejects an un-serializable (circular) payload instead of throwing a raw error', () => {
+      const circular = {};
+      circular.self = circular;
+      const record = minimal();
+      record.result = {
+        callStatus: CALL_STATUSES.SUCCESS,
+        applied: APPLIED.NONE,
+        deployResponsePayload: circular,
+      };
+      expect(() => validateChangeDetails(record)).to.throw(/deployResponsePayload/);
+    });
+  });
+
+  describe('applied roll-up completeness', () => {
+    it('accepts applied:PARTIAL that records only the changes that landed', () => {
+      const record = {
+        schemaVersion: 2,
+        surface: SURFACES.ASO,
+        actorType: ACTOR_TYPES.IMS_USER,
+        target: {
+          changeType: 'alt-text',
+          changes: [
+            { targetPath: '/a', property: 'alt', intendedValue: 'x' },
+            { targetPath: '/b', property: 'alt', intendedValue: 'y' },
+          ],
+        },
+        result: {
+          callStatus: CALL_STATUSES.SUCCESS,
+          applied: APPLIED.PARTIAL,
+          changeResults: [{ targetPath: '/a', property: 'alt', status: CHANGE_RESULT_STATUSES.APPLIED }],
+        },
+      };
+      expect(validateChangeDetails(record)).to.equal(true);
+    });
+  });
+
+  describe('changeDetailsV2Schema (direct)', () => {
+    it('validates a full record with no error', () => {
+      const { error } = changeDetailsV2Schema.validate(full());
+      expect(error).to.equal(undefined);
+    });
+
+    it('collects multiple errors with abortEarly:false', () => {
+      const { error } = changeDetailsV2Schema.validate(
+        { schemaVersion: 2, surface: 'NOPE', actorType: 'NOPE' },
+        { abortEarly: false },
+      );
+      expect(error).to.not.equal(undefined);
+      expect(error.details.length).to.be.greaterThan(1);
+    });
+  });
+});

--- a/packages/spacecat-shared-data-access/test/unit/models/fix-entity/change-details.schema.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/fix-entity/change-details.schema.test.js
@@ -124,8 +124,13 @@ describe('FixEntity changeDetails v2 schema', () => {
       // regression: a stray '2' (int-vs-string drift) must not silently skip validation.
       expect(() => validateChangeDetails({ schemaVersion: '2', surface: 'BOGUS', junk: true }))
         .to.throw(/changeDetails \(v2\) invalid/);
-      // a well-formed record with a coercible string version still validates.
-      expect(validateChangeDetails({ ...minimal(), schemaVersion: '2' })).to.equal(true);
+    });
+
+    it('rejects a string schemaVersion "2" even on an otherwise-valid record (no coercion)', () => {
+      // strict discriminator: writers MUST persist the integer 2, never '2', or
+      // mystique's Python `== 2` int-compare would misread it as legacy.
+      expect(() => validateChangeDetails({ ...minimal(), schemaVersion: '2' }))
+        .to.throw(/schemaVersion/);
     });
 
     it('rejects an unknown future schemaVersion (e.g. 3) rather than passing it', () => {
@@ -145,9 +150,18 @@ describe('FixEntity changeDetails v2 schema', () => {
   });
 
   describe('validateChangeDetails - v2 rejections', () => {
+    // Validate once, then assert on the captured error, so a hypothetical
+    // stateful validator can't pass by only failing on the first call.
     const rejects = (record, match) => {
-      expect(() => validateChangeDetails(record)).to.throw(/changeDetails \(v2\) invalid/);
-      expect(() => validateChangeDetails(record)).to.throw(match);
+      let err;
+      try {
+        validateChangeDetails(record);
+      } catch (e) {
+        err = e;
+      }
+      expect(err, 'expected validateChangeDetails to throw').to.be.an('error');
+      expect(err.message).to.match(/changeDetails \(v2\) invalid/);
+      expect(err.message).to.match(match);
     };
 
     // Each case builds its own record so we never mutate a shared/param object.
@@ -197,7 +211,7 @@ describe('FixEntity changeDetails v2 schema', () => {
     });
 
     it('rejects a bad result.callStatus', () => {
-      rejects(withResult({ callStatus: 'boom', applied: APPLIED.ALL }), /callStatus/);
+      rejects(withResult({ callStatus: 'boom', applied: APPLIED.NONE }), /callStatus/);
     });
 
     it('rejects a bad result.applied value', () => {
@@ -215,7 +229,7 @@ describe('FixEntity changeDetails v2 schema', () => {
     it('rejects a malformed deployResponseSha256', () => {
       rejects(withResult({
         callStatus: CALL_STATUSES.SUCCESS,
-        applied: APPLIED.ALL,
+        applied: APPLIED.NONE,
         deployResponseSha256: 'xyz',
       }), /deployResponseSha256/);
     });
@@ -223,7 +237,7 @@ describe('FixEntity changeDetails v2 schema', () => {
     it('rejects a bad preVerify verdict', () => {
       rejects(withResult({
         callStatus: CALL_STATUSES.SUCCESS,
-        applied: APPLIED.ALL,
+        applied: APPLIED.NONE,
         preVerify: { verdict: 'meh' },
       }), /verdict/);
     });
@@ -231,7 +245,7 @@ describe('FixEntity changeDetails v2 schema', () => {
     it('rejects a non-iso postVerify timestamp', () => {
       rejects(withResult({
         callStatus: CALL_STATUSES.SUCCESS,
-        applied: APPLIED.ALL,
+        applied: APPLIED.NONE,
         postVerify: { verdict: VERIFY_VERDICTS.VERIFIED, postVerifiedAt: 'yesterday' },
       }), /postVerifiedAt/);
     });
@@ -239,7 +253,7 @@ describe('FixEntity changeDetails v2 schema', () => {
     it('rejects a deployResponsePayload string over the 4 KB cap', () => {
       rejects(withResult({
         callStatus: CALL_STATUSES.SUCCESS,
-        applied: APPLIED.ALL,
+        applied: APPLIED.NONE,
         deployResponsePayload: 'x'.repeat(DEPLOY_RESPONSE_PAYLOAD_MAX_BYTES + 1),
       }), /deployResponsePayload/);
     });
@@ -247,7 +261,7 @@ describe('FixEntity changeDetails v2 schema', () => {
     it('rejects a deployResponsePayload object over the 4 KB cap', () => {
       rejects(withResult({
         callStatus: CALL_STATUSES.SUCCESS,
-        applied: APPLIED.ALL,
+        applied: APPLIED.NONE,
         deployResponsePayload: { blob: 'y'.repeat(DEPLOY_RESPONSE_PAYLOAD_MAX_BYTES) },
       }), /deployResponsePayload/);
     });
@@ -313,7 +327,7 @@ describe('FixEntity changeDetails v2 schema', () => {
       const record = minimal();
       record.result = {
         callStatus: CALL_STATUSES.SUCCESS,
-        applied: APPLIED.ALL,
+        applied: APPLIED.NONE,
         deployResponsePayload: 'z'.repeat(DEPLOY_RESPONSE_PAYLOAD_MAX_BYTES),
       };
       expect(validateChangeDetails(record)).to.equal(true);
@@ -333,6 +347,25 @@ describe('FixEntity changeDetails v2 schema', () => {
   });
 
   describe('applied roll-up completeness', () => {
+    it('rejects applied:ALL with no changeResults at all (unfalsifiable claim)', () => {
+      const record = minimal();
+      record.result = { callStatus: CALL_STATUSES.SUCCESS, applied: APPLIED.ALL };
+      expect(() => validateChangeDetails(record))
+        .to.throw(/applied is ALL but result\.changeResults is missing/);
+    });
+
+    it('accepts applied:NONE with a non-empty changeResults array (permissive by design)', () => {
+      const record = minimal();
+      record.result = {
+        callStatus: CALL_STATUSES.SERVER_ERROR,
+        applied: APPLIED.NONE,
+        changeResults: [{
+          targetPath: '/content/p', property: 'alt', status: CHANGE_RESULT_STATUSES.FAILED,
+        }],
+      };
+      expect(validateChangeDetails(record)).to.equal(true);
+    });
+
     it('accepts applied:PARTIAL that records only the changes that landed', () => {
       const record = {
         schemaVersion: 2,


### PR DESCRIPTION
## What

Slice 1 of implementing ADR [adobe/mysticat-architecture#200](https://github.com/adobe/mysticat-architecture/blob/main/platform/decisions/deploy-action-provenance-and-verify.md) (*deploy-action, provenance & universal pre/post-verify*, **SITES-47997**): a **machine-readable, validated v2 shape** for `FixEntity.changeDetails` — the structured deploy-action record (*who/when*, *what/which-pages proposed*, *result of the call*).

- **New `change-details.schema.js`** — a Joi schema (`changeDetailsV2Schema`), the `validateChangeDetails` validator, and the enum bundle (`SURFACES`, `ACTOR_TYPES`, `CALL_STATUSES`, `APPLIED`, `CHANGE_RESULT_STATUSES`, `VERIFY_VERDICTS`). Encodes the ADR's blocking constraints:
  - `applied` is the enum **`ALL | PARTIAL | NONE`** (never a boolean)
  - `callStatus` includes **`no_op`** — the case SITES-47077 / SITES-47078 silently mis-read as success
  - `deployResponsePayload` **≤ 4 KB** cap + `deployResponseSha256` hex integrity hash
  - **bidirectional `(targetPath, property)` key-matching** between `target.changes` (intent) and `result.changeResults` (outcome): no orphan outcomes, and `applied: ALL` must record every proposed change
- **Wired into the `changeDetails` attribute validator**, **reader-tolerant**: records without `schemaVersion: 2` keep the pre-existing non-empty-object guard. Additive — the column stays `type: 'any'`, **no migration**. Validation runs on the create path (`#validateItem`), consistent with the other attribute validators.
- **Exposes `FixEntity.CHANGE_DETAILS`** (enum bundle on the model, to keep generic names off the package-root barrel); exports `validateChangeDetails` / `changeDetailsV2Schema` / `CHANGE_DETAILS_SCHEMA_VERSION` at the package root for the SITES-47091 transition guard, the writers (autofix-worker), and mystique to consume.

## Why

The deploy action was an unvalidated freeform `changeDetails` bag with camelCase-vs-snake_case drift across two runtimes and no defined "result of the call" — the systemic root of the confirmed false positives in SITES-47077 / SITES-47078. This makes the shape first-class and validated so those become impossible-by-construction once the guard gates on `result` (later slice).

## Scope / next

This is **slice (a)** of the ADR rollout. Deliberately **not** in this PR:
- `publishedBy` column + `executedBy/At` → `deployedBy/At` rename (dual-write) — needs a companion mysticat-data-service migration
- Gating the `DEPLOYED`/`PUBLISHED` transition on `result` presence — extends the merged SITES-47091 guard
- SITES-47869 status-vocab reconciliation

## Testing

`change-details.schema.test.js` — **100% line/branch coverage**; full fix-entity + suggestion suites green (264 passing), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)