### PR TITLE
feat(site-config): add showWww flag to llmo config

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -389,6 +389,7 @@ export const configSchema = Joi.object({
       'ams-frontdoor',
       'other',
     ).optional(),
+    showWww: Joi.boolean().optional(),
   }).optional(),
   cdnLogsConfig: Joi.object({
     bucketName: Joi.string().required(),
@@ -719,6 +720,11 @@ export const Config = (data = {}) => {
   self.updateLlmoBrand = (brand) => {
     state.llmo = state.llmo || {};
     state.llmo.brand = brand;
+  };
+
+  self.updateLlmoShowWww = (showWww) => {
+    state.llmo = state.llmo || {};
+    state.llmo.showWww = showWww;
   };
 
   self.addLlmoHumanQuestions = (questions) => {

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -1884,6 +1884,37 @@ describe('Config Tests', () => {
       });
     });
 
+    describe('updateLlmoShowWww', () => {
+      it('should create llmo config if it does not exist and set showWww', () => {
+        config.updateLlmoShowWww(true);
+
+        const llmoConfig = config.getLlmoConfig();
+        expect(llmoConfig.showWww).to.equal(true);
+        expect(llmoConfig.brand).to.be.undefined;
+      });
+
+      it('should update showWww when llmo config already exists', () => {
+        // First create llmo config
+        config.updateLlmoConfig('/old/folder', 'oldBrand');
+
+        // Then update showWww
+        config.updateLlmoShowWww(true);
+
+        const llmoConfig = config.getLlmoConfig();
+        expect(llmoConfig.showWww).to.equal(true);
+        expect(llmoConfig.dataFolder).to.equal('/old/folder'); // Should preserve existing dataFolder
+      });
+
+      it('should update showWww multiple times', () => {
+        config.updateLlmoShowWww(true);
+        config.updateLlmoShowWww(false);
+        config.updateLlmoShowWww(true);
+
+        const llmoConfig = config.getLlmoConfig();
+        expect(llmoConfig.showWww).to.equal(true);
+      });
+    });
+
     describe('getLlmoHumanQuestions', () => {
       it('should return undefined when llmo questions do not exist', () => {
         expect(config.getLlmoHumanQuestions()).to.be.undefined;
@@ -2773,6 +2804,32 @@ describe('Config Tests', () => {
       };
       expect(() => validateConfiguration(config))
         .to.throw(/Configuration validation error: "llmo\.detectedCdn" must be one of/);
+    });
+  });
+
+  describe('LLMO Show Www', () => {
+    it('accepts a valid showWww boolean via validateConfiguration', () => {
+      const config = {
+        llmo: {
+          dataFolder: '/test',
+          brand: 'testBrand',
+          showWww: true,
+        },
+      };
+      const validated = validateConfiguration(config);
+      expect(validated.llmo.showWww).to.equal(true);
+    });
+
+    it('rejects a non-boolean showWww value via validateConfiguration', () => {
+      const config = {
+        llmo: {
+          dataFolder: '/test',
+          brand: 'testBrand',
+          showWww: 'not-a-boolean',
+        },
+      };
+      expect(() => validateConfiguration(config))
+        .to.throw(/Configuration validation error: "llmo\.showWww" must be a boolean/);
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds `showWww` boolean to the `llmo` site config schema (`Joi.boolean().optional()`), plus an `updateLlmoShowWww` setter following the existing single-field llmo setter pattern.
- Lets LLM Optimizer's Brands Management UI (companion PR in `project-elmo-ui`) display a site's domain with its `www.` prefix when the site opts in, instead of the current always-stripped display.

## Context
Two customers (kent.edu, Lumen) were onboarded with `base_url` stripped of `www.` (SpaceCat strips it unconditionally at onboarding). Backend citation-matching already treats www/non-www as equivalent, so this is purely a display-layer opt-in — no other backend behavior changes.

`PATCH /sites/{id}` already deep-merges `config.llmo` (spacecat-api-service), so once this ships, `{ "config": { "llmo": { "showWww": true } } }` persists with no controller changes needed there.

## Test plan
- [x] Unit tests added: schema accepts/rejects `showWww`, `updateLlmoShowWww` setter behavior (mirrors `updateLlmoBrand`/`updateLlmoDataFolder` coverage)
- [x] `npm test -w packages/spacecat-shared-data-access` — 2754 passing
- [x] `npm run lint -w packages/spacecat-shared-data-access` — clean