### PR TITLE
fix: add routingEnabled (timestamp) to edgeOptimizeConfig schema

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -449,6 +449,7 @@ export const configSchema = Joi.object({
       )
       .optional(),
     opted: Joi.number().optional(),
+    routingEnabled: Joi.number().optional(),
     stagingDomains: Joi.array().items(
       Joi.object({
         domain: Joi.string().required(),

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -2856,6 +2856,18 @@ describe('Config Tests', () => {
       expect(config.getEdgeOptimizeConfig()).to.deep.equal(data.edgeOptimizeConfig);
     });
 
+    it('creates a Config with edgeOptimizeConfig routingEnabled property', () => {
+      const data = {
+        edgeOptimizeConfig: {
+          opted: 1,
+          routingEnabled: 1700000000000,
+          enabled: 1700000000000,
+        },
+      };
+      const config = Config(data);
+      expect(config.getEdgeOptimizeConfig()).to.deep.equal(data.edgeOptimizeConfig);
+    });
+
     it('has undefined edgeOptimizeConfig in default config', () => {
       const config = Config();
       expect(config.getEdgeOptimizeConfig()).to.be.undefined;


### PR DESCRIPTION
## What
Adds an optional numeric **`routingEnabled`** field (ms-epoch timestamp) to the `edgeOptimizeConfig` Joi schema in the Site/Organization config model (`packages/spacecat-shared-data-access/src/models/site/config.js`).

## Why
The `optimize-at-edge-enabled-marking` job (spacecat-import-worker) gates `edgeOptimizeConfig.enabled` on two signals: the CDN request-id (routing) check, and prerender content validation (stored on the opportunity). Today the routing check result is computed each run and discarded. Persisting it as `routingEnabled` — the timestamp routing was confirmed live — lets the job (and eventually the UI) distinguish "CDN not routing yet" from "CDN routing, content still being validated."

Numeric only, no boolean form: it's a monotonic "confirmed live at" marker, matching the same pattern `enabled` itself already uses for its own timestamp. The `edgeOptimizeConfig` object is not `.unknown(true)`, so `validateConfiguration` throws on unknown keys — this schema change is required before the import worker can write the field on `site.save()`.

## Change
```js
edgeOptimizeConfig: Joi.object({
  enabled: Joi.alternatives().try(Joi.boolean(), Joi.number()).optional(),
  opted: Joi.number().optional(),
  routingEnabled: Joi.number().optional(),   // NEW
  stagingDomains: Joi.array()...optional(),
}).optional(),
```

## Tests
- New unit test in `config.test.js` (round-trips `routingEnabled` as a numeric timestamp alongside `opted`/`enabled`).
- Full `config.test.js` green (299 passing); lint clean.

## Follow-up
spacecat-import-worker will bump this package and write `routingEnabled` (ms-epoch, monotonic — stamped once when routing is first confirmed live) once released.

## Note
Supersedes an earlier attempt on `feat/edge-optimize-routing-enabled` (which briefly explored a boolean-or-number field) — this PR is the clean, final version, rebuilt directly off current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)