### PR TITLE
feat(project-engine-client): expose v3 prompt-metadata write facade (LLMO-6288)

### DIFF
--- a/packages/spacecat-shared-project-engine-client/CLAUDE.md
+++ b/packages/spacecat-shared-project-engine-client/CLAUDE.md
@@ -5,7 +5,7 @@ Counterfact **mock** used by local dev and the cross-repo e2e harness.
 
 - `src/` — the published surface: the raw `createSerenityProjectEngineApiClient` (an
   `openapi-fetch` client over every generated operation) **and** `createSerenityProjectEngineTransport`,
-  an intent-named facade that wraps the 28 in-spec operations spacecat-api-service consumes behind
+  an intent-named facade that wraps the 32 in-spec operations spacecat-api-service consumes behind
   verb+resource methods with a single error seam. Consumers depend on the facade; the raw client
   stays available for the remaining operations. Plus generated types (`src/generated/types.ts`).
   This is the ONLY thing that ships (`files: ["src"]`).

--- a/packages/spacecat-shared-project-engine-client/src/index.d.ts
+++ b/packages/spacecat-shared-project-engine-client/src/index.d.ts
@@ -111,7 +111,7 @@ type TransportData<P extends keyof paths, M extends keyof paths[P]> =
   | null;
 
 /**
- * Intent-named facade over {@link SerenityProjectEngineApiClient}. Wraps the 28 in-spec
+ * Intent-named facade over {@link SerenityProjectEngineApiClient}. Wraps the 32 in-spec
  * Project Engine operations spacecat-api-service consumes behind verb+resource methods, so
  * consumers depend on this seam rather than the raw client's literal path strings. Each method
  * is THIN: it forwards the caller's openapi-fetch `init` to the underlying client and resolves
@@ -324,6 +324,46 @@ export interface SerenityProjectEngineTransport {
   ): Promise<
     TransportData<'/v2/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}/rename', 'post'>
   >;
+  /**
+   * POST /v3/workspaces/{id}/projects/{project_id}/aio/prompts — aio-create-prompts
+   * (metadata-carrying create, LLMO-6289)
+   */
+  createPromptsWithMetadata(
+    ...init: TransportInitParam<
+      TransportInit<'/v3/workspaces/{id}/projects/{project_id}/aio/prompts', 'post'>
+    >
+  ): Promise<TransportData<'/v3/workspaces/{id}/projects/{project_id}/aio/prompts', 'post'>>;
+  /**
+   * PATCH /v3/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}
+   * — aio-patch-prompt (combined name + metadata merge-patch, LLMO-6289)
+   */
+  patchPrompt(
+    ...init: TransportInitParam<
+      TransportInit<'/v3/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}', 'patch'>
+    >
+  ): Promise<
+    TransportData<'/v3/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}', 'patch'>
+  >;
+  /**
+   * PATCH /v3/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}/metadata
+   * — aio-patch-prompt-metadata (metadata-only merge-patch, LLMO-6289)
+   */
+  patchPromptMetadata(
+    ...init: TransportInitParam<
+      TransportInit<'/v3/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}/metadata', 'patch'>
+    >
+  ): Promise<
+    TransportData<'/v3/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}/metadata', 'patch'>
+  >;
+  /**
+   * PATCH /v3/workspaces/{id}/projects/{project_id}/aio/prompts/metadata
+   * — aio-patch-prompts-metadata-batch (atomic batch metadata merge-patch, LLMO-6289)
+   */
+  patchPromptsMetadataBatch(
+    ...init: TransportInitParam<
+      TransportInit<'/v3/workspaces/{id}/projects/{project_id}/aio/prompts/metadata', 'patch'>
+    >
+  ): Promise<TransportData<'/v3/workspaces/{id}/projects/{project_id}/aio/prompts/metadata', 'patch'>>;
   /** GET /v2/workspaces/{id}/projects/{project_id}/aio/tags — aio-get-project-tags */
   listProjectTags(
     ...init: TransportInitParam<

--- a/packages/spacecat-shared-project-engine-client/src/rest-transport.js
+++ b/packages/spacecat-shared-project-engine-client/src/rest-transport.js
@@ -22,7 +22,7 @@ import { ProjectEngineApiError } from './errors.js';
 
 /**
  * Intent-named facade over the raw {@link createSerenityProjectEngineApiClient} openapi-fetch
- * client. It wraps ONLY the 28 in-spec Project Engine operations that spacecat-api-service
+ * client. It wraps ONLY the 32 in-spec Project Engine operations that spacecat-api-service
  * consumes, behind verb+resource method names, so consumers depend on this seam rather than the
  * raw client and its literal path strings. Each method is THIN: it forwards the caller's
  * openapi-fetch `init` (params.path/query, body) to `client.<METHOD>('<literal path>', init)` and
@@ -221,6 +221,34 @@ export function createSerenityProjectEngineTransport(options) {
      */
     renamePrompt(init) {
       return unwrap('POST', client.POST('/v2/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}/rename', init));
+    },
+    /**
+     * POST /v3/workspaces/{id}/projects/{project_id}/aio/prompts — aio-create-prompts
+     * (metadata-carrying create; each item is `{ name, metadata }`, LLMO-6289)
+     */
+    createPromptsWithMetadata(init) {
+      return unwrap('POST', client.POST('/v3/workspaces/{id}/projects/{project_id}/aio/prompts', init));
+    },
+    /**
+     * PATCH /v3/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}
+     * — aio-patch-prompt (combined name + metadata merge-patch, RFC 7396, LLMO-6289)
+     */
+    patchPrompt(init) {
+      return unwrap('PATCH', client.PATCH('/v3/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}', init));
+    },
+    /**
+     * PATCH /v3/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}/metadata
+     * — aio-patch-prompt-metadata (metadata-only merge-patch, RFC 7396, LLMO-6289)
+     */
+    patchPromptMetadata(init) {
+      return unwrap('PATCH', client.PATCH('/v3/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}/metadata', init));
+    },
+    /**
+     * PATCH /v3/workspaces/{id}/projects/{project_id}/aio/prompts/metadata
+     * — aio-patch-prompts-metadata-batch (atomic batch metadata merge-patch, LLMO-6289)
+     */
+    patchPromptsMetadataBatch(init) {
+      return unwrap('PATCH', client.PATCH('/v3/workspaces/{id}/projects/{project_id}/aio/prompts/metadata', init));
     },
     /** GET /v2/workspaces/{id}/projects/{project_id}/aio/tags — aio-get-project-tags */
     listProjectTags(init) {

--- a/packages/spacecat-shared-project-engine-client/test/rest-transport.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/rest-transport.test.js
@@ -53,7 +53,7 @@ const pathParamsFor = (template) => {
 
 const resolve = (template) => template.replace(/\{(\w+)\}/g, (_, k) => PARAM_VALUES[k]);
 
-// facadeMethod — HTTP method — path template. 1:1 with the 28 operations.
+// facadeMethod — HTTP method — path template. 1:1 with the 32 operations.
 const OPERATIONS = [
   ['listLanguages', 'GET', '/v1/languages'],
   ['listGlobalAiModels', 'GET', '/v1/ai_models'],
@@ -80,16 +80,20 @@ const OPERATIONS = [
   ['listPromptsByTagIds', 'POST', '/v2/workspaces/{id}/projects/{project_id}/aio/prompts/by_tags'],
   ['updatePromptTags', 'PUT', '/v2/workspaces/{id}/projects/{project_id}/aio/prompts/tags'],
   ['renamePrompt', 'POST', '/v2/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}/rename'],
+  ['createPromptsWithMetadata', 'POST', '/v3/workspaces/{id}/projects/{project_id}/aio/prompts'],
+  ['patchPrompt', 'PATCH', '/v3/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}'],
+  ['patchPromptMetadata', 'PATCH', '/v3/workspaces/{id}/projects/{project_id}/aio/prompts/{prompt_id}/metadata'],
+  ['patchPromptsMetadataBatch', 'PATCH', '/v3/workspaces/{id}/projects/{project_id}/aio/prompts/metadata'],
   ['listProjectTags', 'GET', '/v2/workspaces/{id}/projects/{project_id}/aio/tags'],
   ['createProjectTags', 'POST', '/v2/workspaces/{id}/projects/{project_id}/aio/tags'],
   ['updateProjectTag', 'PATCH', '/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}'],
 ];
 
 describe('createSerenityProjectEngineTransport', () => {
-  it('exposes exactly the 28 declared facade methods, all functions', () => {
+  it('exposes exactly the 32 declared facade methods, all functions', () => {
     const transport = make(sandbox.stub().resolves(json({})));
     const names = Object.keys(transport);
-    expect(names).to.have.length(28);
+    expect(names).to.have.length(32);
     expect(names.sort()).to.deep.equal(OPERATIONS.map(([n]) => n).sort());
     names.forEach((n) => expect(transport[n]).to.be.a('function'));
   });


### PR DESCRIPTION
This is a **release-gating** follow-up: once merged it must be **released**, then `@adobe/spacecat-shared-project-engine-client` bumped in spacecat-api-service to clear WP1's WP2-merge-gate. Order: merge → release → bump WP1 dep → merge WP1 (#2877).

## Why

WP2 ([#1818](https://github.com/adobe/spacecat-shared/pull/1818), released as **1.16.0**) re-vendored the delivered v3 swagger, regenerated `types.ts`, and grew the **mock** for the prompt authorship-metadata write surface — but it never added the intent-named **facade wrappers** on `createSerenityProjectEngineTransport`. So 1.16.0 exposes the v3 metadata paths only via the raw openapi-fetch client, **not** as facade methods.

spacecat-api-service **WP1** ([#2877](https://github.com/adobe/spacecat-api-service/pull/2877), LLMO-6289) delegates to four facade methods that don't exist in 1.16.0 — its own WP2-merge-gate test fails, and at runtime the prompt writes would throw `"…is not a function"`.

## What

Adds the four thin facade wrappers (same `unwrap` seam as every other method), matching the routes WP1 delegates to:

| facade method | route |
|---|---|
| `createPromptsWithMetadata` | `POST /v3 …/aio/prompts` |
| `patchPrompt` | `PATCH /v3 …/aio/prompts/{prompt_id}` |
| `patchPromptMetadata` | `PATCH /v3 …/aio/prompts/{prompt_id}/metadata` |
| `patchPromptsMetadataBatch` | `PATCH /v3 …/aio/prompts/metadata` |

Plus their `SerenityProjectEngineTransport` type declarations, the routing-table test rows, and the facade-operation count `28 → 32`. **No swagger / generated-types / mock changes** — those already landed in #1818.

## Verify (Node 24.18.0)

- `npm run lint` — ✅
- `npm run test:types` (tsc) — ✅ (type decls resolve against the vendored v3 paths)
- `npm test` — ✅ **348 passing, 100% coverage** (the routing table exercises each new method → correct verb+path)
- `npm run test:e2e` — ⚠️ not run: the counterfact mock server didn't boot in this sandbox (infra/TLS setup, unrelated to the facade code — `mock/` is untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)