### PR TITLE
fix: optimize edge deploy/rollback api

### DIFF
--- a/packages/spacecat-shared-tokowaka-client/src/index.js
+++ b/packages/spacecat-shared-tokowaka-client/src/index.js
@@ -40,6 +40,7 @@ import {
 import { getEffectiveBaseURL } from './utils/site-utils.js';
 import { removePatternFromMetaconfig, addPatternsToMetaconfig } from './utils/metaconfig-utils.js';
 import { fetchHtmlWithWarmup, calculateForwardedHost } from './utils/custom-html-utils.js';
+import { mapWithConcurrency } from './utils/concurrency-utils.js';
 import {
   EDGE_OPTIMIZE_PROXY_BASE_URL_DEFAULT,
   PRIVATE_HOST_RE,
@@ -73,6 +74,13 @@ export {
 const HTTP_BAD_REQUEST = 400;
 const HTTP_INTERNAL_SERVER_ERROR = 500;
 const HTTP_NOT_IMPLEMENTED = 501;
+
+/**
+ * Max number of per-URL S3 config operations (fetch + upload) to run in parallel
+ * during deploy/rollback. Each URL maps to a distinct S3 object, so the work is
+ * independent; the cap avoids exhausting the S3 socket pool on large opportunities.
+ */
+const URL_CONFIG_CONCURRENCY = 10;
 
 /**
  * Tokowaka Client - Manages edge optimization configurations
@@ -786,49 +794,56 @@ class TokowakaClient {
       );
     }
 
-    // Process each URL separately
+    // Process each URL separately. URLs are independent (each maps to a distinct
+    // S3 object), so fetch+upload run in parallel with bounded concurrency.
+    const urlEntries = Object.entries(suggestionsByUrl);
+    const processed = await mapWithConcurrency(
+      urlEntries,
+      async ([urlPath, urlSuggestions]) => {
+        const fullUrl = new URL(urlPath, baseURL).toString();
+        this.log.debug(`Processing ${urlSuggestions.length} suggestions for URL: ${fullUrl}`);
+
+        // Fetch existing configuration for this URL from S3
+        const existingConfig = await this.fetchConfig(fullUrl);
+
+        // Generate configuration for this URL with eligible suggestions only
+        const newConfig = this.generateConfig(fullUrl, opportunity, urlSuggestions);
+
+        if (!newConfig) {
+          this.log.warn(`No config generated for URL: ${fullUrl}`);
+          return null;
+        }
+
+        // Check if mapper allows configs without patches (e.g., prerender-only config)
+        const allowsNoPatch = mapper.allowConfigsWithoutPatch() && newConfig.patches.length === 0;
+
+        if (!allowsNoPatch && (!newConfig.patches || newConfig.patches.length === 0)) {
+          this.log.warn(`No eligible suggestions to deploy for URL: ${fullUrl}`);
+          return null;
+        }
+
+        if (applyStale && newConfig.patches?.length > 0) {
+          newConfig.patches = newConfig.patches.map((patch) => ({ ...patch, applyStale: true }));
+        }
+
+        // Merge with existing config for this URL
+        const config = this.mergeConfigs(existingConfig, newConfig);
+
+        // Upload to S3
+        const s3Path = await this.uploadConfig(fullUrl, config);
+        return { s3Path, fullUrl };
+      },
+      URL_CONFIG_CONCURRENCY,
+    );
+
     const s3Paths = [];
     const deployedUrls = []; // Track URLs for batch CDN invalidation
-
-    for (const [urlPath, urlSuggestions] of Object.entries(suggestionsByUrl)) {
-      const fullUrl = new URL(urlPath, baseURL).toString();
-      this.log.debug(`Processing ${urlSuggestions.length} suggestions for URL: ${fullUrl}`);
-
-      // Fetch existing configuration for this URL from S3
-      // eslint-disable-next-line no-await-in-loop
-      const existingConfig = await this.fetchConfig(fullUrl);
-
-      // Generate configuration for this URL with eligible suggestions only
-      const newConfig = this.generateConfig(fullUrl, opportunity, urlSuggestions);
-
-      if (!newConfig) {
-        this.log.warn(`No config generated for URL: ${fullUrl}`);
-        // eslint-disable-next-line no-continue
-        continue;
+    processed.forEach((entry) => {
+      if (entry) {
+        s3Paths.push(entry.s3Path);
+        deployedUrls.push(entry.fullUrl);
       }
-
-      // Check if mapper allows configs without patches (e.g., prerender-only config)
-      const allowsNoPatch = mapper.allowConfigsWithoutPatch() && newConfig.patches.length === 0;
-
-      if (!allowsNoPatch && (!newConfig.patches || newConfig.patches.length === 0)) {
-        this.log.warn(`No eligible suggestions to deploy for URL: ${fullUrl}`);
-        // eslint-disable-next-line no-continue
-        continue;
-      }
-
-      if (applyStale && newConfig.patches?.length > 0) {
-        newConfig.patches = newConfig.patches.map((patch) => ({ ...patch, applyStale: true }));
-      }
-
-      // Merge with existing config for this URL
-      const config = this.mergeConfigs(existingConfig, newConfig);
-
-      // Upload to S3
-      // eslint-disable-next-line no-await-in-loop
-      const s3Path = await this.uploadConfig(fullUrl, config);
-      s3Paths.push(s3Path);
-      deployedUrls.push(fullUrl);
-    }
+    });
 
     this.log.info(`Uploaded Tokowaka configs for ${s3Paths.length} URLs`);
 
@@ -970,21 +985,27 @@ class TokowakaClient {
     const rolledBackUrls = [];
     let totalRemovedCount = 0;
 
-    for (const [urlPath, urlSuggestions] of Object.entries(suggestionsByUrl)) {
-      const fullUrl = new URL(urlPath, baseURL).toString();
-      this.log.debug(`Rolling back ${urlSuggestions.length} suggestions for URL: ${fullUrl}`);
-      // eslint-disable-next-line no-await-in-loop
-      const removed = await this.#rollbackPerUrlConfig(
-        fullUrl,
-        urlSuggestions,
-        opportunity,
-        mapper,
-        opportunityType,
-        s3Paths,
-        rolledBackUrls,
-      );
-      totalRemovedCount += removed;
-    }
+    // URLs are independent (each maps to a distinct S3 object), so fetch+upload run
+    // in parallel with bounded concurrency. #rollbackPerUrlConfig appends to the shared
+    // s3Paths / rolledBackUrls accumulators (order is not significant for those).
+    const removedCounts = await mapWithConcurrency(
+      Object.entries(suggestionsByUrl),
+      async ([urlPath, urlSuggestions]) => {
+        const fullUrl = new URL(urlPath, baseURL).toString();
+        this.log.debug(`Rolling back ${urlSuggestions.length} suggestions for URL: ${fullUrl}`);
+        return this.#rollbackPerUrlConfig(
+          fullUrl,
+          urlSuggestions,
+          opportunity,
+          mapper,
+          opportunityType,
+          s3Paths,
+          rolledBackUrls,
+        );
+      },
+      URL_CONFIG_CONCURRENCY,
+    );
+    totalRemovedCount += removedCounts.reduce((sum, n) => sum + n, 0);
 
     // eslint-disable-next-line max-len
     this.log.info(`Updated Tokowaka configs for ${s3Paths.length} URLs, removed ${totalRemovedCount} patches total`);

--- a/packages/spacecat-shared-tokowaka-client/src/index.js
+++ b/packages/spacecat-shared-tokowaka-client/src/index.js
@@ -790,8 +790,9 @@ class TokowakaClient {
       );
     }
 
-    // Each URL is its own file, so we can handle several at the same time.
+    // Each URL has its own S3 config, so we can handle several at the same time.
     const urlEntries = Object.entries(suggestionsByUrl);
+    const loopStart = Date.now();
     const processed = await mapWithConcurrency(
       urlEntries,
       async ([urlPath, urlSuggestions]) => {
@@ -840,7 +841,8 @@ class TokowakaClient {
       }
     });
 
-    this.log.info(`Uploaded Tokowaka configs for ${s3Paths.length} URLs`);
+    this.log.info(`Uploaded Tokowaka configs for ${s3Paths.length}/${urlEntries.length}`
+      + ` URL(s) in ${Date.now() - loopStart}ms (concurrency=${URL_CONFIG_CONCURRENCY})`);
 
     // Update metaconfig with deployed paths
     await this.#updateMetaconfigWithDeployedPaths(metaconfig, deployedUrls, baseURL);
@@ -981,8 +983,10 @@ class TokowakaClient {
     let totalRemovedCount = 0;
 
     // Each URL is its own file, so we can roll back several at the same time.
+    const urlEntries = Object.entries(suggestionsByUrl);
+    const loopStart = Date.now();
     const removedCounts = await mapWithConcurrency(
-      Object.entries(suggestionsByUrl),
+      urlEntries,
       async ([urlPath, urlSuggestions]) => {
         const fullUrl = new URL(urlPath, baseURL).toString();
         this.log.debug(`Rolling back ${urlSuggestions.length} suggestions for URL: ${fullUrl}`);
@@ -1001,7 +1005,8 @@ class TokowakaClient {
     totalRemovedCount += removedCounts.reduce((sum, n) => sum + n, 0);
 
     // eslint-disable-next-line max-len
-    this.log.info(`Updated Tokowaka configs for ${s3Paths.length} URLs, removed ${totalRemovedCount} patches total`);
+    this.log.info(`Updated Tokowaka configs for ${s3Paths.length}/${urlEntries.length} URL(s), `
+      + `removed ${totalRemovedCount} patches total in ${Date.now() - loopStart}ms (concurrency=${URL_CONFIG_CONCURRENCY})`);
 
     // Strip deployment markers and batch-save all eligible per-URL suggestions.
     const savedEligibleSuggestions = eligibleSuggestions

--- a/packages/spacecat-shared-tokowaka-client/src/index.js
+++ b/packages/spacecat-shared-tokowaka-client/src/index.js
@@ -860,16 +860,14 @@ class TokowakaClient {
 
   /**
    * Rolls back a single URL's S3 config by removing the relevant patches.
-   * Returns the number of patches removed, or 0 if nothing changed.
-   * Pushes the uploaded S3 path into s3Paths and the URL into rolledBackUrls on success.
+   * Returns { s3Path, fullUrl, removed } when a config was re-uploaded,
+   * or null when there was nothing to roll back
    * @param {string} fullUrl
    * @param {Array} urlSuggestions - Suggestions for this URL
    * @param {Object} opportunity
    * @param {Object} mapper
    * @param {string} opportunityType
-   * @param {Array} s3Paths - Accumulator array (mutated)
-   * @param {Array} rolledBackUrls - Accumulator array (mutated)
-   * @returns {Promise<number>} Number of patches removed
+   * @returns {Promise<{s3Path: string, fullUrl: string, removed: number}|null>}
    * @private
    */
   async #rollbackPerUrlConfig(
@@ -878,26 +876,22 @@ class TokowakaClient {
     opportunity,
     mapper,
     opportunityType,
-    s3Paths,
-    rolledBackUrls,
   ) {
     const existingConfig = await this.fetchConfig(fullUrl);
     if (!existingConfig) {
       this.log.warn(`No existing configuration found for URL: ${fullUrl}`);
-      return 0;
+      return null;
     }
 
     if (opportunityType === 'prerender') {
       this.log.info(`Rolling back prerender config for URL: ${fullUrl}`);
       const s3Path = await this.uploadConfig(fullUrl, { ...existingConfig, prerender: false });
-      s3Paths.push(s3Path);
-      rolledBackUrls.push(fullUrl);
-      return 1;
+      return { s3Path, fullUrl, removed: 1 };
     }
 
     if (!existingConfig.patches) {
       this.log.info(`No patches found in configuration for URL: ${fullUrl}`);
-      return 0;
+      return null;
     }
 
     const suggestionIdsToRemove = urlSuggestions.map((s) => s.getId());
@@ -909,7 +903,7 @@ class TokowakaClient {
 
     if (updatedConfig.removedCount === 0) {
       this.log.warn(`No patches found for suggestions at URL: ${fullUrl}`);
-      return 0;
+      return null;
     }
 
     this.log.info(`Removed ${updatedConfig.removedCount} patches for URL: ${fullUrl}`);
@@ -917,9 +911,7 @@ class TokowakaClient {
     delete updatedConfig.removedCount;
 
     const s3Path = await this.uploadConfig(fullUrl, updatedConfig);
-    s3Paths.push(s3Path);
-    rolledBackUrls.push(fullUrl);
-    return removed;
+    return { s3Path, fullUrl, removed };
   }
 
   /**
@@ -978,14 +970,11 @@ class TokowakaClient {
 
     // Roll back per-URL suggestions: one S3 config file per URL.
     const suggestionsByUrl = groupSuggestionsByUrlPath(eligibleSuggestions, baseURL, this.log);
-    const s3Paths = [];
-    const rolledBackUrls = [];
-    let totalRemovedCount = 0;
 
     // Each URL is its own file, so we can roll back several at the same time.
     const urlEntries = Object.entries(suggestionsByUrl);
     const loopStart = Date.now();
-    const removedCounts = await mapWithConcurrency(
+    const processed = await mapWithConcurrency(
       urlEntries,
       async ([urlPath, urlSuggestions]) => {
         const fullUrl = new URL(urlPath, baseURL).toString();
@@ -996,13 +985,21 @@ class TokowakaClient {
           opportunity,
           mapper,
           opportunityType,
-          s3Paths,
-          rolledBackUrls,
         );
       },
       URL_CONFIG_CONCURRENCY,
     );
-    totalRemovedCount += removedCounts.reduce((sum, n) => sum + n, 0);
+
+    const s3Paths = [];
+    const rolledBackUrls = [];
+    let totalRemovedCount = 0;
+    processed.forEach((entry) => {
+      if (entry) {
+        s3Paths.push(entry.s3Path);
+        rolledBackUrls.push(entry.fullUrl);
+        totalRemovedCount += entry.removed;
+      }
+    });
 
     // eslint-disable-next-line max-len
     this.log.info(`Updated Tokowaka configs for ${s3Paths.length}/${urlEntries.length} URL(s), `

--- a/packages/spacecat-shared-tokowaka-client/src/index.js
+++ b/packages/spacecat-shared-tokowaka-client/src/index.js
@@ -75,12 +75,8 @@ const HTTP_BAD_REQUEST = 400;
 const HTTP_INTERNAL_SERVER_ERROR = 500;
 const HTTP_NOT_IMPLEMENTED = 501;
 
-/**
- * Max number of per-URL S3 config operations (fetch + upload) to run in parallel
- * during deploy/rollback. Each URL maps to a distinct S3 object, so the work is
- * independent; the cap avoids exhausting the S3 socket pool on large opportunities.
- */
-const URL_CONFIG_CONCURRENCY = 10;
+// URLs to deploy/roll back in parallel
+const URL_CONFIG_CONCURRENCY = 5;
 
 /**
  * Tokowaka Client - Manages edge optimization configurations
@@ -794,8 +790,7 @@ class TokowakaClient {
       );
     }
 
-    // Process each URL separately. URLs are independent (each maps to a distinct
-    // S3 object), so fetch+upload run in parallel with bounded concurrency.
+    // Each URL is its own file, so we can handle several at the same time.
     const urlEntries = Object.entries(suggestionsByUrl);
     const processed = await mapWithConcurrency(
       urlEntries,
@@ -985,9 +980,7 @@ class TokowakaClient {
     const rolledBackUrls = [];
     let totalRemovedCount = 0;
 
-    // URLs are independent (each maps to a distinct S3 object), so fetch+upload run
-    // in parallel with bounded concurrency. #rollbackPerUrlConfig appends to the shared
-    // s3Paths / rolledBackUrls accumulators (order is not significant for those).
+    // Each URL is its own file, so we can roll back several at the same time.
     const removedCounts = await mapWithConcurrency(
       Object.entries(suggestionsByUrl),
       async ([urlPath, urlSuggestions]) => {

--- a/packages/spacecat-shared-tokowaka-client/src/utils/concurrency-utils.js
+++ b/packages/spacecat-shared-tokowaka-client/src/utils/concurrency-utils.js
@@ -23,7 +23,7 @@
  * @template T, R
  * @param {Array<T>} items - Items to process
  * @param {(item: T, index: number) => Promise<R>} mapper - Async mapper per item
- * @param {number} [concurrency=10] - Max number of tasks running at once
+ * @param {number} [concurrency=5] - Max number of tasks running at once
  * @returns {Promise<Array<R>>} - Results in input order
  */
 export async function mapWithConcurrency(items, mapper, concurrency = 5) {

--- a/packages/spacecat-shared-tokowaka-client/src/utils/concurrency-utils.js
+++ b/packages/spacecat-shared-tokowaka-client/src/utils/concurrency-utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -26,7 +26,7 @@
  * @param {number} [concurrency=10] - Max number of tasks running at once
  * @returns {Promise<Array<R>>} - Results in input order
  */
-export async function mapWithConcurrency(items, mapper, concurrency = 10) {
+export async function mapWithConcurrency(items, mapper, concurrency = 5) {
   if (!Array.isArray(items) || items.length === 0) {
     return [];
   }

--- a/packages/spacecat-shared-tokowaka-client/src/utils/concurrency-utils.js
+++ b/packages/spacecat-shared-tokowaka-client/src/utils/concurrency-utils.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Runs an async mapper over items with a bounded number of concurrent executions.
+ *
+ * Results are returned in the same order as the input items (matching Promise.all
+ * semantics). A worker-pool model is used so that a slow item never blocks items
+ * in other lanes: as soon as one task finishes, the next queued item starts.
+ *
+ * The first rejection propagates (like Promise.all); use this only when a single
+ * failure should abort the whole batch.
+ *
+ * @template T, R
+ * @param {Array<T>} items - Items to process
+ * @param {(item: T, index: number) => Promise<R>} mapper - Async mapper per item
+ * @param {number} [concurrency=10] - Max number of tasks running at once
+ * @returns {Promise<Array<R>>} - Results in input order
+ */
+export async function mapWithConcurrency(items, mapper, concurrency = 10) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return [];
+  }
+
+  const limit = Math.max(1, concurrency);
+  const results = new Array(items.length);
+  let nextIndex = 0;
+
+  const worker = async () => {
+    for (;;) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      if (currentIndex >= items.length) {
+        return;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      results[currentIndex] = await mapper(items[currentIndex], currentIndex);
+    }
+  };
+
+  const workerCount = Math.min(limit, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+  return results;
+}

--- a/packages/spacecat-shared-tokowaka-client/src/utils/suggestion-utils.js
+++ b/packages/spacecat-shared-tokowaka-client/src/utils/suggestion-utils.js
@@ -11,6 +11,7 @@
  */
 
 import { buildUrlMatcher } from './pattern-utils.js';
+import { normalizePath } from './s3-utils.js';
 
 /** Returns a shallow copy of obj with the specified keys removed. */
 export function omitKeys(obj, keys) {
@@ -35,7 +36,7 @@ export function isPatternSuggestion(suggestion) {
 }
 
 /**
- * Groups suggestions by URL pathname
+ * Groups suggestions by normalized URL pathname
  * @param {Array} suggestions - Array of suggestion entities
  * @param {string} baseURL - Base URL for pathname extraction
  * @param {Object} log - Logger instance
@@ -53,7 +54,7 @@ export function groupSuggestionsByUrlPath(suggestions, baseURL, log) {
 
     let urlPath;
     try {
-      urlPath = new URL(url, baseURL).pathname;
+      urlPath = normalizePath(new URL(url, baseURL).pathname);
     } catch (e) {
       log.warn(`Failed to extract pathname from URL for suggestion ${suggestion.getId()}: ${url}`);
       return acc;

--- a/packages/spacecat-shared-tokowaka-client/test/utils/concurrency-utils.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/utils/concurrency-utils.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Adobe. All rights reserved.
+ * Copyright 2026 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/packages/spacecat-shared-tokowaka-client/test/utils/concurrency-utils.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/utils/concurrency-utils.test.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { mapWithConcurrency } from '../../src/utils/concurrency-utils.js';
+
+const delay = (ms) => new Promise((resolve) => {
+  setTimeout(resolve, ms);
+});
+
+describe('Concurrency Utils', () => {
+  describe('mapWithConcurrency', () => {
+    it('returns an empty array for empty or non-array input', async () => {
+      expect(await mapWithConcurrency([], async (x) => x)).to.deep.equal([]);
+      expect(await mapWithConcurrency(null, async (x) => x)).to.deep.equal([]);
+      expect(await mapWithConcurrency(undefined, async (x) => x)).to.deep.equal([]);
+    });
+
+    it('maps all items and preserves input order', async () => {
+      const items = [1, 2, 3, 4, 5];
+      const results = await mapWithConcurrency(
+        items,
+        async (n) => {
+          // Reverse the delay so later items finish first, proving order is preserved.
+          await delay((items.length - n) * 5);
+          return n * 10;
+        },
+        2,
+      );
+      expect(results).to.deep.equal([10, 20, 30, 40, 50]);
+    });
+
+    it('passes the index to the mapper', async () => {
+      const results = await mapWithConcurrency(
+        ['a', 'b', 'c'],
+        async (item, index) => `${item}${index}`,
+        2,
+      );
+      expect(results).to.deep.equal(['a0', 'b1', 'c2']);
+    });
+
+    it('never exceeds the concurrency limit', async () => {
+      let active = 0;
+      let maxActive = 0;
+      const items = Array.from({ length: 20 }, (_, i) => i);
+
+      await mapWithConcurrency(
+        items,
+        async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await delay(5);
+          active -= 1;
+        },
+        4,
+      );
+
+      expect(maxActive).to.be.at.most(4);
+    });
+
+    it('defaults concurrency to 10 when not provided', async () => {
+      let active = 0;
+      let maxActive = 0;
+      const items = Array.from({ length: 30 }, (_, i) => i);
+
+      await mapWithConcurrency(items, async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await delay(5);
+        active -= 1;
+      });
+
+      expect(maxActive).to.be.at.most(10);
+    });
+
+    it('treats concurrency < 1 as 1 (sequential)', async () => {
+      let active = 0;
+      let maxActive = 0;
+
+      await mapWithConcurrency(
+        [1, 2, 3],
+        async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await delay(5);
+          active -= 1;
+        },
+        0,
+      );
+
+      expect(maxActive).to.equal(1);
+    });
+
+    it('propagates the first rejection', async () => {
+      let rejected = false;
+      try {
+        await mapWithConcurrency(
+          [1, 2, 3],
+          async (n) => {
+            if (n === 2) {
+              throw new Error('boom');
+            }
+            return n;
+          },
+          2,
+        );
+      } catch (error) {
+        rejected = true;
+        expect(error.message).to.equal('boom');
+      }
+      expect(rejected).to.be.true;
+    });
+  });
+});

--- a/packages/spacecat-shared-tokowaka-client/test/utils/concurrency-utils.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/utils/concurrency-utils.test.js
@@ -67,7 +67,7 @@ describe('Concurrency Utils', () => {
       expect(maxActive).to.be.at.most(4);
     });
 
-    it('defaults concurrency to 10 when not provided', async () => {
+    it('defaults concurrency to 5 when not provided', async () => {
       let active = 0;
       let maxActive = 0;
       const items = Array.from({ length: 30 }, (_, i) => i);
@@ -79,7 +79,8 @@ describe('Concurrency Utils', () => {
         active -= 1;
       });
 
-      expect(maxActive).to.be.at.most(10);
+      // 30 items with delay would all run at once if unbounded; the default caps it at 5.
+      expect(maxActive).to.equal(5);
     });
 
     it('treats concurrency < 1 as 1 (sequential)', async () => {

--- a/packages/spacecat-shared-tokowaka-client/test/utils/suggestion-utils.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/utils/suggestion-utils.test.js
@@ -104,6 +104,40 @@ describe('Suggestion Utils', () => {
       // Should skip sugg-1 due to URL parsing error
       expect(Object.keys(result)).to.have.lengthOf(0); // Both fail due to invalid base
     });
+
+    it('should merge trailing-slash and non-trailing-slash variants of the same path', () => {
+      const suggestions = [
+        {
+          getId: () => 'sugg-1',
+          getData: () => ({ url: 'https://example.com/page1' }),
+        },
+        {
+          getId: () => 'sugg-2',
+          getData: () => ({ url: 'https://example.com/page1/' }),
+        },
+      ];
+
+      const result = groupSuggestionsByUrlPath(suggestions, 'https://example.com', log);
+
+      // "/page1" and "/page1/" resolve to the same S3 object, so they share one group.
+      expect(Object.keys(result)).to.have.lengthOf(1);
+      expect(result).to.have.property('/page1');
+      expect(result['/page1']).to.have.lengthOf(2);
+    });
+
+    it('should preserve the root path "/" (no trailing slash stripping)', () => {
+      const suggestions = [
+        {
+          getId: () => 'sugg-1',
+          getData: () => ({ url: 'https://example.com/' }),
+        },
+      ];
+
+      const result = groupSuggestionsByUrlPath(suggestions, 'https://example.com', log);
+
+      expect(result).to.have.property('/');
+      expect(result['/']).to.have.lengthOf(1);
+    });
   });
 
   describe('filterEligibleSuggestions', () => {


### PR DESCRIPTION
**What**
The edge-deploy and edge-rollback APIs were creeping up toward the 15s gateway timeout. Digging in, the culprit is the per-URL loop in deploySuggestions and rollbackSuggestions - we fetch, patch, and upload each URL's config to S3 one at a time. That's N × (GET + PUT) in series, so latency scales linearly with the number of URLs in an opportunity.

Since every URL writes to its own distinct S3 object, the work is fully independent. This PR runs those per-URL operations in parallel with a bounded concurrency cap (5) instead of sequentially.

**Changes**
Added a small mapWithConcurrency helper (worker-pool, order-preserving, bounded).
Parallelized the per-URL loop in deploySuggestions and rollbackSuggestions.
Left the shared-metaconfig read-modify-write and CDN invalidation untouched — those are already single/batched and can't be parallelized safely.