### PR TITLE
feat(data-access): expose deployedAt on FixEntity (SITES-47997/48823)

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/fix-entity/fix-entity.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/fix-entity/fix-entity.schema.js
@@ -33,6 +33,14 @@ const schema = new SchemaBuilder(FixEntity, FixEntityCollection)
     type: 'string',
     validate: (value) => !value || isIsoDate(value),
   })
+  // SITES-47997/48823 — the DEPLOYED moment (written/confirmed to author),
+  // distinct from executedAt (apply executed) and publishedAt (live). Maps to
+  // the fix_entities.deployed_at column; stamped by mystique on the -> DEPLOYED
+  // transition. Optional (null for rows created before the column).
+  .addAttribute('deployedAt', {
+    type: 'string',
+    validate: (value) => !value || isIsoDate(value),
+  })
   .addAttribute('publishedAt', {
     type: 'string',
     validate: (value) => !value || isIsoDate(value),

--- a/packages/spacecat-shared-data-access/src/models/fix-entity/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/fix-entity/index.d.ts
@@ -20,6 +20,8 @@ export interface FixEntity extends BaseModel {
   setChangeDetails(value: object): this;
   getExecutedAt(): string;
   setExecutedAt(value: string): this;
+  getDeployedAt(): string;
+  setDeployedAt(value: string): this;
   getExecutedBy(): string;
   setExecutedBy(value: string): this;
   getOpportunity(): Promise<Opportunity>;

--- a/packages/spacecat-shared-data-access/test/fixtures/fix-entity.fixture.js
+++ b/packages/spacecat-shared-data-access/test/fixtures/fix-entity.fixture.js
@@ -24,6 +24,7 @@ const fixEntities = [
     },
     executedBy: 'developer123',
     executedAt: '2025-01-09T23:21:55.834Z',
+    deployedAt: '2025-01-10T23:21:55.834Z',
     publishedAt: '2025-01-10T23:21:55.834Z',
   },
   {
@@ -39,6 +40,7 @@ const fixEntities = [
     },
     executedBy: 'developer456',
     executedAt: '2025-01-09T23:21:55.834Z',
+    deployedAt: '2025-02-09T23:21:55.834Z',
     publishedAt: '2025-02-09T23:21:55.834Z',
   },
   {
@@ -55,6 +57,7 @@ const fixEntities = [
     },
     executedBy: 'developer789',
     executedAt: '2025-02-09T23:21:55.834Z',
+    deployedAt: '2025-03-09T23:21:55.834Z',
     publishedAt: '2025-03-09T23:21:55.834Z',
   },
   {
@@ -71,6 +74,7 @@ const fixEntities = [
     },
     executedBy: 'developer789',
     executedAt: '2025-02-09T23:21:55.834Z',
+    deployedAt: '2025-03-09T23:21:55.834Z',
     publishedAt: '2025-03-09T23:21:55.834Z',
   },
   {
@@ -87,6 +91,7 @@ const fixEntities = [
     },
     executedBy: 'developer789',
     executedAt: '2025-02-09T23:21:55.834Z',
+    deployedAt: '2025-03-09T23:21:55.834Z',
     publishedAt: '2025-03-09T23:21:55.834Z',
   },
   {
@@ -103,6 +108,7 @@ const fixEntities = [
     },
     executedBy: 'developer789',
     executedAt: '2025-02-09T23:21:55.834Z',
+    deployedAt: '2025-03-09T23:21:55.834Z',
     publishedAt: '2025-03-09T23:21:55.834Z',
   },
 ];

--- a/packages/spacecat-shared-data-access/test/it/postgrest/docker-compose.yml
+++ b/packages/spacecat-shared-data-access/test/it/postgrest/docker-compose.yml
@@ -27,19 +27,21 @@ services:
     # updated to the new schema in SITES-47254 (they live on AsyncJob now), so the
     # old ">= v5.52.0 breaks the Preflight IT suite" blocker no longer applies.
     # v5.57.0 additionally carries the brand_to_semrush_projects site_id/soft-delete
-    # and brands semrush_sub_workspace_id columns (mysticat-data-service #765) that
-    # this branch's model changes require.
+    # and brands semrush_sub_workspace_id columns (mysticat-data-service #765).
+    # v5.80.0 adds the fix_entities.deployed_at column (mysticat-data-service #869,
+    # SITES-47997/48823) that the FixEntity model now maps — the reason for this bump.
     #
     # To obtain or refresh the digest:
     #   aws ecr describe-images \
     #     --profile <your-profile> --region us-east-1 \
     #     --repository-name mysticat-data-service \
-    #     --image-ids imageTag=v5.57.0 \
+    #     --image-ids imageTag=v5.80.0 \
     #     --query 'imageDetails[0].imageDigest' --output text
-    #   -> sha256:86e548a57d1e5390fec4db5d713574fecb092158f69f283eedf78e4ce2633e4d
+    #   (prior v5.57.0 digest was sha256:86e548a57d1e5390fec4db5d713574fecb092158f69f283eedf78e4ce2633e4d;
+    #    re-fetch for v5.80.0 if pinning a digest locally — CI runs without one.)
     # Then export MYSTICAT_DATA_SERVICE_DIGEST=sha256:<the-digest> before npm run test:it,
     # or set it in the .env file consumed by docker compose. Leave unset for local dev.
-    image: ${MYSTICAT_DATA_SERVICE_REPOSITORY:-682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service}:${MYSTICAT_DATA_SERVICE_TAG:-v5.57.0}${MYSTICAT_DATA_SERVICE_DIGEST:+@${MYSTICAT_DATA_SERVICE_DIGEST}}
+    image: ${MYSTICAT_DATA_SERVICE_REPOSITORY:-682033462621.dkr.ecr.us-east-1.amazonaws.com/mysticat-data-service}:${MYSTICAT_DATA_SERVICE_TAG:-v5.80.0}${MYSTICAT_DATA_SERVICE_DIGEST:+@${MYSTICAT_DATA_SERVICE_DIGEST}}
     depends_on:
       db:
         condition: service_healthy

--- a/packages/spacecat-shared-data-access/test/unit/models/fix-entity/fix-entity.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/fix-entity/fix-entity.collection.test.js
@@ -31,6 +31,7 @@ describe('FixEntityCollection', () => {
     changeDetails: { field: 'title', oldValue: 'Old', newValue: 'New' },
     executedAt: '2024-01-01T00:00:00.000Z',
     executedBy: 'user123',
+    deployedAt: '2024-01-01T00:00:00.000Z',
     publishedAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z',
   };

--- a/packages/spacecat-shared-data-access/test/unit/models/fix-entity/fix-entity.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/fix-entity/fix-entity.model.test.js
@@ -36,6 +36,7 @@ describe('FixEntityModel', () => {
       changeDetails: { field: 'title', oldValue: 'Old', newValue: 'New' },
       executedAt: '2024-01-01T00:00:00.000Z',
       executedBy: 'user123',
+      deployedAt: '2024-01-01T00:00:00.000Z',
       publishedAt: '2024-01-01T00:00:00.000Z',
       updatedAt: '2024-01-01T00:00:00.000Z',
     };


### PR DESCRIPTION
## What
Exposes **`deployedAt`** on the `FixEntity` model — the DEPLOYED-moment timestamp (written/confirmed to author), distinct from `executedAt` (apply executed) and `publishedAt` (live).

- `fix-entity.schema.js`: new `deployedAt` attribute (mirrors `publishedAt`; auto-maps to the `fix_entities.deployed_at` column).
- `index.d.ts`: `getDeployedAt()` / `setDeployedAt()`.
- Fixtures + model/collection tests updated (coverage 100%).

## Why
The `deployed_at` column was added to `fix_entities` (companion mysticat-data-service migration, already merged + promoted to all envs) and is stamped on the `-> DEPLOYED` transition, but the data-access model didn't map it — so the SpaceCat API couldn't return it. This closes that gap. SITES-47997 / SITES-48823.

## Safety
- **Additive + optional** — records created before the column return `deployedAt: null`; adding a field to the response is backward-compatible.
- **Column is live in dev/stage/prod** and `fix_entities` uses a **table-level** SELECT grant (auto-covers new columns), so PostgREST selecting `deployed_at` won't error.
- Consumer follow-up: bump this dep in `spacecat-api-service` and add `deployedAt` to `src/dto/fix.js` (separate PR, after this publishes).

## Design note
mystique + the migration implemented `deployedAt` as a **distinct new timestamp** (executed / deployed / published as three moments), per the requested design — rather than the `executedAt → deployedAt` *rename* sketched in the CLAUDE.md SITES-47997 note. Flagging for the SITES-47997 owner to confirm this supersedes the rename.
