### PR TITLE
fix(project-engine-client): by_tags mock defaults omitted sort_dir to descending (LLMO-6666)

### DIFF
--- a/packages/spacecat-shared-project-engine-client/mock/prompt-sort.js
+++ b/packages/spacecat-shared-project-engine-client/mock/prompt-sort.js
@@ -78,8 +78,10 @@ export const sortPromptsByMetadata = (prompts, { sortField, sortDir } = {}) => {
   }
 
   const key = field.slice('metadata.'.length); // 'created_at' | 'updated_at'
-  // Ascending ONLY for the literal `'asc'`; absent / `'desc'` / anything else is descending — live
-  // Semrush defaults an omitted `sort_dir` to descending (verified 2026-08-04, see below).
+  // Ascending ONLY for the literal `'asc'`; absent / `'desc'` / unrecognised is descending. Only
+  // the OMITTED default is live-verified (2026-08-04, below); grouping an unrecognised value with
+  // it is a mock choice, not verified — but unreachable end-to-end: the api-service controller
+  // allow-lists `order` to asc/desc, so a bad value 400s before it reaches the mock.
   const descending = String(sortDir ?? '').toLowerCase() !== 'asc';
   /** @param {T} prompt @returns {any} the sort-key value, or `undefined` when absent/null */
   const valueOf = (prompt) => {

--- a/packages/spacecat-shared-project-engine-client/mock/prompt-sort.js
+++ b/packages/spacecat-shared-project-engine-client/mock/prompt-sort.js
@@ -37,8 +37,8 @@ export const SORTABLE_FIELDS = /** @type {const} */ (['metadata.created_at', 'me
  * - An unrecognised `sortField` (including the wrong `sort` key, an empty value, or a non-metadata
  *   field) returns the input order unchanged — a 200 in default order, so the mock never becomes
  *   stricter than prod.
- * - `sortDir` is descending only for the literal `'desc'` (case-insensitive); every other value,
- *   including absent and `'asc'`, is ascending.
+ * - `sortDir` is ascending only for the literal `'asc'` (case-insensitive); every other value —
+ *   absent, `'desc'`, or unrecognised — is descending, matching live's omitted-`sort_dir` default.
  * - A prompt whose sort key is missing — `metadata` absent/`null`, or that specific timestamp unset
  *   — sorts LAST in BOTH directions. Missing values are the tail, never interleaved, so a project
  *   mixing stamped and unstamped prompts is deterministic regardless of direction.
@@ -47,13 +47,14 @@ export const SORTABLE_FIELDS = /** @type {const} */ (['metadata.created_at', 'me
  *   sorting on a metadata field while the response omits the `metadata` key is valid and never
  *   throws (the handler sorts the prompt list, then maps to items).
  *
- * CAVEAT — two of these are mock-DEFINED conventions, not live-VERIFIED. The 2026-07-29 probe
- * captured the sort keys but NOT (a) where a missing key lands or (b) the default when `sort_dir`
- * is absent. We define missing-key = LAST-in-both-directions (matching the spec's "NULLS LAST",
- * §16 gate G5) and absent-`sort_dir` = ascending. LLMO-6667's api-service assertions pin whatever
- * this mock does, so if real Semrush diverges (e.g. NULLS-FIRST on DESC) the suite would go green
- * against a mock that disagrees with prod — confirm both against live before relying on 6667 as a
- * prod-faithfulness guarantee. Tracked on LLMO-6666.
+ * Provenance of the two edge behaviors (LLMO-6666):
+ * - Default direction (absent `sort_dir`) = descending is LIVE-VERIFIED (2026-08-04, prod Lovesac
+ *   `2840/en`): a read with `sort_field` and no `sort_dir` returned the exact same order as an
+ *   explicit `sort_dir=desc`. This originally defaulted to ascending and was corrected here.
+ * - Missing-key position = LAST-in-both-directions is still mock-DEFINED, not live-verified: the
+ *   fleet is fully stamped post-backfill, so no null-metadata prompt exists to observe live. It
+ *   matches the spec's "NULLS LAST" (§16 gate G5); confirm against Semrush's `ORDER BY … NULLS`
+ *   semantics before treating it as a prod-faithfulness guarantee. Tracked on LLMO-6666.
  *
  * Values are compared with `<` / `>`; the timestamps are ISO-8601 strings, which order correctly
  * lexicographically. No dependency on their being parseable dates — an opaque interim value still
@@ -77,7 +78,9 @@ export const sortPromptsByMetadata = (prompts, { sortField, sortDir } = {}) => {
   }
 
   const key = field.slice('metadata.'.length); // 'created_at' | 'updated_at'
-  const descending = String(sortDir ?? '').toLowerCase() === 'desc';
+  // Ascending ONLY for the literal `'asc'`; absent / `'desc'` / anything else is descending — live
+  // Semrush defaults an omitted `sort_dir` to descending (verified 2026-08-04, see below).
+  const descending = String(sortDir ?? '').toLowerCase() !== 'asc';
   /** @param {T} prompt @returns {any} the sort-key value, or `undefined` when absent/null */
   const valueOf = (prompt) => {
     const value = prompt?.metadata?.[key];

--- a/packages/spacecat-shared-project-engine-client/test/mock/prompt-sort.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/prompt-sort.test.js
@@ -55,6 +55,19 @@ describe('prompt-sort (by_tags sort_field / sort_dir)', () => {
       .to.deep.equal(['c', 'b', 'a']);
   });
 
+  it('resolves null / undefined / empty-string sort_dir to the descending default', () => {
+    // Pin the exact input shapes the `String(sortDir ?? '').toLowerCase() !== 'asc'` expression
+    // relies on: null and undefined take the `?? ''` nullish branch, while '' is NON-nullish and
+    // reaches descending only via `!== 'asc'`. Asserting '' separately guards against a future
+    // refactor to `(sortDir || '')`, which would keep '' descending but silently change intent.
+    expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.created_at', sortDir: null })))
+      .to.deep.equal(['c', 'b', 'a']);
+    expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.created_at', sortDir: undefined })))
+      .to.deep.equal(['c', 'b', 'a']);
+    expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.created_at', sortDir: '' })))
+      .to.deep.equal(['c', 'b', 'a']);
+  });
+
   it('is case-insensitive on sort_dir (asc is the only special-cased value)', () => {
     expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.created_at', sortDir: 'ASC' })))
       .to.deep.equal(['a', 'b', 'c']);

--- a/packages/spacecat-shared-project-engine-client/test/mock/prompt-sort.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/prompt-sort.test.js
@@ -47,14 +47,17 @@ describe('prompt-sort (by_tags sort_field / sort_dir)', () => {
       .to.deep.equal(['c', 'a', 'b']);
   });
 
-  it('defaults to ascending when sort_dir is absent or unrecognised', () => {
+  it('defaults to DESCENDING when sort_dir is absent or unrecognised (matches live Semrush)', () => {
+    // Live-verified 2026-08-04 (prod Lovesac 2840/en): an omitted sort_dir sorts descending.
     expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.created_at' })))
-      .to.deep.equal(['a', 'b', 'c']);
+      .to.deep.equal(['c', 'b', 'a']);
     expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.created_at', sortDir: 'sideways' })))
-      .to.deep.equal(['a', 'b', 'c']);
+      .to.deep.equal(['c', 'b', 'a']);
   });
 
-  it('is case-insensitive on sort_dir', () => {
+  it('is case-insensitive on sort_dir (asc is the only special-cased value)', () => {
+    expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.created_at', sortDir: 'ASC' })))
+      .to.deep.equal(['a', 'b', 'c']);
     expect(ids(sortPromptsByMetadata(prompts, { sortField: 'metadata.created_at', sortDir: 'DESC' })))
       .to.deep.equal(['c', 'b', 'a']);
   });


### PR DESCRIPTION
## Summary

A **live-verify against prod** (2026-08-04, Lovesac `2840/en`, read-only) found the `by_tags` mock diverged from real Semrush on the **default sort direction**:

- A read with `sort_field=metadata.created_at` and **no `sort_dir`** returned the **exact same order** as an explicit `sort_dir=desc` (`noord == desc`, id-for-id; `asc != desc`). So **live Semrush defaults an omitted `sort_dir` to descending.**
- The mock (added in #1859) defaulted an absent `sort_dir` to **ascending**.
- It's **reachable end-to-end**: the api-service transport sets `sort_dir` only when `order` is present, and the controller's `parsedQuery` doesn't default `order` — so a caller sending `sort` without `order` gets **desc in prod, asc against the mock**.

## Change

- `mock/prompt-sort.js`: ascending only for the literal `'asc'`; **absent / `'desc'` / unrecognised → descending**. Updated the semantics doc and the provenance note.
- `test/mock/prompt-sort.test.js`: assert the descending default; add `'ASC'` case-insensitivity.

## Not changed

- **NULLS position** (missing sort key sorts last, both directions) stays mock-defined — the fleet is fully stamped post-backfill, so there's no live null-metadata prompt to observe. Still matches the spec's "NULLS LAST" (§16 G5); to be confirmed with the Semrush team.
- **No consumer assertion changes**: the LLMO-6667 api-service IT always sends an explicit `order`, so it's unaffected.

Verified locally: unit + e2e green, `tsc` + ESLint clean.