### PR TITLE
fix(LLMO-5751): clear LAST_MOD_MISSING status on redeploy, like STALE

### DIFF
--- a/packages/spacecat-shared-tokowaka-client/src/index.js
+++ b/packages/spacecat-shared-tokowaka-client/src/index.js
@@ -1483,7 +1483,8 @@ class TokowakaClient {
       const succeeded = result.succeededSuggestions.map((s) => {
         const currentData = s.getData();
         const updated = { ...currentData, edgeDeployed: deploymentTimestamp };
-        if (updated.edgeOptimizeStatus === 'STALE') {
+        const statusesToExcludeFromOptimization = ['STALE', 'LAST_MOD_MISSING'];
+        if (statusesToExcludeFromOptimization.includes(updated.edgeOptimizeStatus)) {
           delete updated.edgeOptimizeStatus;
         }
         s.setData(updated);

--- a/packages/spacecat-shared-tokowaka-client/test/index.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/index.test.js
@@ -6059,6 +6059,24 @@ describe('TokowakaClient', () => {
       expect(s1.getData()).to.not.have.property('edgeOptimizeStatus');
     });
 
+    it('should clear edgeOptimizeStatus LAST_MOD_MISSING when deploying', async () => {
+      const s1 = makeSuggestion('s1', { url: 'https://example.com/page1', transformRules: {}, edgeOptimizeStatus: 'LAST_MOD_MISSING' });
+
+      deploySuggestionsStub.resolves({
+        succeededSuggestions: [s1],
+        failedSuggestions: [],
+      });
+
+      await client.deployToEdge({
+        site: mockSite,
+        opportunity: mockOpportunity,
+        targetSuggestions: [s1],
+        allSuggestions: [s1],
+      });
+
+      expect(s1.getData()).to.not.have.property('edgeOptimizeStatus');
+    });
+
     it('should mark ineligible suggestions as failed with statusCode 400', async () => {
       const s1 = makeSuggestion('s1', { url: 'https://example.com/page1' });
       const ineligible = { suggestion: s1, reason: 'not eligible' };


### PR DESCRIPTION
## Summary
- `edgeOptimizeStatus: STALE` is cleared on the next successful redeploy in `#deployPerUrlSuggestions`, but `LAST_MOD_MISSING` was not — leaving those suggestions permanently excluded from optimization even after a fresh deploy.
- Extend the existing clear-on-redeploy logic to also cover `LAST_MOD_MISSING`, via a `statusesToExcludeFromOptimization` list.

## Test plan
- [x] `npm test -w packages/spacecat-shared-tokowaka-client` — 973 passing, 100% coverage
- [x] `npm run lint -w packages/spacecat-shared-tokowaka-client` — clean
- [x] Added unit test mirroring the existing STALE-clearing test for `LAST_MOD_MISSING`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
