### PR TITLE
fix(akamai-client): configurable rule-tree timeout + patchRuleTree + accurate timeout message

### DIFF
--- a/packages/spacecat-shared-akamai-client/src/akamai-client.js
+++ b/packages/spacecat-shared-akamai-client/src/akamai-client.js
@@ -557,7 +557,11 @@ export default class AkamaiClient {
     }
     const headers = {
       'Content-Type': 'application/json-patch+json',
-      ...(etag ? { 'If-Match': etag } : {}),
+      // RFC 7232 If-Match values must be a quoted string; PAPI enforces this strictly and rejects
+      // an unquoted etag with a generic, unhelpful 400 ("The system cannot understand your
+      // request") regardless of what the patch ops say — reproduced empirically: every op
+      // combination failed identically with a bare `If-Match: <etag>`, and succeeded once quoted.
+      ...(etag ? { 'If-Match': `"${etag}"` } : {}),
     };
     this.log.info(
       `Patching rule tree for property ${propertyId} v${version} `

--- a/packages/spacecat-shared-akamai-client/src/akamai-client.js
+++ b/packages/spacecat-shared-akamai-client/src/akamai-client.js
@@ -28,13 +28,8 @@ const RULE_FORMAT_RE = /^[a-z0-9-]+$/i;
 // printable-ASCII, whitespace-free token (PAPI returns a hex etag) — this stops a malformed value
 // from injecting extra headers via CR/LF, mirroring RULE_FORMAT_RE's guard for ruleFormat.
 const ETAG_RE = /^[!-~]+$/;
-// tracingFetch defaults to a 10s timeout, fine for cheap metadata calls (getLatestVersion,
-// createVersion, activate, ...) but too short for a rule-tree PUT/PATCH/GET on a property with many
-// rules: PAPI's `validateRules=true` check is a semantic pass over the whole tree and its latency
-// scales with rule count. A property that legitimately needs >10s gets its request aborted
-// client-side before Akamai can respond, so the version is created but the rule content never
-// gets written — reproduced against a real customer property (all attempts died at exactly
-// "Request timeout after 10000ms"). Give the size-scaling calls a much longer default instead.
+// Rule-tree GET/PUT/PATCH run PAPI's validateRules pass, whose latency scales with tree size and
+// can exceed tracingFetch's 10s default (aborting the write). Give them a longer default.
 const DEFAULT_RULE_TREE_TIMEOUT_MS = 60000;
 
 function requireText(name, value) {
@@ -427,11 +422,8 @@ export default class AkamaiClient {
     }
     const id = encodePathSegment(propertyId);
     const params = { contractId, groupId };
-    // Opt-in: ask PAPI to validate the stored tree and return its errors/warnings arrays. Off by
-    // default (a plain read is cheap); on, PAPI runs its full validation pass so the response
-    // carries `errors`/`warnings` — used to tell whether a version can be activated. Its latency
-    // scales with tree size (the same pass the PUT runs), which is why the size-scaling timeout
-    // applies.
+    // Opt-in: PAPI runs its full validation pass and returns errors/warnings (used to tell whether
+    // a version is activatable). Off by default; slow and size-scaling, so the timeout applies.
     if (options.validateRules) {
       params.validateRules = 'true';
     }
@@ -574,10 +566,7 @@ export default class AkamaiClient {
     }
     const headers = {
       'Content-Type': 'application/json-patch+json',
-      // RFC 7232 If-Match values must be a quoted string; PAPI enforces this strictly and rejects
-      // an unquoted etag with a generic, unhelpful 400 ("The system cannot understand your
-      // request") regardless of what the patch ops say — reproduced empirically: every op
-      // combination failed identically with a bare `If-Match: <etag>`, and succeeded once quoted.
+      // PAPI requires an RFC 7232 quoted etag; a bare token yields a generic, unhelpful 400.
       ...(etag ? { 'If-Match': `"${etag}"` } : {}),
     };
     this.log.info(

--- a/packages/spacecat-shared-akamai-client/src/akamai-client.js
+++ b/packages/spacecat-shared-akamai-client/src/akamai-client.js
@@ -28,6 +28,14 @@ const RULE_FORMAT_RE = /^[a-z0-9-]+$/i;
 // printable-ASCII, whitespace-free token (PAPI returns a hex etag) — this stops a malformed value
 // from injecting extra headers via CR/LF, mirroring RULE_FORMAT_RE's guard for ruleFormat.
 const ETAG_RE = /^[!-~]+$/;
+// tracingFetch defaults to a 10s timeout, fine for cheap metadata calls (getLatestVersion,
+// createVersion, activate, ...) but too short for a rule-tree PUT/PATCH/GET on a property with many
+// rules: PAPI's `validateRules=true` check is a semantic pass over the whole tree and its latency
+// scales with rule count. A property that legitimately needs >10s gets its request aborted
+// client-side before Akamai can respond, so the version is created but the rule content never
+// gets written — reproduced against a real customer property (all attempts died at exactly
+// "Request timeout after 10000ms"). Give the size-scaling calls a much longer default instead.
+const DEFAULT_RULE_TREE_TIMEOUT_MS = 60000;
 
 function requireText(name, value) {
   if (!hasText(value)) {
@@ -165,6 +173,9 @@ export default class AkamaiClient {
    * @param {string} [config.accountSwitchKey]
    * @param {string[]} [config.notifyEmails] - Required only to call activate();
    *   emails PAPI notifies about activation progress.
+   * @param {number} [config.ruleTreeTimeoutMs] - Timeout for calls whose latency scales with
+   *   rule-tree size (getRuleTree, updateRuleTree, patchRuleTree). Defaults to 60s, well above
+   *   tracingFetch's generic 10s default used by every other (cheap, metadata-only) call.
    * @param {object} [log]
    */
   constructor(config = {}, log = console) {
@@ -179,6 +190,7 @@ export default class AkamaiClient {
     this.#accessToken = config.accessToken;
     this.accountSwitchKey = config.accountSwitchKey;
     this.notifyEmails = config.notifyEmails;
+    this.ruleTreeTimeoutMs = config.ruleTreeTimeoutMs || DEFAULT_RULE_TREE_TIMEOUT_MS;
     this.log = log;
   }
 
@@ -191,7 +203,9 @@ export default class AkamaiClient {
     return `https://${this.host}${path}${qs ? `?${qs}` : ''}`;
   }
 
-  async #request(method, path, { params, body, headers } = {}) {
+  async #request(method, path, {
+    params, body, headers, timeout,
+  } = {}) {
     const bodyStr = body ? JSON.stringify(body) : undefined;
 
     // The EG1-HMAC-SHA256 signature is bound to the exact request URL, so a followed redirect
@@ -222,6 +236,7 @@ export default class AkamaiClient {
             ...headers,
           },
           body: bodyStr,
+          ...(timeout ? { timeout } : {}),
         });
       } catch (e) {
         throw new Error(`PAPI ${method} ${path} request failed: ${e.message}`);
@@ -415,7 +430,7 @@ export default class AkamaiClient {
     const data = await this.#request(
       'GET',
       `/papi/v1/properties/${id}/versions/${version}/rules`,
-      { params: { contractId, groupId } },
+      { params: { contractId, groupId }, timeout: this.ruleTreeTimeoutMs },
     );
     // `etag` is the version's optimistic-concurrency token; patchRuleTree passes it back as
     // If-Match so a concurrent edit fails the PATCH instead of silently clobbering.
@@ -495,7 +510,9 @@ export default class AkamaiClient {
     return this.#request(
       'PUT',
       `/papi/v1/properties/${id}/versions/${version}/rules`,
-      { params, body: ruleTree, headers },
+      {
+        params, body: ruleTree, headers, timeout: this.ruleTreeTimeoutMs,
+      },
     );
   }
 
@@ -549,7 +566,9 @@ export default class AkamaiClient {
     return this.#request(
       'PATCH',
       `/papi/v1/properties/${id}/versions/${version}/rules`,
-      { params, body: ops, headers },
+      {
+        params, body: ops, headers, timeout: this.ruleTreeTimeoutMs,
+      },
     );
   }
 

--- a/packages/spacecat-shared-akamai-client/src/akamai-client.js
+++ b/packages/spacecat-shared-akamai-client/src/akamai-client.js
@@ -420,21 +420,38 @@ export default class AkamaiClient {
    * @param {string} groupId
    * @returns {Promise<{ruleTree: object, ruleFormat: string|undefined, etag: string|undefined}>}
    */
-  async getRuleTree(propertyId, version, contractId, groupId) {
+  async getRuleTree(propertyId, version, contractId, groupId, options = {}) {
     requirePropertyRef(propertyId, contractId, groupId);
     if (!Number.isInteger(version)) {
       throw new Error('version must be an integer');
     }
     const id = encodePathSegment(propertyId);
-    this.log.info(`Fetching rule tree for property ${propertyId} v${version}`);
+    const params = { contractId, groupId };
+    // Opt-in: ask PAPI to validate the stored tree and return its errors/warnings arrays. Off by
+    // default (a plain read is cheap); on, PAPI runs its full validation pass so the response
+    // carries `errors`/`warnings` — used to tell whether a version can be activated. Its latency
+    // scales with tree size (the same pass the PUT runs), which is why the size-scaling timeout
+    // applies.
+    if (options.validateRules) {
+      params.validateRules = 'true';
+    }
+    const suffix = options.validateRules ? ' (validate)' : '';
+    this.log.info(`Fetching rule tree for property ${propertyId} v${version}${suffix}`);
     const data = await this.#request(
       'GET',
       `/papi/v1/properties/${id}/versions/${version}/rules`,
-      { params: { contractId, groupId }, timeout: this.ruleTreeTimeoutMs },
+      { params, timeout: this.ruleTreeTimeoutMs },
     );
     // `etag` is the version's optimistic-concurrency token; patchRuleTree passes it back as
-    // If-Match so a concurrent edit fails the PATCH instead of silently clobbering.
-    return { ruleTree: data, ruleFormat: data.ruleFormat, etag: data.etag };
+    // If-Match so a concurrent edit fails the PATCH instead of silently clobbering. `errors`/
+    // `warnings` are present only when validateRules was requested (undefined otherwise).
+    return {
+      ruleTree: data,
+      ruleFormat: data.ruleFormat,
+      etag: data.etag,
+      errors: data.errors,
+      warnings: data.warnings,
+    };
   }
 
   /**

--- a/packages/spacecat-shared-akamai-client/src/akamai-client.js
+++ b/packages/spacecat-shared-akamai-client/src/akamai-client.js
@@ -185,7 +185,12 @@ export default class AkamaiClient {
     this.#accessToken = config.accessToken;
     this.accountSwitchKey = config.accountSwitchKey;
     this.notifyEmails = config.notifyEmails;
-    this.ruleTreeTimeoutMs = config.ruleTreeTimeoutMs || DEFAULT_RULE_TREE_TIMEOUT_MS;
+    // Honor an explicitly configured positive timeout; fall back to the default when unset or
+    // invalid. (Plain `||`/`??` would mis-handle 0 — AbortSignal.timeout treats it as instant.)
+    const ms = config.ruleTreeTimeoutMs;
+    this.ruleTreeTimeoutMs = typeof ms === 'number' && Number.isFinite(ms) && ms > 0
+      ? ms
+      : DEFAULT_RULE_TREE_TIMEOUT_MS;
     this.log = log;
   }
 
@@ -413,7 +418,10 @@ export default class AkamaiClient {
    * @param {number} version
    * @param {string} contractId
    * @param {string} groupId
-   * @returns {Promise<{ruleTree: object, ruleFormat: string|undefined, etag: string|undefined}>}
+   * @param {{ validateRules?: boolean }} [options] - when validateRules is true, PAPI runs a full
+   *   validation pass and the result also includes `errors`/`warnings`.
+   * @returns {Promise<{ruleTree: object, ruleFormat?: string, etag?: string, errors?: object[],
+   *   warnings?: object[]}>} errors/warnings present only when validateRules was requested
    */
   async getRuleTree(propertyId, version, contractId, groupId, options = {}) {
     requirePropertyRef(propertyId, contractId, groupId);
@@ -567,7 +575,7 @@ export default class AkamaiClient {
     const headers = {
       'Content-Type': 'application/json-patch+json',
       // PAPI requires an RFC 7232 quoted etag; a bare token yields a generic, unhelpful 400.
-      ...(etag ? { 'If-Match': `"${etag}"` } : {}),
+      ...(etag ? { 'If-Match': `"${String(etag).replace(/^"+|"+$/g, '')}"` } : {}),
     };
     this.log.info(
       `Patching rule tree for property ${propertyId} v${version} `

--- a/packages/spacecat-shared-akamai-client/src/index.d.ts
+++ b/packages/spacecat-shared-akamai-client/src/index.d.ts
@@ -29,6 +29,10 @@ export interface AkamaiClientConfig {
   accessToken: string;
   accountSwitchKey?: string;
   notifyEmails?: string[];
+  /** Timeout (ms) for calls whose latency scales with rule-tree size (getRuleTree,
+   * updateRuleTree, patchRuleTree). Defaults to 60000, above tracingFetch's generic 10s default
+   * used by every other (cheap, metadata-only) call. */
+  ruleTreeTimeoutMs?: number;
 }
 
 export interface PropertyMatch {
@@ -75,6 +79,8 @@ export default class AkamaiClient {
   accountSwitchKey?: string;
 
   notifyEmails?: string[];
+
+  ruleTreeTimeoutMs: number;
 
   searchBy(key: 'hostname' | 'edgeHostname' | 'propertyName', value: string): Promise<object[]>;
 

--- a/packages/spacecat-shared-akamai-client/src/index.d.ts
+++ b/packages/spacecat-shared-akamai-client/src/index.d.ts
@@ -51,6 +51,9 @@ export interface RuleTreeResult {
   ruleTree: object;
   ruleFormat?: string;
   etag?: string;
+  /** Present when getRuleTree is called with { validateRules: true }. */
+  errors?: object[];
+  warnings?: object[];
 }
 
 export type Network = 'STAGING' | 'PRODUCTION';
@@ -93,6 +96,7 @@ export default class AkamaiClient {
     version: number,
     contractId: string,
     groupId: string,
+    options?: { validateRules?: boolean },
   ): Promise<RuleTreeResult>;
 
   createVersion(

--- a/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
+++ b/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
@@ -294,8 +294,9 @@ describe('AkamaiClient', () => {
   // semantic pass over the whole tree), so they use the client's configurable ruleTreeTimeoutMs
   // instead of tracingFetch's generic 10s default. Reproduced against a real customer property
   // whose PUT consistently exceeded 10s and got aborted client-side before Akamai could respond —
-  // these tests use small ms values (not real 10s/60s waits) to prove the configured value is what
-  // actually gates each call, fast.
+  // these tests use small ms values (not real waits): the abort firing on an 80ms response proves
+  // the 30ms timeout gated the call. The regex matches any ms — the exact-ms wording is asserted
+  // in spacecat-shared-utils (where that fix lives); this package sees it only after utils ships.
 
   describe('rule-tree call timeout', () => {
     it('getRuleTree times out using the configured ruleTreeTimeoutMs, not the 10s default', async () => {
@@ -307,7 +308,7 @@ describe('AkamaiClient', () => {
         .reply(200, { rules: {} });
 
       await expect(c.getRuleTree(PROPERTY_ID, 5, CONTRACT_ID, GROUP_ID))
-        .to.be.rejectedWith(/request failed: Request timeout after 30ms/);
+        .to.be.rejectedWith(/request failed: Request timeout after \d+ms/);
     });
 
     it('updateRuleTree times out using the configured ruleTreeTimeoutMs', async () => {
@@ -319,7 +320,7 @@ describe('AkamaiClient', () => {
         .reply(200, { errors: [] });
 
       await expect(c.updateRuleTree(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, { rules: {} }))
-        .to.be.rejectedWith(/request failed: Request timeout after 30ms/);
+        .to.be.rejectedWith(/request failed: Request timeout after \d+ms/);
     });
 
     it('patchRuleTree times out using the configured ruleTreeTimeoutMs', async () => {
@@ -332,7 +333,7 @@ describe('AkamaiClient', () => {
         .reply(200, { errors: [] });
 
       await expect(c.patchRuleTree(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, ops))
-        .to.be.rejectedWith(/request failed: Request timeout after 30ms/);
+        .to.be.rejectedWith(/request failed: Request timeout after \d+ms/);
     });
 
     it('a short ruleTreeTimeoutMs does not affect cheap, metadata-only calls', async () => {

--- a/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
+++ b/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
@@ -652,10 +652,12 @@ describe('AkamaiClient', () => {
   describe('patchRuleTree', () => {
     const OPS = [{ op: 'add', path: '/rules/children/-', value: { name: 'X' } }];
 
-    it('sends the json-patch content-type, If-Match etag, and validateRules; returns body', async () => {
+    it('sends the json-patch content-type, QUOTED If-Match etag, and validateRules; returns body', async () => {
       nock(API_BASE)
         .matchHeader('content-type', 'application/json-patch+json')
-        .matchHeader('if-match', 'etag123')
+        // RFC 7232 requires a quoted etag; PAPI rejects a bare token with a generic 400. The client
+        // wraps the caller's raw etag in double quotes, so the wire value is `"etag123"`.
+        .matchHeader('if-match', '"etag123"')
         .patch(`/papi/v1/properties/${PROPERTY_ID}/versions/6/rules`, OPS)
         .query({ contractId: CONTRACT_ID, groupId: GROUP_ID, validateRules: 'true' })
         .reply(200, { errors: [], warnings: [{ detail: 'w' }] });

--- a/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
+++ b/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
@@ -134,6 +134,16 @@ describe('AkamaiClient', () => {
       const c = new AkamaiClient(CREDS);
       expect(c).to.be.instanceOf(AkamaiClient);
     });
+
+    it('defaults ruleTreeTimeoutMs to 60000', () => {
+      const c = new AkamaiClient(CREDS, log);
+      expect(c.ruleTreeTimeoutMs).to.equal(60000);
+    });
+
+    it('accepts a custom ruleTreeTimeoutMs', () => {
+      const c = new AkamaiClient({ ...CREDS, ruleTreeTimeoutMs: 45000 }, log);
+      expect(c.ruleTreeTimeoutMs).to.equal(45000);
+    });
   });
 
   // ─── low-level request behavior (via getLatestVersion) ────────────────
@@ -276,6 +286,67 @@ describe('AkamaiClient', () => {
 
       await expect(client.activate(PROPERTY_ID, 5, CONTRACT_ID, GROUP_ID, 'STAGING'))
         .to.be.rejectedWith(/unexpected redirect \(307\)/);
+    });
+  });
+
+  // ─── rule-tree call timeout ─────────────────────────────────────────────
+  // getRuleTree/updateRuleTree/patchRuleTree scale with rule-tree size (PAPI's validateRules is a
+  // semantic pass over the whole tree), so they use the client's configurable ruleTreeTimeoutMs
+  // instead of tracingFetch's generic 10s default. Reproduced against a real customer property
+  // whose PUT consistently exceeded 10s and got aborted client-side before Akamai could respond —
+  // these tests use small ms values (not real 10s/60s waits) to prove the configured value is what
+  // actually gates each call, fast.
+
+  describe('rule-tree call timeout', () => {
+    it('getRuleTree times out using the configured ruleTreeTimeoutMs, not the 10s default', async () => {
+      const c = new AkamaiClient({ ...CREDS, ruleTreeTimeoutMs: 30 }, log);
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/versions/5/rules`)
+        .query(true)
+        .delay(80)
+        .reply(200, { rules: {} });
+
+      await expect(c.getRuleTree(PROPERTY_ID, 5, CONTRACT_ID, GROUP_ID))
+        .to.be.rejectedWith(/request failed: Request timeout after 30ms/);
+    });
+
+    it('updateRuleTree times out using the configured ruleTreeTimeoutMs', async () => {
+      const c = new AkamaiClient({ ...CREDS, ruleTreeTimeoutMs: 30 }, log);
+      nock(API_BASE)
+        .put(`/papi/v1/properties/${PROPERTY_ID}/versions/6/rules`)
+        .query(true)
+        .delay(80)
+        .reply(200, { errors: [] });
+
+      await expect(c.updateRuleTree(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, { rules: {} }))
+        .to.be.rejectedWith(/request failed: Request timeout after 30ms/);
+    });
+
+    it('patchRuleTree times out using the configured ruleTreeTimeoutMs', async () => {
+      const c = new AkamaiClient({ ...CREDS, ruleTreeTimeoutMs: 30 }, log);
+      const ops = [{ op: 'add', path: '/rules/children/-', value: { name: 'X' } }];
+      nock(API_BASE)
+        .patch(`/papi/v1/properties/${PROPERTY_ID}/versions/6/rules`, ops)
+        .query(true)
+        .delay(80)
+        .reply(200, { errors: [] });
+
+      await expect(c.patchRuleTree(PROPERTY_ID, 6, CONTRACT_ID, GROUP_ID, ops))
+        .to.be.rejectedWith(/request failed: Request timeout after 30ms/);
+    });
+
+    it('a short ruleTreeTimeoutMs does not affect cheap, metadata-only calls', async () => {
+      // getLatestVersion doesn't scale with rule-tree size, so it should keep tracingFetch's
+      // generic (much longer) default even when ruleTreeTimeoutMs is configured very small.
+      const c = new AkamaiClient({ ...CREDS, ruleTreeTimeoutMs: 30 }, log);
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/versions/latest`)
+        .query(true)
+        .delay(80)
+        .reply(200, { versions: { items: [{ propertyVersion: 7 }] } });
+
+      const version = await c.getLatestVersion(PROPERTY_ID, CONTRACT_ID, GROUP_ID);
+      expect(version).to.equal(7);
     });
   });
 

--- a/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
+++ b/packages/spacecat-shared-akamai-client/test/akamai-client.test.js
@@ -543,6 +543,39 @@ describe('AkamaiClient', () => {
       await expect(client.getRuleTree(PROPERTY_ID, '5', CONTRACT_ID, GROUP_ID))
         .to.be.rejectedWith('version must be an integer');
     });
+
+    it('adds validateRules=true and returns errors/warnings when requested', async () => {
+      nock(API_BASE)
+        .get(`/papi/v1/properties/${PROPERTY_ID}/versions/5/rules`)
+        .query({ contractId: CONTRACT_ID, groupId: GROUP_ID, validateRules: 'true' })
+        .reply(200, {
+          ruleFormat: 'v2024-01-01',
+          rules: { name: 'default' },
+          errors: [{ detail: 'bad rule' }],
+          warnings: [{ detail: 'a warning' }],
+        });
+
+      const result = await client.getRuleTree(
+        PROPERTY_ID,
+        5,
+        CONTRACT_ID,
+        GROUP_ID,
+        { validateRules: true },
+      );
+      expect(result.errors).to.deep.equal([{ detail: 'bad rule' }]);
+      expect(result.warnings).to.deep.equal([{ detail: 'a warning' }]);
+    });
+
+    it('omits validateRules and leaves errors/warnings undefined by default', async () => {
+      nock(API_BASE, { badheaders: [] })
+        .get(`/papi/v1/properties/${PROPERTY_ID}/versions/5/rules`)
+        .query((q) => q.contractId === CONTRACT_ID && q.groupId === GROUP_ID && !('validateRules' in q))
+        .reply(200, { ruleFormat: 'v2024-01-01', rules: { name: 'default' } });
+
+      const result = await client.getRuleTree(PROPERTY_ID, 5, CONTRACT_ID, GROUP_ID);
+      expect(result.errors).to.equal(undefined);
+      expect(result.warnings).to.equal(undefined);
+    });
   });
 
   describe('createVersion', () => {

--- a/packages/spacecat-shared-utils/src/tracing-fetch.js
+++ b/packages/spacecat-shared-utils/src/tracing-fetch.js
@@ -124,17 +124,18 @@ const createTimeoutError = (timeout) => {
  * @param {string|Request} resource - The resource to fetch
  * @param {Object} options - Options for the fetch call
  * @param {Object} signal - The timeout signal
+ * @param {number} timeout - The timeout value in milliseconds, for a correct error message on
+ *   abort. `@adobe/fetch`'s TimeoutSignal keeps its ms value behind a private Symbol (no public
+ *   `_ms` or similar), so it cannot be read back off the signal — it must be threaded through
+ *   explicitly by the caller, which already has it in scope.
  * @returns {Promise<Response>} The fetch response
  */
-const fetchWithTimeout = async (resource, options, signal) => {
+const fetchWithTimeout = async (resource, options, signal, timeout) => {
   try {
     const fetchOptions = { ...options, signal };
     return await adobeFetch(resource, fetchOptions);
   } catch (error) {
     if (error instanceof AbortError) {
-      // Extract timeout from signal (implementation detail, but necessary)
-      // eslint-disable-next-line no-underscore-dangle
-      const timeout = signal._ms || 10000;
       throw createTimeoutError(timeout);
     }
     throw error;
@@ -175,14 +176,14 @@ export async function tracingFetch(url, options) {
 
   // fallback to adobe fetch outside an aws lambda function
   if (!isAWSLambda()) {
-    return fetchWithTimeout(url, options, signal);
+    return fetchWithTimeout(url, options, signal, timeout);
   }
 
   const parentSegment = AWSXRay.getSegment();
 
   // If no parent segment, perform fetch without tracing
   if (!parentSegment) {
-    return fetchWithTimeout(url, options, signal);
+    return fetchWithTimeout(url, options, signal, timeout);
   }
 
   // With parent segment, create subsegment and add tracing
@@ -203,7 +204,7 @@ export async function tracingFetch(url, options) {
     const requestWithSignal = new Request(request, { signal });
 
     // Use the same fetchWithTimeout function but catch errors to handle subsegment
-    const response = await fetchWithTimeout(requestWithSignal, { }, signal);
+    const response = await fetchWithTimeout(requestWithSignal, { }, signal, timeout);
 
     setSubSegmentFlagsByStatusCode(subSegment, response.status);
     addFetchRequestDataToSegment(subSegment, request, response);

--- a/packages/spacecat-shared-utils/src/tracing-fetch.js
+++ b/packages/spacecat-shared-utils/src/tracing-fetch.js
@@ -124,10 +124,8 @@ const createTimeoutError = (timeout) => {
  * @param {string|Request} resource - The resource to fetch
  * @param {Object} options - Options for the fetch call
  * @param {Object} signal - The timeout signal
- * @param {number} timeout - The timeout value in milliseconds, for a correct error message on
- *   abort. `@adobe/fetch`'s TimeoutSignal keeps its ms value behind a private Symbol (no public
- *   `_ms` or similar), so it cannot be read back off the signal — it must be threaded through
- *   explicitly by the caller, which already has it in scope.
+ * @param {number} timeout - Timeout in ms; passed explicitly because `@adobe/fetch`'s signal
+ *   doesn't expose its ms value, so it can't be read back for the abort message.
  * @returns {Promise<Response>} The fetch response
  */
 const fetchWithTimeout = async (resource, options, signal, timeout) => {

--- a/packages/spacecat-shared-utils/test/tracing-fetch.test.js
+++ b/packages/spacecat-shared-utils/test/tracing-fetch.test.js
@@ -322,7 +322,10 @@ describe('tracing fetch function', () => {
       await tracingFetch(url, { timeout: shortTimeout });
       throw new Error('Expected fetch to throw a timeout error');
     } catch (error) {
-      expect(error.message).to.include('timeout');
+      // The message must reflect the actual configured timeout (50ms), not a hardcoded 10000 —
+      // @adobe/fetch's TimeoutSignal keeps its ms value behind a private Symbol, so it can't be
+      // read back off the signal; it must be the value tracingFetch itself was called with.
+      expect(error.message).to.equal('Request timeout after 50ms');
       expect(error.code).to.equal('ETIMEOUT');
 
       // Check if the subsegment was properly handled
@@ -353,7 +356,7 @@ describe('tracing fetch function', () => {
       await tracingFetch(url, { timeout: shortTimeout });
       throw new Error('Expected fetch to throw a timeout error');
     } catch (error) {
-      expect(error.message).to.include('timeout');
+      expect(error.message).to.equal('Request timeout after 50ms');
       expect(error.code).to.equal('ETIMEOUT');
     }
   });


### PR DESCRIPTION
## What
`AkamaiClient` gains the pieces the LLMO Akamai onboarding needs for large properties, plus a latent message-bug fix in `spacecat-shared-utils`:

- **Configurable `ruleTreeTimeoutMs`** (default `60000`), applied only to the three calls whose latency scales with rule-tree size — `getRuleTree`, `updateRuleTree`, `patchRuleTree`. Cheap metadata calls (`getLatestVersion`, `createVersion`, `activate`, …) keep tracingFetch's 10s default.
- **New `patchRuleTree`** — applies a JSON Patch (RFC 6902) to a version's stored tree with `validateRules=true`. `If-Match`, when supplied, is sent as an RFC 7232 quoted etag (PAPI rejects a bare token with a generic 400).
- **`getRuleTree` `options.validateRules`** — opt-in full validation pass that returns `errors`/`warnings` (used to tell whether a version is activatable).
- **`index.d.ts`** updated for all of the above.
- **tracing-fetch message fix** — the timeout error always reported `"10000ms"` regardless of the configured timeout (it read a non-existent `_ms` off `@adobe/fetch`'s signal). The abort always fired at the right time; only the message was wrong. The real value is now threaded through.

## Why
On a large Akamai property, PAPI's `validateRules` pass over the whole tree genuinely takes longer than tracingFetch's 10s default, so the rule-tree write was aborted client-side before Akamai could respond — the version got created (a cheap call) but its rule content never landed.

## Testing
- `akamai-client.test.js`: the three rule-tree calls use the configured `ruleTreeTimeoutMs` (not the 10s default); cheap calls unaffected; `patchRuleTree` content-type / quoted If-Match / validateRules; `getRuleTree` validateRules returns errors/warnings.
- `tracing-fetch.test.js`: asserts the timeout message reports the configured value.
- `npm test` + `npm run lint` clean in `spacecat-shared-akamai-client` and `spacecat-shared-utils`.

## Merge order
**Merge this first.** adobe/spacecat-api-service#3013 consumes the published release of this package (its PATCH deploy uses `patchRuleTree`; its deploy-status uses `getRuleTree({ validateRules })`). Once this releases, adobe/spacecat-api-service#3013 swaps its temporary gist-tarball dependency for the published version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
