### PR TITLE
feat: add support for searching trial users by external user id

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/trial-user/trial-user.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/trial-user/trial-user.schema.js
@@ -52,6 +52,10 @@ const schema = new SchemaBuilder(TrialUser, TrialUserCollection)
   .addIndex(
     { composite: ['organizationId'] },
     { composite: ['updatedAt'] },
+  )
+  .addIndex(
+    { composite: ['externalUserId'] },
+    { composite: ['updatedAt'] },
   );
 
 export default schema.build();

--- a/packages/spacecat-shared-data-access/test/it/trial-user/trial-user.test.js
+++ b/packages/spacecat-shared-data-access/test/it/trial-user/trial-user.test.js
@@ -73,6 +73,21 @@ describe('TrialUser IT', async () => {
     );
   });
 
+  it('gets a trial user by external user id', async () => {
+    const sampleTrialUser = sampleData.trialUsers[0];
+    const externalUserId = sampleTrialUser.getExternalUserId();
+
+    const trialUser = await TrialUser.findByExternalUserId(externalUserId);
+
+    expect(trialUser).to.be.an('object');
+    expect(trialUser.getExternalUserId()).to.equal(externalUserId);
+    expect(
+      sanitizeTimestamps(trialUser.toJSON()),
+    ).to.eql(
+      sanitizeTimestamps(sampleTrialUser.toJSON()),
+    );
+  });
+
   it('gets all trial users by organization id', async () => {
     const sampleTrialUser = sampleData.trialUsers[0];
     const organizationId = sampleTrialUser.getOrganizationId();


### PR DESCRIPTION
## Summary

**Goal:** Expose the newly added `external_user_id` DB index (mysticat-data-service) through the JS data-access layer for `TrialUser`.

related to index added in DB https://github.com/adobe/mysticat-data-service/pull/886 

### Files changed

| File | Change |
|---|---|
| `packages/spacecat-shared-data-access/src/models/trial-user/trial-user.schema.js` | Added a new index: `{ composite: ['externalUserId'] }` / `{ composite: ['updatedAt'] }` |
| `packages/spacecat-shared-data-access/test/it/trial-user/trial-user.test.js` | Added integration test `'gets a trial user by external user id'` covering `TrialUser.findByExternalUserId(...)` |

### What this generates

The new schema index auto-generates these methods on `TrialUserCollection`:

- `findByExternalUserId(externalUserId)`
- `allByExternalUserId(externalUserId)`
- `findByExternalUserIdAndUpdatedAt(externalUserId, updatedAt)`
- `allByExternalUserIdAndUpdatedAt(externalUserId, updatedAt)`

### Test coverage

- **New:** IT test exercising `findByExternalUserId`, following the existing `findByEmailId` / `allByOrganizationId` pattern in the same file.
- **Automatic:** `test/it/postgrest/all-collections-methods-coverage.test.js` generically sweeps all `allBy*`/`findBy*` accessors, so it picks up the new methods without any manual entry.
- **Not added:** entity-specific unit tests — this codebase only unit-tests *hand-written* custom collection methods, not schema-generated `findBy*`/`allBy*` accessors.