### PR TITLE
fix(html-analyzer): strip FontFaceObserver/Next.js font-detection elements from HTML diff (LLMO-6061)

### DIFF
--- a/packages/spacecat-shared-html-analyzer/src/html-filter.js
+++ b/packages/spacecat-shared-html-analyzer/src/html-filter.js
@@ -209,7 +209,7 @@ function removeAccessibilityElementsCheerio($) {
 
 /**
  * Returns true if the text is entirely composed of font-detection noise:
- * either the font-metrics test string (substring match to cover &N variants)
+ * either the font-metrics test string (startsWith to cover &N suffix variants)
  * or exclusively repeated "word" tokens (≥ MIN_REPS).
  * @param {string} text - trimmed textContent of the element
  * @returns {boolean}
@@ -218,7 +218,7 @@ export function isFontDetectionLeaf(text) {
   if (!text) {
     return false;
   }
-  if (text.includes(FONT_DETECTION_TEST_STRING)) {
+  if (text.startsWith(FONT_DETECTION_TEST_STRING)) {
     return true;
   }
   const tokens = text.trim().split(/\s+/);

--- a/packages/spacecat-shared-html-analyzer/src/html-filter.js
+++ b/packages/spacecat-shared-html-analyzer/src/html-filter.js
@@ -209,9 +209,8 @@ function removeAccessibilityElementsCheerio($) {
 
 /**
  * Returns true if the text is entirely composed of font-detection noise:
- * either the font-metrics test string or exclusively repeated "word" tokens.
- * Used on both leaf elements and (in a second pass) on container text to catch
- * split-span cases where each child holds fewer than MIN_REPS occurrences.
+ * either the font-metrics test string (substring match to cover &N variants)
+ * or exclusively repeated "word" tokens (≥ MIN_REPS).
  * @param {string} text - trimmed textContent of the element
  * @returns {boolean}
  */
@@ -228,11 +227,6 @@ export function isFontDetectionLeaf(text) {
 
 /**
  * Remove FontFaceObserver / Next.js font-detection test elements (browser environment).
- * Two-pass strategy:
- *   1. Leaf pass — removes single-element noise nodes.
- *   2. Container pass — removes wrappers whose combined text is entirely noise,
- *      catching split-span cases (<div><span>word</span><span>word</span>…</div>)
- *      where each child individually falls below the repetition threshold.
  * Exported for direct unit testing without a full browser environment.
  * @param {Element} element - DOM element to filter
  */
@@ -245,19 +239,10 @@ export function removeFontDetectionElements(element) {
       el.remove();
     }
   });
-  element.querySelectorAll('*').forEach((el) => {
-    if (el.children.length === 0) {
-      return; // already handled in pass 1
-    }
-    if (isFontDetectionLeaf((el.textContent || '').trim())) {
-      el.remove();
-    }
-  });
 }
 
 /**
  * Remove FontFaceObserver / Next.js font-detection test elements (Node.js / cheerio).
- * Two-pass strategy mirrors the browser version — see removeFontDetectionElements.
  * @param {CheerioAPI} $ - Cheerio instance
  */
 function removeFontDetectionElementsCheerio($) {
@@ -265,15 +250,6 @@ function removeFontDetectionElementsCheerio($) {
     const $el = $(el);
     if ($el.children().length > 0) {
       return;
-    }
-    if (isFontDetectionLeaf($el.text().trim())) {
-      $el.remove();
-    }
-  });
-  $('*').each((i, el) => {
-    const $el = $(el);
-    if ($el.children().length === 0) {
-      return; // already handled in pass 1
     }
     if (isFontDetectionLeaf($el.text().trim())) {
       $el.remove();

--- a/packages/spacecat-shared-html-analyzer/src/html-filter.js
+++ b/packages/spacecat-shared-html-analyzer/src/html-filter.js
@@ -100,6 +100,15 @@ const VIDEO_PLAYER_SELECTORS = [
   '.flowplayer', // Flowplayer
 ].join(', ');
 
+// FontFaceObserver / Next.js @next/font inject transient test elements into the DOM to
+// detect when custom fonts have loaded. Puppeteer captures these before the library cleans
+// them up; the Chrome extension sees the page after cleanup so it's unaffected.
+// The two patterns are:
+//   1. A <div> containing only 10+ repetitions of "word" (character-width measurement)
+//   2. Spans containing "mmMwWLliI0fiflO" (the classic font-metrics test string)
+const FONT_DETECTION_TEST_STRING = 'mmMwWLliI0fiflO';
+const FONT_DETECTION_WORD_MIN_REPS = 10;
+
 /**
  * Validates if an element is likely a cookie banner based on text content
  * Optimized: Set lookup + early exit for common keywords (3x faster)
@@ -199,6 +208,60 @@ function removeAccessibilityElementsCheerio($) {
 }
 
 /**
+ * Returns true if the element is a leaf (no element children) whose text content is
+ * either the font-metrics test string or only repeated "word" tokens.
+ * Operates on the element's OWN text to avoid false-positive matches on ancestors.
+ * @param {string} text - trimmed textContent of the element
+ * @returns {boolean}
+ */
+function isFontDetectionLeaf(text) {
+  if (!text) {
+    return false;
+  }
+  if (text.includes(FONT_DETECTION_TEST_STRING)) {
+    return true;
+  }
+  // Must consist solely of "word" tokens and whitespace
+  if (/[^word\s]/.test(text)) {
+    return false;
+  }
+  return (text.match(/\bword\b/g) || []).length >= FONT_DETECTION_WORD_MIN_REPS;
+}
+
+/**
+ * Remove FontFaceObserver / Next.js font-detection test elements (browser environment).
+ * Only targets leaf elements (no element children) to avoid removing ancestor containers
+ * that also hold legitimate content.
+ * @param {Element} element - DOM element to filter
+ */
+function removeFontDetectionElements(element) {
+  element.querySelectorAll('*').forEach((el) => {
+    if (el.children.length > 0) {
+      return; // skip non-leaf elements — their text includes descendants' content
+    }
+    if (isFontDetectionLeaf((el.textContent || '').trim())) {
+      el.remove();
+    }
+  });
+}
+
+/**
+ * Remove FontFaceObserver / Next.js font-detection test elements (Node.js / cheerio).
+ * @param {CheerioAPI} $ - Cheerio instance
+ */
+function removeFontDetectionElementsCheerio($) {
+  $('*').each((i, el) => {
+    const $el = $(el);
+    if ($el.children().length > 0) {
+      return; // skip non-leaf elements
+    }
+    if (isFontDetectionLeaf($el.text().trim())) {
+      $el.remove();
+    }
+  });
+}
+
+/**
  * Remove navigation and footer elements (Node.js environment)
  * Optimized: single cheerio query instead of 35 separate queries (35x performance improvement)
  * @param {CheerioAPI} $ - Cheerio instance
@@ -280,6 +343,9 @@ function filterHtmlBrowser(htmlContent, ignoreNavFooter, returnText, includeNosc
   // Remove video player containers — JS-injected wrappers (e.g. Video.js) that render
   // control text (play/pause, caption settings, playback rate, etc.) client-side only
   documentElement.querySelectorAll(VIDEO_PLAYER_SELECTORS).forEach((n) => n.remove());
+
+  // Remove font-detection test elements injected by FontFaceObserver / Next.js @next/font
+  removeFontDetectionElements(documentElement);
 
   // Remove consent banners with intelligent detection
   removeCookieBanners(documentElement);
@@ -363,6 +429,9 @@ async function filterHtmlNode(htmlContent, ignoreNavFooter, returnText, includeN
   // Remove video player containers — JS-injected wrappers (e.g. Video.js) that render
   // control text (play/pause, caption settings, playback rate, etc.) client-side only
   $(VIDEO_PLAYER_SELECTORS).remove();
+
+  // Remove font-detection test elements injected by FontFaceObserver / Next.js @next/font
+  removeFontDetectionElementsCheerio($);
 
   // Remove cookie banners with comprehensive detection
   removeCookieBannersCheerio($);

--- a/packages/spacecat-shared-html-analyzer/src/html-filter.js
+++ b/packages/spacecat-shared-html-analyzer/src/html-filter.js
@@ -208,36 +208,46 @@ function removeAccessibilityElementsCheerio($) {
 }
 
 /**
- * Returns true if the element is a leaf (no element children) whose text content is
- * either the font-metrics test string or only repeated "word" tokens.
- * Operates on the element's OWN text to avoid false-positive matches on ancestors.
+ * Returns true if the text is entirely composed of font-detection noise:
+ * either the font-metrics test string or exclusively repeated "word" tokens.
+ * Used on both leaf elements and (in a second pass) on container text to catch
+ * split-span cases where each child holds fewer than MIN_REPS occurrences.
  * @param {string} text - trimmed textContent of the element
  * @returns {boolean}
  */
-function isFontDetectionLeaf(text) {
+export function isFontDetectionLeaf(text) {
   if (!text) {
     return false;
   }
   if (text.includes(FONT_DETECTION_TEST_STRING)) {
     return true;
   }
-  // Must consist solely of "word" tokens and whitespace
-  if (/[^word\s]/.test(text)) {
-    return false;
-  }
-  return (text.match(/\bword\b/g) || []).length >= FONT_DETECTION_WORD_MIN_REPS;
+  const tokens = text.trim().split(/\s+/);
+  return tokens.length >= FONT_DETECTION_WORD_MIN_REPS && tokens.every((t) => t === 'word');
 }
 
 /**
  * Remove FontFaceObserver / Next.js font-detection test elements (browser environment).
- * Only targets leaf elements (no element children) to avoid removing ancestor containers
- * that also hold legitimate content.
+ * Two-pass strategy:
+ *   1. Leaf pass — removes single-element noise nodes.
+ *   2. Container pass — removes wrappers whose combined text is entirely noise,
+ *      catching split-span cases (<div><span>word</span><span>word</span>…</div>)
+ *      where each child individually falls below the repetition threshold.
+ * Exported for direct unit testing without a full browser environment.
  * @param {Element} element - DOM element to filter
  */
-function removeFontDetectionElements(element) {
+export function removeFontDetectionElements(element) {
   element.querySelectorAll('*').forEach((el) => {
     if (el.children.length > 0) {
-      return; // skip non-leaf elements — their text includes descendants' content
+      return;
+    }
+    if (isFontDetectionLeaf((el.textContent || '').trim())) {
+      el.remove();
+    }
+  });
+  element.querySelectorAll('*').forEach((el) => {
+    if (el.children.length === 0) {
+      return; // already handled in pass 1
     }
     if (isFontDetectionLeaf((el.textContent || '').trim())) {
       el.remove();
@@ -247,13 +257,23 @@ function removeFontDetectionElements(element) {
 
 /**
  * Remove FontFaceObserver / Next.js font-detection test elements (Node.js / cheerio).
+ * Two-pass strategy mirrors the browser version — see removeFontDetectionElements.
  * @param {CheerioAPI} $ - Cheerio instance
  */
 function removeFontDetectionElementsCheerio($) {
   $('*').each((i, el) => {
     const $el = $(el);
     if ($el.children().length > 0) {
-      return; // skip non-leaf elements
+      return;
+    }
+    if (isFontDetectionLeaf($el.text().trim())) {
+      $el.remove();
+    }
+  });
+  $('*').each((i, el) => {
+    const $el = $(el);
+    if ($el.children().length === 0) {
+      return; // already handled in pass 1
     }
     if (isFontDetectionLeaf($el.text().trim())) {
       $el.remove();

--- a/packages/spacecat-shared-html-analyzer/test/index.test.js
+++ b/packages/spacecat-shared-html-analyzer/test/index.test.js
@@ -284,6 +284,37 @@ describe('HTML Visibility Analyzer', () => {
       expect(text).to.not.include('Play Pause');
     });
 
+    it('should remove FontFaceObserver mmMwWLliI0fiflO font-test spans', async () => {
+      const words = Array(20).fill('word').join(' ');
+      const html = `<html><body>
+        <h1>Real Content</h1>
+        <p>Important text here</p>
+        <div>${words}</div>
+        <br><span style="white-space: nowrap;">mmMwWLliI0fiflO&amp;1</span>
+        <br><span style="white-space: nowrap; font-family: serif;">mmMwWLliI0fiflO&amp;1</span>
+        <br><span style="white-space: nowrap; font-family: sans-serif;">mmMwWLliI0fiflO&amp;1</span>
+      </body></html>`;
+
+      const text = await stripTagsToText(html, true);
+
+      expect(text).to.include('Real Content');
+      expect(text).to.include('Important text here');
+      expect(text).to.not.include('mmMwWLliI0fiflO');
+      expect(text).to.not.match(/(\bword\b\s*){10,}/);
+    });
+
+    it('should not strip legitimate content containing the word "word"', async () => {
+      const html = `<html><body>
+        <h1>Word Processing Tips</h1>
+        <p>Use the right word in the right context. A word can change meaning.</p>
+      </body></html>`;
+
+      const text = await stripTagsToText(html, true);
+
+      expect(text).to.include('Word Processing Tips');
+      expect(text).to.include('Use the right word in the right context');
+    });
+
     it('should remove noscript elements by default', async () => {
       const html = '<html><body><h1>Title</h1><noscript>Please enable JavaScript</noscript><p>Content</p></body></html>';
       const text = await stripTagsToText(html);

--- a/packages/spacecat-shared-html-analyzer/test/index.test.js
+++ b/packages/spacecat-shared-html-analyzer/test/index.test.js
@@ -320,21 +320,6 @@ describe('HTML Visibility Analyzer', () => {
       expect(text).to.include('Use the right word in the right context');
     });
 
-    it('should remove split-span font-detection noise where each span holds fewer than 10 repetitions', async () => {
-      const spans = Array(20).fill('<span>word</span>').join(' ');
-      const html = `<html><body>
-        <h1>Real Content</h1>
-        <p>Important text here</p>
-        <div>${spans}</div>
-      </body></html>`;
-
-      const text = await stripTagsToText(html, true);
-
-      expect(text).to.include('Real Content');
-      expect(text).to.include('Important text here');
-      expect(text).to.not.match(/(\bword\b\s*){10,}/);
-    });
-
     it('should remove noscript elements by default', async () => {
       const html = '<html><body><h1>Title</h1><noscript>Please enable JavaScript</noscript><p>Content</p></body></html>';
       const text = await stripTagsToText(html);
@@ -458,15 +443,6 @@ describe('HTML Visibility Analyzer', () => {
       const root = makeContainer([leaf]);
       removeFontDetectionElements(root);
       expect(leaf.remove.called).to.equal(false);
-    });
-
-    it('should remove a container whose combined child text is all "word" tokens (split-span)', () => {
-      const children = Array(20).fill(null).map(() => makeLeaf('word'));
-      const container = makeContainer(children);
-      const root = makeContainer([container]);
-      root.querySelectorAll.returns([...children, container]);
-      removeFontDetectionElements(root);
-      expect(container.remove.calledOnce).to.equal(true);
     });
   });
 

--- a/packages/spacecat-shared-html-analyzer/test/index.test.js
+++ b/packages/spacecat-shared-html-analyzer/test/index.test.js
@@ -12,6 +12,7 @@
 
 import * as cheerio from 'cheerio';
 import { expect } from 'chai';
+import sinon from 'sinon';
 import {
   analyzeTextComparison,
   calculateStats,
@@ -20,6 +21,10 @@ import {
   generateMarkdownDiff,
   getAddedMarkdownBlocks,
 } from '../src/index.js';
+import {
+  isFontDetectionLeaf,
+  removeFontDetectionElements,
+} from '../src/html-filter.js';
 
 describe('HTML Visibility Analyzer', () => {
   const simpleHtml = '<html><body><h1>Title</h1><p>Content here</p></body></html>';
@@ -315,6 +320,21 @@ describe('HTML Visibility Analyzer', () => {
       expect(text).to.include('Use the right word in the right context');
     });
 
+    it('should remove split-span font-detection noise where each span holds fewer than 10 repetitions', async () => {
+      const spans = Array(20).fill('<span>word</span>').join(' ');
+      const html = `<html><body>
+        <h1>Real Content</h1>
+        <p>Important text here</p>
+        <div>${spans}</div>
+      </body></html>`;
+
+      const text = await stripTagsToText(html, true);
+
+      expect(text).to.include('Real Content');
+      expect(text).to.include('Important text here');
+      expect(text).to.not.match(/(\bword\b\s*){10,}/);
+    });
+
     it('should remove noscript elements by default', async () => {
       const html = '<html><body><h1>Title</h1><noscript>Please enable JavaScript</noscript><p>Content</p></body></html>';
       const text = await stripTagsToText(html);
@@ -363,6 +383,90 @@ describe('HTML Visibility Analyzer', () => {
       expect(textWith).to.include('Content');
       expect(textWith).to.include('First noscript');
       expect(textWith).to.include('Second noscript');
+    });
+  });
+
+  describe('isFontDetectionLeaf (unit)', () => {
+    it('should return false for empty string', () => {
+      expect(isFontDetectionLeaf('')).to.equal(false);
+    });
+
+    it('should return true for the mmMwWLliI0fiflO test string', () => {
+      expect(isFontDetectionLeaf('mmMwWLliI0fiflO')).to.equal(true);
+    });
+
+    it('should return true for 10+ space-separated "word" tokens', () => {
+      expect(isFontDetectionLeaf(Array(20).fill('word').join(' '))).to.equal(true);
+    });
+
+    it('should return false for fewer than 10 "word" tokens', () => {
+      expect(isFontDetectionLeaf('word word word')).to.equal(false);
+    });
+
+    it('should return false when other letters from {w,o,r,d} form different words', () => {
+      const mixed = `${Array(10).fill('word').join(' ')} door wood row`;
+      expect(isFontDetectionLeaf(mixed)).to.equal(false);
+    });
+
+    it('should return false for concatenated "word" repetitions without spaces', () => {
+      expect(isFontDetectionLeaf('word'.repeat(15))).to.equal(false);
+    });
+
+    it('should return false for legitimate prose mentioning "word" many times', () => {
+      const prose = Array(10).fill('the right word matters').join(' ');
+      expect(isFontDetectionLeaf(prose)).to.equal(false);
+    });
+  });
+
+  describe('removeFontDetectionElements (browser path unit)', () => {
+    function makeLeaf(text) {
+      return {
+        children: [],
+        get textContent() { return text; },
+        remove: sinon.stub(),
+      };
+    }
+
+    function makeContainer(children) {
+      const combined = children.map((c) => c.textContent).join(' ');
+      const el = {
+        children,
+        get textContent() { return combined; },
+        remove: sinon.stub(),
+        querySelectorAll: sinon.stub(),
+      };
+      el.querySelectorAll.returns([...children, el]);
+      return el;
+    }
+
+    it('should remove a leaf with the mmMwWLliI0fiflO test string', () => {
+      const leaf = makeLeaf('mmMwWLliI0fiflO');
+      const root = makeContainer([leaf]);
+      removeFontDetectionElements(root);
+      expect(leaf.remove.calledOnce).to.equal(true);
+    });
+
+    it('should remove a leaf with 20 repeated "word" tokens', () => {
+      const leaf = makeLeaf(Array(20).fill('word').join(' '));
+      const root = makeContainer([leaf]);
+      removeFontDetectionElements(root);
+      expect(leaf.remove.calledOnce).to.equal(true);
+    });
+
+    it('should not remove a leaf with legitimate content', () => {
+      const leaf = makeLeaf('Real content here');
+      const root = makeContainer([leaf]);
+      removeFontDetectionElements(root);
+      expect(leaf.remove.called).to.equal(false);
+    });
+
+    it('should remove a container whose combined child text is all "word" tokens (split-span)', () => {
+      const children = Array(20).fill(null).map(() => makeLeaf('word'));
+      const container = makeContainer(children);
+      const root = makeContainer([container]);
+      root.querySelectorAll.returns([...children, container]);
+      removeFontDetectionElements(root);
+      expect(container.remove.calledOnce).to.equal(true);
     });
   });
 

--- a/packages/spacecat-shared-html-analyzer/test/index.test.js
+++ b/packages/spacecat-shared-html-analyzer/test/index.test.js
@@ -380,6 +380,15 @@ describe('HTML Visibility Analyzer', () => {
       expect(isFontDetectionLeaf('mmMwWLliI0fiflO')).to.equal(true);
     });
 
+    it('should return true for mmMwWLliI0fiflO with &N suffix variants', () => {
+      expect(isFontDetectionLeaf('mmMwWLliI0fiflO&1')).to.equal(true);
+      expect(isFontDetectionLeaf('mmMwWLliI0fiflO&2')).to.equal(true);
+    });
+
+    it('should return false when mmMwWLliI0fiflO appears mid-text, not at start', () => {
+      expect(isFontDetectionLeaf('some text mmMwWLliI0fiflO')).to.equal(false);
+    });
+
     it('should return true for 10+ space-separated "word" tokens', () => {
       expect(isFontDetectionLeaf(Array(20).fill('word').join(' '))).to.equal(true);
     });


### PR DESCRIPTION
## Summary

- Adds a new `removeFontDetectionElements` filter (browser + Cheerio/Node.js paths) to strip transient font-detection test elements injected by **FontFaceObserver** and **Next.js `@next/font`** before Puppeteer captures the DOM
- Detects two patterns: spans/divs containing the classic font-metrics string `mmMwWLliI0fiflO` (prefix match to cover `&N` suffix variants) and elements consisting entirely of 10+ space-separated `"word"` tokens
- Exports `isFontDetectionLeaf` and `removeFontDetectionElements` as named exports for direct unit testing
- Fixes false HTML diffs caused by these ephemeral elements being present at capture time but absent in the Chrome extension view

## Test plan

- [x] Unit tests for `isFontDetectionLeaf` covering empty string, exact match, `&N` suffix, mid-text match, 10+ word tokens, fewer than 10 tokens, mixed tokens, concatenated (no-space), and legitimate prose
- [x] Unit tests for `removeFontDetectionElements` (browser path) using a lightweight DOM stub — confirms leaf removal and preserves legitimate content
- [x] Integration test for `stripTagsToText` confirms both font-metric spans and repeated-word divs are stripped while real content is preserved
- [x] Negative test: legitimate sentences mentioning "word" multiple times are not stripped

Jira: [LLMO-6061](https://jira.corp.adobe.com/browse/LLMO-6061)

🤖 Generated with [Claude Code](https://claude.com/claude-code)