### PR TITLE
fix(bot-blocker): exclude Cloudflare JS Detections script from challenge-platform pattern (SITES-49160)

### DIFF
--- a/packages/spacecat-shared-utils/src/bot-blocker-detect/bot-blocker-detect.js
+++ b/packages/spacecat-shared-utils/src/bot-blocker-detect/bot-blocker-detect.js
@@ -78,7 +78,7 @@ const CHALLENGE_PATTERNS = {
     /Verifying you are human/i,
     /Please wait.*CloudFlare/i,
     /cf-turnstile/i,
-    /challenge-platform/i,
+    /challenge-platform\/(?!scripts\/jsd\/)/i,
     /cf-chl-widget/i, // Cloudflare challenge widget
     /ray\s*id.*cloudflare/i, // Cloudflare Ray ID in error pages
     /__cf_chl_tk/i, // Cloudflare challenge token

--- a/packages/spacecat-shared-utils/test/bot-blocker-detect/bot-blocker-detect.test.js
+++ b/packages/spacecat-shared-utils/test/bot-blocker-detect/bot-blocker-detect.test.js
@@ -772,6 +772,39 @@ describe('Bot Blocker Detection', () => {
       expect(result.type).to.equal('cloudflare');
     });
 
+    it('does not flag Cloudflare JS Detections script (jsd/main.js) as a challenge page', () => {
+      // Cloudflare Bot Fight Mode injects /cdn-cgi/challenge-platform/scripts/jsd/main.js
+      // as a silent fingerprinting script — this is NOT a challenge page
+      const realContent = 'This is real page content. '.repeat(400); // ~11KB
+      const jsdScript = '<script src="/cdn-cgi/challenge-platform/scripts/jsd/main.js"></script>';
+      const html = `<html><head><title>Real Page</title>${jsdScript}</head><body><p>${realContent}</p></body></html>`;
+      const headers = { 'cf-ray': '123456789-CDG' };
+
+      const result = analyzeBotProtection({
+        status: 200,
+        headers,
+        html,
+      });
+
+      expect(result.crawlable).to.be.true;
+      expect(result.type).to.equal('cloudflare-allowed');
+    });
+
+    it('still detects real Cloudflare challenge-platform pages (non-jsd paths)', () => {
+      const html = '<html><body><div class="challenge-platform/h/b/abc123"></div></body></html>';
+      const headers = { 'cf-ray': '123456789-CDG' };
+
+      const result = analyzeBotProtection({
+        status: 200,
+        headers,
+        html,
+      });
+
+      expect(result.crawlable).to.be.false;
+      expect(result.type).to.equal('cloudflare');
+      expect(result.confidence).to.equal(0.99);
+    });
+
     it('returns cloudflare-allowed when Cloudflare present but no challenge', () => {
       // Create HTML > 10KB to ensure it's not flagged as "suspiciously short"
       const realContent = 'This is real page content. '.repeat(400); // ~11KB


### PR DESCRIPTION
## Summary

- Cloudflare Bot Fight Mode (JS Detections feature) injects `/cdn-cgi/challenge-platform/scripts/jsd/main.js` into every page response as a silent browser fingerprinting script — it is NOT a challenge page
- Our `/challenge-platform/i` pattern in `bot-blocker-detect.js` was matching this script path, causing a false positive that flagged sites like behr.com and goodyear.com as bot-blocked
- Customers confirmed their Cloudflare WAF rules show "Skip" action for our traffic, yet the CDN Configuration UI showed them as `blocked`
- Fix: updated the pattern to `/challenge-platform\/(?!scripts\/jsd\/)/i` — a negative lookahead that excludes the JSD path while still detecting real Cloudflare challenge pages

## Root Cause Confirmed

Debug logging added to the bot-blocker endpoint (dev environment) returned the following `htmlSnippet` for behr.com:

```
a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';
document.getElementsByTagName('head')[0].appendChild(a);
```

Only 1 occurrence of `challenge-platform` in the entire HTML — the JSD script injection, not a challenge page.

## Test plan

- [ ] Unit tests pass with 100% coverage on `bot-blocker-detect.js`
- [ ] New test: Cloudflare JS Detections script (`jsd/main.js`) does NOT trigger a block
- [ ] New test: real `challenge-platform` non-jsd paths still trigger a block
- [ ] After merge and version bump in `spacecat-api-service`: verify behr.com and goodyear.com show as `crawlable: true` in the bot-blocker endpoint

## Follow-up: version bump required in consuming repos

After this is merged and a new version of `@adobe/spacecat-shared-utils` is published, bump the dependency in:

1. **`spacecat-api-service`** — fixes the CDN Configuration UI bot-blocker endpoint
2. **`spacecat-content-scraper`** — fixes scraper health checks that use the same detection code and are causing scrape jobs to abort for affected sites

Fixes [SITES-49160](https://jira.corp.adobe.com/browse/SITES-49160)

🤖 Generated with [Claude Code](https://claude.com/claude-code)