### PR TITLE
feat(http-utils): secondary FACS resource param + resolver registry in facsWrapper

### DIFF
--- a/packages/spacecat-shared-http-utils/src/auth/facs-wrapper.js
+++ b/packages/spacecat-shared-http-utils/src/auth/facs-wrapper.js
@@ -14,7 +14,12 @@ import { Response } from '@adobe/fetch';
 import { LaunchDarklyClient } from '@adobe/spacecat-shared-launchdarkly-client';
 
 import { FT_MAC_FACS_PERMISSIONS, X_PRODUCT_HEADER } from './constants.js';
-import { extractRouteParams, findMatchedRouteKey, resolveRouteCapability } from './route-utils.js';
+import {
+  extractParamNamesInOrder,
+  extractRouteParams,
+  findMatchedRouteKey,
+  resolveRouteCapability,
+} from './route-utils.js';
 import { buildAliasLookupsPerProduct, resolveFacsResource } from './facs-resource-resolver.js';
 import { findFacsResourceBinding, normalizeImsOrgId } from './facs-state-layer.js';
 
@@ -176,7 +181,7 @@ function routeMatchesAnyProductMap(context, productsRoutes) {
  * }}} opts
  * @returns {Function} A wrapped handler.
  */
-export function facsWrapper(fn, { routeFacsCapabilities } = {}) {
+export function facsWrapper(fn, { routeFacsCapabilities, secondaryResolvers = {} } = {}) {
   if (!routeFacsCapabilities || typeof routeFacsCapabilities !== 'object') {
     throw new Error('facsWrapper: routeFacsCapabilities is required');
   }
@@ -205,6 +210,47 @@ export function facsWrapper(fn, { routeFacsCapabilities } = {}) {
   const aliasLookupsPerProduct = buildAliasLookupsPerProduct(
     routeFacsCapabilities.PRODUCTS_FACS_RESOURCE_PARAM_ALIASES,
   );
+
+  // Secondary resource resolution (opt-in per product) — see
+  // platform/decisions/facs-wrapper-secondary-resource-param.md. A product may
+  // declare a SECONDARY resource param the wrapper falls back to when no PRIMARY
+  // resource resolves for a route (e.g. LLMO site routes carrying `:siteId`,
+  // whose authorization is decided against the site's brands). The grant/deny
+  // decision is delegated to a resolver the consuming service registers by key in
+  // `secondaryResolvers`, so the shared wrapper stays product/route-agnostic.
+  // Absent config → no secondary behavior (byte-identical to before).
+  //
+  //   PRODUCTS_FACS_SECONDARY_RESOURCE: {
+  //     LLMO: { resourceType: 'site', aliases: ['siteId'], resolver: 'llmoSiteToBrands' },
+  //   }
+  //   secondaryResolvers: { llmoSiteToBrands: async (context, args) => boolean }
+  const secondaryConfig = routeFacsCapabilities.PRODUCTS_FACS_SECONDARY_RESOURCE;
+  const secondaryResolverKeyByProduct = new Map();
+  const secondaryAliasSpec = {};
+  if (secondaryConfig && typeof secondaryConfig === 'object') {
+    for (const [product, cfg] of Object.entries(secondaryConfig)) {
+      if (!cfg || typeof cfg.resourceType !== 'string'
+          || !Array.isArray(cfg.aliases) || cfg.aliases.length === 0
+          || typeof cfg.resolver !== 'string') {
+        throw new Error(
+          `facsWrapper: PRODUCTS_FACS_SECONDARY_RESOURCE.${product} must be `
+          + '{ resourceType: string, aliases: string[], resolver: string }',
+        );
+      }
+      // Fail fast at construction if a declared resolver is not registered — a
+      // request-time miss would silently fail-closed and be hard to diagnose.
+      if (typeof secondaryResolvers[cfg.resolver] !== 'function') {
+        throw new Error(
+          `facsWrapper: secondary resolver '${cfg.resolver}' for product `
+          + `'${product}' is not registered in secondaryResolvers`,
+        );
+      }
+      secondaryAliasSpec[product] = { [cfg.resourceType]: cfg.aliases };
+      secondaryResolverKeyByProduct.set(product.toUpperCase(), cfg.resolver);
+    }
+  }
+  // Reuse the alias→resourceType inversion (per product) for the secondary map.
+  const secondaryAliasLookupsPerProduct = buildAliasLookupsPerProduct(secondaryAliasSpec);
 
   return async (request, context) => {
     const { log } = context;
@@ -405,6 +451,90 @@ export function facsWrapper(fn, { routeFacsCapabilities } = {}) {
     });
 
     if (!resource) {
+      // (6b) Secondary resource fallback (opt-in per product). Before deferring,
+      // check whether THIS route is scoped to the product's SECONDARY resource
+      // (e.g. LLMO `:siteId`). If so, the wrapper — not the controller — decides
+      // authorization via the registered resolver. Routes that carry no secondary
+      // param (collection endpoints like list-sites) fall through to the defer
+      // below, where `context.attributes.facs` lets the controller ReBAC-filter.
+      const secondaryAliasLookup = secondaryAliasLookupsPerProduct.get(upperProduct);
+      if (secondaryAliasLookup && secondaryAliasLookup.size > 0) {
+        // A route is secondary-scoped iff one of its declared PATH params is a
+        // secondary alias. LLMO's secondary is the `:siteId` path param, so
+        // "route declares the secondary" ⟺ "value present on a matched route".
+        const secondaryParamName = extractParamNamesInOrder(routePattern)
+          .find((name) => secondaryAliasLookup.has(name));
+        if (secondaryParamName) {
+          const secondaryResourceType = secondaryAliasLookup.get(secondaryParamName);
+          // A matched route always carries a non-empty value for every declared PATH
+          // param (route-utils drops empty segments and requires equal segment counts,
+          // so a request missing the value fails to match and never reaches here). A
+          // secondary-scoped route therefore always resolves a value — the ADR's
+          // "absent → fail-closed" contract holds structurally, not via a runtime
+          // check. Resolver presence is guaranteed by the construction-time validation.
+          const secondaryResourceId = routeParams[secondaryParamName];
+          const resolverFn = secondaryResolvers[secondaryResolverKeyByProduct.get(upperProduct)];
+
+          let granted;
+          try {
+            granted = await resolverFn(context, {
+              resourceType: secondaryResourceType,
+              resourceId: String(secondaryResourceId),
+              capability: routeCapability,
+              product: upperProduct,
+              subjectId: subjectUserId,
+              orgId: normalizedOrgId,
+            });
+          } catch (e) {
+            // (b) Resolver error → fail-closed.
+            log.error({
+              tag: 'facs',
+              deny: 'secondary-resolver-error',
+              method,
+              suffix,
+              capability: routeCapability,
+              product: productCode,
+              resourceType: secondaryResourceType,
+              resourceId: String(secondaryResourceId),
+              user: subjectUserId,
+              err: e.message,
+            }, 'FACS denied: secondary resolver threw — failing closed');
+            return forbidden('Forbidden');
+          }
+
+          if (granted === true) {
+            log.info({
+              tag: 'facs',
+              grant: 'secondary-resolver',
+              method,
+              suffix,
+              capability: routeCapability,
+              product: productCode,
+              resourceType: secondaryResourceType,
+              resourceId: String(secondaryResourceId),
+              user: subjectUserId,
+              org: normalizedOrgId,
+            }, 'FACS grant: secondary resolver authorized the request');
+            return fn(request, context);
+          }
+
+          log.warn({
+            tag: 'facs',
+            deny: 'secondary-resolver',
+            method,
+            suffix,
+            capability: routeCapability,
+            product: productCode,
+            resourceType: secondaryResourceType,
+            resourceId: String(secondaryResourceId),
+            user: subjectUserId,
+            org: normalizedOrgId,
+          }, 'FACS denied: secondary resolver did not authorize the request');
+          return forbidden('Forbidden');
+        }
+      }
+
+      // (6c) No secondary scope for this route → defer to the controller.
       // Reaching here means the session is FACS-enrolled (passed the internal,
       // internal-org and LD-flag gates) and resource-scoped (the JWT short-circuit
       // at step 5 did not fire, so the caller lacks the org-wide capability), yet

--- a/packages/spacecat-shared-http-utils/src/index.d.ts
+++ b/packages/spacecat-shared-http-utils/src/index.d.ts
@@ -49,7 +49,35 @@ export interface FacsRouteCapabilities {
   PRODUCTS_FACS_RESOURCE_PARAM_ALIASES?: Record<string, Record<string, string[]>>;
   INTERNAL_ROUTES?: string[];
   FACS_NON_RESOURCE_PARAMS?: string[];
+  /**
+   * Per-product SECONDARY resource param (opt-in). When no PRIMARY resource resolves
+   * for a route, the wrapper falls back to the secondary param (identified by `aliases`)
+   * and delegates the grant/deny decision to the registered resolver named by `resolver`
+   * (see `secondaryResolvers` on `facsWrapper`). Used for cross-resource authorization
+   * such as LLMO site routes decided against the site's brands.
+   */
+  PRODUCTS_FACS_SECONDARY_RESOURCE?: Record<
+    string,
+    { resourceType: string; aliases: string[]; resolver: string }
+  >;
 }
+
+/**
+ * A secondary-resource resolver registered by the consuming service and referenced by key
+ * from `FacsRouteCapabilities.PRODUCTS_FACS_SECONDARY_RESOURCE[<product>].resolver`.
+ * Returns `true` to grant, `false` to deny; a thrown error is treated as deny (fail-closed).
+ */
+export type FacsSecondaryResolver = (
+  context: object,
+  args: {
+    resourceType: string;
+    resourceId: string;
+    capability: string;
+    product: string;
+    subjectId?: string;
+    orgId?: string;
+  },
+) => Promise<boolean>;
 
 /**
  * FACS authorization wrapper for the helix-shared-wrap `.with()` chain.
@@ -57,12 +85,16 @@ export interface FacsRouteCapabilities {
  * feature flag. Internal identities and Adobe internal orgs always bypass.
  *
  * @param fn - The handler to wrap.
- * @param opts - Options containing the FACS route-capability configuration.
+ * @param opts - Options containing the FACS route-capability configuration and, optionally,
+ *   the secondary-resource resolvers referenced by `PRODUCTS_FACS_SECONDARY_RESOURCE`.
  * @returns A wrapped handler.
  */
 export function facsWrapper(
   fn: (request: Request, context: object) => Promise<Response>,
-  opts: { routeFacsCapabilities: FacsRouteCapabilities },
+  opts: {
+    routeFacsCapabilities: FacsRouteCapabilities;
+    secondaryResolvers?: Record<string, FacsSecondaryResolver>;
+  },
 ): (request: Request, context: object) => Promise<Response>;
 
 /**

--- a/packages/spacecat-shared-http-utils/test/auth/facs-wrapper.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/facs-wrapper.test.js
@@ -924,4 +924,171 @@ describe('facsWrapper', () => {
       expect(captured.warn.user).to.equal(undefined);
     });
   });
+
+  describe('secondary resource resolution (opt-in)', () => {
+    // A product with a PRIMARY (brand) resource plus a SECONDARY (site) resource
+    // whose grant/deny decision is delegated to a registered resolver.
+    const secRouteCaps = {
+      PRODUCTS_ROUTES: {
+        LLMO: {
+          'GET /insights': 'llmo/can_read',
+          'GET /brands/:brandId': 'llmo/can_read',
+          'GET /sites/:siteId/agentic-categories': 'llmo/can_read',
+        },
+      },
+      PRODUCTS_FACS_RESOURCE_PARAM_ALIASES: {
+        LLMO: { brand: ['brandId'] },
+      },
+      PRODUCTS_FACS_SECONDARY_RESOURCE: {
+        LLMO: { resourceType: 'site', aliases: ['siteId'], resolver: 'llmoSiteToBrands' },
+      },
+    };
+
+    describe('creation-time guards', () => {
+      it('throws when a secondary config entry is malformed', () => {
+        expect(() => facsWrapper(handler, {
+          routeFacsCapabilities: {
+            PRODUCTS_ROUTES: { LLMO: { 'GET /x': 'llmo/can_read' } },
+            PRODUCTS_FACS_SECONDARY_RESOURCE: { LLMO: { resourceType: 'site' } },
+          },
+          secondaryResolvers: { llmoSiteToBrands: async () => true },
+        })).to.throw(/PRODUCTS_FACS_SECONDARY_RESOURCE.LLMO must be/);
+      });
+
+      it('throws when the declared resolver is not registered', () => {
+        expect(() => facsWrapper(handler, {
+          routeFacsCapabilities: secRouteCaps,
+          secondaryResolvers: {},
+        })).to.throw(/secondary resolver 'llmoSiteToBrands' for product 'LLMO' is not registered/);
+      });
+
+      it('accepts a valid secondary config with a registered resolver', () => {
+        expect(() => facsWrapper(handler, {
+          routeFacsCapabilities: secRouteCaps,
+          secondaryResolvers: { llmoSiteToBrands: async () => true },
+        })).to.not.throw();
+      });
+    });
+
+    describe('request-time behavior', () => {
+      let ldClient;
+      let mockedWrapper;
+      let resolverStub;
+
+      beforeEach(async () => {
+        ldClient = { isFlagEnabledForIMSOrg: sandbox.stub().resolves(true) };
+        const mod = await esmock('../../src/auth/facs-wrapper.js', {
+          '@adobe/spacecat-shared-launchdarkly-client': {
+            LaunchDarklyClient: { createFrom: sandbox.stub().returns(ldClient) },
+          },
+          '../../src/auth/facs-state-layer.js': {
+            findFacsResourceBinding: sandbox.stub(),
+            normalizeImsOrgId: (s) => (s && typeof s === 'string' && !s.includes('@') ? `${s}@AdobeOrg` : s),
+          },
+        });
+        mockedWrapper = mod.facsWrapper;
+        resolverStub = sandbox.stub();
+        // No org-wide JWT grant → the wrapper reaches the resource seam.
+        context.attributes.authInfo = makeAuthInfo({ hasFacsPermission: () => false });
+        context.dataAccess = { services: { postgrestClient: { from: () => {} } } };
+      });
+
+      function siteReq() {
+        context.pathInfo = {
+          method: 'GET',
+          suffix: '/sites/site-abc/agentic-categories',
+          headers: { 'x-product': 'llmo' },
+        };
+      }
+
+      it('grants when the secondary resolver returns true', async () => {
+        resolverStub.resolves(true);
+        siteReq();
+        const wrapped = mockedWrapper(handler, {
+          routeFacsCapabilities: secRouteCaps,
+          secondaryResolvers: { llmoSiteToBrands: resolverStub },
+        });
+        const result = await wrapped({}, context);
+        expect(result).to.deep.equal({ status: 200 });
+        expect(handler.calledOnce).to.be.true;
+        expect(resolverStub.calledOnce).to.be.true;
+        const [ctxArg, args] = resolverStub.firstCall.args;
+        expect(ctxArg).to.equal(context);
+        expect(args).to.deep.equal({
+          resourceType: 'site',
+          resourceId: 'site-abc',
+          capability: 'llmo/can_read',
+          product: 'LLMO',
+          subjectId: 'user@example.com',
+          orgId: 'CUST-ORG-123@AdobeOrg',
+        });
+        expect(logStub.info.calledWithMatch({ tag: 'facs', grant: 'secondary-resolver' })).to.be.true;
+        // The wrapper decided authorization; no defer flag is surfaced to the controller.
+        expect(context.attributes.facs).to.equal(undefined);
+      });
+
+      it('denies (403) when the secondary resolver returns false', async () => {
+        resolverStub.resolves(false);
+        siteReq();
+        const wrapped = mockedWrapper(handler, {
+          routeFacsCapabilities: secRouteCaps,
+          secondaryResolvers: { llmoSiteToBrands: resolverStub },
+        });
+        const result = await wrapped({}, context);
+        expect(result.status).to.equal(403);
+        expect(handler.called).to.be.false;
+        expect(logStub.warn.calledWithMatch({ tag: 'facs', deny: 'secondary-resolver' })).to.be.true;
+      });
+
+      it('fails closed (403) when the secondary resolver throws', async () => {
+        resolverStub.rejects(new Error('postgrest down'));
+        siteReq();
+        const wrapped = mockedWrapper(handler, {
+          routeFacsCapabilities: secRouteCaps,
+          secondaryResolvers: { llmoSiteToBrands: resolverStub },
+        });
+        const result = await wrapped({}, context);
+        expect(result.status).to.equal(403);
+        expect(handler.called).to.be.false;
+        expect(logStub.error.calledWithMatch({ tag: 'facs', deny: 'secondary-resolver-error' })).to.be.true;
+      });
+
+      it('JWT org-wide grant short-circuits before the secondary resolver runs', async () => {
+        context.attributes.authInfo = makeAuthInfo({ hasFacsPermission: () => true });
+        siteReq();
+        const wrapped = mockedWrapper(handler, {
+          routeFacsCapabilities: secRouteCaps,
+          secondaryResolvers: { llmoSiteToBrands: resolverStub },
+        });
+        const result = await wrapped({}, context);
+        expect(result).to.deep.equal({ status: 200 });
+        expect(handler.calledOnce).to.be.true;
+        expect(resolverStub.called).to.be.false;
+      });
+
+      it('defers (no resolver call) for a non-secondary route even when a secondary is configured', async () => {
+        // GET /insights carries neither brandId nor siteId → primary resolves null
+        // and it is not a secondary-scoped route → falls through to the collection
+        // defer (INV-1: secondary config does not change non-site routes).
+        context.pathInfo = {
+          method: 'GET',
+          suffix: '/insights',
+          headers: { 'x-product': 'llmo' },
+        };
+        const wrapped = mockedWrapper(handler, {
+          routeFacsCapabilities: secRouteCaps,
+          secondaryResolvers: { llmoSiteToBrands: resolverStub },
+        });
+        const result = await wrapped({}, context);
+        expect(result).to.deep.equal({ status: 200 });
+        expect(handler.calledOnce).to.be.true;
+        expect(resolverStub.called).to.be.false;
+        expect(context.attributes.facs).to.deep.equal({
+          enabled: true,
+          product: 'LLMO',
+          subjectId: 'user@example.com',
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
## What

Adds an opt-in **secondary FACS resource param** + a **resolver registry** to `facsWrapper`.

When a route resolves no PRIMARY ReBAC resource, a *secondary-scoped* route (one whose path declares a configured secondary param, e.g. LLMO `:siteId`) delegates the grant/deny decision to a resolver the consuming service registers by key — enabling **cross-resource authorization** (site → brands) at the wrapper instead of per-controller.

## API

- `routeFacsCapabilities.PRODUCTS_FACS_SECONDARY_RESOURCE`: `{ <PRODUCT>: { resourceType, aliases, resolver } }` (opt-in; absent → no change).
- `facsWrapper(fn, { routeFacsCapabilities, secondaryResolvers })` — `secondaryResolvers` maps the resolver key → `async (context, { resourceType, resourceId, capability, product, subjectId, orgId }) => boolean`.

## Behavior

- Fires **only** at the existing defer seam (no primary resource). Non-secondary routes (collections) and absent config are **unchanged** (defer preserved).
- Resolver throws → **fail-closed 403**. JWT org-wide grant still short-circuits first (no DB/resolver work).
- Construction **fail-fasts** on a malformed secondary entry or an unregistered resolver key.
- Only path-param secondaries are supported (the LLMO `:siteId` case); a matched route always carries its path param, so the "absent → fail-closed" contract holds structurally.

## Tests

+8 unit tests (construction guards, grant / deny / fail-closed-on-throw, JWT short-circuit, collection-defer). `facs-wrapper.js` at **100%** stmts/branch/funcs/lines; 495 passing.

## Design

`mysticat-architecture/platform/decisions/facs-wrapper-secondary-resource-param.md` (approved by MysticatBot, adobe/mysticat-architecture#241). Consuming-service wiring (LLMO config + resolver + surgical #2947 revert) lands in a follow-up spacecat-api-service PR after this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
