### PR TITLE
feat(project-engine-client): honour sort_field / sort_dir on the by_tags mock (LLMO-6666)

### DIFF
--- a/packages/spacecat-shared-project-engine-client/mock/context.js
+++ b/packages/spacecat-shared-project-engine-client/mock/context.js
@@ -49,6 +49,7 @@ import { tagId } from './tag-id.js';
 import { parentIdField } from './parent-id.js';
 import { buildTagView } from './tag-view.js';
 import { resolveUrl } from './url-resolve.js';
+import { sortPromptsByMetadata } from './prompt-sort.js';
 import { brandUrlHttpsTag } from './brand-url-validation.js';
 import { SEEDS, DEFAULT_SEED } from './seeds.js';
 
@@ -118,6 +119,12 @@ export class Context {
     // function rather than inline in the coverage-excluded handler — same `$.context` lib-helper
     // convention as `tagId`. The consumer resolves a raw brand URL through this before writing it.
     this.resolveUrl = resolveUrl;
+    // The `by_tags` prompt-list sort (mock/prompt-sort.js). Exposed so the `.../prompts/by_tags`
+    // route orders its items on the wire `sort_field` / `sort_dir` through one pure, unit-tested
+    // function rather than inline in the coverage-excluded handler — same `$.context` lib-helper
+    // convention as `resolveUrl`. The consumer sorts the authorship read on `metadata.created_at` /
+    // `metadata.updated_at`; the wrong `sort` / `order` keys fall through to store order.
+    this.sortPromptsByMetadata = sortPromptsByMetadata;
     // The brand-URL `https://` validator (mock/brand-url-validation.js). Exposed so the
     // `POST .../brand_urls` route rejects a non-https value with the live gateway's 400 through one
     // pure, unit-tested function — same `$.context` lib-helper convention as `tagId`.

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/prompts/by_tags.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/prompts/by_tags.js
@@ -49,9 +49,19 @@
  * matching live's always-visible draft tree. `publish.js` flips `is_new` back to `false` for
  * every prompt in the project on a successful publish, which is what moves a prompt from
  * draft-only into this endpoint's default (published) view.
+ *
+ * Sort (LLMO-6666): live orders the returned `items` on the request-body `sort_field` / `sort_dir`
+ * (`AIOPromptsListRequest`) — the authorship read sorts on `metadata.created_at` /
+ * `metadata.updated_at`. The wrong `sort` / `order` keys are silently ignored by live (200 in
+ * default order), so the mock honours only `sort_field` / `sort_dir` (via the pure, unit-tested
+ * `context.sortPromptsByMetadata`) and returns store order for anything else — what makes a
+ * caller sending the correct keys distinguishable from the wrong ones (before this every
+ * ordering assertion was vacuous, the one thing blocking the sorted read from being covered). The
+ * sort runs on the prompt list, independent of `include_metadata` gating, and a prompt with
+ * an unset sort key sorts last deterministically. See `mock/prompt-sort.js` for the full contract.
  */
 
-/** POST — list prompts, optionally tag-id filtered (OR), gated by draft/publish state → 200. */
+/** POST — list prompts, tag-id filtered, gated by draft/publish, ordered by sort_field → 200. */
 export function POST($) {
   const {
     path, query, body, context,
@@ -71,6 +81,19 @@ export function POST($) {
     ? byTag
     : byTag.filter((p) => String(p.name ?? '').toLowerCase().includes(search));
 
+  // Sort ordering (LLMO-6666). Live orders this list on the request-body `sort_field` / `sort_dir`
+  // (`AIOPromptsListRequest`); the authorship read sorts on `metadata.created_at` /
+  // `metadata.updated_at`. The wrong `sort` / `order` keys are silently ignored by live and return
+  // default order — the pure helper honours only `sort_field` / `sort_dir`, so wrong keys fall
+  // through to store order here, making the two request shapes distinguishable. Sorting
+  // the PROMPT list (before the item mapping below) keeps it independent of `include_metadata`: the
+  // stored `metadata` drives the order even when the emitted item omits the key. An unrecognised
+  // `sort_field`, or a prompt whose sort key is unset, is handled deterministically in the helper.
+  const ordered = context.sortPromptsByMetadata(matched, {
+    sortField: body?.sort_field,
+    sortDir: body?.sort_dir,
+  });
+
   // A prompt REFERENCES its tags; the tag object is a view, derived here from the project's tag
   // collection through the one shared serializer. Live embeds the full tag — a descendant carries
   // its own `parent_id` + root-first `path`, a root carries neither — and the embedded object is
@@ -88,7 +111,7 @@ export function POST($) {
   // `metadata` is pulled out of the spread so it is only re-attached when `include_metadata=true`;
   // when omitted the item carries no `metadata` key at all (not `undefined`), matching the flag-off
   // payload shape. Every other stored field flows through `...rest` unchanged.
-  const items = matched.map((p) => {
+  const items = ordered.map((p) => {
     const { metadata, tags: stored, ...rest } = p;
     const tags = (Array.isArray(stored) ? stored : []).map((t) => byId.get(t.id) ?? t);
     // Prod OMITS `tags` entirely on an untagged prompt rather than emitting `[]` (Rainer review,

--- a/packages/spacecat-shared-project-engine-client/mock/prompt-sort.js
+++ b/packages/spacecat-shared-project-engine-client/mock/prompt-sort.js
@@ -69,6 +69,9 @@ export const SORTABLE_FIELDS = /** @type {const} */ (['metadata.created_at', 'me
 export const sortPromptsByMetadata = (prompts, { sortField, sortDir } = {}) => {
   const list = Array.isArray(prompts) ? [...prompts] : [];
   const field = typeof sortField === 'string' ? sortField : '';
+  // Cast unavoidable: a `readonly` tuple's `.includes()` narrows its arg to the tuple's literal
+  // union, so tsc rejects an arbitrary `string`. Widening `field` to `any` is the standard
+  // membership-test escape; the runtime check is exactly what narrows it back to a valid field.
   if (!SORTABLE_FIELDS.includes(/** @type {any} */ (field))) {
     return list;
   }

--- a/packages/spacecat-shared-project-engine-client/mock/prompt-sort.js
+++ b/packages/spacecat-shared-project-engine-client/mock/prompt-sort.js
@@ -47,6 +47,14 @@ export const SORTABLE_FIELDS = /** @type {const} */ (['metadata.created_at', 'me
  *   sorting on a metadata field while the response omits the `metadata` key is valid and never
  *   throws (the handler sorts the prompt list, then maps to items).
  *
+ * CAVEAT — two of these are mock-DEFINED conventions, not live-VERIFIED. The 2026-07-29 probe
+ * captured the sort keys but NOT (a) where a missing key lands or (b) the default when `sort_dir`
+ * is absent. We define missing-key = LAST-in-both-directions (matching the spec's "NULLS LAST",
+ * §16 gate G5) and absent-`sort_dir` = ascending. LLMO-6667's api-service assertions pin whatever
+ * this mock does, so if real Semrush diverges (e.g. NULLS-FIRST on DESC) the suite would go green
+ * against a mock that disagrees with prod — confirm both against live before relying on 6667 as a
+ * prod-faithfulness guarantee. Tracked on LLMO-6666.
+ *
  * Values are compared with `<` / `>`; the timestamps are ISO-8601 strings, which order correctly
  * lexicographically. No dependency on their being parseable dates — an opaque interim value still
  * orders consistently with itself.

--- a/packages/spacecat-shared-project-engine-client/mock/prompt-sort.js
+++ b/packages/spacecat-shared-project-engine-client/mock/prompt-sort.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// @ts-check
+
+/** The recognised `sort_field` values — the authorship timestamps the consumer sorts on. */
+export const SORTABLE_FIELDS = /** @type {const} */ (['metadata.created_at', 'metadata.updated_at']);
+
+/**
+ * The `by_tags` prompt-list ordering the live Semrush Project Engine performs — the single source
+ * of truth behind the `.../aio/prompts/by_tags.js` handler, exposed on the per-request context as
+ * `context.sortPromptsByMetadata` (every route reads its lib helpers through `$.context`, never an
+ * import — see {@link Context}). Kept a pure function so it is unit-tested on its own (the route
+ * handler is coverage-excluded), the same convention as {@link resolveUrl} / `tagId` (LLMO-6666).
+ *
+ * Wire contract (verified live 2026-07-29 against LLMO-Dev-2, Brand-A, project `997e17c3`):
+ * - The sort keys are the request-body fields `sort_field` and `sort_dir` of
+ *   `model.AIOPromptsListRequest`. The authorship surface sorts on `metadata.created_at` and
+ *   `metadata.updated_at`; those are the only recognised `sort_field` values.
+ * - `sort` / `order` are NOT the wire keys — the live API silently ignores them and returns default
+ *   (store) order with a 200. The handler only ever passes `sort_field` / `sort_dir` here, so a
+ *   caller that sends the wrong keys lands on the `sortField`-unrecognised branch below and gets
+ *   store order — which is exactly what makes the two request shapes distinguishable now (the whole
+ *   point of LLMO-6666; before this, every ordering assertion was vacuous).
+ *
+ * Semantics (defined here, deterministically, so the api-service assertion in LLMO-6667 can pin
+ * them):
+ * - An unrecognised `sortField` (including the wrong `sort` key, an empty value, or a non-metadata
+ *   field) returns the input order unchanged — a 200 in default order, so the mock never becomes
+ *   stricter than prod.
+ * - `sortDir` is descending only for the literal `'desc'` (case-insensitive); every other value,
+ *   including absent and `'asc'`, is ascending.
+ * - A prompt whose sort key is missing — `metadata` absent/`null`, or that specific timestamp unset
+ *   — sorts LAST in BOTH directions. Missing values are the tail, never interleaved, so a project
+ *   mixing stamped and unstamped prompts is deterministic regardless of direction.
+ * - The sort is STABLE: ties on the compared value, and the all-missing tail, preserve input
+ *   (store) order. `include_metadata` gating is orthogonal — it reads the STORED `metadata`, so
+ *   sorting on a metadata field while the response omits the `metadata` key is valid and never
+ *   throws (the handler sorts the prompt list, then maps to items).
+ *
+ * Values are compared with `<` / `>`; the timestamps are ISO-8601 strings, which order correctly
+ * lexicographically. No dependency on their being parseable dates — an opaque interim value still
+ * orders consistently with itself.
+ *
+ * @template {{ metadata?: Record<string, unknown> | null }} T
+ * @param {readonly T[]} prompts the filtered prompt list (store order)
+ * @param {{ sortField?: unknown, sortDir?: unknown }} [sort] the request-body `sort_field` /
+ *   `sort_dir`, verbatim
+ * @returns {T[]} a new array in the requested order; the input order when `sortField` is not a
+ *   recognised metadata sort key
+ */
+export const sortPromptsByMetadata = (prompts, { sortField, sortDir } = {}) => {
+  const list = Array.isArray(prompts) ? [...prompts] : [];
+  const field = typeof sortField === 'string' ? sortField : '';
+  if (!SORTABLE_FIELDS.includes(/** @type {any} */ (field))) {
+    return list;
+  }
+
+  const key = field.slice('metadata.'.length); // 'created_at' | 'updated_at'
+  const descending = String(sortDir ?? '').toLowerCase() === 'desc';
+  /** @param {T} prompt @returns {any} the sort-key value, or `undefined` when absent/null */
+  const valueOf = (prompt) => {
+    const value = prompt?.metadata?.[key];
+    return value === undefined || value === null ? undefined : value;
+  };
+
+  // Decorate with the original index so ties and the missing-value tail keep store order (a stable
+  // sort — Array.prototype.sort is not guaranteed stable across every runtime for this shape, so it
+  // is made explicit rather than assumed).
+  return list
+    .map((prompt, index) => ({ prompt, index }))
+    .sort((a, b) => {
+      const av = valueOf(a.prompt);
+      const bv = valueOf(b.prompt);
+      // A missing sort key sorts last in BOTH directions; all-missing and ties fall through to the
+      // stable store-order tiebreak below.
+      if (av === undefined && bv === undefined) {
+        return a.index - b.index;
+      }
+      if (av === undefined) {
+        return 1;
+      }
+      if (bv === undefined) {
+        return -1;
+      }
+      if (av < bv) {
+        return descending ? 1 : -1;
+      }
+      if (av > bv) {
+        return descending ? -1 : 1;
+      }
+      return a.index - b.index;
+    })
+    .map((decorated) => decorated.prompt);
+};

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -508,6 +508,15 @@ async function waitForReady(baseUrl, deadline, getStderr) {
       expect(orderedNames(asc, byName)).to.deep.equal(['sort Y?', 'sort Z?', 'sort X?']);
     });
 
+    it('preserves store order when NO sort keys are sent (legacy behavior unchanged)', async () => {
+      // Backward-compat regression guard: every pre-existing consumer lists without sort keys and
+      // must see the same store order as before this change. `seedFixtures` inserts X, Y, Z in that
+      // order, so a bare list returns them in that order — the pre-change contract.
+      const { byName } = await seedFixtures();
+      const { data: def } = await listByTags([], { draft: true });
+      expect(orderedNames(def, byName)).to.deep.equal(['sort X?', 'sort Y?', 'sort Z?']);
+    });
+
     it('ignores the WRONG keys (sort / order): returns store order, so the two shapes are distinguishable', async () => {
       const { byName } = await seedFixtures();
       const { data: wrong } = await listByTags([], { draft: true, sort: 'metadata.created_at', order: 'asc' });

--- a/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
+++ b/packages/spacecat-shared-project-engine-client/test/e2e/project-engine-mock.e2e.js
@@ -124,7 +124,9 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     'content-type': 'application/json',
     Accept: 'application/json',
   };
-  const listByTags = (tagIds, { draft, includeMetadata } = {}) => {
+  const listByTags = (tagIds, {
+    draft, includeMetadata, sortField, sortDir, sort, order,
+  } = {}) => {
     const query = {
       ...(draft ? { draft: true } : {}),
       ...(includeMetadata ? { include_metadata: true } : {}),
@@ -136,7 +138,15 @@ async function waitForReady(baseUrl, deadline, getStderr) {
           path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT },
           ...(Object.keys(query).length > 0 ? { query } : {}),
         },
-        body: { tag_ids: tagIds },
+        body: {
+          tag_ids: tagIds,
+          // The wire sort keys (`sort_field` / `sort_dir`); the ignored `sort` / `order` are also
+          // passable so a case can prove they are NOT honoured (LLMO-6666).
+          ...(sortField !== undefined ? { sort_field: sortField } : {}),
+          ...(sortDir !== undefined ? { sort_dir: sortDir } : {}),
+          ...(sort !== undefined ? { sort } : {}),
+          ...(order !== undefined ? { order } : {}),
+        },
       },
     );
   };
@@ -442,6 +452,87 @@ async function waitForReady(baseUrl, deadline, getStderr) {
     // Without `include_metadata`, the same list omits the `metadata` key entirely (default shape).
     const { data: bare } = await listByTags([], { draft: true });
     expect(bare.items.find((p) => p.id === item.id)).to.not.have.property('metadata');
+  });
+
+  // by_tags sort (LLMO-6666). Fixtures are stamped so store order matches NEITHER the created_at
+  // nor the updated_at order, so an ordering assertion fails if the keys regress (rather than
+  // passing on store order by accident — the vacuity these cases exist to remove). Results are
+  // filtered to the ids created here (the seed carries its own prompt), which preserves relative
+  // order under a stable sort.
+  describe('by_tags ordering on sort_field / sort_dir', () => {
+    // Store order [X, Y, Z]. created_at ascending → [Y, Z, X]; updated_at ascending → [X, Z, Y]:
+    // both differ from store order and from each other.
+    const FIXTURES = [
+      { name: 'sort X?', metadata: { created_at: '2026-03-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' } },
+      { name: 'sort Y?', metadata: { created_at: '2026-01-01T00:00:00Z', updated_at: '2026-03-01T00:00:00Z' } },
+      { name: 'sort Z?', metadata: { created_at: '2026-02-01T00:00:00Z', updated_at: '2026-02-01T00:00:00Z' } },
+    ];
+
+    // Creates the fixtures and returns a name→id map, so a case can express expected order by the
+    // stable X/Y/Z labels rather than opaque ids.
+    const seedFixtures = async (items = FIXTURES) => {
+      const { data: created, error } = await client.POST(V3_CREATE, {
+        params: { path: { id: SEED_WORKSPACE, project_id: SEED_PROJECT } },
+        body: { items },
+      });
+      expect(error).to.equal(undefined);
+      const byName = new Map(created.items.map((p) => [p.name, p.id]));
+      return { ids: [...byName.values()], byName };
+    };
+    const orderedNames = (listed, byName) => {
+      const idToName = new Map([...byName].map(([n, id]) => [id, n]));
+      return listed.items.filter((p) => idToName.has(p.id)).map((p) => idToName.get(p.id));
+    };
+
+    it('orders by metadata.created_at ascending and descending', async () => {
+      const { byName } = await seedFixtures();
+      const { data: asc } = await listByTags([], { draft: true, sortField: 'metadata.created_at', sortDir: 'asc' });
+      expect(orderedNames(asc, byName)).to.deep.equal(['sort Y?', 'sort Z?', 'sort X?']);
+      const { data: desc } = await listByTags([], { draft: true, sortField: 'metadata.created_at', sortDir: 'desc' });
+      expect(orderedNames(desc, byName)).to.deep.equal(['sort X?', 'sort Z?', 'sort Y?']);
+    });
+
+    it('orders by metadata.updated_at ascending and descending', async () => {
+      const { byName } = await seedFixtures();
+      const { data: asc } = await listByTags([], { draft: true, sortField: 'metadata.updated_at', sortDir: 'asc' });
+      expect(orderedNames(asc, byName)).to.deep.equal(['sort X?', 'sort Z?', 'sort Y?']);
+      const { data: desc } = await listByTags([], { draft: true, sortField: 'metadata.updated_at', sortDir: 'desc' });
+      expect(orderedNames(desc, byName)).to.deep.equal(['sort Y?', 'sort Z?', 'sort X?']);
+    });
+
+    it('sorts even without include_metadata (order is driven by the STORED metadata)', async () => {
+      const { byName } = await seedFixtures();
+      const { data: asc } = await listByTags([], { draft: true, sortField: 'metadata.created_at', sortDir: 'asc' });
+      // Items carry no metadata key (opt-in omitted) but are still ordered by the stored value.
+      expect(asc.items.filter((p) => byName.get('sort X?') === p.id)[0]).to.not.have.property('metadata');
+      expect(orderedNames(asc, byName)).to.deep.equal(['sort Y?', 'sort Z?', 'sort X?']);
+    });
+
+    it('ignores the WRONG keys (sort / order): returns store order, so the two shapes are distinguishable', async () => {
+      const { byName } = await seedFixtures();
+      const { data: wrong } = await listByTags([], { draft: true, sort: 'metadata.created_at', order: 'asc' });
+      expect(orderedNames(wrong, byName)).to.deep.equal(['sort X?', 'sort Y?', 'sort Z?']);
+    });
+
+    it('returns store order for an unrecognised sort_field (200, not stricter than prod)', async () => {
+      const { byName } = await seedFixtures();
+      const { data: listed, error } = await listByTags([], { draft: true, sortField: 'metadata.name', sortDir: 'asc' });
+      expect(error).to.equal(undefined);
+      expect(orderedNames(listed, byName)).to.deep.equal(['sort X?', 'sort Y?', 'sort Z?']);
+    });
+
+    it('sorts a prompt with absent metadata LAST in both directions', async () => {
+      // Store order [X, none, Y]: the unstamped prompt is created between two stamped ones.
+      const { byName } = await seedFixtures([
+        FIXTURES[0],
+        { name: 'sort none?' },
+        FIXTURES[1],
+      ]);
+      const { data: asc } = await listByTags([], { draft: true, sortField: 'metadata.created_at', sortDir: 'asc' });
+      expect(orderedNames(asc, byName)).to.deep.equal(['sort Y?', 'sort X?', 'sort none?']);
+      const { data: desc } = await listByTags([], { draft: true, sortField: 'metadata.created_at', sortDir: 'desc' });
+      expect(orderedNames(desc, byName)).to.deep.equal(['sort X?', 'sort Y?', 'sort none?']);
+    });
   });
 
   it('v3 create dedupe hit PRESERVES the existing stored metadata and reports is_new: false', async () => {

--- a/packages/spacecat-shared-project-engine-client/test/mock/context.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/context.test.js
@@ -59,6 +59,20 @@ describe('mock Context', () => {
     expect(ctx.resolveUrl('not a url')).to.deep.equal({});
   });
 
+  it('exposes the shared sortPromptsByMetadata helper for the by_tags route', () => {
+    const ctx = new Context();
+    // Context just re-exposes the pure sort; the wire key sort_field reorders on the metadata
+    // timestamp, and the ignored `sort` key falls through to store order (LLMO-6666).
+    const list = [
+      { id: 'b', metadata: { created_at: '2026-02-01T00:00:00Z' } },
+      { id: 'a', metadata: { created_at: '2026-01-01T00:00:00Z' } },
+    ];
+    expect(ctx.sortPromptsByMetadata(list, { sortField: 'metadata.created_at', sortDir: 'asc' })
+      .map((p) => p.id)).to.deep.equal(['a', 'b']);
+    expect(ctx.sortPromptsByMetadata(list, { sort: 'metadata.created_at' })
+      .map((p) => p.id)).to.deep.equal(['b', 'a']);
+  });
+
   it('exposes the ai-model catalog for the catalog route + add-path resolution', () => {
     const ctx = new Context();
     expect(ctx.aiModelCatalog).to.be.an('array').with.length.greaterThan(0);

--- a/packages/spacecat-shared-project-engine-client/test/mock/prompt-sort.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/prompt-sort.test.js
@@ -67,6 +67,13 @@ describe('prompt-sort (by_tags sort_field / sort_dir)', () => {
     expect(ids(sortPromptsByMetadata(prompts, {}))).to.deep.equal(['c', 'a', 'b']);
   });
 
+  it('returns store order for a bare sort_dir with no sort_field', () => {
+    // A direction with nothing to sort on is not a sort — it must not reorder (guards the
+    // sortField-absent path explicitly, not just via the wrong-keys case above).
+    expect(ids(sortPromptsByMetadata(prompts, { sortDir: 'asc' }))).to.deep.equal(['c', 'a', 'b']);
+    expect(ids(sortPromptsByMetadata(prompts, { sortDir: 'desc' }))).to.deep.equal(['c', 'a', 'b']);
+  });
+
   it('returns store order for an unrecognised sort_field (mirrors live: 200 in default order)', () => {
     expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.name', sortDir: 'asc' })))
       .to.deep.equal(['c', 'a', 'b']);

--- a/packages/spacecat-shared-project-engine-client/test/mock/prompt-sort.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/prompt-sort.test.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { sortPromptsByMetadata, SORTABLE_FIELDS } from '../../mock/prompt-sort.js';
+
+// The route handler is coverage-excluded, so the `by_tags` ordering is unit-tested here against the
+// wire contract captured live 2026-07-29 (LLMO-6666): sort_field / sort_dir are the wire keys,
+// sort / order are ignored, metadata.created_at / metadata.updated_at are sortable, and a
+// missing sort key sorts last deterministically. `ids` maps a result back to input order so a case
+// asserts the reorder, never just that the field survived.
+describe('prompt-sort (by_tags sort_field / sort_dir)', () => {
+  const ids = (list) => list.map((p) => p.id);
+
+  // Store order is c, a, b — deliberately NOT the created_at order — so an ascending sort reorders.
+  const prompts = [
+    { id: 'c', metadata: { created_at: '2026-03-01T00:00:00Z', updated_at: '2026-03-09T00:00:00Z' } },
+    { id: 'a', metadata: { created_at: '2026-01-01T00:00:00Z', updated_at: '2026-03-05T00:00:00Z' } },
+    { id: 'b', metadata: { created_at: '2026-02-01T00:00:00Z', updated_at: '2026-03-01T00:00:00Z' } },
+  ];
+
+  it('exposes the two sortable authorship fields', () => {
+    expect([...SORTABLE_FIELDS]).to.deep.equal(['metadata.created_at', 'metadata.updated_at']);
+  });
+
+  it('sorts by metadata.created_at ascending and descending', () => {
+    expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.created_at', sortDir: 'asc' })))
+      .to.deep.equal(['a', 'b', 'c']);
+    expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.created_at', sortDir: 'desc' })))
+      .to.deep.equal(['c', 'b', 'a']);
+  });
+
+  it('sorts by metadata.updated_at ascending and descending (independent of created_at order)', () => {
+    // updated_at order (b<a<c) differs from created_at order, so this proves the field selection.
+    expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.updated_at', sortDir: 'asc' })))
+      .to.deep.equal(['b', 'a', 'c']);
+    expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.updated_at', sortDir: 'desc' })))
+      .to.deep.equal(['c', 'a', 'b']);
+  });
+
+  it('defaults to ascending when sort_dir is absent or unrecognised', () => {
+    expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.created_at' })))
+      .to.deep.equal(['a', 'b', 'c']);
+    expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.created_at', sortDir: 'sideways' })))
+      .to.deep.equal(['a', 'b', 'c']);
+  });
+
+  it('is case-insensitive on sort_dir', () => {
+    expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.created_at', sortDir: 'DESC' })))
+      .to.deep.equal(['c', 'b', 'a']);
+  });
+
+  it('returns store order for the WRONG keys (sort / order), making the two shapes distinguishable', () => {
+    // The handler only ever passes sort_field / sort_dir; a caller sending the ignored keys lands
+    // here with sortField undefined → store order. This is the crux of LLMO-6666.
+    expect(ids(sortPromptsByMetadata(prompts, { sort: 'metadata.created_at', order: 'asc' })))
+      .to.deep.equal(['c', 'a', 'b']);
+    expect(ids(sortPromptsByMetadata(prompts, {}))).to.deep.equal(['c', 'a', 'b']);
+  });
+
+  it('returns store order for an unrecognised sort_field (mirrors live: 200 in default order)', () => {
+    expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.name', sortDir: 'asc' })))
+      .to.deep.equal(['c', 'a', 'b']);
+    expect(ids(sortPromptsByMetadata(prompts, { sortField: 'name', sortDir: 'asc' })))
+      .to.deep.equal(['c', 'a', 'b']);
+  });
+
+  it('sorts prompts with an unset sort key LAST in both directions, stable among themselves', () => {
+    const mixed = [
+      { id: 'stamped-late', metadata: { created_at: '2026-02-01T00:00:00Z' } },
+      { id: 'no-metadata' },
+      { id: 'stamped-early', metadata: { created_at: '2026-01-01T00:00:00Z' } },
+      { id: 'null-metadata', metadata: null },
+      { id: 'unset-key', metadata: { updated_at: '2026-05-01T00:00:00Z' } }, // created_at absent
+    ];
+    // Ascending: stamped ascend, then the three missing keep store order (no-metadata, then
+    // null-metadata, then unset-key).
+    expect(ids(sortPromptsByMetadata(mixed, { sortField: 'metadata.created_at', sortDir: 'asc' })))
+      .to.deep.equal(['stamped-early', 'stamped-late', 'no-metadata', 'null-metadata', 'unset-key']);
+    // Descending: stamped descend, missing STILL last (not flipped to the front) and still stable.
+    expect(ids(sortPromptsByMetadata(mixed, { sortField: 'metadata.created_at', sortDir: 'desc' })))
+      .to.deep.equal(['stamped-late', 'stamped-early', 'no-metadata', 'null-metadata', 'unset-key']);
+  });
+
+  it('is a stable sort: equal values keep store order', () => {
+    const tied = [
+      { id: 'first', metadata: { created_at: '2026-01-01T00:00:00Z' } },
+      { id: 'second', metadata: { created_at: '2026-01-01T00:00:00Z' } },
+      { id: 'third', metadata: { created_at: '2026-01-01T00:00:00Z' } },
+    ];
+    expect(ids(sortPromptsByMetadata(tied, { sortField: 'metadata.created_at', sortDir: 'desc' })))
+      .to.deep.equal(['first', 'second', 'third']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [...prompts];
+    const before = ids(input);
+    sortPromptsByMetadata(input, { sortField: 'metadata.created_at', sortDir: 'asc' });
+    expect(ids(input)).to.deep.equal(before);
+  });
+
+  it('tolerates a non-array input and an empty list', () => {
+    expect(sortPromptsByMetadata(undefined, { sortField: 'metadata.created_at' })).to.deep.equal([]);
+    expect(sortPromptsByMetadata([], { sortField: 'metadata.created_at' })).to.deep.equal([]);
+  });
+});


### PR DESCRIPTION
## Summary

The `by_tags` prompt-list mock implemented no sort logic, so it returned store order regardless of the keys sent — making every ordering assertion vacuous and **blocking the sorted authorship read from being covered end to end**. `spacecat-api-service` already sends the correct wire keys on `main` (LLMO-6289), but nothing could prove it: a caller sending `sort_field` and one sending the ignored `sort` were indistinguishable against this mock.

## Changes

- **`mock/prompt-sort.js`** — a pure, unit-tested `sortPromptsByMetadata` that:
  - honours the wire keys `sort_field` / `sort_dir` on `metadata.created_at` / `metadata.updated_at`;
  - returns store order for the wrong `sort` / `order` keys (so the two request shapes are now distinguishable) and for an unrecognised `sort_field` (a 200 in default order — not stricter than prod);
  - sorts a missing/unset key **last in both directions**, with a stable store-order tiebreak;
  - is orthogonal to `include_metadata` (it reads the stored metadata, so sorting works even when the response omits the key).
- Wired onto `Context` as `context.sortPromptsByMetadata` (same `$.context` lib-helper convention as `resolveUrl`) and called from the `by_tags` handler.
- **Unit coverage** (`test/mock/prompt-sort.test.js` + a `context.test.js` expose test) and **e2e coverage** (`test/e2e/project-engine-mock.e2e.js`) driving the live Counterfact mock: both fields, both directions, wrong-keys, unrecognised field, absent-metadata-last, and sort-without-`include_metadata`.

Verified locally: unit + e2e green, `tsc` clean, ESLint clean.

Unblocks **LLMO-6667** (api-service `by_tags` ordering assertions).