### PR TITLE
feat: add weekly-offsite job interval (LLMO-6401)

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/configuration/configuration.model.js
+++ b/packages/spacecat-shared-data-access/src/models/configuration/configuration.model.js
@@ -41,6 +41,7 @@ class Configuration {
     DAILY_1AM: 'daily-1am',
     WEEKLY: 'weekly',
     WEEKLY_DIGEST_EMAIL: 'weekly-digest-email', // runs on Tuesday for weekly digest emails (LLMO-2682)
+    WEEKLY_OFFSITE: 'weekly-offsite', // runs on Tuesday for offsite opportunities (LLMO-6401)
     EARLY_MONDAY: 'early-monday',
     EVERY_SATURDAY: 'every-saturday',
     EVERY_SUNDAY: 'every-sunday',


### PR DESCRIPTION
## What

Adds a new `WEEKLY_OFFSITE: 'weekly-offsite'` value to `Configuration.JOB_INTERVALS`.

## Why

Part of **LLMO-6401** — move the offsite opportunity audits (`cited-analysis`, `reddit-analysis`, `youtube-analysis`) onto a dedicated **weekly Tuesday** schedule, decoupled from the Monday `weekly` interval (and distinct from the `weekly-digest-email` job).

## Notes

- Schema validation (`configuration.schema.js`) derives the allowed set from `Object.values(Configuration.JOB_INTERVALS)`, so `weekly-offsite` is accepted automatically as a `job.interval` value — no schema change needed.
- **This should be released first**: services that persist `global-config` validate `interval` against this enum, so the new value must be published before the S3 config can be flipped.

## Companion PRs

- `spacecat-jobs-dispatcher` — adds `weekly-offsite` to the dispatcher's interval allow-list.
- `spacecat-infrastructure` — adds the Tuesday EventBridge schedule.
- Ops step (not a PR): flip the three offsite jobs in S3 `config/spacecat/global-config.json` from `weekly` → `weekly-offsite`.
