### PR TITLE
fix: add .playkit-player to VIDEO_PLAYER_SELECTORS

### DIFF
--- a/packages/spacecat-shared-html-analyzer/src/html-filter.js
+++ b/packages/spacecat-shared-html-analyzer/src/html-filter.js
@@ -98,6 +98,7 @@ const VIDEO_PLAYER_SELECTORS = [
   '.jwplayer', // JW Player
   '.mejs-container', // MediaElement.js
   '.flowplayer', // Flowplayer
+  '.playkit-player', // Kaltura PlayKit
 ].join(', ');
 
 /**


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/LLMO-6427

## Summary
- Adds `.playkit-player` (Kaltura PlayKit) to `VIDEO_PLAYER_SELECTORS` in `spacecat-shared-html-analyzer`
- Prevents Kaltura PlayKit's video player controls (Play, Seek, 00:00/06:24, Unmute, etc.) from leaking into the extracted/prerender text content and confusing the AI agent markdown view

## Test plan
- [x] `npm run lint -w packages/spacecat-shared-html-analyzer` passes
- [x] `npm test -w packages/spacecat-shared-html-analyzer` passes (77 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)