### PR TITLE
fix(data-access): reconcile status-transition tables from SITES-47286 warn findings

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/fix-entity/fix-entity.transitions.js
+++ b/packages/spacecat-shared-data-access/src/models/fix-entity/fix-entity.transitions.js
@@ -45,7 +45,9 @@ export const FIX_ENTITY_TRANSITIONS = {
   [STATUSES.PENDING]: [STATUSES.DEPLOYED, STATUSES.FAILED],
   [STATUSES.DEPLOYED]: [STATUSES.PUBLISHED, STATUSES.ROLLED_BACK],
   // bounded retry; the attempts cap (SITES-46548) is not enforced here.
-  [STATUSES.FAILED]: [STATUSES.PENDING],
+  // ROLLED_BACK reconciles the ADR table to api-service's existing revert rule
+  // ("ROLLED_BACK requires FAILED", fixes.js) — SITES-47286 warn finding (~6x/25d).
+  [STATUSES.FAILED]: [STATUSES.PENDING, STATUSES.ROLLED_BACK],
   [STATUSES.PUBLISHED]: [STATUSES.ROLLED_BACK],
   [STATUSES.ROLLED_BACK]: [], // terminal
 };

--- a/packages/spacecat-shared-data-access/src/models/suggestion/suggestion.transitions.js
+++ b/packages/spacecat-shared-data-access/src/models/suggestion/suggestion.transitions.js
@@ -64,8 +64,10 @@ export const SUGGESTION_TRANSITIONS = {
   [S.SKIPPED]: [S.NEW, S.OUTDATED],
   // re-detection reopens an outdated suggestion.
   [S.OUTDATED]: [S.NEW],
-  // near-terminal: allow reopen to NEW to correct an incorrect classification (sandsinh review).
-  [S.REJECTED]: [S.NEW],
+  // near-terminal: reopen to NEW to correct a misclassification (sandsinh review), or a
+  // re-audit outdates a rejected suggestion once its issue is no longer detected
+  // (SITES-47286 warn finding: REJECTED -> OUTDATED, ~247x/25d, legitimate re-audit flow).
+  [S.REJECTED]: [S.NEW, S.OUTDATED],
 };
 
 /**

--- a/packages/spacecat-shared-data-access/test/unit/models/fix-entity/fix-entity.transitions.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/fix-entity/fix-entity.transitions.test.js
@@ -29,6 +29,7 @@ describe('FixEntity transitions', () => {
     ['DEPLOYED', 'PUBLISHED'],
     ['DEPLOYED', 'ROLLED_BACK'],
     ['FAILED', 'PENDING'],
+    ['FAILED', 'ROLLED_BACK'], // revert of a failed fix (SITES-47286, reconciled to api-service rule)
     ['PUBLISHED', 'ROLLED_BACK'],
   ];
 

--- a/packages/spacecat-shared-data-access/test/unit/models/suggestion/suggestion.transitions.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/suggestion/suggestion.transitions.test.js
@@ -36,6 +36,7 @@ describe('Suggestion transitions', () => {
     ['SKIPPED', 'NEW'], // un-skip
     ['OUTDATED', 'NEW'],
     ['REJECTED', 'NEW'], // reopen after incorrect classification (sandsinh review)
+    ['REJECTED', 'OUTDATED'], // re-audit outdates a rejected suggestion (SITES-47286)
   ];
 
   const illegal = [


### PR DESCRIPTION
## What
Reconciles the Suggestion/FixEntity status-transition tables (SITES-47091 guard) based on the **warn-mode violation review** in SITES-47286 — adds two transitions that are legitimate but were disallowed:

- **`Suggestion: REJECTED → OUTDATED`** (~247×/25d) — a re-audit outdates a rejected suggestion once its issue is no longer detected.
- **`FixEntity: FAILED → ROLLED_BACK`** (~6×/25d) — reconciles the ADR table to api-service's existing revert rule (`ROLLED_BACK requires FAILED`, `fixes.js`).

## Deliberately still disallowed (caller-side issues, tracked separately)
- **`Suggestion: OUTDATED → FIXED`** (~159×) — the bulk `PATCH /suggestions/status` endpoint promotes OUTDATED items to FIXED; that's the bug, fixed caller-side in **SITES-49063** (relates to SITES-46878). The guard correctly keeps flagging it.
- **`Suggestion: NEW → REJECTED`** (~6×) — bypasses the "reject only from PENDING_VALIDATION" rule via the generic setter; left disallowed pending a caller-side decision.

## Why
This is step **#4** of the guard rollout (SITES-47286): the guard has run in **warn** mode in prod (api-service + autofix-worker) since ~07-09; this reconciles the tables to the real, legitimate traffic so that flipping `STATUS_TRANSITION_ENFORCEMENT=enforce` (#5) won't throw on valid flows — once the two caller-side items above are also addressed.

## Safety
Additive to the allow-lists; the default **warn** mode is unchanged (behaviour-neutral until enforce). `2780` data-access unit tests pass, 100% coverage on the changed files, lint clean.

SITES-47286 (parent SITES-47076).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
