### PR TITLE
fix: bound cdnlogsFilter value length and entry counts

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/config.js
+++ b/packages/spacecat-shared-data-access/src/models/site/config.js
@@ -85,12 +85,22 @@ export const CDN_LOGS_FILTER_KEYS = [
   'cdn_provider',
 ];
 
-const CDN_LOGS_FILTER_SCHEMA = Joi.array().items(
+// Bounds on the filter values. `value` entries become Athena regex patterns
+// downstream; SQL injection is already prevented by escaping in the audit worker,
+// but capping length/count limits regex abuse (ReDoS) and stored size.
+const CDN_LOGS_FILTER_MAX_ENTRIES = 50;
+const CDN_LOGS_FILTER_MAX_VALUES = 100;
+const CDN_LOGS_FILTER_MAX_VALUE_LENGTH = 500;
+
+const CDN_LOGS_FILTER_SCHEMA = Joi.array().max(CDN_LOGS_FILTER_MAX_ENTRIES).items(
   Joi.object({
     // Athena folds column identifiers to lowercase; normalize before matching
     // the allowlist so a stored 'X_forwarded_host' is accepted as the same column.
     key: Joi.string().lowercase().valid(...CDN_LOGS_FILTER_KEYS).required(),
-    value: Joi.array().items(Joi.string()).required(),
+    value: Joi.array()
+      .max(CDN_LOGS_FILTER_MAX_VALUES)
+      .items(Joi.string().max(CDN_LOGS_FILTER_MAX_VALUE_LENGTH))
+      .required(),
     type: Joi.string().valid('include', 'exclude').optional(),
   }),
 );

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -2690,6 +2690,33 @@ describe('Config Tests', () => {
       expect(config.getLlmoCdnlogsFilter()).to.deep.equal(cdnlogsFilter);
     });
 
+    it('rejects a cdnlogsFilter with more than 50 entries', () => {
+      const config = Config();
+      const entries = Array.from({ length: 51 }, () => ({ key: 'url', value: ['x'], type: 'include' }));
+      expect(() => config.updateLlmoCdnlogsFilter(entries)).to.throw('CDN logs filter validation error');
+    });
+
+    it('accepts a cdnlogsFilter with exactly 50 entries', () => {
+      const config = Config();
+      const entries = Array.from({ length: 50 }, () => ({ key: 'url', value: ['x'], type: 'include' }));
+      config.updateLlmoCdnlogsFilter(entries);
+      expect(config.getLlmoCdnlogsFilter()).to.deep.equal(entries);
+    });
+
+    it('rejects a cdnlogsFilter entry with more than 100 values', () => {
+      const config = Config();
+      expect(() => config.updateLlmoCdnlogsFilter([
+        { key: 'url', value: Array.from({ length: 101 }, () => 'x'), type: 'include' },
+      ])).to.throw('CDN logs filter validation error');
+    });
+
+    it('accepts a cdnlogsFilter entry with exactly 100 values', () => {
+      const config = Config();
+      const filter = [{ key: 'url', value: Array.from({ length: 100 }, () => 'x'), type: 'include' }];
+      config.updateLlmoCdnlogsFilter(filter);
+      expect(config.getLlmoCdnlogsFilter()).to.deep.equal(filter);
+    });
+
     it('rejects a cdnlogsFilter key that is not on the allowlist (VULN-37491)', () => {
       const config = Config();
       const maliciousKey = "url, '(?i)(x)')) UNION ALL SELECT CONCAT('https://x?s=', CAST(current_schema AS VARCHAR)), CAST(1 AS BIGINT) -- ";

--- a/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/config.test.js
@@ -2676,6 +2676,20 @@ describe('Config Tests', () => {
       ]);
     });
 
+    it('rejects a cdnlogsFilter value string that exceeds the length cap', () => {
+      const config = Config();
+      expect(() => config.updateLlmoCdnlogsFilter([
+        { key: 'url', value: ['a'.repeat(501)], type: 'include' },
+      ])).to.throw('CDN logs filter validation error');
+    });
+
+    it('accepts a cdnlogsFilter value string at the length cap', () => {
+      const config = Config();
+      const cdnlogsFilter = [{ key: 'url', value: ['a'.repeat(500)], type: 'include' }];
+      config.updateLlmoCdnlogsFilter(cdnlogsFilter);
+      expect(config.getLlmoCdnlogsFilter()).to.deep.equal(cdnlogsFilter);
+    });
+
     it('rejects a cdnlogsFilter key that is not on the allowlist (VULN-37491)', () => {
       const config = Config();
       const maliciousKey = "url, '(?i)(x)')) UNION ALL SELECT CONCAT('https://x?s=', CAST(current_schema AS VARCHAR)), CAST(1 AS BIGINT) -- ";


### PR DESCRIPTION
## Change
Adds bounds to the `cdnlogsFilter` config schema:
- max 50 filter entries
- max 100 values per entry
- max 500 chars per value string

## Why
`value` entries become Athena regex patterns downstream. SQL injection is already prevented by quote-escaping in the audit worker (adobe/spacecat-audit-worker), and invalid keys are rejected by the existing allowlist. These bounds are defense-in-depth: they limit regex abuse (ReDoS) and cap stored config size, and are well above any legitimate filter usage observed in the fleet.

## Tests
- Added coverage for over-cap rejection and at-cap acceptance.
- Config tests pass; changed files lint clean.

Ref: LLMO-6621