### PR TITLE
feat(data-access): add prerender validation fields to Suggestion/GeoExperiment

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/geo-experiment/geo-experiment.model.js
+++ b/packages/spacecat-shared-data-access/src/models/geo-experiment/geo-experiment.model.js
@@ -61,6 +61,7 @@ class GeoExperiment extends BaseModel {
   static METADATA_KEYS = {
     SCHEDULE_CONFIG: 'scheduleConfig',
     IMPACT_MEASUREMENT_TASK_ID: 'impactMeasurementTaskId',
+    VALIDATION: 'validation',
   };
 
   /**

--- a/packages/spacecat-shared-data-access/src/models/suggestion/suggestion.data-schemas.js
+++ b/packages/spacecat-shared-data-access/src/models/suggestion/suggestion.data-schemas.js
@@ -523,10 +523,9 @@ export const DATA_SCHEMAS = {
   // - validation — written by import-worker's validate-site.js after running the S3-vs-live
   //   content comparison for this suggestion's URL, only for suggestions reached via a
   //   geoExperimentId-triggered validation call (the bulk/automatic hourly job does not write
-  //   per-suggestion status). status is a plain boolean; reason is only present when
-  //   status is false, and is one of 'waf-blocked', 'content-issue', or 'error' — the same
-  //   flat vocabulary used at the Opportunity.data.validation / GeoExperiment.metadata.validation
-  //   levels.
+  //   per-suggestion status). status is a plain boolean; reason is only present when status is
+  //   false. reason is a free-form string (not a fixed enum here) so import-worker can evolve
+  //   its reason vocabulary without a schema change in this package.
   [OPPORTUNITY_TYPES.PRERENDER]: {
     schema: Joi.object({
       url: Joi.string().uri().required(),
@@ -538,9 +537,9 @@ export const DATA_SCHEMAS = {
       organicTraffic: Joi.number().optional(),
       aggregationKey: Joi.string().allow(null).optional(),
       validation: Joi.object({
-        status: Joi.boolean().required(),
-        reason: Joi.string().valid('waf-blocked', 'content-issue', 'error').optional(),
-        validatedAt: Joi.string().isoDate().required(),
+        status: Joi.boolean().optional(),
+        reason: Joi.string().optional(),
+        validatedAt: Joi.string().isoDate().optional(),
       }).optional(),
     }).unknown(true),
     projections: {

--- a/packages/spacecat-shared-data-access/src/models/suggestion/suggestion.data-schemas.js
+++ b/packages/spacecat-shared-data-access/src/models/suggestion/suggestion.data-schemas.js
@@ -519,6 +519,14 @@ export const DATA_SCHEMAS = {
       },
     },
   },
+  // Field ownership:
+  // - validation — written by import-worker's validate-site.js after running the S3-vs-live
+  //   content comparison for this suggestion's URL, only for suggestions reached via a
+  //   geoExperimentId-triggered validation call (the bulk/automatic hourly job does not write
+  //   per-suggestion status). status is a plain boolean; reason is only present when
+  //   status is false, and is one of 'waf-blocked', 'content-issue', or 'error' — the same
+  //   flat vocabulary used at the Opportunity.data.validation / GeoExperiment.metadata.validation
+  //   levels.
   [OPPORTUNITY_TYPES.PRERENDER]: {
     schema: Joi.object({
       url: Joi.string().uri().required(),
@@ -529,6 +537,11 @@ export const DATA_SCHEMAS = {
       prerenderedHtmlKey: Joi.string().optional(),
       organicTraffic: Joi.number().optional(),
       aggregationKey: Joi.string().allow(null).optional(),
+      validation: Joi.object({
+        status: Joi.boolean().required(),
+        reason: Joi.string().valid('waf-blocked', 'content-issue', 'error').optional(),
+        validatedAt: Joi.string().isoDate().required(),
+      }).optional(),
     }).unknown(true),
     projections: {
       minimal: {

--- a/packages/spacecat-shared-data-access/test/unit/models/geo-experiment/geo-experiment.model.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/geo-experiment/geo-experiment.model.test.js
@@ -78,6 +78,7 @@ describe('GeoExperimentModel', () => {
     expect(GeoExperiment.METADATA_KEYS).to.deep.equal({
       SCHEDULE_CONFIG: 'scheduleConfig',
       IMPACT_MEASUREMENT_TASK_ID: 'impactMeasurementTaskId',
+      VALIDATION: 'validation',
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds a `validation` sub-object to the `PRERENDER` suggestion data schema: `{ status?: boolean, reason?: string, validatedAt?: string }`. Written by import-worker after running its S3-vs-live content comparison for a suggestion, for suggestions reached via a `geoExperimentId`-triggered validation call (not the bulk/automatic hourly job). `reason` is deliberately a free-form string, not a fixed enum, so import-worker's reason vocabulary can evolve without a schema change here.
- Adds `GeoExperiment.METADATA_KEYS.VALIDATION = 'validation'` — the well-known metadata key import-worker will write the same aggregate `{status, reason?, validatedAt}` shape into, alongside the existing `SCHEDULE_CONFIG`/`IMPACT_MEASUREMENT_TASK_ID` keys.
- `status` is intentionally a plain boolean (not `boolean | 'error'`) — matches a parallel fix landing in import-worker for the existing `Opportunity.data.validation` shape, so all three levels (`Suggestion.data`, `Opportunity.data`, `GeoExperiment.metadata`) now use the identical `validation` shape.
- No schema migration — both `Suggestion.data` and `GeoExperiment.metadata` are pre-existing freeform fields; this only adds documentation/validation for the new keys.

## Test plan
- [x] `geo-experiment.model.test.js` updated for the new `METADATA_KEYS` entry
- [x] Full `suggestion`/`geo-experiment` unit suites pass (167 tests)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)