### PR TITLE
fix(site): guard config writes against the config schema

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/site.model.js
+++ b/packages/spacecat-shared-data-access/src/models/site/site.model.js
@@ -18,6 +18,8 @@ import {
   AUTHORING_TYPES,
 } from '@adobe/spacecat-shared-utils';
 import BaseModel from '../base/base.model.js';
+import { validateConfiguration } from './config.js';
+import { guardConfigValidation } from '../../util/config-validation-guard.js';
 
 const HLX_HOST = /\.(?:aem|hlx)\.(?:page|live)$/i;
 export const AEM_CS_HOST = /^author-p(\d+)-e(\d+)/i;
@@ -81,6 +83,34 @@ class Site extends BaseModel {
   async toggleLive() {
     const newIsLive = !this.getIsLive();
     this.setIsLive(newIsLive);
+    return this;
+  }
+
+  /**
+   * Sets the site config, guarding it against the config schema
+   * (`validateConfiguration`). Overrides the auto-generated setter so every
+   * writer (e.g. the `PATCH /sites/{id}` config merge) is checked at one
+   * chokepoint. Behavior is governed by `CONFIG_VALIDATION_ENFORCEMENT`
+   * (default `warn`; `enforce` throws; `off` skips) — see
+   * config-validation-guard.js for the rollout rationale.
+   *
+   * Note: this only guards writes. Reads still go through the lenient
+   * `Config()` getter (attribute `get:` transform), which intentionally
+   * tolerates legacy invalid config already stored on existing sites so a
+   * bad historical record doesn't break every read of that site.
+   *
+   * @param {object} value - candidate config object
+   * @returns {this}
+   */
+  setConfig(value) {
+    guardConfigValidation({
+      entityName: Site.ENTITY_NAME,
+      entityId: this.getId(),
+      value,
+      validate: validateConfiguration,
+      log: this.log,
+    });
+    this.patcher.patchValue('config', value, false);
     return this;
   }
 

--- a/packages/spacecat-shared-data-access/src/util/config-validation-guard.js
+++ b/packages/spacecat-shared-data-access/src/util/config-validation-guard.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { ValidationError } from '../errors/index.js';
+
+export const ENFORCEMENT_MODES = {
+  OFF: 'off',
+  WARN: 'warn',
+  ENFORCE: 'enforce',
+};
+
+/**
+ * Resolves the config-validation enforcement mode from the environment.
+ *
+ * `CONFIG_VALIDATION_ENFORCEMENT` ∈ { off, warn, enforce }; defaults to `warn`.
+ * Read at call time so deployments (and tests) can flip it without a re-import.
+ *
+ * Rollout rationale: `Site.setConfig()` previously accepted any value with no
+ * schema validation at all on the update path (only entity `create()` runs
+ * attribute validation — see base.collection.js `#validateItem`/`#prepareItem`).
+ * Some existing sites carry legacy config that already fails today's Joi
+ * schema (e.g. an `imports` entry that predates a stricter schema addition).
+ * Flipping straight to `enforce` would reject unrelated PATCH requests on
+ * those sites. Ship `warn` first to surface violations in logs, then flip to
+ * `enforce` once legacy data is cleaned up or confirmed rare.
+ *
+ * @returns {string} one of ENFORCEMENT_MODES
+ */
+export const getConfigEnforcementMode = () => {
+  const raw = (process.env.CONFIG_VALIDATION_ENFORCEMENT || '').trim().toLowerCase();
+  return Object.values(ENFORCEMENT_MODES).includes(raw) ? raw : ENFORCEMENT_MODES.WARN;
+};
+
+/**
+ * Guards a config write. Validates `value` against the config schema via
+ * `validateConfiguration`. A valid config passes silently. An invalid config
+ * is, depending on the enforcement mode, ignored (`off`), logged without
+ * blocking (`warn`), or rejected (`enforce`).
+ *
+ * @param {object} params
+ * @param {string} params.entityName - e.g. 'Site' (for the log message)
+ * @param {string} [params.entityId] - entity id (for the log message)
+ * @param {object} params.value - the candidate config object
+ * @param {(value: object) => object} params.validate - validateConfiguration
+ * @param {object} [params.log] - logger with a `warn` method
+ * @throws {ValidationError} in `enforce` mode when validation fails
+ */
+export const guardConfigValidation = ({
+  entityName, entityId, value, validate, log,
+}) => {
+  const mode = getConfigEnforcementMode();
+  if (mode === ENFORCEMENT_MODES.OFF) {
+    return;
+  }
+
+  try {
+    validate(value);
+  } catch (error) {
+    const message = `config validation violation: ${entityName} ${entityId ?? '<unknown>'}: ${error.message}`;
+    if (log) {
+      log.warn(message);
+    }
+
+    if (mode === ENFORCEMENT_MODES.ENFORCE) {
+      throw new ValidationError(`Invalid config for ${entityName}: ${error.message}`);
+    }
+  }
+};

--- a/packages/spacecat-shared-data-access/test/unit/models/site/site.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/site.model.test.js
@@ -30,12 +30,14 @@ describe('SiteModel', () => {
 
   let mockElectroService;
   let mockRecord;
+  let mockLogger;
 
   beforeEach(() => {
     mockRecord = sampleSite;
 
     ({
       mockElectroService,
+      mockLogger,
       model: instance,
     } = createElectroMocks(Site, mockRecord));
 
@@ -621,6 +623,50 @@ describe('SiteModel', () => {
       it('sets projectId', () => {
         instance.setProjectId('1e9c6f94-f226-41f3-9005-4bb766765ac2');
         expect(instance.getProjectId()).to.equal('1e9c6f94-f226-41f3-9005-4bb766765ac2');
+      });
+    });
+
+    describe('setConfig', () => {
+      const original = process.env.CONFIG_VALIDATION_ENFORCEMENT;
+
+      afterEach(() => {
+        if (original === undefined) {
+          delete process.env.CONFIG_VALIDATION_ENFORCEMENT;
+        } else {
+          process.env.CONFIG_VALIDATION_ENFORCEMENT = original;
+        }
+      });
+
+      it('sets a valid config without warning', () => {
+        process.env.CONFIG_VALIDATION_ENFORCEMENT = 'enforce';
+        mockLogger.warn.resetHistory(); // ignore construction-time warnings
+        instance.setConfig({ slack: {}, handlers: {} });
+        expect(instance.getConfig().state).to.deep.equal({ slack: {}, handlers: {} });
+        expect(mockLogger.warn).to.not.have.been.called;
+      });
+
+      it('warns but still applies an invalid config in warn mode (default)', () => {
+        delete process.env.CONFIG_VALIDATION_ENFORCEMENT;
+        mockLogger.warn.resetHistory(); // ignore construction-time warnings
+        const invalidConfig = { llmo: { dataFolder: 'test', brand: 'Test', showWww: 'nope' } };
+        instance.setConfig(invalidConfig);
+        expect(instance.getConfig().state).to.deep.equal(invalidConfig);
+        expect(mockLogger.warn).to.have.been.calledOnce;
+      });
+
+      it('throws on an invalid config in enforce mode', () => {
+        process.env.CONFIG_VALIDATION_ENFORCEMENT = 'enforce';
+        const invalidConfig = { llmo: { dataFolder: 'test', brand: 'Test', showWww: 'nope' } };
+        expect(() => instance.setConfig(invalidConfig)).to.throw('Site');
+      });
+
+      it('does not validate when enforcement is off', () => {
+        process.env.CONFIG_VALIDATION_ENFORCEMENT = 'off';
+        mockLogger.warn.resetHistory();
+        const invalidConfig = { llmo: { dataFolder: 'test', brand: 'Test', showWww: 'nope' } };
+        expect(() => instance.setConfig(invalidConfig)).to.not.throw();
+        expect(instance.getConfig().state).to.deep.equal(invalidConfig);
+        expect(mockLogger.warn).to.not.have.been.called;
       });
     });
   });

--- a/packages/spacecat-shared-data-access/test/unit/util/config-validation-guard.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/util/config-validation-guard.test.js
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use as chaiUse } from 'chai';
+import sinonChai from 'sinon-chai';
+import { spy } from 'sinon';
+
+import {
+  ENFORCEMENT_MODES,
+  getConfigEnforcementMode,
+  guardConfigValidation,
+} from '../../../src/util/config-validation-guard.js';
+import { ValidationError } from '../../../src/errors/index.js';
+
+chaiUse(sinonChai);
+
+const validate = (value) => {
+  if (value?.invalid) {
+    throw new Error('boom: invalid config');
+  }
+};
+
+describe('config-validation-guard', () => {
+  const original = process.env.CONFIG_VALIDATION_ENFORCEMENT;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.CONFIG_VALIDATION_ENFORCEMENT;
+    } else {
+      process.env.CONFIG_VALIDATION_ENFORCEMENT = original;
+    }
+  });
+
+  describe('getConfigEnforcementMode', () => {
+    it('defaults to warn when unset', () => {
+      delete process.env.CONFIG_VALIDATION_ENFORCEMENT;
+      expect(getConfigEnforcementMode()).to.equal(ENFORCEMENT_MODES.WARN);
+    });
+
+    it('defaults to warn for an unrecognized value', () => {
+      process.env.CONFIG_VALIDATION_ENFORCEMENT = 'banana';
+      expect(getConfigEnforcementMode()).to.equal(ENFORCEMENT_MODES.WARN);
+    });
+
+    it('reads enforce (case-insensitive, trimmed)', () => {
+      process.env.CONFIG_VALIDATION_ENFORCEMENT = '  ENFORCE ';
+      expect(getConfigEnforcementMode()).to.equal(ENFORCEMENT_MODES.ENFORCE);
+    });
+
+    it('reads off', () => {
+      process.env.CONFIG_VALIDATION_ENFORCEMENT = 'off';
+      expect(getConfigEnforcementMode()).to.equal(ENFORCEMENT_MODES.OFF);
+    });
+  });
+
+  describe('guardConfigValidation', () => {
+    const base = { entityName: 'Site', entityId: 'id-1', validate };
+
+    it('passes silently on a valid config', () => {
+      const log = { warn: spy() };
+      process.env.CONFIG_VALIDATION_ENFORCEMENT = 'enforce';
+      expect(() => guardConfigValidation({
+        ...base, value: { invalid: false }, log,
+      })).to.not.throw();
+      expect(log.warn).to.not.have.been.called;
+    });
+
+    it('warns but does not throw in warn mode (default)', () => {
+      delete process.env.CONFIG_VALIDATION_ENFORCEMENT;
+      const log = { warn: spy() };
+      guardConfigValidation({
+        ...base, value: { invalid: true }, log,
+      });
+      expect(log.warn).to.have.been.calledOnce;
+      expect(log.warn.firstCall.args[0]).to.contain('Site id-1');
+      expect(log.warn.firstCall.args[0]).to.contain('boom: invalid config');
+    });
+
+    it('tolerates a missing logger in warn mode', () => {
+      process.env.CONFIG_VALIDATION_ENFORCEMENT = 'warn';
+      expect(() => guardConfigValidation({ ...base, value: { invalid: true } })).to.not.throw();
+    });
+
+    it('renders <unknown> placeholder when entityId is missing', () => {
+      process.env.CONFIG_VALIDATION_ENFORCEMENT = 'warn';
+      const log = { warn: spy() };
+      guardConfigValidation({
+        entityName: 'Site', validate, value: { invalid: true }, log,
+      });
+      expect(log.warn.firstCall.args[0]).to.contain('Site <unknown>');
+    });
+
+    it('throws a ValidationError in enforce mode', () => {
+      process.env.CONFIG_VALIDATION_ENFORCEMENT = 'enforce';
+      let thrown;
+      try {
+        guardConfigValidation({ ...base, value: { invalid: true } });
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).to.be.instanceOf(ValidationError);
+      expect(thrown.message).to.equal('Invalid config for Site: boom: invalid config');
+    });
+
+    it('still logs the detailed violation in enforce mode', () => {
+      process.env.CONFIG_VALIDATION_ENFORCEMENT = 'enforce';
+      const log = { warn: spy() };
+      expect(() => guardConfigValidation({
+        ...base, value: { invalid: true }, log,
+      })).to.throw(ValidationError);
+      expect(log.warn).to.have.been.calledOnce;
+    });
+
+    it('does nothing in off mode', () => {
+      process.env.CONFIG_VALIDATION_ENFORCEMENT = 'off';
+      const log = { warn: spy() };
+      expect(() => guardConfigValidation({
+        ...base, value: { invalid: true }, log,
+      })).to.not.throw();
+      expect(log.warn).to.not.have.been.called;
+    });
+  });
+});


### PR DESCRIPTION
## Summary
`Site.setConfig()` previously accepted any value with no schema validation at all — only entity `create()` runs attribute validation (`base.collection.js` `#validateItem`/`#prepareItem`); the generic auto-generated update setter just patches the raw value. The only thing touching Joi on the update path was the lenient `Config()` getter, which logs a warning and silently falls back to the raw data on a validation failure.

## Context
Found while manually verifying the `showWww` display fix (#1850): `PATCH /sites/{id}` with an invalid `showWww` value (e.g. a non-boolean) returned `200` and silently stored the bad value instead of being rejected, even though the Joi schema itself correctly flags the error (confirmed via the exact log line: `"llmo.showWww" must be a boolean"`).

This isn't specific to `showWww` or even to `config` — it's a general create-vs-update validation asymmetry in this data-access layer. Scoping this fix to `Site.config` only (not `BaseModel.save()` platform-wide) per discussion, since a platform-wide fix has much higher blast radius across every entity/attribute.

## Approach
- Overrides `setConfig` on `Site` to validate via `validateConfiguration` before patching, following the exact same override + rollout pattern already established for `Suggestion`/`FixEntity.setStatus` (`STATUS_TRANSITION_ENFORCEMENT`).
- New `CONFIG_VALIDATION_ENFORCEMENT` env var (`off` | `warn` (default) | `enforce`), read via a new `config-validation-guard.js` util mirroring `status-transition-guard.js`.
- Ships in `warn` mode by default — **no behavior change today**. At least one seeded local-dev site already carries config that fails the current schema (an unrelated pre-existing `imports` entry type mismatch), so flipping straight to `enforce` would reject unrelated PATCH requests on that site. Flip to `enforce` once legacy data is confirmed clean/rare.
- Reads are intentionally untouched — the lenient `Config()` getter still tolerates legacy invalid config on existing sites so a bad historical record doesn't break every read of that site.

## Test plan
- [x] New unit tests: `config-validation-guard.test.js` (mirrors `status-transition-guard.test.js` coverage), `Site.setConfig` tests (valid config, warn-mode fallback, enforce-mode throw, off-mode no-op)
- [x] `npm test -w packages/spacecat-shared-data-access` — 2772 passing, no regressions
- [x] `npm run lint -w packages/spacecat-shared-data-access` — clean
- [x] Manually verified against a local dev server: invalid `showWww` value is now rejected with `enforce` mode set, and the exact `"llmo.showWww" must be a boolean"` error surfaces