### PR TITLE
fix: add domain and summary to RUM bundle failure logs (rum-api-client)

### DIFF
--- a/packages/spacecat-shared-rum-api-client/src/client.js
+++ b/packages/spacecat-shared-rum-api-client/src/client.js
@@ -176,6 +176,7 @@ export default class RUMAPIClient {
         ...opts,
         domainkey,
         checkpoints: [...allCheckpoints],
+        queryType: queries.join(','),
       }, this.log);
 
       const results = {};

--- a/packages/spacecat-shared-rum-api-client/src/client.js
+++ b/packages/spacecat-shared-rum-api-client/src/client.js
@@ -140,6 +140,7 @@ export default class RUMAPIClient {
         ...opts,
         domainkey,
         checkpoints,
+        queryType: query,
       }, this.log);
 
       this.log.debug(`Query "${query}" fetched ${bundles.length} bundles`); // maybe even remove?

--- a/packages/spacecat-shared-rum-api-client/src/common/rum-bundler-client.js
+++ b/packages/spacecat-shared-rum-api-client/src/common/rum-bundler-client.js
@@ -262,6 +262,7 @@ async function fetchBundles(opts, log) {
     filterBotTraffic = true,
     startTime,
     endTime,
+    queryType,
   } = opts;
 
   if (!hasText(domain) || !hasText(domainkey)) {
@@ -316,7 +317,7 @@ async function fetchBundles(opts, log) {
 
   // Add failedUrls to opts object for access by callers
   if (failedUrls.length > 0) {
-    log.warn(`[RUM] ${failedUrls.length}/${urls.length} bundle requests failed for domain: ${domain}`);
+    log.warn(`[RUM] ${failedUrls.length}/${urls.length} bundle requests failed for domain: ${domain}${queryType ? ` (query: ${queryType})` : ''}`);
     // eslint-disable-next-line no-param-reassign
     opts.failedUrls = failedUrls;
   }

--- a/packages/spacecat-shared-rum-api-client/src/common/rum-bundler-client.js
+++ b/packages/spacecat-shared-rum-api-client/src/common/rum-bundler-client.js
@@ -290,7 +290,7 @@ async function fetchBundles(opts, log) {
           return response.json();
         } else {
           const failedUrl = response.url || chunk[index];
-          log.warn(`Skipping response at index ${index}: status ${response.status} - url: ${sanitizeURL(failedUrl)}`);
+          log.warn(`Skipping response at index ${index}: status ${response.status} for domain: ${domain} - url: ${sanitizeURL(failedUrl)}`);
           failedUrls.push(failedUrl);
           return null;
         }
@@ -316,6 +316,7 @@ async function fetchBundles(opts, log) {
 
   // Add failedUrls to opts object for access by callers
   if (failedUrls.length > 0) {
+    log.warn(`[RUM] ${failedUrls.length}/${urls.length} bundle requests failed for domain: ${domain}`);
     // eslint-disable-next-line no-param-reassign
     opts.failedUrls = failedUrls;
   }

--- a/packages/spacecat-shared-rum-api-client/test/common/rum-bundler-client.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/common/rum-bundler-client.test.js
@@ -236,6 +236,45 @@ describe('Rum bundler client', () => {
     expect(log.warn.calledWithMatch(`bundle requests failed for domain: ${domain}`)).to.be.true;
   });
 
+  it('should include queryType in summary warn when provided', async () => {
+    const domain = 'some-domain.com';
+    const domainkey = 'testkey';
+    const granularity = 'DAILY';
+    const interval = 3;
+    const allCheckpoints = ['good', 'bad'];
+    const queryType = 'user-engagement';
+
+    const dates = generateDailyDates(interval);
+    const rumBundles = generateRumBundles(dates, allCheckpoints);
+
+    for (let i = 0; i < dates.length; i += 1) {
+      const date = dates[i];
+      if (i < 2) {
+        nock(BASE_URL)
+          .get(`/bundles/${domain}/${date[0]}/${date[1]}/${date[2]}?domainkey=${domainkey}`)
+          .reply(200, rumBundles[date.join()]);
+      } else {
+        nock(BASE_URL)
+          .get(`/bundles/${domain}/${date[0]}/${date[1]}/${date[2]}?domainkey=${domainkey}`)
+          .reply(500, 'Internal Server Error');
+      }
+    }
+
+    const log = { warn: sinon.spy(), info: sinon.spy() };
+    const opts = {
+      domain,
+      domainkey,
+      granularity,
+      interval,
+      checkpoints: ['good'],
+      queryType,
+    };
+
+    await fetchBundles(opts, log);
+
+    expect(log.warn.calledWithMatch(`bundle requests failed for domain: ${domain} (query: ${queryType})`)).to.be.true;
+  });
+
   // Start and End Date Tests
   describe('startTime and endTime functionality', () => {
     it('should fetch bundles for specific date range with daily granularity', async () => {

--- a/packages/spacecat-shared-rum-api-client/test/common/rum-bundler-client.test.js
+++ b/packages/spacecat-shared-rum-api-client/test/common/rum-bundler-client.test.js
@@ -233,6 +233,7 @@ describe('Rum bundler client', () => {
     expect(bundles.length).to.equal(2);
     expect(opts.failedUrls.length).to.equal(2);
     expect(opts.failedUrls[0]).to.include(`/bundles/${domain}/`);
+    expect(log.warn.calledWithMatch(`bundle requests failed for domain: ${domain}`)).to.be.true;
   });
 
   // Start and End Date Tests


### PR DESCRIPTION
## Summary

- Adds **domain** to per-response warn log when a RUM bundle request fails
- Adds **query type** to summary warn log so Splunk alerts can distinguish which import type hits RUM rate limits
- `queryType` forwarded from `client.js:query()` → `fetchBundles()` via opts
- `queryMulti` now also passes `queryType` as joined query names (e.g. `cwv,user-engagement`)

**Before:**
```
[RUM] 2/8 bundle requests failed for domain: lilly.com
```
**After (single query):**
```
[RUM] 2/8 bundle requests failed for domain: lilly.com (query: user-engagement)
```
**After (multi query):**
```
[RUM] 2/8 bundle requests failed for domain: lilly.com (query: cwv,user-engagement)
```

## Motivation

SHM Sunday imports (`user-engagement`, `cwv-weekly`) suspected to hit 429s from RUM API due to N-site parallel Lambda fan-out × 31 concurrent chunk requests. Without import type in the log, Splunk can't distinguish which query is failing. Enables alerting on `service=import-worker "bundle requests failed" "query: user-engagement"`.

## Test plan

- [x] 209 tests passing, 100% line/statement/branch coverage on changed files
- [x] Truthy `queryType` branch explicitly tested (new test)
- [x] Existing `failedUrls` test assertion still matches (substring match)
- [ ] Observe Sunday 2026-07-27 Splunk run: `service=import-worker "bundle requests failed for domain"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)