### PR TITLE
feat: schema changes for trial users entity to allow searching by external user id

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/trial-user/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/trial-user/index.d.ts
@@ -43,9 +43,19 @@ export interface TrialUserCollection extends BaseCollection<TrialUser> {
   allByProviderAndExternalUserId(provider: ProviderType, externalId: string): Promise<TrialUser[]>;
   allByOrganizationId(organizationId: string): Promise<TrialUser[]>;
   allByEmailId(emailId: string): Promise<TrialUser[]>;
+  allByExternalUserId(externalUserId: string): Promise<TrialUser[]>;
+  allByExternalUserIdAndUpdatedAt(
+    externalUserId: string,
+    updatedAt: string
+  ): Promise<TrialUser[]>;
   findByProvider(provider: ProviderType): Promise<TrialUser | null>;
   findByProviderAndExternalUserId(provider: ProviderType, externalId: string):
     Promise<TrialUser | null>;
   findByOrganizationId(organizationId: string): Promise<TrialUser | null>;
   findByEmailId(emailId: string): Promise<TrialUser | null>;
+  findByExternalUserId(externalUserId: string): Promise<TrialUser | null>;
+  findByExternalUserIdAndUpdatedAt(
+    externalUserId: string,
+    updatedAt: string
+  ): Promise<TrialUser | null>;
 }

--- a/packages/spacecat-shared-data-access/src/models/trial-user/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/trial-user/index.d.ts
@@ -53,7 +53,17 @@ export interface TrialUserCollection extends BaseCollection<TrialUser> {
     Promise<TrialUser | null>;
   findByOrganizationId(organizationId: string): Promise<TrialUser | null>;
   findByEmailId(emailId: string): Promise<TrialUser | null>;
+  /**
+   * externalUserId is optional and not enforced unique (no DB unique constraint), so this
+   * returns one arbitrary match when multiple trial users share the same externalUserId.
+   * Use allByExternalUserId if you need every matching record.
+   */
   findByExternalUserId(externalUserId: string): Promise<TrialUser | null>;
+  /**
+   * externalUserId is optional and not enforced unique (no DB unique constraint), so this
+   * returns one arbitrary match when multiple trial users share the same externalUserId.
+   * Use allByExternalUserIdAndUpdatedAt if you need every matching record.
+   */
   findByExternalUserIdAndUpdatedAt(
     externalUserId: string,
     updatedAt: string

--- a/packages/spacecat-shared-data-access/src/models/trial-user/trial-user.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/trial-user/trial-user.schema.js
@@ -53,6 +53,11 @@ const schema = new SchemaBuilder(TrialUser, TrialUserCollection)
     { composite: ['organizationId'] },
     { composite: ['updatedAt'] },
   )
+  // externalUserId is not enforced unique (no DB unique constraint) and is optional, so
+  // findByExternalUserId only returns one arbitrary match. Prefer allByExternalUserId
+  // unless the caller can guarantee uniqueness for their use case.
+  // Note: this schema is now at 4 of the 5-index cap enforced by SchemaBuilder
+  // (#buildIndexes) - budget the next lookup index accordingly.
   .addIndex(
     { composite: ['externalUserId'] },
     { composite: ['updatedAt'] },

--- a/packages/spacecat-shared-data-access/test/it/trial-user/trial-user.test.js
+++ b/packages/spacecat-shared-data-access/test/it/trial-user/trial-user.test.js
@@ -88,6 +88,12 @@ describe('TrialUser IT', async () => {
     );
   });
 
+  it('returns null when no trial user matches the external user id', async () => {
+    const trialUser = await TrialUser.findByExternalUserId('nonexistent-id');
+
+    expect(trialUser).to.be.null;
+  });
+
   it('gets all trial users by organization id', async () => {
     const sampleTrialUser = sampleData.trialUsers[0];
     const organizationId = sampleTrialUser.getOrganizationId();

--- a/packages/spacecat-shared-data-access/test/it/trial-user/trial-user.test.js
+++ b/packages/spacecat-shared-data-access/test/it/trial-user/trial-user.test.js
@@ -94,6 +94,54 @@ describe('TrialUser IT', async () => {
     expect(trialUser).to.be.null;
   });
 
+  it('gets all/one trial users sharing an externalUserId, pinning the arbitrary-match contract', async () => {
+    const organizationId = sampleData.organizations[0].getId();
+    const sharedExternalUserId = 'ext-user-shared';
+
+    const first = await TrialUser.create({
+      organizationId,
+      emailId: 'shared1@example.com',
+      externalUserId: sharedExternalUserId,
+      status: 'INVITED',
+      updatedBy: 'system',
+    });
+    const second = await TrialUser.create({
+      organizationId,
+      emailId: 'shared2@example.com',
+      externalUserId: sharedExternalUserId,
+      status: 'INVITED',
+      updatedBy: 'system',
+    });
+
+    const allMatches = await TrialUser.allByExternalUserId(sharedExternalUserId);
+    expect(allMatches).to.be.an('array');
+    expect(allMatches.map((trialUser) => trialUser.getId())).to.have.members([
+      first.getId(),
+      second.getId(),
+    ]);
+
+    const singleMatch = await TrialUser.findByExternalUserId(sharedExternalUserId);
+    expect(singleMatch).to.be.an('object');
+    expect([first.getId(), second.getId()]).to.include(singleMatch.getId());
+
+    const secondUpdatedAt = second.getUpdatedAt();
+
+    const allByUpdatedAt = await TrialUser.allByExternalUserIdAndUpdatedAt(
+      sharedExternalUserId,
+      secondUpdatedAt,
+    );
+    expect(allByUpdatedAt).to.be.an('array');
+    expect(allByUpdatedAt.length).to.equal(1);
+    expect(allByUpdatedAt[0].getId()).to.equal(second.getId());
+
+    const findByUpdatedAt = await TrialUser.findByExternalUserIdAndUpdatedAt(
+      sharedExternalUserId,
+      secondUpdatedAt,
+    );
+    expect(findByUpdatedAt).to.be.an('object');
+    expect(findByUpdatedAt.getId()).to.equal(second.getId());
+  });
+
   it('gets all trial users by organization id', async () => {
     const sampleTrialUser = sampleData.trialUsers[0];
     const organizationId = sampleTrialUser.getOrganizationId();


### PR DESCRIPTION
## PR Summary: Add `externalUserId` lookup for TrialUser

**Goal:** Expose the `external_user_id` DB index (added in mysticat-data-service) through the JS data-access layer for `TrialUser`, so callers can look up trial users by their external IDP user ID.

### Review feedback addressed

- **Blocking:** `index.d.ts` was missing type declarations for the new accessors (TS consumers would get a compile error) — fixed.
- **Suggestion:** documented that `externalUserId` isn't guaranteed unique, so `findBy*` returns an arbitrary match — callers needing all matches should use `allBy*`.
- **Nit:** added the not-found IT assertion to pin the `null` contract.
- **Nit:** flagged via comment thaf the 5-index cap enforced by`SchemaBuilder`, so the next lookup index needs budget consideration.