### PR TITLE
feat(content-client): dual Google Drive service-account with fallback

### DIFF
--- a/packages/spacecat-shared-content-client/src/clients/content-client.js
+++ b/packages/spacecat-shared-content-client/src/clients/content-client.js
@@ -211,24 +211,30 @@ const removeRedirectLoops = (currentRedirects, newRedirects, log) => {
   return noCycleRedirects;
 };
 
-// Google Drive returns 404 "File not found" when the folder is NOT SHARED with the service
-// account (not only when a document is genuinely missing), and 403 / "does not have permission"
-// when shared read-only. So both 403 and 404 signal a possible sharing problem and must trigger
-// the fallback (verified on prod: the old SA got "File not found" for a folder shared only with
-// the new SA). Accepted side effect: a genuinely missing document also triggers one extra
-// fallback attempt before the error propagates. Keep in sync with the spacecat-auth-service
-// `categorizeError` predicate (src/google-drive/handler.js).
-const GDRIVE_SHARING_ERROR = /\b(403|404)\b|forbidden|not found|access denied|insufficient|does not have permission|not shared/i;
+// A "folder not shared with this service account" failure surfaces as an HTTP 403 (shared
+// read-only / "does not have permission" / insufficientFilePermissions) or 404 ("File not found" —
+// Drive returns 404 for a folder the SA cannot see; verified on prod: the old SA got "File not
+// found" for a folder shared only with the new SA). Prefer the SDK error's STRUCTURED status code;
+// only fall back to a few specific reason phrases. Do NOT substring-match the whole message for
+// bare "not found" / "insufficient" / loose "403"/"404" — those false-match unrelated errors (e.g.
+// "module not found", "insufficient memory", a 404 in a trace id). Keep in sync with the
+// spacecat-auth-service `categorizeError` predicate (src/google-drive/handler.js).
+const GDRIVE_SHARING_REASON = /forbidden|insufficientFilePermissions|does not have permission|not shared|file not found/i;
 
 /**
  * True when a Google Drive error looks like a folder-sharing / permission problem (the service
- * account cannot see or edit the folder) — the signal to retry with the fallback SA.
+ * account cannot see or edit the folder) — the signal to retry with the fallback SA. Prefers the
+ * error's structured HTTP status (403/404) over message matching.
  * @param {Error & {code?: any, status?: any}} error
  * @returns {boolean}
  */
-const isGDriveSharingError = (error) => GDRIVE_SHARING_ERROR.test(
-  `${error?.message || ''} ${error?.code || ''} ${error?.status || ''}`,
-);
+const isGDriveSharingError = (error) => {
+  const status = Number(error?.status ?? error?.code);
+  if (status === 403 || status === 404) {
+    return true;
+  }
+  return GDRIVE_SHARING_REASON.test(error?.message || '');
+};
 
 /**
  * Build the fallback Google Drive service-account config, or null when no fallback is configured.
@@ -368,11 +374,9 @@ export default class ContentClient {
    * primary error also pins to the fallback, which is acceptable for the not-shared case this
    * targets). A no-op passthrough for OneDrive or when no fallback is configured.
    *
-   * Retry safety: a sharing/permission failure surfaces on the FIRST Drive access (resolving the
-   * document / redirects file), i.e. before any write in a compound read-then-write op, so
-   * re-running the whole `op` on the fallback does not double-apply a write. A future write op that
-   * can throw a sharing-matching error AFTER a partial mutation would break that assumption — wrap
-   * only its read then.
+   * Callers pass ONLY the initial Drive read here (via `#getDocument` / `#getRedirectsFile`) — the
+   * point at which a folder-not-shared error surfaces. Writes run afterwards, outside this wrapper,
+   * on the winning SA's handle, so a retry never replays a (non-idempotent) write.
    * @template T
    * @param {() => Promise<T>} op
    * @returns {Promise<T>}
@@ -397,6 +401,14 @@ export default class ContentClient {
       await this.#initClient();
       return op();
     }
+  }
+
+  async #getDocument(docPath) {
+    return this.#withGDriveFallback(() => this.rawClient.getDocument(docPath));
+  }
+
+  async #getRedirectsFile() {
+    return this.#withGDriveFallback(() => this.rawClient.getRedirects());
   }
 
   #logDuration(message, startTime) {
@@ -472,10 +484,8 @@ export default class ContentClient {
     this.log.debug(`Getting page metadata for ${this.site.getId()} and path ${path}`);
 
     const docPath = this.#resolveDocPath(path);
-    const metadata = await this.#withGDriveFallback(async () => {
-      const document = await this.rawClient.getDocument(docPath);
-      return document.getMetadata();
-    });
+    const document = await this.#getDocument(docPath);
+    const metadata = await document.getMetadata();
 
     this.#logDuration('getPageMetadata', startTime);
 
@@ -492,20 +502,17 @@ export default class ContentClient {
     this.log.debug(`Updating page metadata for ${this.site.getId()} and path ${path}`);
 
     const docPath = this.#resolveDocPath(path);
-    const mergedMetadata = await this.#withGDriveFallback(async () => {
-      const document = await this.rawClient.getDocument(docPath);
-      const originalMetadata = await document.getMetadata();
+    const document = await this.#getDocument(docPath);
+    const originalMetadata = await document.getMetadata();
 
-      const merged = overwrite
-        ? new Map([...originalMetadata, ...metadata])
-        : new Map([...metadata, ...originalMetadata]);
+    const mergedMetadata = overwrite
+      ? new Map([...originalMetadata, ...metadata])
+      : new Map([...metadata, ...originalMetadata]);
 
-      const response = await document.updateMetadata(merged);
-      if (response?.status !== 200) {
-        throw new Error(`Failed to update metadata for path ${path}: ${response.statusText}`);
-      }
-      return merged;
-    });
+    const response = await document.updateMetadata(mergedMetadata);
+    if (response?.status !== 200) {
+      throw new Error(`Failed to update metadata for path ${path}: ${response.statusText}`);
+    }
 
     this.#logDuration('updatePageMetadata', startTime);
 
@@ -517,10 +524,8 @@ export default class ContentClient {
 
     this.log.debug(`Getting redirects for ${this.site.getId()}`);
 
-    const redirects = await this.#withGDriveFallback(async () => {
-      const redirectsFile = await this.rawClient.getRedirects();
-      return redirectsFile.get();
-    });
+    const redirectsFile = await this.#getRedirectsFile();
+    const redirects = await redirectsFile.get();
     this.#logDuration('getRedirects', startTime);
 
     return redirects;
@@ -533,26 +538,24 @@ export default class ContentClient {
 
     this.log.debug(`Updating redirects for ${this.site.getId()}`);
 
-    await this.#withGDriveFallback(async () => {
-      const redirectsFile = await this.rawClient.getRedirects();
-      const currentRedirects = await redirectsFile.get();
-      // validate combination of existing and new redirects
-      const cleanNewRedirects = removeDuplicatedRedirects(currentRedirects, redirects, this.log);
-      if (cleanNewRedirects.length === 0) {
-        this.log.debug('No valid redirects to update');
-        return;
-      }
-      const noCycleRedirects = removeRedirectLoops(currentRedirects, cleanNewRedirects, this.log);
-      if (noCycleRedirects.length === 0) {
-        this.log.debug('No valid redirects to update');
-        return;
-      }
+    const redirectsFile = await this.#getRedirectsFile();
+    const currentRedirects = await redirectsFile.get();
+    // validate combination of existing and new redirects
+    const cleanNewRedirects = removeDuplicatedRedirects(currentRedirects, redirects, this.log);
+    if (cleanNewRedirects.length === 0) {
+      this.log.debug('No valid redirects to update');
+      return;
+    }
+    const noCycleRedirects = removeRedirectLoops(currentRedirects, cleanNewRedirects, this.log);
+    if (noCycleRedirects.length === 0) {
+      this.log.debug('No valid redirects to update');
+      return;
+    }
 
-      const response = await redirectsFile.append(noCycleRedirects);
-      if (response.status !== 200) {
-        throw new Error('Failed to update redirects');
-      }
-    });
+    const response = await redirectsFile.append(noCycleRedirects);
+    if (response.status !== 200) {
+      throw new Error('Failed to update redirects');
+    }
 
     this.#logDuration('updateRedirects', startTime);
   }
@@ -563,10 +566,8 @@ export default class ContentClient {
     this.log.debug(`Getting document links for ${this.site.getId()} and path ${path}`);
 
     const docPath = this.#resolveDocPath(path);
-    const links = await this.#withGDriveFallback(async () => {
-      const document = await this.rawClient.getDocument(docPath);
-      return document.getLinks();
-    });
+    const document = await this.#getDocument(docPath);
+    const links = await document.getLinks();
 
     this.#logDuration('getDocumentLinks', startTime);
 
@@ -582,16 +583,14 @@ export default class ContentClient {
     this.log.debug(`Updating page link for ${this.site.getId()} and path ${path}`);
 
     const docPath = this.#resolveDocPath(path);
-    await this.#withGDriveFallback(async () => {
-      const document = await this.rawClient.getDocument(docPath);
+    const document = await this.#getDocument(docPath);
 
-      this.log.debug('Updating link from', brokenLink.from, 'to', brokenLink.to);
-      const response = await document.updateLink(brokenLink.from, brokenLink.to);
+    this.log.debug('Updating link from', brokenLink.from, 'to', brokenLink.to);
+    const response = await document.updateLink(brokenLink.from, brokenLink.to);
 
-      if (response.status !== 200) {
-        throw new Error(`Failed to update link from ${brokenLink.from} to ${brokenLink.to} // ${brokenLink}`);
-      }
-    });
+    if (response.status !== 200) {
+      throw new Error(`Failed to update link from ${brokenLink.from} to ${brokenLink.to} // ${brokenLink}`);
+    }
 
     this.#logDuration('updateBrokenInternalLink', startTime);
   }
@@ -606,14 +605,12 @@ export default class ContentClient {
 
     const docPath = this.#resolveDocPath(path);
     this.log.debug(`Doc path: ${docPath}`);
-    await this.#withGDriveFallback(async () => {
-      const document = await this.rawClient.getDocument(docPath);
-      this.log.debug(`Document: ${document}`);
-      const response = await document.updateImageAltText(imageAltText);
-      if (response?.status !== 200) {
-        throw new Error(`Failed to update image alt text for path ${path}`);
-      }
-    });
+    const document = await this.#getDocument(docPath);
+    this.log.debug(`Document: ${document}`);
+    const response = await document.updateImageAltText(imageAltText);
+    if (response?.status !== 200) {
+      throw new Error(`Failed to update image alt text for path ${path}`);
+    }
 
     this.#logDuration('updateImageAltText', startTime);
   }

--- a/packages/spacecat-shared-content-client/src/clients/content-client.js
+++ b/packages/spacecat-shared-content-client/src/clients/content-client.js
@@ -211,6 +211,48 @@ const removeRedirectLoops = (currentRedirects, newRedirects, log) => {
   return noCycleRedirects;
 };
 
+const GDRIVE_SHARING_ERROR = /\b(403|404)\b|not found|access denied|insufficient|permission|not shared/i;
+
+/**
+ * True when a Google Drive error looks like a folder-sharing / permission problem (the service
+ * account cannot see the folder) — the signal to retry with the fallback SA. Mirrors the
+ * spacecat-auth-service categorizeError predicate.
+ * @param {Error & {code?: any, status?: any}} error
+ * @returns {boolean}
+ */
+const isGDriveSharingError = (error) => GDRIVE_SHARING_ERROR.test(
+  `${error?.message || ''} ${error?.code || ''} ${error?.status || ''}`,
+);
+
+/**
+ * Build the fallback Google Drive service-account config, or null when no fallback is configured.
+ * A customer's Drive folder may be shared with only one of the two SAs during the migration, so we
+ * keep a second SA to retry with. Any GDRIVE_*_FALLBACK env var overrides the matching SA field;
+ * fields without a _FALLBACK (the Google-universal constants) are reused from the primary config.
+ * Mirrors the dual-SA convention already live in spacecat-auth-service and mystique.
+ * @param {Record<string, any>} env
+ * @param {{[key: string]: string}} envMapping
+ * @param {{[key: string]: string}} primaryConfig
+ * @returns {{[key: string]: string} | null}
+ */
+const buildGDriveFallbackConfig = (env, envMapping, primaryConfig) => {
+  if (!hasText(env.GDRIVE_EMAIL_FALLBACK) || !hasText(env.GDRIVE_PRIVATE_KEY_FALLBACK)) {
+    return null;
+  }
+  const fallback = { ...primaryConfig };
+  for (const [configVar, envVar] of Object.entries(envMapping)) {
+    const fallbackValue = env[`${envVar}_FALLBACK`];
+    if (hasText(fallbackValue)) {
+      // The primary GDRIVE_PRIVATE_KEY is newline-unescaped by the consumer (e.g. autofix-worker
+      // run.js); the fallback key is not, so normalize it here. Idempotent for real newlines.
+      fallback[configVar] = configVar === 'private_key'
+        ? fallbackValue.replace(/\\n/g, '\n')
+        : fallbackValue;
+    }
+  }
+  return fallback;
+};
+
 export default class ContentClient {
   /**
    * @param {{log: Logging, env: Record<string, any>}} context
@@ -245,7 +287,11 @@ export default class ContentClient {
     } catch (e) {
       log.debug(`Customer ${site.getBaseURL()} secrets containing onedrive domain id not configured: ${e.message}`);
     }
-    return new ContentClient(config, site, log);
+    let fallbackConfig = null;
+    if (contentSourceType === CONTENT_SOURCE_TYPE_DRIVE_GOOGLE && envMapping) {
+      fallbackConfig = buildGDriveFallbackConfig(env, envMapping, config);
+    }
+    return new ContentClient(config, site, log, fallbackConfig);
   }
 
   static async createFromDomain(domain, env, log = console) {
@@ -282,12 +328,14 @@ export default class ContentClient {
    * @param {Site} site
    * @param {Logging} log
    */
-  constructor(config, site, log) {
+  constructor(config, site, log, fallbackConfig = null) {
     validateSite(site);
     validateConfiguration(config, site.getHlxConfig()?.content.source?.type);
 
     this.log = log;
     this.config = config;
+    this.fallbackConfig = fallbackConfig;
+    this.usingFallback = false;
     this.contentSource = site.getHlxConfig()?.content?.source;
     this.site = site;
     this.rawClient = null;
@@ -295,7 +343,36 @@ export default class ContentClient {
 
   async #initClient() {
     if (!this.rawClient) {
-      this.rawClient = await createContentSDKClient(this.config, this.contentSource, this.log);
+      const config = this.usingFallback ? this.fallbackConfig : this.config;
+      this.rawClient = await createContentSDKClient(config, this.contentSource, this.log);
+    }
+  }
+
+  /**
+   * Run a Google Drive operation against the current service account. If it fails with a
+   * folder-sharing / permission error and a fallback SA is configured, rebuild the SDK client with
+   * the fallback SA and retry once, then keep using the fallback for the rest of this instance's
+   * lifetime. A no-op passthrough for OneDrive or when no fallback is configured.
+   * @template T
+   * @param {() => Promise<T>} op
+   * @returns {Promise<T>}
+   */
+  async #withGDriveFallback(op) {
+    await this.#initClient();
+    try {
+      return await op();
+    } catch (e) {
+      const canFallback = this.fallbackConfig && !this.usingFallback
+        && this.contentSource?.type === CONTENT_SOURCE_TYPE_DRIVE_GOOGLE
+        && isGDriveSharingError(e);
+      if (!canFallback) {
+        throw e;
+      }
+      this.log.warn(`ContentClient: primary Google Drive SA (${this.config.client_email}) cannot access content for ${this.site.getId()} (${e.message}); retrying with fallback SA (${this.fallbackConfig.client_email})`);
+      this.usingFallback = true;
+      this.rawClient = null;
+      await this.#initClient();
+      return op();
     }
   }
 
@@ -369,13 +446,13 @@ export default class ContentClient {
 
     validatePath(path);
 
-    await this.#initClient();
-
     this.log.debug(`Getting page metadata for ${this.site.getId()} and path ${path}`);
 
     const docPath = this.#resolveDocPath(path);
-    const document = await this.rawClient.getDocument(docPath);
-    const metadata = await document.getMetadata();
+    const metadata = await this.#withGDriveFallback(async () => {
+      const document = await this.rawClient.getDocument(docPath);
+      return document.getMetadata();
+    });
 
     this.#logDuration('getPageMetadata', startTime);
 
@@ -389,25 +466,23 @@ export default class ContentClient {
     validatePath(path);
     validateMetadata(metadata);
 
-    await this.#initClient();
-
     this.log.debug(`Updating page metadata for ${this.site.getId()} and path ${path}`);
 
     const docPath = this.#resolveDocPath(path);
-    const document = await this.rawClient.getDocument(docPath);
-    const originalMetadata = await document.getMetadata();
+    const mergedMetadata = await this.#withGDriveFallback(async () => {
+      const document = await this.rawClient.getDocument(docPath);
+      const originalMetadata = await document.getMetadata();
 
-    let mergedMetadata;
-    if (overwrite) {
-      mergedMetadata = new Map([...originalMetadata, ...metadata]);
-    } else {
-      mergedMetadata = new Map([...metadata, ...originalMetadata]);
-    }
+      const merged = overwrite
+        ? new Map([...originalMetadata, ...metadata])
+        : new Map([...metadata, ...originalMetadata]);
 
-    const response = await document.updateMetadata(mergedMetadata);
-    if (response?.status !== 200) {
-      throw new Error(`Failed to update metadata for path ${path}: ${response.statusText}`);
-    }
+      const response = await document.updateMetadata(merged);
+      if (response?.status !== 200) {
+        throw new Error(`Failed to update metadata for path ${path}: ${response.statusText}`);
+      }
+      return merged;
+    });
 
     this.#logDuration('updatePageMetadata', startTime);
 
@@ -416,12 +491,13 @@ export default class ContentClient {
 
   async getRedirects() {
     const startTime = process.hrtime.bigint();
-    await this.#initClient();
 
     this.log.debug(`Getting redirects for ${this.site.getId()}`);
 
-    const redirectsFile = await this.rawClient.getRedirects();
-    const redirects = await redirectsFile.get();
+    const redirects = await this.#withGDriveFallback(async () => {
+      const redirectsFile = await this.rawClient.getRedirects();
+      return redirectsFile.get();
+    });
     this.#logDuration('getRedirects', startTime);
 
     return redirects;
@@ -432,28 +508,28 @@ export default class ContentClient {
 
     validateLinks(redirects, 'Redirect');
 
-    await this.#initClient();
-
     this.log.debug(`Updating redirects for ${this.site.getId()}`);
 
-    const redirectsFile = await this.rawClient.getRedirects();
-    const currentRedirects = await redirectsFile.get();
-    // validate combination of existing and new redirects
-    const cleanNewRedirects = removeDuplicatedRedirects(currentRedirects, redirects, this.log);
-    if (cleanNewRedirects.length === 0) {
-      this.log.debug('No valid redirects to update');
-      return;
-    }
-    const noCycleRedirects = removeRedirectLoops(currentRedirects, cleanNewRedirects, this.log);
-    if (noCycleRedirects.length === 0) {
-      this.log.debug('No valid redirects to update');
-      return;
-    }
+    await this.#withGDriveFallback(async () => {
+      const redirectsFile = await this.rawClient.getRedirects();
+      const currentRedirects = await redirectsFile.get();
+      // validate combination of existing and new redirects
+      const cleanNewRedirects = removeDuplicatedRedirects(currentRedirects, redirects, this.log);
+      if (cleanNewRedirects.length === 0) {
+        this.log.debug('No valid redirects to update');
+        return;
+      }
+      const noCycleRedirects = removeRedirectLoops(currentRedirects, cleanNewRedirects, this.log);
+      if (noCycleRedirects.length === 0) {
+        this.log.debug('No valid redirects to update');
+        return;
+      }
 
-    const response = await redirectsFile.append(noCycleRedirects);
-    if (response.status !== 200) {
-      throw new Error('Failed to update redirects');
-    }
+      const response = await redirectsFile.append(noCycleRedirects);
+      if (response.status !== 200) {
+        throw new Error('Failed to update redirects');
+      }
+    });
 
     this.#logDuration('updateRedirects', startTime);
   }
@@ -461,13 +537,13 @@ export default class ContentClient {
   async getDocumentLinks(path) {
     const startTime = process.hrtime.bigint();
 
-    await this.#initClient();
-
     this.log.debug(`Getting document links for ${this.site.getId()} and path ${path}`);
 
     const docPath = this.#resolveDocPath(path);
-    const document = await this.rawClient.getDocument(docPath);
-    const links = await document.getLinks();
+    const links = await this.#withGDriveFallback(async () => {
+      const document = await this.rawClient.getDocument(docPath);
+      return document.getLinks();
+    });
 
     this.#logDuration('getDocumentLinks', startTime);
 
@@ -480,19 +556,19 @@ export default class ContentClient {
     validateLinks([brokenLink], 'URL');
     validatePath(path);
 
-    await this.#initClient();
-
     this.log.debug(`Updating page link for ${this.site.getId()} and path ${path}`);
 
     const docPath = this.#resolveDocPath(path);
-    const document = await this.rawClient.getDocument(docPath);
+    await this.#withGDriveFallback(async () => {
+      const document = await this.rawClient.getDocument(docPath);
 
-    this.log.debug('Updating link from', brokenLink.from, 'to', brokenLink.to);
-    const response = await document.updateLink(brokenLink.from, brokenLink.to);
+      this.log.debug('Updating link from', brokenLink.from, 'to', brokenLink.to);
+      const response = await document.updateLink(brokenLink.from, brokenLink.to);
 
-    if (response.status !== 200) {
-      throw new Error(`Failed to update link from ${brokenLink.from} to ${brokenLink.to} // ${brokenLink}`);
-    }
+      if (response.status !== 200) {
+        throw new Error(`Failed to update link from ${brokenLink.from} to ${brokenLink.to} // ${brokenLink}`);
+      }
+    });
 
     this.#logDuration('updateBrokenInternalLink', startTime);
   }
@@ -502,18 +578,19 @@ export default class ContentClient {
 
     validatePath(path);
     validateImageAltText(imageAltText);
-    await this.#initClient();
 
     this.log.debug(`Updating image alt text for ${this.site.getId()} and path ${path}`);
 
     const docPath = this.#resolveDocPath(path);
     this.log.debug(`Doc path: ${docPath}`);
-    const document = await this.rawClient.getDocument(docPath);
-    this.log.debug(`Document: ${document}`);
-    const response = await document.updateImageAltText(imageAltText);
-    if (response?.status !== 200) {
-      throw new Error(`Failed to update image alt text for path ${path}`);
-    }
+    await this.#withGDriveFallback(async () => {
+      const document = await this.rawClient.getDocument(docPath);
+      this.log.debug(`Document: ${document}`);
+      const response = await document.updateImageAltText(imageAltText);
+      if (response?.status !== 200) {
+        throw new Error(`Failed to update image alt text for path ${path}`);
+      }
+    });
 
     this.#logDuration('updateImageAltText', startTime);
   }

--- a/packages/spacecat-shared-content-client/src/clients/content-client.js
+++ b/packages/spacecat-shared-content-client/src/clients/content-client.js
@@ -211,12 +211,18 @@ const removeRedirectLoops = (currentRedirects, newRedirects, log) => {
   return noCycleRedirects;
 };
 
-const GDRIVE_SHARING_ERROR = /\b(403|404)\b|not found|access denied|insufficient|permission|not shared/i;
+// Google Drive returns 404 "File not found" when the folder is NOT SHARED with the service
+// account (not only when a document is genuinely missing), and 403 / "does not have permission"
+// when shared read-only. So both 403 and 404 signal a possible sharing problem and must trigger
+// the fallback (verified on prod: the old SA got "File not found" for a folder shared only with
+// the new SA). Accepted side effect: a genuinely missing document also triggers one extra
+// fallback attempt before the error propagates. Keep in sync with the spacecat-auth-service
+// `categorizeError` predicate (src/google-drive/handler.js).
+const GDRIVE_SHARING_ERROR = /\b(403|404)\b|forbidden|not found|access denied|insufficient|does not have permission|not shared/i;
 
 /**
  * True when a Google Drive error looks like a folder-sharing / permission problem (the service
- * account cannot see the folder) — the signal to retry with the fallback SA. Mirrors the
- * spacecat-auth-service categorizeError predicate.
+ * account cannot see or edit the folder) — the signal to retry with the fallback SA.
  * @param {Error & {code?: any, status?: any}} error
  * @returns {boolean}
  */
@@ -239,6 +245,9 @@ const buildGDriveFallbackConfig = (env, envMapping, primaryConfig) => {
   if (!hasText(env.GDRIVE_EMAIL_FALLBACK) || !hasText(env.GDRIVE_PRIVATE_KEY_FALLBACK)) {
     return null;
   }
+  // Spread the primary so the fallback inherits the Google-universal constants (and any non-gdrive
+  // keys already on it, which the gdrive SDK ignores); the loop then overrides the per-SA fields
+  // that have a _FALLBACK value.
   const fallback = { ...primaryConfig };
   for (const [configVar, envVar] of Object.entries(envMapping)) {
     const fallbackValue = env[`${envVar}_FALLBACK`];
@@ -349,10 +358,21 @@ export default class ContentClient {
   }
 
   /**
-   * Run a Google Drive operation against the current service account. If it fails with a
-   * folder-sharing / permission error and a fallback SA is configured, rebuild the SDK client with
-   * the fallback SA and retry once, then keep using the fallback for the rest of this instance's
-   * lifetime. A no-op passthrough for OneDrive or when no fallback is configured.
+   * TODO(SITES-47990): remove after the EDS Google Drive SA migration completes, together with
+   * `fallbackConfig`, `usingFallback`, `buildGDriveFallbackConfig` and the `GDRIVE_*_FALLBACK` env.
+   *
+   * Run a Google Drive `op` against the current service account. If it fails with a folder-sharing
+   * / permission error (see `isGDriveSharingError`) and a fallback SA is set, rebuild the SDK
+   * client with the fallback SA, retry `op` once, then keep using the fallback SA for the rest of
+   * this instance's lifetime (a ContentClient is per-site, so the winning SA is stable; a transient
+   * primary error also pins to the fallback, which is acceptable for the not-shared case this
+   * targets). A no-op passthrough for OneDrive or when no fallback is configured.
+   *
+   * Retry safety: a sharing/permission failure surfaces on the FIRST Drive access (resolving the
+   * document / redirects file), i.e. before any write in a compound read-then-write op, so
+   * re-running the whole `op` on the fallback does not double-apply a write. A future write op that
+   * can throw a sharing-matching error AFTER a partial mutation would break that assumption — wrap
+   * only its read then.
    * @template T
    * @param {() => Promise<T>} op
    * @returns {Promise<T>}
@@ -368,7 +388,10 @@ export default class ContentClient {
       if (!canFallback) {
         throw e;
       }
-      this.log.warn(`ContentClient: primary Google Drive SA (${this.config.client_email}) cannot access content for ${this.site.getId()} (${e.message}); retrying with fallback SA (${this.fallbackConfig.client_email})`);
+      // Keep the raw SDK error out of the warn line (it can carry request URLs / token material and
+      // warn logs are long-retained); the detail goes to debug.
+      this.log.warn(`ContentClient: primary Google Drive SA (${this.config.client_email}) cannot access content for ${this.site.getId()}; retrying with fallback SA (${this.fallbackConfig.client_email})`);
+      this.log.debug(`ContentClient: primary Google Drive SA failure detail for ${this.site.getId()}: ${e.message}`);
       this.usingFallback = true;
       this.rawClient = null;
       await this.#initClient();

--- a/packages/spacecat-shared-content-client/test/clients/content-client.test.js
+++ b/packages/spacecat-shared-content-client/test/clients/content-client.test.js
@@ -1249,9 +1249,12 @@ describe('ContentClient', () => {
       GDRIVE_X509_CLIENT_CERT_URL_FALLBACK: 'fallback-cert-url',
     });
 
+    // a realistic Google Drive SDK error carries a structured HTTP status
+    const gdriveErr = (status, msg) => Object.assign(new Error(msg), { status });
+
     // stubs the helix SDK so the primary client is built first, the fallback client second
     const mockDualSAClient = async (primaryClient, fallbackClient) => {
-      const contentSDK = sinon.stub();
+      const contentSDK = sandbox.stub();
       contentSDK.onCall(0).returns(primaryClient);
       contentSDK.onCall(1).returns(fallbackClient);
       const Client = await esmock('../../src/clients/content-client.js', {
@@ -1261,7 +1264,7 @@ describe('ContentClient', () => {
     };
 
     beforeEach(() => {
-      warnLog = { info: sinon.spy(), debug: sinon.spy(), warn: sinon.spy() };
+      warnLog = { info: sandbox.spy(), debug: sandbox.spy(), warn: sandbox.spy() };
     });
 
     it('createFrom builds a fallback config, overriding per-SA fields and un-escaping the key', async () => {
@@ -1290,12 +1293,13 @@ describe('ContentClient', () => {
       expect(client.fallbackConfig).to.be.null;
     });
 
-    it('retries with the fallback SA when the primary hits a sharing error', async () => {
+    it('retries with the fallback SA when the primary hits a sharing error (by reason phrase)', async () => {
+      // no HTTP status on this one — exercises the reason-phrase branch of the predicate
       const primaryClient = {
-        getDocument: sinon.stub().rejects(new Error('403: The caller does not have permission')),
+        getDocument: sandbox.stub().rejects(new Error('The caller does not have permission')),
       };
-      const fallbackDoc = { getMetadata: sinon.stub().resolves(sampleMetadata) };
-      const fallbackClient = { getDocument: sinon.stub().returns(fallbackDoc) };
+      const fallbackDoc = { getMetadata: sandbox.stub().resolves(sampleMetadata) };
+      const fallbackClient = { getDocument: sandbox.stub().returns(fallbackDoc) };
       const { Client, contentSDK } = await mockDualSAClient(primaryClient, fallbackClient);
 
       const client = await Client.createFrom(
@@ -1312,9 +1316,11 @@ describe('ContentClient', () => {
     });
 
     it('keeps using the fallback SA for subsequent operations once it has switched', async () => {
-      const primaryClient = { getDocument: sinon.stub().rejects(new Error('404 not found')) };
+      const primaryClient = { getDocument: sandbox.stub().rejects(gdriveErr(404, 'File not found')) };
       const fallbackClient = {
-        getDocument: sinon.stub().returns({ getMetadata: sinon.stub().resolves(sampleMetadata) }),
+        getDocument: sandbox.stub().returns({
+          getMetadata: sandbox.stub().resolves(sampleMetadata),
+        }),
       };
       const { Client, contentSDK } = await mockDualSAClient(primaryClient, fallbackClient);
       const client = await Client.createFrom(
@@ -1335,13 +1341,13 @@ describe('ContentClient', () => {
 
     it('applies a write (updateImageAltText) through the fallback SA after a primary sharing error', async () => {
       const primaryClient = {
-        getDocument: sinon.stub().rejects(new Error('404 File not found')),
+        getDocument: sandbox.stub().rejects(gdriveErr(404, 'File not found')),
       };
       const fallbackDoc = {
-        getMetadata: sinon.stub().resolves(new Map()),
-        updateImageAltText: sinon.stub().resolves({ status: 200 }),
+        getMetadata: sandbox.stub().resolves(new Map()),
+        updateImageAltText: sandbox.stub().resolves({ status: 200 }),
       };
-      const fallbackClient = { getDocument: sinon.stub().returns(fallbackDoc) };
+      const fallbackClient = { getDocument: sandbox.stub().returns(fallbackDoc) };
       const { Client, contentSDK } = await mockDualSAClient(primaryClient, fallbackClient);
       const client = await Client.createFrom(
         { env: fallbackEnv(), log: warnLog },
@@ -1359,6 +1365,53 @@ describe('ContentClient', () => {
       expect(warnLog.warn.calledOnce).to.be.true;
     });
 
+    it('applies a redirects write through the fallback SA (append runs once, on the fallback)', async () => {
+      // the initial getRedirects() read fails on the primary, so the fallback is used for the
+      // whole operation; the append (write) must run exactly once, on the fallback file.
+      const primaryClient = { getRedirects: sandbox.stub().rejects(gdriveErr(404, 'File not found')) };
+      const fallbackRedirectsFile = {
+        get: sandbox.stub().resolves([]),
+        append: sandbox.stub().resolves({ status: 200 }),
+      };
+      const fallbackClient = { getRedirects: sandbox.stub().returns(fallbackRedirectsFile) };
+      const { Client, contentSDK } = await mockDualSAClient(primaryClient, fallbackClient);
+      const client = await Client.createFrom(
+        { env: fallbackEnv(), log: warnLog },
+        siteConfigGoogleDrive,
+      );
+
+      await client.updateRedirects([{ from: '/old', to: '/new' }]);
+
+      expect(contentSDK.calledTwice).to.be.true; // primary read failed, rebuilt on fallback
+      expect(client.usingFallback).to.be.true;
+      expect(primaryClient.getRedirects.calledOnce).to.be.true;
+      expect(fallbackClient.getRedirects.calledOnce).to.be.true;
+      expect(fallbackRedirectsFile.append.calledOnce).to.be.true; // written once, never replayed
+      expect(warnLog.warn.calledOnce).to.be.true;
+    });
+
+    it('does not retry or replay a write-phase failure (append error propagates)', async () => {
+      // the read (getRedirects) succeeds on the primary; only the append (write) fails. Because the
+      // write runs OUTSIDE the fallback wrapper, it is neither retried nor replayed on a second SA.
+      const redirectsFile = {
+        get: sandbox.stub().resolves([]),
+        append: sandbox.stub().rejects(gdriveErr(403, 'does not have permission')),
+      };
+      const primaryClient = { getRedirects: sandbox.stub().returns(redirectsFile) };
+      const fallbackClient = { getRedirects: sandbox.stub() };
+      const { Client, contentSDK } = await mockDualSAClient(primaryClient, fallbackClient);
+      const client = await Client.createFrom(
+        { env: fallbackEnv(), log: warnLog },
+        siteConfigGoogleDrive,
+      );
+
+      await expect(client.updateRedirects([{ from: '/old', to: '/new' }])).to.be.rejected;
+      expect(redirectsFile.append.calledOnce).to.be.true; // exactly one append attempt
+      expect(contentSDK.calledOnce).to.be.true; // fallback client never built
+      expect(fallbackClient.getRedirects.notCalled).to.be.true;
+      expect(warnLog.warn.notCalled).to.be.true;
+    });
+
     it('reuses the primary value for any per-SA field whose _FALLBACK is blank', async () => {
       const env2 = { ...fallbackEnv(), GDRIVE_PROJECT_ID_FALLBACK: '' }; // empty = not hasText
       const client = await ContentClient.createFrom(
@@ -1372,11 +1425,11 @@ describe('ContentClient', () => {
 
     it('does not retry on a non-sharing error even when a fallback is configured', async () => {
       const primaryClient = {
-        getDocument: sinon.stub().returns({
-          getMetadata: sinon.stub().rejects(new Error('some random parsing error')),
+        getDocument: sandbox.stub().returns({
+          getMetadata: sandbox.stub().rejects(new Error('some random parsing error')),
         }),
       };
-      const fallbackClient = { getDocument: sinon.stub() };
+      const fallbackClient = { getDocument: sandbox.stub() };
       const { Client, contentSDK } = await mockDualSAClient(primaryClient, fallbackClient);
       const client = await Client.createFrom(
         { env: fallbackEnv(), log: warnLog },
@@ -1390,21 +1443,21 @@ describe('ContentClient', () => {
     });
 
     it('propagates the error when both the primary and fallback SAs fail', async () => {
-      const primaryClient = { getDocument: sinon.stub().rejects(new Error('403 Access denied (primary)')) };
-      const fallbackClient = { getDocument: sinon.stub().rejects(new Error('403 Access denied (fallback)')) };
+      const primaryClient = { getDocument: sandbox.stub().rejects(gdriveErr(403, 'Access denied (primary)')) };
+      const fallbackClient = { getDocument: sandbox.stub().rejects(gdriveErr(403, 'Access denied (fallback)')) };
       const { Client } = await mockDualSAClient(primaryClient, fallbackClient);
       const client = await Client.createFrom(
         { env: fallbackEnv(), log: warnLog },
         siteConfigGoogleDrive,
       );
 
-      await expect(client.getPageMetadata('/test-path')).to.be.rejectedWith('403 Access denied (fallback)');
+      await expect(client.getPageMetadata('/test-path')).to.be.rejectedWith('Access denied (fallback)');
       expect(client.usingFallback).to.be.true;
     });
 
     it('does not attempt the gdrive fallback for OneDrive sites', async () => {
-      const primaryClient = { getDocument: sinon.stub().rejects(new Error('403 Access denied')) };
-      const fallbackClient = { getDocument: sinon.stub() };
+      const primaryClient = { getDocument: sandbox.stub().rejects(gdriveErr(403, 'Access denied')) };
+      const fallbackClient = { getDocument: sandbox.stub() };
       const { Client, contentSDK } = await mockDualSAClient(primaryClient, fallbackClient);
       // OneDrive site with a stray GDRIVE fallback present in env — must be ignored
       const client = await Client.createFrom(
@@ -1412,7 +1465,7 @@ describe('ContentClient', () => {
         siteConfigOneDrive,
       );
 
-      await expect(client.getPageMetadata('/test-path')).to.be.rejectedWith('403 Access denied');
+      await expect(client.getPageMetadata('/test-path')).to.be.rejectedWith('Access denied');
       expect(client.fallbackConfig).to.be.null; // fallback only built for drive.google
       expect(contentSDK.calledOnce).to.be.true;
       expect(warnLog.warn.notCalled).to.be.true;

--- a/packages/spacecat-shared-content-client/test/clients/content-client.test.js
+++ b/packages/spacecat-shared-content-client/test/clients/content-client.test.js
@@ -1322,13 +1322,52 @@ describe('ContentClient', () => {
         siteConfigGoogleDrive,
       );
 
-      await client.getPageMetadata('/test-path');
-      await client.getPageMetadata('/second-path');
+      const first = await client.getPageMetadata('/test-path');
+      const second = await client.getPageMetadata('/second-path');
 
+      expect(first).to.deep.equal(sampleMetadata);
+      expect(second).to.deep.equal(sampleMetadata); // 2nd call served by the fallback SA
       expect(contentSDK.calledTwice).to.be.true; // not rebuilt again for the 2nd call
       expect(primaryClient.getDocument.calledOnce).to.be.true;
       expect(fallbackClient.getDocument.calledTwice).to.be.true;
       expect(warnLog.warn.calledOnce).to.be.true;
+    });
+
+    it('applies a write (updateImageAltText) through the fallback SA after a primary sharing error', async () => {
+      const primaryClient = {
+        getDocument: sinon.stub().rejects(new Error('404 File not found')),
+      };
+      const fallbackDoc = {
+        getMetadata: sinon.stub().resolves(new Map()),
+        updateImageAltText: sinon.stub().resolves({ status: 200 }),
+      };
+      const fallbackClient = { getDocument: sinon.stub().returns(fallbackDoc) };
+      const { Client, contentSDK } = await mockDualSAClient(primaryClient, fallbackClient);
+      const client = await Client.createFrom(
+        { env: fallbackEnv(), log: warnLog },
+        siteConfigGoogleDrive,
+      );
+
+      const imageAltText = [{ imageUrl: 'https://example.com/image.png', altText: 'desc' }];
+      await expect(client.updateImageAltText('/test-path', imageAltText)).to.be.fulfilled;
+
+      expect(contentSDK.calledTwice).to.be.true;
+      expect(client.usingFallback).to.be.true;
+      expect(fallbackClient.getDocument.calledOnceWith('/test-path')).to.be.true;
+      // the write itself ran on the fallback SA's document
+      expect(fallbackDoc.updateImageAltText.calledOnceWith(imageAltText)).to.be.true;
+      expect(warnLog.warn.calledOnce).to.be.true;
+    });
+
+    it('reuses the primary value for any per-SA field whose _FALLBACK is blank', async () => {
+      const env2 = { ...fallbackEnv(), GDRIVE_PROJECT_ID_FALLBACK: '' }; // empty = not hasText
+      const client = await ContentClient.createFrom(
+        { env: env2, log: warnLog },
+        siteConfigGoogleDrive,
+      );
+      // blank _FALLBACK is skipped, so project_id falls back to the primary value
+      expect(client.fallbackConfig.project_id).to.equal('drive-project-id');
+      expect(client.fallbackConfig.client_email).to.equal('fallback-email');
     });
 
     it('does not retry on a non-sharing error even when a fallback is configured', async () => {

--- a/packages/spacecat-shared-content-client/test/clients/content-client.test.js
+++ b/packages/spacecat-shared-content-client/test/clients/content-client.test.js
@@ -1235,4 +1235,148 @@ describe('ContentClient', () => {
       await expect(client.updateImageAltText(path, imageAltText)).to.be.rejectedWith('Failed to update image alt text for path /test-path');
     });
   });
+
+  describe('dual service account fallback (Google Drive)', () => {
+    let warnLog;
+
+    const fallbackEnv = () => ({
+      ...env,
+      GDRIVE_EMAIL_FALLBACK: 'fallback-email',
+      GDRIVE_PRIVATE_KEY_FALLBACK: 'fallback\\nprivate\\nkey',
+      GDRIVE_PRIVATE_KEY_ID_FALLBACK: 'fallback-key-id',
+      GDRIVE_CLIENT_ID_FALLBACK: 'fallback-client-id',
+      GDRIVE_PROJECT_ID_FALLBACK: 'fallback-project-id',
+      GDRIVE_X509_CLIENT_CERT_URL_FALLBACK: 'fallback-cert-url',
+    });
+
+    // stubs the helix SDK so the primary client is built first, the fallback client second
+    const mockDualSAClient = async (primaryClient, fallbackClient) => {
+      const contentSDK = sinon.stub();
+      contentSDK.onCall(0).returns(primaryClient);
+      contentSDK.onCall(1).returns(fallbackClient);
+      const Client = await esmock('../../src/clients/content-client.js', {
+        '@adobe/spacecat-helix-content-sdk': { createFrom: contentSDK },
+      });
+      return { Client, contentSDK };
+    };
+
+    beforeEach(() => {
+      warnLog = { info: sinon.spy(), debug: sinon.spy(), warn: sinon.spy() };
+    });
+
+    it('createFrom builds a fallback config, overriding per-SA fields and un-escaping the key', async () => {
+      const client = await ContentClient.createFrom(
+        { env: fallbackEnv(), log: warnLog },
+        siteConfigGoogleDrive,
+      );
+      expect(client.fallbackConfig).to.deep.equal({
+        auth_provider_x509_cert_url: 'https://auth-provider.uri', // constant, reused from primary
+        auth_uri: 'https://auth.uri', // constant, reused
+        client_email: 'fallback-email', // overridden
+        client_id: 'fallback-client-id', // overridden
+        client_x509_cert_url: 'fallback-cert-url', // overridden
+        private_key: 'fallback\nprivate\nkey', // overridden AND newline-unescaped
+        private_key_id: 'fallback-key-id', // overridden
+        project_id: 'fallback-project-id', // overridden
+        token_uri: 'https://some.token.uri', // constant, reused
+        type: 'drive-type', // constant, reused
+        universe_domain: 'drive-universe-domain', // constant, reused
+      });
+      expect(client.usingFallback).to.be.false;
+    });
+
+    it('does not build a fallback config when no fallback env is set', async () => {
+      const client = await ContentClient.createFrom(context, siteConfigGoogleDrive);
+      expect(client.fallbackConfig).to.be.null;
+    });
+
+    it('retries with the fallback SA when the primary hits a sharing error', async () => {
+      const primaryClient = {
+        getDocument: sinon.stub().rejects(new Error('403: The caller does not have permission')),
+      };
+      const fallbackDoc = { getMetadata: sinon.stub().resolves(sampleMetadata) };
+      const fallbackClient = { getDocument: sinon.stub().returns(fallbackDoc) };
+      const { Client, contentSDK } = await mockDualSAClient(primaryClient, fallbackClient);
+
+      const client = await Client.createFrom(
+        { env: fallbackEnv(), log: warnLog },
+        siteConfigGoogleDrive,
+      );
+      const metadata = await client.getPageMetadata('/test-path');
+
+      expect(metadata).to.deep.equal(sampleMetadata);
+      expect(contentSDK.calledTwice).to.be.true; // primary then fallback SDK client built
+      expect(client.usingFallback).to.be.true;
+      expect(fallbackClient.getDocument.calledOnceWith('/test-path')).to.be.true;
+      expect(warnLog.warn.calledOnce).to.be.true;
+    });
+
+    it('keeps using the fallback SA for subsequent operations once it has switched', async () => {
+      const primaryClient = { getDocument: sinon.stub().rejects(new Error('404 not found')) };
+      const fallbackClient = {
+        getDocument: sinon.stub().returns({ getMetadata: sinon.stub().resolves(sampleMetadata) }),
+      };
+      const { Client, contentSDK } = await mockDualSAClient(primaryClient, fallbackClient);
+      const client = await Client.createFrom(
+        { env: fallbackEnv(), log: warnLog },
+        siteConfigGoogleDrive,
+      );
+
+      await client.getPageMetadata('/test-path');
+      await client.getPageMetadata('/second-path');
+
+      expect(contentSDK.calledTwice).to.be.true; // not rebuilt again for the 2nd call
+      expect(primaryClient.getDocument.calledOnce).to.be.true;
+      expect(fallbackClient.getDocument.calledTwice).to.be.true;
+      expect(warnLog.warn.calledOnce).to.be.true;
+    });
+
+    it('does not retry on a non-sharing error even when a fallback is configured', async () => {
+      const primaryClient = {
+        getDocument: sinon.stub().returns({
+          getMetadata: sinon.stub().rejects(new Error('some random parsing error')),
+        }),
+      };
+      const fallbackClient = { getDocument: sinon.stub() };
+      const { Client, contentSDK } = await mockDualSAClient(primaryClient, fallbackClient);
+      const client = await Client.createFrom(
+        { env: fallbackEnv(), log: warnLog },
+        siteConfigGoogleDrive,
+      );
+
+      await expect(client.getPageMetadata('/test-path')).to.be.rejectedWith('some random parsing error');
+      expect(contentSDK.calledOnce).to.be.true; // fallback client never built
+      expect(fallbackClient.getDocument.notCalled).to.be.true;
+      expect(warnLog.warn.notCalled).to.be.true;
+    });
+
+    it('propagates the error when both the primary and fallback SAs fail', async () => {
+      const primaryClient = { getDocument: sinon.stub().rejects(new Error('403 Access denied (primary)')) };
+      const fallbackClient = { getDocument: sinon.stub().rejects(new Error('403 Access denied (fallback)')) };
+      const { Client } = await mockDualSAClient(primaryClient, fallbackClient);
+      const client = await Client.createFrom(
+        { env: fallbackEnv(), log: warnLog },
+        siteConfigGoogleDrive,
+      );
+
+      await expect(client.getPageMetadata('/test-path')).to.be.rejectedWith('403 Access denied (fallback)');
+      expect(client.usingFallback).to.be.true;
+    });
+
+    it('does not attempt the gdrive fallback for OneDrive sites', async () => {
+      const primaryClient = { getDocument: sinon.stub().rejects(new Error('403 Access denied')) };
+      const fallbackClient = { getDocument: sinon.stub() };
+      const { Client, contentSDK } = await mockDualSAClient(primaryClient, fallbackClient);
+      // OneDrive site with a stray GDRIVE fallback present in env — must be ignored
+      const client = await Client.createFrom(
+        { env: fallbackEnv(), log: warnLog },
+        siteConfigOneDrive,
+      );
+
+      await expect(client.getPageMetadata('/test-path')).to.be.rejectedWith('403 Access denied');
+      expect(client.fallbackConfig).to.be.null; // fallback only built for drive.google
+      expect(contentSDK.calledOnce).to.be.true;
+      expect(warnLog.warn.notCalled).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Adds optional dual Google Drive service-account support to `@adobe/spacecat-shared-content-client`. When a fallback service account is configured, `ContentClient` retries a Google Drive operation against it if the primary service account cannot access the folder.

## 2. Reasoning
Part of the EDS Google Drive service-account migration (SITES-47990): the old Helix SA (`experience-success-studio@helix-225321`) is being replaced by the new Adobe SA (`aem-sites-optimizer@adbe-gcp0843`). `ContentClient` is the single seam every SpaceCat service uses to read and apply EDS Google Drive content — it builds one Google service account from `GDRIVE_*` env vars and hands it to `@adobe/spacecat-helix-content-sdk`. During the migration a customer's Drive folder may be shared with only one of the two service accounts, so a single-account client fails for any customer whose folder is not yet re-shared with that account. This closes the V1 gap (SITES-48193): the same dual-SA behaviour is already live in `spacecat-auth-service` (onboarding validate) and `mystique` (V2), but the V1 autofix apply path — which goes through `ContentClient` — had no fallback.

## 3. High-level overview of the changes
- `ContentClient.createFrom` now also builds a fallback Google Drive service-account config from `GDRIVE_*_FALLBACK` env vars. The fallback reuses the Google-universal constant fields (type, auth_uri, token_uri, universe_domain, auth-provider cert URL) from the primary and only overrides the per-account fields (email, private key, private key id, client id, project id, client cert URL). The fallback private key is newline-unescaped the same way the primary is.
- Google Drive operations now run through a fallback-aware wrapper. On a folder-sharing / permission failure (403 / 404 / not-found / access-denied), it rebuilds the SDK client with the fallback account, retries the operation once, and then keeps using the fallback account for the remainder of that `ContentClient` instance's lifetime (so subsequent calls do not re-probe the primary).
- Behaviour is unchanged when no fallback is configured (single account, as today). The fallback is Google-Drive-only — OneDrive is untouched — and the Helix-admin-token methods (`getEditURL` / `getResourcePath` / `getLivePreviewURLs`) do not use the Google Drive account and are unaffected.
- Operationally visible: when the fallback is used, a warning is logged identifying the primary account that failed and the fallback account being tried.

## 4. Required information
- Jira / issue: SITES-48193 (sub-task of SITES-47990) — https://jira.corp.adobe.com/browse/SITES-48193

## 5. Affected / used mysticat-workspace projects
- `spacecat-autofix-worker` — contract / consumer. Its V1 Google Drive autofix apply (alt-text, broken-backlinks, broken-internal-links, meta-tags) goes through `ContentClient` and is currently broken for folders shared only with the new SA. To adopt this fix it must bump `@adobe/spacecat-shared-content-client` to the release containing this change, set the `GDRIVE_*_FALLBACK` secrets in Vault, and redeploy.
- `spacecat-api-service` — consumed, no behaviour change. It also uses `ContentClient`, but only via the Helix-admin-token methods (edit / preview URL resolution), which do not use the Google Drive service account, so it is unaffected by this migration.

## 6. Additional information outside the code
- Vault `dx_mysticat/dev/autofix-worker` was patched (2026-07-29) with the new-SA `GDRIVE_*_FALLBACK` fields ahead of consumer testing; the primary remains the old SA, so runtime behaviour is unchanged until the consumer adopts this release. Stage and prod are not yet patched.
- The same dual-SA pattern is already live on prod in `spacecat-auth-service`: recordedfuture's onboarding validate exercised the fallback (primary/old SA "file not found" → fallback/new SA validated), which is the behaviour this change brings to the `ContentClient` apply path.
- No end-to-end Google Drive apply has been exercised against this code yet — that requires the `spacecat-autofix-worker` dependency bump and a deploy.

## 7. Test plan
- Local: no end-to-end run was possible without a real Google Drive site; the fallback build, the retry-on-sharing-error path, the sticky-fallback-across-calls behaviour, the no-retry-on-non-sharing-error path, both-accounts-fail propagation, and OneDrive-skips-fallback are covered by unit tests in this package (run by CI).
- dev / stage / prod: after this is released, bump `@adobe/spacecat-shared-content-client` in `spacecat-autofix-worker`; set `GDRIVE_*_FALLBACK` in Vault `dx_mysticat/{dev,stage,prod}/autofix-worker` (dev already done) and redeploy; then run alt-text autofix on an internal Friends-and-Family Google Drive site whose folder is shared with the new SA only, and confirm the fallback fires in the autofix-worker CloudWatch logs (warning: "retrying with fallback SA").

## 8. Deployment & merge order
- Related — `adobe/spacecat-auth-service#613`: merged and live on prod; the reference implementation of this dual-SA pattern for the onboarding validate path.
- Related — the ASO UI "Connect to AEM Sites" dialog change (SITES-48438) and the public-docs change (SITES-48014, docs PR #72): flip the customer-facing SA email to the new account.
- Depends-on / blocks — this change must merge and release, then `spacecat-autofix-worker` bumps the dependency; it must all land before the migration cleanup (SITES-48016) removes the old SA, or V1 Google Drive autofix breaks.
- Ordered sequence: (1) merge + release this spacecat-shared change; (2) bump `@adobe/spacecat-shared-content-client` in `spacecat-autofix-worker`; (3) set Vault `GDRIVE_*_FALLBACK` for stage + prod autofix-worker; (4) redeploy autofix-worker; (5) later, SITES-48016 removes the old SA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
