### PR TITLE
feat(data-access): add routingEnabled to edgeOptimizeConfig schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33072,7 +33072,7 @@
     },
     "packages/spacecat-shared-project-engine-client": {
       "name": "@adobe/spacecat-shared-project-engine-client",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "openapi-fetch": "0.17.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,6 +168,24 @@
         "unified": "11.x"
       }
     },
+    "node_modules/@adobe/helix-markdown-support/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/@adobe/helix-markdown-support/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@adobe/helix-markdown-support/node_modules/mdast-util-to-hast": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
@@ -4437,6 +4455,13 @@
         "npm": ">=9.5.0"
       }
     },
+    "node_modules/@redocly/openapi-core/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/@redocly/openapi-core/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4452,6 +4477,19 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@redocly/openapi-core/node_modules/minimatch": {
@@ -8854,6 +8892,13 @@
         "url": "https://github.com/sponsors/pmcelhaney"
       }
     },
+    "node_modules/counterfact/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/counterfact/node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -8883,6 +8928,19 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/counterfact/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/counterfact/node_modules/readdirp": {
@@ -13325,9 +13383,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -13340,6 +13409,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/js2xmlparser": {
@@ -33081,7 +33151,7 @@
         "c8": "11.0.0",
         "chai": "6.2.2",
         "counterfact": "2.14.0",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.0",
         "mocha": "11.7.6",
         "mocha-multi-reporters": "1.5.1",
         "openapi-typescript": "7.13.0",
@@ -37980,7 +38050,7 @@
         "c8": "11.0.0",
         "chai": "6.2.2",
         "counterfact": "2.14.0",
-        "js-yaml": "4.2.0",
+        "js-yaml": "4.3.0",
         "mocha": "11.7.6",
         "mocha-multi-reporters": "1.5.1",
         "openapi-typescript": "7.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28446,7 +28446,7 @@
     },
     "packages/spacecat-shared-data-access": {
       "name": "@adobe/spacecat-shared-data-access",
-      "version": "4.9.0",
+      "version": "4.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/packages/spacecat-shared-data-access/CHANGELOG.md
+++ b/packages/spacecat-shared-data-access/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [@adobe/spacecat-shared-data-access-v4.10.0](https://github.com/adobe/spacecat-shared/compare/@adobe/spacecat-shared-data-access-v4.9.0...@adobe/spacecat-shared-data-access-v4.10.0) (2026-07-20)
+
+### Features
+
+* Add allSiteIdsByTier and allByEnrollmentAndTier collection meth… ([#1569](https://github.com/adobe/spacecat-shared/issues/1569)) ([3ac585b](https://github.com/adobe/spacecat-shared/commit/3ac585bd1b3fe93d32b8d0ad027af81cf6e37830))
+
 ## [@adobe/spacecat-shared-data-access-v4.9.0](https://github.com/adobe/spacecat-shared/compare/@adobe/spacecat-shared-data-access-v4.8.0...@adobe/spacecat-shared-data-access-v4.9.0) (2026-07-15)
 
 ### Features

--- a/packages/spacecat-shared-data-access/package.json
+++ b/packages/spacecat-shared-data-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/spacecat-shared-data-access",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "Shared modules of the Spacecat Services - Data Access",
   "type": "module",
   "engines": {

--- a/packages/spacecat-shared-data-access/src/models/site-enrollment/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/site-enrollment/index.d.ts
@@ -27,6 +27,8 @@ export interface SiteEnrollmentCollection extends
     BaseCollection<SiteEnrollment> {
   allBySiteId(siteId: string): Promise<SiteEnrollment[]>;
   allByEntitlementId(entitlementId: string): Promise<SiteEnrollment[]>;
+  allSiteIdsByProductCode(productCode: string): Promise<string[]>;
+  allSiteIdsByTier(tier: string, productCode?: string): Promise<string[]>;
 
   findBySiteId(siteId: string): Promise<SiteEnrollment | null>;
   findByEntitlementId(entitlementId: string): Promise<SiteEnrollment | null>;

--- a/packages/spacecat-shared-data-access/src/models/site-enrollment/site-enrollment.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/site-enrollment/site-enrollment.collection.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import { hasText } from '@adobe/spacecat-shared-utils';
 import BaseCollection from '../base/base.collection.js';
 import DataAccessError from '../../errors/data-access.error.js';
 
@@ -45,6 +46,39 @@ class SiteEnrollmentCollection extends BaseCollection {
     }
 
     return (data || []).map((row) => row.site_id);
+  }
+
+  /**
+   * Returns all site IDs enrolled at a given entitlement tier (e.g. 'PAID',
+   * 'FREE_TRIAL', 'PLG') in a single JOIN query. Optionally narrows the tier
+   * match to a single product code.
+   *
+   * @param {string} tier - Entitlement tier to filter by.
+   * @param {string} [productCode] - Optional product code to further filter by.
+   * @returns {Promise<string[]>} Array of siteId strings.
+   */
+  async allSiteIdsByTier(tier, productCode) {
+    if (!hasText(tier)) {
+      throw new DataAccessError('tier is required', { entityName: 'SiteEnrollment', tableName: 'site_enrollments' });
+    }
+
+    let query = this.postgrestService
+      .from(this.tableName)
+      .select('site_id, entitlements!inner(tier, product_code)')
+      .eq('entitlements.tier', tier);
+
+    if (productCode) {
+      query = query.eq('entitlements.product_code', productCode);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      this.log.error(`[SiteEnrollmentCollection] Failed to query site_enrollments by tier - ${error.message}`, error);
+      throw new DataAccessError('Failed to query site_enrollments by tier', { entityName: 'SiteEnrollment', tableName: 'site_enrollments' }, error);
+    }
+
+    return [...new Set((data || []).map((row) => row.site_id))];
   }
 
   async create(item, options = {}) {

--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -449,6 +449,7 @@ export const configSchema = Joi.object({
       )
       .optional(),
     opted: Joi.number().optional(),
+    routingEnabled: Joi.boolean().optional(),
     stagingDomains: Joi.array().items(
       Joi.object({
         domain: Joi.string().required(),

--- a/packages/spacecat-shared-data-access/src/models/site/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/site/index.d.ts
@@ -409,6 +409,8 @@ export interface SiteCollection extends BaseCollection<Site> {
   allByProjectName(projectName: string): Promise<Site[]>;
   allByOrganizationIdAndProjectId(organizationId: string, projectId: string): Promise<Site[]>;
   allByOrganizationIdAndProjectName(organizationId: string, projectName: string): Promise<Site[]>;
+  allByEnrollmentProductCode(productCode: string, options?: object): Promise<Site[]>;
+  allByEnrollmentAndTier(tier: string, productCode?: string, options?: object): Promise<Site[]>;
   allSitesToAudit(): Promise<string[]>;
   allWithLatestAudit(auditType: string, order?: string, deliveryType?: string): Promise<Site[]>;
   findByBaseURL(baseURL: string): Promise<Site | null>;

--- a/packages/spacecat-shared-data-access/src/models/site/site.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/site/site.collection.js
@@ -174,6 +174,38 @@ class SiteCollection extends BaseCollection {
     return sites;
   }
 
+  /**
+   * Returns all sites enrolled at a given entitlement tier (e.g. 'PAID',
+   * 'FREE_TRIAL', 'PLG'). Optionally narrows the result to a single product
+   * code (e.g. 'LLMO').
+   *
+   * Uses entityRegistry to chain through SiteEnrollmentCollection, then
+   * batch-fetches full Site objects.
+   *
+   * @param {string} tier - Entitlement tier to filter by.
+   * @param {string} [productCode] - Optional product code to further filter by.
+   * @param {object} [options] - batchGetByKeys options (e.g. attribute projection).
+   * @returns {Promise<Site[]>}
+   */
+  async allByEnrollmentAndTier(tier, productCode, options = {}) {
+    if (!hasText(tier)) {
+      throw new DataAccessError('tier is required', this);
+    }
+
+    const siteEnrollmentCollection = this.entityRegistry.getCollection('SiteEnrollmentCollection');
+
+    const siteIds = await siteEnrollmentCollection.allSiteIdsByTier(tier, productCode);
+    if (siteIds.length === 0) {
+      return [];
+    }
+
+    const { data: sites } = await this.batchGetByKeys(
+      siteIds.map((siteId) => ({ siteId })),
+      options,
+    );
+    return sites;
+  }
+
   async allByOrganizationIdAndProjectName(organizationId, projectName) {
     if (!hasText(organizationId)) {
       throw new DataAccessError('organizationId is required', this);

--- a/packages/spacecat-shared-data-access/test/it/site-enrollment/site-enrollment.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site-enrollment/site-enrollment.test.js
@@ -72,6 +72,32 @@ describe('SiteEnrollment IT', async () => {
     }
   });
 
+  it('gets all site IDs by tier', async () => {
+    const siteIds = await SiteEnrollment.allSiteIdsByTier('PAID');
+
+    expect(siteIds).to.be.an('array');
+    expect(siteIds).to.have.members([
+      '78fec9c7-2141-4600-b7b1-ea5c78752b91',
+      '56a691db-d32e-4308-ac99-a21de0580557',
+    ]);
+  });
+
+  it('gets all site IDs by tier filtered by product code', async () => {
+    const siteIds = await SiteEnrollment.allSiteIdsByTier('PAID', 'LLMO');
+
+    expect(siteIds).to.eql(['56a691db-d32e-4308-ac99-a21de0580557']);
+  });
+
+  it('returns empty array when no enrollments match the tier', async () => {
+    const siteIds = await SiteEnrollment.allSiteIdsByTier('PLG');
+
+    expect(siteIds).to.eql([]);
+  });
+
+  it('throws when tier is missing for allSiteIdsByTier', async () => {
+    await expect(SiteEnrollment.allSiteIdsByTier()).to.be.rejectedWith('tier is required');
+  });
+
   it('adds a new site enrollment', async () => {
     const data = {
       siteId: sampleData.sites[0].getId(),

--- a/packages/spacecat-shared-data-access/test/it/site/site.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site/site.test.js
@@ -576,6 +576,57 @@ describe('Site IT', async () => {
     expect(reloadedProfile.main_profile.id).to.equal(sample.main_profile.id);
   });
 
+  describe('allByEnrollmentAndTier', () => {
+    it('returns sites enrolled at a given tier', async () => {
+      const sites = await Site.allByEnrollmentAndTier('PAID');
+
+      expect(sites).to.be.an('array');
+      const ids = sites.map((s) => s.getId()).sort();
+      expect(ids).to.eql([
+        '56a691db-d32e-4308-ac99-a21de0580557',
+        '78fec9c7-2141-4600-b7b1-ea5c78752b91',
+      ]);
+    });
+
+    it('narrows by product code when supplied', async () => {
+      const sites = await Site.allByEnrollmentAndTier('PAID', 'LLMO');
+
+      expect(sites).to.be.an('array');
+      expect(sites).to.have.lengthOf(1);
+      expect(sites[0].getId()).to.equal('56a691db-d32e-4308-ac99-a21de0580557');
+    });
+
+    it('returns FREE_TRIAL enrolled sites', async () => {
+      const sites = await Site.allByEnrollmentAndTier('FREE_TRIAL', 'LLMO');
+
+      expect(sites).to.have.lengthOf(1);
+      expect(sites[0].getId()).to.equal('5d6d4439-6659-46c2-b646-92d110fa5a52');
+    });
+
+    it('returns empty array when tier has no enrollments', async () => {
+      const sites = await Site.allByEnrollmentAndTier('PLG');
+
+      expect(sites).to.eql([]);
+    });
+
+    it('honors attribute projection via options', async () => {
+      const sites = await Site.allByEnrollmentAndTier('PAID', 'LLMO', {
+        attributes: ['siteId', 'baseURL'],
+      });
+
+      expect(sites).to.have.lengthOf(1);
+      const json = sites[0].toJSON();
+      expect(json.siteId).to.equal('56a691db-d32e-4308-ac99-a21de0580557');
+      expect(json.baseURL).to.be.a('string');
+      expect(json.organizationId).to.be.undefined;
+      expect(json.deliveryType).to.be.undefined;
+    });
+
+    it('throws when tier is missing', async () => {
+      await expect(Site.allByEnrollmentAndTier('')).to.be.rejectedWith('tier is required');
+    });
+  });
+
   it('removes a site', async () => {
     const site = await Site.findById(sampleData.sites[0].getId());
 

--- a/packages/spacecat-shared-data-access/test/unit/models/site-enrollment/site-enrollment.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site-enrollment/site-enrollment.collection.test.js
@@ -162,4 +162,107 @@ describe('SiteEnrollmentCollection', () => {
       expect(mockLogger.error).to.have.been.called;
     });
   });
+
+  describe('allSiteIdsByTier', () => {
+    let fromStub;
+    let selectStub;
+    let firstEqStub;
+    let secondEqStub;
+
+    beforeEach(() => {
+      secondEqStub = sinon.stub();
+      firstEqStub = sinon.stub().returns({ eq: secondEqStub });
+      selectStub = sinon.stub().returns({ eq: firstEqStub });
+      fromStub = sinon.stub().returns({ select: selectStub });
+      instance.postgrestService.from = fromStub;
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('throws DataAccessError when tier is falsy', async () => {
+      await expect(instance.allSiteIdsByTier(null)).to.be.rejectedWith('tier is required');
+      await expect(instance.allSiteIdsByTier(undefined)).to.be.rejectedWith('tier is required');
+      await expect(instance.allSiteIdsByTier('')).to.be.rejectedWith('tier is required');
+    });
+
+    it('deduplicates repeated site IDs from multiple matching entitlements', async () => {
+      firstEqStub.resolves({
+        data: [
+          { site_id: 'cfa88998-a0a0-4136-b21d-0ff2aa127443' },
+          { site_id: 'd1e2f3a4-b5c6-7890-abcd-ef1234567890' },
+          { site_id: 'cfa88998-a0a0-4136-b21d-0ff2aa127443' },
+        ],
+        error: null,
+      });
+
+      const result = await instance.allSiteIdsByTier('PAID');
+
+      expect(result).to.deep.equal([
+        'cfa88998-a0a0-4136-b21d-0ff2aa127443',
+        'd1e2f3a4-b5c6-7890-abcd-ef1234567890',
+      ]);
+    });
+
+    it('returns site IDs filtered by tier only when no productCode given', async () => {
+      firstEqStub.resolves({
+        data: [
+          { site_id: 'cfa88998-a0a0-4136-b21d-0ff2aa127443' },
+          { site_id: 'd1e2f3a4-b5c6-7890-abcd-ef1234567890' },
+        ],
+        error: null,
+      });
+
+      const result = await instance.allSiteIdsByTier('PAID');
+
+      expect(result).to.deep.equal([
+        'cfa88998-a0a0-4136-b21d-0ff2aa127443',
+        'd1e2f3a4-b5c6-7890-abcd-ef1234567890',
+      ]);
+      expect(fromStub).to.have.been.calledOnceWithExactly('site_enrollments');
+      expect(selectStub).to.have.been.calledOnceWithExactly('site_id, entitlements!inner(tier, product_code)');
+      expect(firstEqStub).to.have.been.calledOnceWithExactly('entitlements.tier', 'PAID');
+      expect(secondEqStub).to.not.have.been.called;
+    });
+
+    it('applies productCode filter when provided', async () => {
+      secondEqStub.resolves({
+        data: [{ site_id: 'cfa88998-a0a0-4136-b21d-0ff2aa127443' }],
+        error: null,
+      });
+
+      const result = await instance.allSiteIdsByTier('FREE_TRIAL', 'LLMO');
+
+      expect(result).to.deep.equal(['cfa88998-a0a0-4136-b21d-0ff2aa127443']);
+      expect(firstEqStub).to.have.been.calledOnceWithExactly('entitlements.tier', 'FREE_TRIAL');
+      expect(secondEqStub).to.have.been.calledOnceWithExactly('entitlements.product_code', 'LLMO');
+    });
+
+    it('returns empty array when no enrollments match', async () => {
+      firstEqStub.resolves({ data: [], error: null });
+
+      const result = await instance.allSiteIdsByTier('PLG');
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('returns empty array when data is null', async () => {
+      firstEqStub.resolves({ data: null, error: null });
+
+      const result = await instance.allSiteIdsByTier('PAID');
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('logs error and throws DataAccessError when query fails', async () => {
+      const dbError = new Error('DB connection failed');
+      firstEqStub.resolves({ data: null, error: dbError });
+
+      await expect(instance.allSiteIdsByTier('PAID'))
+        .to.be.rejectedWith('Failed to query site_enrollments by tier');
+
+      expect(mockLogger.error).to.have.been.called;
+    });
+  });
 });

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -2856,6 +2856,29 @@ describe('Config Tests', () => {
       expect(config.getEdgeOptimizeConfig()).to.deep.equal(data.edgeOptimizeConfig);
     });
 
+    it('creates a Config with edgeOptimizeConfig routingEnabled property', () => {
+      const data = {
+        edgeOptimizeConfig: {
+          opted: 1,
+          routingEnabled: true,
+          enabled: 1700000000000,
+        },
+      };
+      const config = Config(data);
+      expect(config.getEdgeOptimizeConfig()).to.deep.equal(data.edgeOptimizeConfig);
+    });
+
+    it('preserves a false routingEnabled value on edgeOptimizeConfig', () => {
+      const data = {
+        edgeOptimizeConfig: {
+          opted: 1,
+          routingEnabled: false,
+        },
+      };
+      const config = Config(data);
+      expect(config.getEdgeOptimizeConfig().routingEnabled).to.be.false;
+    });
+
     it('has undefined edgeOptimizeConfig in default config', () => {
       const config = Config();
       expect(config.getEdgeOptimizeConfig()).to.be.undefined;

--- a/packages/spacecat-shared-data-access/test/unit/models/site/site.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/site.collection.test.js
@@ -455,4 +455,73 @@ describe('SiteCollection', () => {
       );
     });
   });
+
+  describe('allByEnrollmentAndTier', () => {
+    let mockSiteEnrollmentCollection;
+
+    beforeEach(() => {
+      mockSiteEnrollmentCollection = {
+        allSiteIdsByTier: stub(),
+      };
+      mockEntityRegistry.getCollection = stub()
+        .withArgs('SiteEnrollmentCollection')
+        .returns(mockSiteEnrollmentCollection);
+    });
+
+    it('throws DataAccessError when tier is falsy', async () => {
+      await expect(instance.allByEnrollmentAndTier('')).to.be.rejectedWith('tier is required');
+      await expect(instance.allByEnrollmentAndTier(null)).to.be.rejectedWith('tier is required');
+      await expect(instance.allByEnrollmentAndTier(undefined)).to.be.rejectedWith('tier is required');
+    });
+
+    it('returns empty array and skips batchGetByKeys when no site IDs found', async () => {
+      mockSiteEnrollmentCollection.allSiteIdsByTier.resolves([]);
+      instance.batchGetByKeys = stub();
+
+      const result = await instance.allByEnrollmentAndTier('PAID');
+
+      expect(result).to.deep.equal([]);
+      expect(mockSiteEnrollmentCollection.allSiteIdsByTier)
+        .to.have.been.calledOnceWithExactly('PAID', undefined);
+      expect(instance.batchGetByKeys).to.not.have.been.called;
+    });
+
+    it('returns sites fetched by batchGetByKeys with default empty options', async () => {
+      const siteIds = ['cfa88998-a0a0-4136-b21d-0ff2aa127443', 'd1e2f3a4-b5c6-7890-abcd-ef1234567890'];
+      const mockSites = [{ getId: () => siteIds[0] }, { getId: () => siteIds[1] }];
+      mockSiteEnrollmentCollection.allSiteIdsByTier.resolves(siteIds);
+      instance.batchGetByKeys = stub().resolves({ data: mockSites });
+
+      const result = await instance.allByEnrollmentAndTier('FREE_TRIAL');
+
+      expect(result).to.deep.equal(mockSites);
+      expect(mockSiteEnrollmentCollection.allSiteIdsByTier)
+        .to.have.been.calledOnceWithExactly('FREE_TRIAL', undefined);
+      expect(instance.batchGetByKeys).to.have.been.calledOnceWithExactly(
+        [
+          { siteId: 'cfa88998-a0a0-4136-b21d-0ff2aa127443' },
+          { siteId: 'd1e2f3a4-b5c6-7890-abcd-ef1234567890' },
+        ],
+        {},
+      );
+    });
+
+    it('forwards productCode and options to underlying calls', async () => {
+      const siteIds = ['cfa88998-a0a0-4136-b21d-0ff2aa127443'];
+      const mockSites = [{ getId: () => siteIds[0] }];
+      const options = { attributes: ['siteId', 'baseURL'] };
+      mockSiteEnrollmentCollection.allSiteIdsByTier.resolves(siteIds);
+      instance.batchGetByKeys = stub().resolves({ data: mockSites });
+
+      const result = await instance.allByEnrollmentAndTier('PLG', 'LLMO', options);
+
+      expect(result).to.deep.equal(mockSites);
+      expect(mockSiteEnrollmentCollection.allSiteIdsByTier)
+        .to.have.been.calledOnceWithExactly('PLG', 'LLMO');
+      expect(instance.batchGetByKeys).to.have.been.calledOnceWithExactly(
+        [{ siteId: 'cfa88998-a0a0-4136-b21d-0ff2aa127443' }],
+        options,
+      );
+    });
+  });
 });

--- a/packages/spacecat-shared-project-engine-client/CHANGELOG.md
+++ b/packages/spacecat-shared-project-engine-client/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [@adobe/spacecat-shared-project-engine-client-v1.15.0](https://github.com/adobe/spacecat-shared/compare/@adobe/spacecat-shared-project-engine-client-v1.14.0...@adobe/spacecat-shared-project-engine-client-v1.15.0) (2026-07-20)
+
+### Features
+
+* **project-engine-client:** mock authorship root source→origin + legacy seed (LLMO-6273) ([3ead32b](https://github.com/adobe/spacecat-shared/commit/3ead32b1f126b3f15d1acac0f86209929b0aad73))
+
 ## [@adobe/spacecat-shared-project-engine-client-v1.14.0](https://github.com/adobe/spacecat-shared/compare/@adobe/spacecat-shared-project-engine-client-v1.13.0...@adobe/spacecat-shared-project-engine-client-v1.14.0) (2026-07-20)
 
 ### Features

--- a/packages/spacecat-shared-project-engine-client/docs/mock-usage.md
+++ b/packages/spacecat-shared-project-engine-client/docs/mock-usage.md
@@ -31,7 +31,7 @@ npm run mock              # serves on http://localhost:4010
 | Env var | Default | Purpose |
 | --- | --- | --- |
 | `MOCK_PORT` | `4010` | listen port |
-| `MOCK_SEED` | `workspace-with-data` | named startup fixture (`empty-workspace` \| `workspace-with-data` \| `two-hierarchies`); unknown → default |
+| `MOCK_SEED` | `workspace-with-data` | named startup fixture (`empty-workspace` \| `workspace-with-data` \| `two-hierarchies` \| `legacy-source-workspace`); unknown → default |
 | `MOCK_SEED_FILE` | — | path to a JSON `Snapshot` to boot from; **takes precedence** over `MOCK_SEED` |
 
 ```bash
@@ -161,18 +161,24 @@ Three named seeds ship in `mock/seeds.js`:
 - **`workspace-with-data`** (default) — one LIVE US/en market under the brand's **child**
   sub-workspace (`SEED_IDS.workspaceId`, the id a correctly-anchored brand resolves to — NOT the org
   parent), with a catalog-valid AI model (`search-gpt`), the four bare dimension roots (`category`,
-  `intent`, `source`, `type`) carrying the closed vocabularies as children plus a depth-2 category
+  `intent`, `origin`, `type`) carrying the closed vocabularies as children plus a depth-2 category
   with two depth-3 sub-categories, a prompt dual-tagged with its category and sub-category plus one
   closed value per dimension, an own-brand benchmark, and a brand URL. The sub-category `human` and
-  the `source` value `human` deliberately share a name and differ only by parent, so the
+  the `origin` value `human` deliberately share a name and differ only by parent, so the
   cross-dimension collision case stays exercised. Canonical ids are exported as `SEED_IDS`
   (`parentWorkspaceId`, `workspaceId`, `projectId`, `aiModelId`, `promptId`, `benchmarkId`,
   `brandUrlId`, the four `*RootTagId`s, `categoryTagId`, `childTagId`, `childCollidingTagId`,
-  `sourceHumanTagId`, `intentCommercialTagId`, `typeBrandedTagId`).
+  `originHumanTagId`, `intentCommercialTagId`, `typeBrandedTagId`).
 - **`two-hierarchies`** — a strict superset of `workspace-with-data` plus a second, fully
   independent parent/child hierarchy with its own LIVE DE/de market (`SEED_IDS.secondWorkspaceId` /
   `secondProjectId`), for the dual-org case where two mock-wired orgs each need a distinct
   `semrush_workspace_id`.
+- **`legacy-source-workspace`** — the same shape as `workspace-with-data`, except the authorship
+  root is still named `source` (with `ai` / `human` beneath it) rather than `origin`. This is the
+  **pre-rename** fixture the authorship rename's tolerant resolver is tested against
+  (origin-dimension.md §7 gate 3): a live project still carrying a `source` root, which the resolver
+  must accept in place and never duplicate. Its ids are `SEED_IDS.legacySourceRootTagId` /
+  `legacySourceHumanTagId`. Removed by WP-O6 once the `source` fallback is dropped.
 
 Boot from a custom state with `MOCK_SEED_FILE=/path/to/snapshot.json` or replace state at runtime
 with `POST /__seed` (§5). A `Snapshot` is a plain JSON object keyed `<resource>:<scope>`:

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags.js
@@ -13,7 +13,7 @@
 /**
  * Stateful handlers for /v2/workspaces/{id}/projects/{project_id}/aio/tags — the project-level AIO
  * tag taxonomy (the Categories surface), modelled as a dimension-root tree: each DIMENSION
- * (`category`, `intent`, `source`, `type`) is a bare-named root with no `parent_id`, and every
+ * (`category`, `intent`, `origin`, `type`) is a bare-named root with no `parent_id`, and every
  * VALUE is a bare-named descendant carrying its parent's id. No tag name contains a `:`; a tag's
  * dimension is `path[0]`. Categories sit at depth 2 and sub-categories at depth 3. The per-project
  * `tags` collection (`tags:{ws}:{pid}`) is scoped so the same taxonomy registered across N market

--- a/packages/spacecat-shared-project-engine-client/mock/factories.js
+++ b/packages/spacecat-shared-project-engine-client/mock/factories.js
@@ -361,7 +361,7 @@ export const createTagNodeMock = (overrides = {}) => ({
  * the shape the mock persists in the per-project `tags` collection.
  *
  * The tag taxonomy is a dimension-root tree (see the dimension-root tag model): each **dimension**
- * — `category`, `intent`, `source`, `type` — is a bare-named ROOT with no `parent_id`, and every
+ * — `category`, `intent`, `origin`, `type` — is a bare-named ROOT with no `parent_id`, and every
  * **value** is a bare-named descendant carrying its parent's id. No name ever contains a `:`. A
  * category sits at depth 2 and a sub-category at depth 3; the API caps no depth. Because roots
  * legitimately have no parent, `parent_id` is left OUT of the defaults (optional, supplied via

--- a/packages/spacecat-shared-project-engine-client/mock/seeds.js
+++ b/packages/spacecat-shared-project-engine-client/mock/seeds.js
@@ -73,7 +73,7 @@ const US_GEO_TARGET_ID = 2840; // Google geoTargetId (United States)
 const DIMENSION_ROOTS = Object.freeze({
   category: 'category',
   intent: 'intent',
-  source: 'source',
+  origin: 'origin',
   type: 'type',
 });
 
@@ -81,16 +81,23 @@ const DIMENSION_ROOTS = Object.freeze({
 const INTENT_VALUES = Object.freeze([
   'Informational', 'Task', 'Commercial', 'Transactional', 'Navigational',
 ]);
-const SOURCE_VALUES = Object.freeze(['ai', 'human']);
+const ORIGIN_VALUES = Object.freeze(['ai', 'human']);
 const TYPE_VALUES = Object.freeze(['branded', 'non-branded']);
 
 const CATEGORY_ROOT_TAG_ID = tagId(DIMENSION_ROOTS.category);
 const INTENT_ROOT_TAG_ID = tagId(DIMENSION_ROOTS.intent);
-const SOURCE_ROOT_TAG_ID = tagId(DIMENSION_ROOTS.source);
+const ORIGIN_ROOT_TAG_ID = tagId(DIMENSION_ROOTS.origin);
 const TYPE_ROOT_TAG_ID = tagId(DIMENSION_ROOTS.type);
 
+// The pre-rename authorship root name, retained only for the legacy seed fixture (WP-O1 item 4):
+// a project whose authorship root is still `source`, so api-service's tolerant resolver
+// (origin-dimension.md §7 gate 3) has a fixture to run against. Removed by WP-O6.
+const LEGACY_AUTHORSHIP_ROOT_NAME = 'source';
+const LEGACY_SOURCE_ROOT_TAG_ID = tagId(LEGACY_AUTHORSHIP_ROOT_NAME);
+const LEGACY_SOURCE_HUMAN_TAG_ID = tagId('human', LEGACY_SOURCE_ROOT_TAG_ID);
+
 // H1's open taxonomy: one depth-2 category with two depth-3 sub-categories. The sub-category named
-// `human` deliberately collides by NAME with the `source` value `human` — under bare names those
+// `human` deliberately collides by NAME with the `origin` value `human` — under bare names those
 // are two distinct tags only because ids are keyed on `(parent, name)`. Seeding the collision keeps
 // the cross-dimension case (model spec §7 gate 4) exercisable end-to-end rather than hypothetical.
 const CATEGORY_NAME = 'Running Shoes';
@@ -100,9 +107,9 @@ const CATEGORY_TAG_ID = tagId(CATEGORY_NAME, CATEGORY_ROOT_TAG_ID); // depth-2 c
 const CHILD_TAG_ID = tagId(CATEGORY_CHILD_NAME, CATEGORY_TAG_ID); // depth-3 sub-category
 const CHILD_COLLIDING_TAG_ID = tagId(CATEGORY_CHILD_COLLIDING_NAME, CATEGORY_TAG_ID);
 
-// The closed-dimension values H1's seeded prompt carries. `sourceHuman` shares its NAME with the
+// The closed-dimension values H1's seeded prompt carries. `originHuman` shares its NAME with the
 // sub-category above and its id with nothing.
-const SOURCE_HUMAN_TAG_ID = tagId('human', SOURCE_ROOT_TAG_ID);
+const ORIGIN_HUMAN_TAG_ID = tagId('human', ORIGIN_ROOT_TAG_ID);
 const INTENT_COMMERCIAL_TAG_ID = tagId('Commercial', INTENT_ROOT_TAG_ID);
 const TYPE_BRANDED_TAG_ID = tagId('branded', TYPE_ROOT_TAG_ID);
 
@@ -216,26 +223,32 @@ const childTag = (name, parentId) => createAIOTagMock({
  * The four dimension roots and the closed dimensions' full child vocabularies — the tree every
  * project is provisioned with, before any customer-authored category exists. Pass `categories` to
  * append the open `category` subtree: each entry is a depth-2 category and its depth-3
- * sub-categories.
+ * sub-categories. `authorshipRootName` defaults to the current `origin` root; pass the pre-rename
+ * `source` name to build the legacy fixture (WP-O1 item 4) — the `ai`/`human` vocabulary is
+ * unchanged, only the root it hangs off differs.
  * @param {Array<{ name: string, children?: string[] }>} [categories]
+ * @param {string} [authorshipRootName]
  * @returns {Array<Schemas['model.AIOTag']>} roots first, then descendants (parents before children)
  */
-const dimensionRootTree = (categories = []) => [
-  rootTag(DIMENSION_ROOTS.category),
-  rootTag(DIMENSION_ROOTS.intent),
-  rootTag(DIMENSION_ROOTS.source),
-  rootTag(DIMENSION_ROOTS.type),
-  ...INTENT_VALUES.map((v) => childTag(v, INTENT_ROOT_TAG_ID)),
-  ...SOURCE_VALUES.map((v) => childTag(v, SOURCE_ROOT_TAG_ID)),
-  ...TYPE_VALUES.map((v) => childTag(v, TYPE_ROOT_TAG_ID)),
-  ...categories.flatMap(({ name, children = [] }) => {
-    const categoryId = tagId(name, CATEGORY_ROOT_TAG_ID);
-    return [
-      childTag(name, CATEGORY_ROOT_TAG_ID),
-      ...children.map((child) => childTag(child, categoryId)),
-    ];
-  }),
-];
+const dimensionRootTree = (categories = [], authorshipRootName = DIMENSION_ROOTS.origin) => {
+  const authorshipRootId = tagId(authorshipRootName);
+  return [
+    rootTag(DIMENSION_ROOTS.category),
+    rootTag(DIMENSION_ROOTS.intent),
+    rootTag(authorshipRootName),
+    rootTag(DIMENSION_ROOTS.type),
+    ...INTENT_VALUES.map((v) => childTag(v, INTENT_ROOT_TAG_ID)),
+    ...ORIGIN_VALUES.map((v) => childTag(v, authorshipRootId)),
+    ...TYPE_VALUES.map((v) => childTag(v, TYPE_ROOT_TAG_ID)),
+    ...categories.flatMap(({ name, children = [] }) => {
+      const categoryId = tagId(name, CATEGORY_ROOT_TAG_ID);
+      return [
+        childTag(name, CATEGORY_ROOT_TAG_ID),
+        ...children.map((child) => childTag(child, categoryId)),
+      ];
+    }),
+  ];
+};
 
 /**
  * Authors one full sub-workspace hierarchy (a live market with a model, a tagged prompt, an
@@ -303,7 +316,7 @@ export const EMPTY_WORKSPACE = Object.freeze({
  *
  * The prompt is dual-tagged (its depth-2 category AND its depth-3 sub-category, per the id-based
  * alignment spec's delete-resilience rule) and carries one closed value per dimension. Its
- * sub-category `human` and its source value `human` share a name and nothing else.
+ * sub-category `human` and its origin value `human` share a name and nothing else.
  */
 export const WORKSPACE_WITH_DATA = Object.freeze(peHierarchy({
   childWorkspaceId: CHILD_WORKSPACE_ID,
@@ -322,7 +335,7 @@ export const WORKSPACE_WITH_DATA = Object.freeze(peHierarchy({
   promptTags: [
     childTag(CATEGORY_NAME, CATEGORY_ROOT_TAG_ID),
     childTag(CATEGORY_CHILD_COLLIDING_NAME, CATEGORY_TAG_ID),
-    childTag('human', SOURCE_ROOT_TAG_ID),
+    childTag('human', ORIGIN_ROOT_TAG_ID),
     childTag('Commercial', INTENT_ROOT_TAG_ID),
     childTag('branded', TYPE_ROOT_TAG_ID),
   ],
@@ -359,7 +372,7 @@ export const TWO_HIERARCHIES = Object.freeze({
     promptName: 'Was ist der beste Laufschuh?',
     promptTags: [
       childTag('Laufschuhe', CATEGORY_ROOT_TAG_ID),
-      childTag('ai', SOURCE_ROOT_TAG_ID),
+      childTag('ai', ORIGIN_ROOT_TAG_ID),
       childTag('Informational', INTENT_ROOT_TAG_ID),
       childTag('non-branded', TYPE_ROOT_TAG_ID),
     ],
@@ -371,6 +384,46 @@ export const TWO_HIERARCHIES = Object.freeze({
 });
 
 /**
+ * The pre-rename shape: identical to `workspace-with-data`, except the authorship root is still
+ * named `source` (with `ai` / `human` beneath it) instead of `origin`, and the prompt's authorship
+ * tag hangs off that `source` root. This is the fixture api-service's tolerant resolver runs
+ * against (origin-dimension.md §7 gate 3) — a live project that still carries a `source`-named
+ * authorship root, which the resolver must accept in place and never duplicate into a second root.
+ *
+ * It intentionally REUSES `workspace-with-data`'s scalar ids (workspace / project / prompt /
+ * benchmark / brand-url) — the two seeds never load together, so this is a drop-in replacement for
+ * the default, not a copy-paste slip. Only the authorship root name (and the ids derived beneath
+ * it) differ. Deleted by WP-O6 once the `source` fallback is dropped.
+ */
+export const WORKSPACE_WITH_SOURCE_ROOT = Object.freeze(peHierarchy({
+  childWorkspaceId: CHILD_WORKSPACE_ID,
+  projectId: PROJECT_ID,
+  aiModelAssignmentId: AI_MODEL_ASSIGNMENT_ID,
+  name: 'Seeded Project',
+  domain: 'example.com',
+  brandName: 'Seeded Brand',
+  languageId: ENGLISH_LANGUAGE_ID,
+  countryCode: 'us',
+  locationId: US_GEO_TARGET_ID,
+  locationName: 'United States',
+  modelKey: 'search-gpt',
+  promptId: PROMPT_ID,
+  promptName: 'What is the best running shoe?',
+  promptTags: [
+    childTag(CATEGORY_NAME, CATEGORY_ROOT_TAG_ID),
+    childTag(CATEGORY_CHILD_COLLIDING_NAME, CATEGORY_TAG_ID),
+    childTag('human', LEGACY_SOURCE_ROOT_TAG_ID),
+    childTag('Commercial', INTENT_ROOT_TAG_ID),
+    childTag('branded', TYPE_ROOT_TAG_ID),
+  ],
+  benchmarkId: BENCHMARK_ID,
+  brandUrlId: BRAND_URL_ID,
+  projectTags: dimensionRootTree([
+    { name: CATEGORY_NAME, children: [CATEGORY_CHILD_NAME, CATEGORY_CHILD_COLLIDING_NAME] },
+  ], LEGACY_AUTHORSHIP_ROOT_NAME),
+}));
+
+/**
  * All seed sets by name, for the runner to select via env/flag. Typed as a string map so a
  * runtime `MOCK_SEED` (an arbitrary string) can index it with a fallback (see {@link Context}).
  * @type {Record<string, import('./store.js').Snapshot>}
@@ -379,6 +432,7 @@ export const SEEDS = Object.freeze({
   'empty-workspace': EMPTY_WORKSPACE,
   'workspace-with-data': WORKSPACE_WITH_DATA,
   'two-hierarchies': TWO_HIERARCHIES,
+  'legacy-source-workspace': WORKSPACE_WITH_SOURCE_ROOT,
 });
 
 /** Default seed loaded when none is specified. */
@@ -398,18 +452,23 @@ export const SEED_IDS = Object.freeze({
   // The four dimension roots — every project carries exactly these at the root level.
   categoryRootTagId: CATEGORY_ROOT_TAG_ID,
   intentRootTagId: INTENT_ROOT_TAG_ID,
-  sourceRootTagId: SOURCE_ROOT_TAG_ID,
+  originRootTagId: ORIGIN_ROOT_TAG_ID,
   typeRootTagId: TYPE_ROOT_TAG_ID,
   // H1's open taxonomy: a depth-2 category and its two depth-3 sub-categories. `childTagId` carries
   // no prompts; `childCollidingTagId` is the sub-category named `human`, whose name — and only
-  // whose name — matches the `source` value below.
+  // whose name — matches the `origin` value below.
   categoryTagId: CATEGORY_TAG_ID,
   childTagId: CHILD_TAG_ID,
   childCollidingTagId: CHILD_COLLIDING_TAG_ID,
   // H1's closed-dimension values, as carried by the seeded prompt.
-  sourceHumanTagId: SOURCE_HUMAN_TAG_ID,
+  originHumanTagId: ORIGIN_HUMAN_TAG_ID,
   intentCommercialTagId: INTENT_COMMERCIAL_TAG_ID,
   typeBrandedTagId: TYPE_BRANDED_TAG_ID,
+  // The legacy pre-rename fixture (`legacy-source-workspace`): the authorship root is still named
+  // `source`, for api-service's tolerant-resolver test (origin-dimension.md §7 gate 3). WP-O6 drops
+  // both the seed and these ids.
+  legacySourceRootTagId: LEGACY_SOURCE_ROOT_TAG_ID,
+  legacySourceHumanTagId: LEGACY_SOURCE_HUMAN_TAG_ID,
   // Hierarchy 2 (present only in `two-hierarchies`).
   secondParentWorkspaceId: PARENT_WORKSPACE_ID_2,
   secondWorkspaceId: CHILD_WORKSPACE_ID_2,

--- a/packages/spacecat-shared-project-engine-client/package.json
+++ b/packages/spacecat-shared-project-engine-client/package.json
@@ -63,7 +63,7 @@
     "c8": "11.0.0",
     "chai": "6.2.2",
     "counterfact": "2.14.0",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.0",
     "mocha": "11.7.6",
     "mocha-multi-reporters": "1.5.1",
     "openapi-typescript": "7.13.0",

--- a/packages/spacecat-shared-project-engine-client/package.json
+++ b/packages/spacecat-shared-project-engine-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/spacecat-shared-project-engine-client",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Shared modules of the Spacecat Services - Semrush Project Engine client and generated types",
   "type": "module",
   "main": "src/index.js",

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -41,7 +41,7 @@ const SHUTDOWN_TIMEOUT_MS = 5_000;
 const SEED_WORKSPACE = SEED_IDS.workspaceId;
 const SEED_PROJECT = SEED_IDS.projectId;
 // Every project's root level holds exactly these four dimension roots and nothing else.
-const DIMENSION_ROOT_NAMES = ['category', 'intent', 'source', 'type'];
+const DIMENSION_ROOT_NAMES = ['category', 'intent', 'origin', 'type'];
 
 function sleep(ms) {
   return new Promise((resolve) => {
@@ -482,7 +482,7 @@ async function waitForReady(baseUrl, deadline, getStderr) {
       if (t.path === undefined) {
         expect(t).to.not.have.property('parent_id');
       } else {
-        expect(t.path[0].name).to.be.oneOf(['category', 'intent', 'source', 'type']);
+        expect(t.path[0].name).to.be.oneOf(['category', 'intent', 'origin', 'type']);
         expect(t.parent_id).to.be.a('string');
       }
     });
@@ -617,7 +617,7 @@ async function waitForReady(baseUrl, deadline, getStderr) {
   // filter branch (OR semantics), not just the list-all branch. `tagged` is name-keyed and
   // ROOT-only: it derives `tagId(name)` with no parent, so a prompt tagged 'brand' is found via
   // tag_ids: [tagId('brand')]. Neither probe name is a dimension root — a bare name that IS one
-  // (`category`, `intent`, `source`, `type`) would resolve to that real root's id, which is exactly
+  // (`category`, `intent`, `origin`, `type`) would resolve to that real root's id, which is exactly
   // why no caller may reach this endpoint with dimension-root data.
   // Fresh creates are draft-gated (see the dedicated gating test above), so this read passes
   // draft:true — it's exercising the filter branch, not the publish gate.
@@ -1206,18 +1206,18 @@ async function waitForReady(baseUrl, deadline, getStderr) {
   // A sub-category and a closed-dimension value may share a bare NAME and must stay distinct tags —
   // ids are keyed on (parent, name). This is the cross-dimension collision case the dimension-root
   // model must survive; the seed bakes it so it is exercised rather than assumed.
-  it('keeps a sub-category and a same-named source value as distinct tags', async () => {
+  it('keeps a sub-category and a same-named origin value as distinct tags', async () => {
     const { data: subcategories } = await listTags(SEED_IDS.categoryTagId);
-    const { data: sources } = await listTags(SEED_IDS.sourceRootTagId);
+    const { data: origins } = await listTags(SEED_IDS.originRootTagId);
 
     const subHuman = subcategories.items.find((t) => t.name === 'human');
-    const srcHuman = sources.items.find((t) => t.name === 'human');
+    const originHuman = origins.items.find((t) => t.name === 'human');
 
     expect(subHuman.id).to.equal(SEED_IDS.childCollidingTagId);
-    expect(srcHuman.id).to.equal(SEED_IDS.sourceHumanTagId);
-    expect(subHuman.id).to.not.equal(srcHuman.id);
+    expect(originHuman.id).to.equal(SEED_IDS.originHumanTagId);
+    expect(subHuman.id).to.not.equal(originHuman.id);
     expect(subHuman.path[0].name).to.equal('category');
-    expect(srcHuman.path[0].name).to.equal('source');
+    expect(originHuman.path[0].name).to.equal('origin');
   });
 
   // __reset restores the boot seed (the four dimension roots, no ad-hoc tags), so a created
@@ -1544,11 +1544,11 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     expect(prompt.tags.map((t) => t.id)).to.have.members([
       SEED_IDS.categoryTagId,
       SEED_IDS.childCollidingTagId,
-      SEED_IDS.sourceHumanTagId,
+      SEED_IDS.originHumanTagId,
       SEED_IDS.intentCommercialTagId,
     ]);
 
-    // … and the same-named `human` sub-category is untouched by the source value's deletion.
+    // … and the same-named `human` sub-category is untouched by the origin value's deletion.
     const { data: subcategories } = await listTags(SEED_IDS.categoryTagId);
     expect(subcategories.items.map((t) => t.id)).to.include(SEED_IDS.childCollidingTagId);
   });
@@ -1565,7 +1565,7 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     const { response } = await delTags([
       SEED_IDS.categoryTagId,
       SEED_IDS.childCollidingTagId,
-      SEED_IDS.sourceHumanTagId,
+      SEED_IDS.originHumanTagId,
       SEED_IDS.intentCommercialTagId,
       SEED_IDS.typeBrandedTagId,
     ]);

--- a/packages/spacecat-shared-project-engine-client/test/mock/seeds.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/seeds.test.js
@@ -28,8 +28,9 @@ import {
 
 describe('seeds', () => {
   it('exposes named seed sets with a valid default', () => {
-    expect(Object.keys(SEEDS))
-      .to.include.members(['empty-workspace', 'workspace-with-data', 'two-hierarchies']);
+    expect(Object.keys(SEEDS)).to.include.members([
+      'empty-workspace', 'workspace-with-data', 'two-hierarchies', 'legacy-source-workspace',
+    ]);
     expect(SEEDS).to.have.property(DEFAULT_SEED);
   });
 
@@ -83,7 +84,7 @@ describe('seeds', () => {
 
     // Exactly the four dimension roots sit at the root level (model spec §7 gate 2).
     const roots = tags.filter((t) => !t.parent_id);
-    expect(roots.map((t) => t.name)).to.deep.equal(['category', 'intent', 'source', 'type']);
+    expect(roots.map((t) => t.name)).to.deep.equal(['category', 'intent', 'origin', 'type']);
 
     // The closed dimensions carry their full fixed vocabularies as bare children.
     const childNamesOf = (parentId) => tags
@@ -91,7 +92,7 @@ describe('seeds', () => {
       .map((t) => t.name);
     expect(childNamesOf(SEED_IDS.intentRootTagId))
       .to.deep.equal(['Informational', 'Task', 'Commercial', 'Transactional', 'Navigational']);
-    expect(childNamesOf(SEED_IDS.sourceRootTagId)).to.deep.equal(['ai', 'human']);
+    expect(childNamesOf(SEED_IDS.originRootTagId)).to.deep.equal(['ai', 'human']);
     expect(childNamesOf(SEED_IDS.typeRootTagId)).to.deep.equal(['branded', 'non-branded']);
 
     // The open dimension: a depth-2 category under `category`, with depth-3 sub-categories.
@@ -100,14 +101,14 @@ describe('seeds', () => {
     expect(category).to.include({ name: 'Running Shoes', parent_id: SEED_IDS.categoryRootTagId });
     expect(childNamesOf(SEED_IDS.categoryTagId)).to.deep.equal(['Trail', 'human']);
 
-    // The sub-category `human` and the source value `human` share a name and NOTHING else — the
+    // The sub-category `human` and the origin value `human` share a name and NOTHING else — the
     // cross-dimension collision the model spec §7 gate 4 requires to be survivable.
     const subcategoryHuman = tags.find((t) => t.id === SEED_IDS.childCollidingTagId);
-    const sourceHuman = tags.find((t) => t.id === SEED_IDS.sourceHumanTagId);
-    expect(subcategoryHuman.name).to.equal(sourceHuman.name);
-    expect(subcategoryHuman.id).to.not.equal(sourceHuman.id);
+    const originHuman = tags.find((t) => t.id === SEED_IDS.originHumanTagId);
+    expect(subcategoryHuman.name).to.equal(originHuman.name);
+    expect(subcategoryHuman.id).to.not.equal(originHuman.id);
     expect(subcategoryHuman.parent_id).to.equal(SEED_IDS.categoryTagId);
-    expect(sourceHuman.parent_id).to.equal(SEED_IDS.sourceRootTagId);
+    expect(originHuman.parent_id).to.equal(SEED_IDS.originRootTagId);
 
     // The seeded prompt is dual-tagged (category + sub-category) and carries one closed value per
     // dimension, reusing the ids the standalone tree registered so `by_tags` correlates.
@@ -117,10 +118,39 @@ describe('seeds', () => {
     expect(prompt.tags.map((t) => t.id)).to.deep.equal([
       SEED_IDS.categoryTagId,
       SEED_IDS.childCollidingTagId,
-      SEED_IDS.sourceHumanTagId,
+      SEED_IDS.originHumanTagId,
       SEED_IDS.intentCommercialTagId,
       SEED_IDS.typeBrandedTagId,
     ]);
+  });
+
+  it('legacy-source-workspace seeds the pre-rename shape: a `source` authorship root with ai/human', () => {
+    const store = new InMemoryStore();
+    store.load(SEEDS['legacy-source-workspace']);
+    const ops = createStatefulOps(store);
+    const { workspaceId, projectId } = SEED_IDS;
+
+    const tags = ops.tags.list({ workspaceId, projectId });
+    // The authorship root is still named `source` (not `origin`) — the fixture api-service's
+    // tolerant resolver runs against (origin-dimension.md §7 gate 3), and it carries no `origin`.
+    const roots = tags.filter((t) => !t.parent_id);
+    expect(roots.map((t) => t.name)).to.deep.equal(['category', 'intent', 'source', 'type']);
+    expect(roots.map((t) => t.name)).to.not.include('origin');
+
+    // Every tag id in the loaded seed is unique — mechanically locks down the UUID-reuse safety
+    // assumption. The legacy seed intentionally reuses `workspace-with-data`'s scalar ids, but the
+    // two never load together, so nothing beneath the renamed root should collide with anything.
+    expect(new Set(tags.map((t) => t.id)).size).to.equal(tags.length);
+
+    // `ai`/`human` hang off the legacy `source` root, and the prompt's authorship tag does too.
+    const childNamesOf = (parentId) => tags
+      .filter((t) => t.parent_id === parentId).map((t) => t.name);
+    expect(childNamesOf(SEED_IDS.legacySourceRootTagId)).to.deep.equal(['ai', 'human']);
+    const legacyHuman = tags.find((t) => t.id === SEED_IDS.legacySourceHumanTagId);
+    expect(legacyHuman).to.include({ name: 'human', parent_id: SEED_IDS.legacySourceRootTagId });
+
+    const [prompt] = ops.prompts.list({ workspaceId, projectId });
+    expect(prompt.tags.map((t) => t.id)).to.include(SEED_IDS.legacySourceHumanTagId);
   });
 
   it('two-hierarchies is a superset with a second, independent live market (DE/de)', () => {

--- a/packages/spacecat-shared-project-engine-client/test/mock/tag-id.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/tag-id.test.js
@@ -62,10 +62,10 @@ describe('tag-id', () => {
     expect(tagId('Pricing', 'tag-electronics')).to.not.equal(tagId('Pricing', 'tag-furniture'));
   });
 
-  // A sub-category named `human` and the `source` value `human` must coexist on one prompt
+  // A sub-category named `human` and the `origin` value `human` must coexist on one prompt
   // (model spec §7 gate 4). They share a bare name and differ only by parent.
   it('separates a sub-category from a same-named closed-dimension value', () => {
-    expect(tagId('human', 'tag-running-shoes')).to.not.equal(tagId('human', 'tag-source'));
+    expect(tagId('human', 'tag-running-shoes')).to.not.equal(tagId('human', 'tag-origin'));
   });
 
   // Omitting the parent is how a ROOT id is derived — and it is what `POST /aio/prompts/tagged`
@@ -75,7 +75,7 @@ describe('tag-id', () => {
   });
 
   it('distinguishes a root from a child of the same name', () => {
-    expect(tagId('human')).to.not.equal(tagId('human', 'tag-source'));
+    expect(tagId('human')).to.not.equal(tagId('human', 'tag-origin'));
   });
 
   // The separator makes the preimage unambiguous: without it, the category `ab` under parent `c`

--- a/packages/spacecat-shared-project-engine-client/test/mock/tag-view.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/tag-view.test.js
@@ -15,22 +15,22 @@ import { expect } from 'chai';
 import { buildTagView } from '../../mock/tag-view.js';
 import * as factories from '../../mock/factories.js';
 
-// A dimension-root tree: `category` → `Running Shoes` → `human`, plus the `source` value `human`.
+// A dimension-root tree: `category` → `Running Shoes` → `human`, plus the `origin` value `human`.
 // The two `human` tags share a bare name and differ only by parent, which is the collision the
 // whole dimension-root model exists to survive.
 const CATEGORY_ROOT = 'root-category';
-const SOURCE_ROOT = 'root-source';
+const ORIGIN_ROOT = 'root-origin';
 const RUNNING_SHOES = 'cat-running-shoes';
 const SUB_HUMAN = 'sub-human';
-const SOURCE_HUMAN = 'source-human';
+const ORIGIN_HUMAN = 'origin-human';
 
 const tree = () => [
   { id: CATEGORY_ROOT, name: 'category' },
-  { id: SOURCE_ROOT, name: 'source' },
+  { id: ORIGIN_ROOT, name: 'origin' },
   { id: RUNNING_SHOES, name: 'Running Shoes', parent_id: CATEGORY_ROOT },
   { id: SUB_HUMAN, name: 'human', parent_id: RUNNING_SHOES },
   {
-    id: SOURCE_HUMAN, name: 'human', parent_id: SOURCE_ROOT, prompts_count: 3,
+    id: ORIGIN_HUMAN, name: 'human', parent_id: ORIGIN_ROOT, prompts_count: 3,
   },
 ];
 
@@ -89,7 +89,7 @@ describe('tag-view', () => {
 
     it('preserves the stored prompts_count, defaulting to 0', () => {
       const { byId } = buildTagView(tree(), factories);
-      expect(byId.get(SOURCE_HUMAN).prompts_count).to.equal(3);
+      expect(byId.get(ORIGIN_HUMAN).prompts_count).to.equal(3);
       expect(byId.get(SUB_HUMAN).prompts_count).to.equal(0);
     });
   });
@@ -97,9 +97,9 @@ describe('tag-view', () => {
   it('distinguishes two same-named tags by their dimension root', () => {
     const { byId } = buildTagView(tree(), factories);
 
-    expect(byId.get(SUB_HUMAN).name).to.equal(byId.get(SOURCE_HUMAN).name);
+    expect(byId.get(SUB_HUMAN).name).to.equal(byId.get(ORIGIN_HUMAN).name);
     expect(byId.get(SUB_HUMAN).path[0].name).to.equal('category');
-    expect(byId.get(SOURCE_HUMAN).path[0].name).to.equal('source');
+    expect(byId.get(ORIGIN_HUMAN).path[0].name).to.equal('origin');
   });
 
   it('serialize() answers the same object the byId index holds', () => {

--- a/packages/spacecat-shared-user-manager-client/package.json
+++ b/packages/spacecat-shared-user-manager-client/package.json
@@ -60,7 +60,7 @@
     "c8": "11.0.0",
     "chai": "6.2.2",
     "counterfact": "2.14.0",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.0",
     "mocha": "11.7.6",
     "mocha-multi-reporters": "1.5.1",
     "openapi-typescript": "7.13.0",


### PR DESCRIPTION
## What
Adds an optional boolean **`routingEnabled`** field to the `edgeOptimizeConfig` Joi schema in the Site/Organization config model (`packages/spacecat-shared-data-access/src/models/site/config.js`).

## Why
The `optimize-at-edge-enabled-marking` job (spacecat-import-worker) gates `edgeOptimizeConfig.enabled` on **two** signals:
1. **routing** — the CDN request-id check (`checkEdgeOptimizeStatus('/')`), currently computed each run and discarded, and
2. **prerender validation** — content correctness (stored on the opportunity).

To let the worker persist signal (1) alongside `opted`/`enabled` — so the UI can distinguish "CDN not routing yet" from "content still validating" — the config must accept a `routingEnabled` field. The `edgeOptimizeConfig` object is not `.unknown(true)`, so `validateConfiguration` currently **throws** on any extra key at `site.save()`. This adds the field as strictly optional; no behavior change for existing configs.

## Change
```js
edgeOptimizeConfig: Joi.object({
  enabled: Joi.alternatives().try(Joi.boolean(), Joi.number()).optional(),
  opted: Joi.number().optional(),
  routingEnabled: Joi.boolean().optional(),   // NEW
  stagingDomains: Joi.array()...optional(),
}).optional(),
```

## Tests
- Two new unit tests in `config.test.js` (accepts `routingEnabled: true` round-trips full config; preserves `routingEnabled: false`).
- Full `config.test.js` green (300 passing); lint clean.

## Follow-up
spacecat-import-worker will bump this package and write `routingEnabled` in the marking handler once released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)