### PR TITLE
fix: validate cdnlogsFilter key against a column allowlist in site config

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -70,6 +70,30 @@ const RESERVED_SCRAPER_HEADER_NAMES = new Set([
 
 const LLMO_TAG_PATTERN = /^(market|product|topic):\s?.+/;
 const AWS_REGION_PATTERN = /^[a-z]{2}(?:-[a-z]+)+-\d+$/i;
+
+// Columns on the CDN log tables that a cdnlogsFilter entry is allowed to target.
+// `key` is interpolated (unquoted) into Athena SQL by the audit worker's
+// buildSiteFilters(), so it MUST be constrained to this allowlist to prevent SQL
+// injection (VULN-37491). Keep in sync with ALLOWED_FILTER_KEYS in
+// spacecat-audit-worker/src/utils/cdn-utils.js.
+export const CDN_LOGS_FILTER_KEYS = [
+  'url',
+  'host',
+  'x_forwarded_host',
+  'user_agent',
+  'referer',
+  'cdn_provider',
+];
+
+const CDN_LOGS_FILTER_SCHEMA = Joi.array().items(
+  Joi.object({
+    // Athena folds column identifiers to lowercase; normalize before matching
+    // the allowlist so a stored 'X_forwarded_host' is accepted as the same column.
+    key: Joi.string().lowercase().valid(...CDN_LOGS_FILTER_KEYS).required(),
+    value: Joi.array().items(Joi.string()).required(),
+    type: Joi.string().valid('include', 'exclude').optional(),
+  }),
+);
 const LLMO_TAG = Joi.alternatives()
   .try(
     // Tag market, product, topic like this: "market: ch", "product: firefly", "topic: copyright"
@@ -351,13 +375,7 @@ export const configSchema = Joi.object({
       }),
     ).optional(),
     tags: Joi.array().items(Joi.string()).optional(),
-    cdnlogsFilter: Joi.array().items(
-      Joi.object({
-        key: Joi.string().required(),
-        value: Joi.array().items(Joi.string()).required(),
-        type: Joi.string().valid('include', 'exclude').optional(),
-      }),
-    ).optional(),
+    cdnlogsFilter: CDN_LOGS_FILTER_SCHEMA.optional(),
     countryCodeIgnoreList: Joi.array().items(
       Joi.string().length(2),
     ).optional(),
@@ -842,8 +860,17 @@ export const Config = (data = {}) => {
   };
 
   self.updateLlmoCdnlogsFilter = (cdnlogsFilter) => {
+    // Reject invalid filter keys at write time (VULN-37491): `key` is
+    // interpolated into Athena SQL downstream, so anything off the allowlist
+    // must never be persisted. Validate only the filter here to avoid coupling
+    // to unrelated required fields elsewhere in the config.
+    const { error, value } = CDN_LOGS_FILTER_SCHEMA.validate(cdnlogsFilter);
+    if (error) {
+      throw new Error(`CDN logs filter validation error: ${error.message}`, { cause: error });
+    }
+
     state.llmo = state.llmo || {};
-    state.llmo.cdnlogsFilter = cdnlogsFilter;
+    state.llmo.cdnlogsFilter = value;
   };
 
   self.updateLlmoCountryCodeIgnoreList = (countryCodeIgnoreList) => {

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -13,7 +13,7 @@
 import { expect } from 'chai';
 
 import {
-  Config, validateConfiguration,
+  Config, validateConfiguration, CDN_LOGS_FILTER_KEYS,
 } from '../../../../src/models/site/config.js';
 import { registerLogger } from '../../../../src/util/logger-registry.js';
 
@@ -2609,7 +2609,7 @@ describe('Config Tests', () => {
           dataFolder: '/test',
           brand: 'testBrand',
           cdnlogsFilter: [
-            { key: 'path', value: ['/api/', '/content/'] },
+            { key: 'url', value: ['/api/', '/content/'] },
           ],
         },
       };
@@ -2623,8 +2623,8 @@ describe('Config Tests', () => {
           dataFolder: '/test',
           brand: 'testBrand',
           cdnlogsFilter: [
-            { key: 'path', value: ['/api/'], type: 'include' },
-            { key: 'status_code', value: ['404'], type: 'exclude' },
+            { key: 'url', value: ['/api/'], type: 'include' },
+            { key: 'host', value: ['example.com'], type: 'exclude' },
           ],
         },
       };
@@ -2650,11 +2650,38 @@ describe('Config Tests', () => {
     it('should be able to update cdnlogsFilter', () => {
       const config = Config();
       const cdnlogsFilter = [
-        { key: 'path', value: ['/api/'], type: 'include' },
-        { key: 'status_code', value: ['200'], type: 'exclude' },
+        { key: 'url', value: ['/api/'], type: 'include' },
+        { key: 'host', value: ['example.com'], type: 'exclude' },
       ];
       config.updateLlmoCdnlogsFilter(cdnlogsFilter);
       expect(config.getLlmoCdnlogsFilter()).to.deep.equal(cdnlogsFilter);
+    });
+
+    it('accepts every allowed cdnlogsFilter key', () => {
+      CDN_LOGS_FILTER_KEYS.forEach((key) => {
+        const config = Config();
+        const cdnlogsFilter = [{ key, value: ['x'], type: 'include' }];
+        config.updateLlmoCdnlogsFilter(cdnlogsFilter);
+        expect(config.getLlmoCdnlogsFilter()).to.deep.equal(cdnlogsFilter);
+      });
+    });
+
+    it('normalizes an uppercase cdnlogsFilter key to lowercase', () => {
+      const config = Config();
+      config.updateLlmoCdnlogsFilter([
+        { key: 'X_forwarded_host', value: ['example.com'], type: 'include' },
+      ]);
+      expect(config.getLlmoCdnlogsFilter()).to.deep.equal([
+        { key: 'x_forwarded_host', value: ['example.com'], type: 'include' },
+      ]);
+    });
+
+    it('rejects a cdnlogsFilter key that is not on the allowlist (VULN-37491)', () => {
+      const config = Config();
+      const maliciousKey = "url, '(?i)(x)')) UNION ALL SELECT CONCAT('https://x?s=', CAST(current_schema AS VARCHAR)), CAST(1 AS BIGINT) -- ";
+      expect(() => config.updateLlmoCdnlogsFilter([
+        { key: maliciousKey, value: ['x'], type: 'include' },
+      ])).to.throw('CDN logs filter validation error');
     });
   });
 


### PR DESCRIPTION
## Problem
Site config accepts an `llmo.cdnlogsFilter` array whose entries carry a `key` naming a CDN log column. The schema previously allowed any string for `key`, so a value that isn't a real column could be persisted and later used to build Athena filter clauses downstream (audit worker).

## Change
- Constrain `cdnlogsFilter[].key` in the config Joi schema to the known CDN log columns (`url`, `host`, `x_forwarded_host`, `user_agent`, `referer`, `cdn_provider`).
- Normalize case (Athena folds identifiers to lowercase), so `X_forwarded_host` is accepted and stored as `x_forwarded_host`.
- Reject invalid keys at write time in `updateLlmoCdnlogsFilter()` so a bad key surfaces as a validation error instead of being persisted.

This keeps persisted filters aligned with the exact set of columns the audit worker will accept (companion change: adobe/spacecat-audit-worker#2826).

## Tests
- Added coverage for all allowed keys, case normalization, and invalid-key rejection.
- data-access config tests pass; changed files lint clean.

Ref: LLMO-6621