### PR TITLE
feat(ims-client): optional pair selector on ImsPromiseClient.createFrom

### DIFF
--- a/docs/specs/ims-client-promise-pair-selector/spec.md
+++ b/docs/specs/ims-client-promise-pair-selector/spec.md
@@ -1,0 +1,170 @@
+# IMS promise-client pair selector
+
+| Field | Value |
+|-------|-------|
+| **Status** | Draft |
+| **Author** | Char |
+| **Created** | 2026-08-11 |
+| **Updated** | 2026-08-11 |
+| **Decided** | N/A |
+| **Approvers** | N/A |
+| **Jira** | LLMO-6928 (parent LLMO-6623) |
+
+## Summary
+
+Let `ImsPromiseClient.createFrom` build a client from a *named* IMS
+emitter/consumer credential pair, not only the single hard-coded pair. This is
+the dependency-root change for LLMO-6623: giving the Semrush-facing paths a
+dedicated promise-token pair (scoped for Semrush UDH) with limited blast radius,
+instead of reusing the shared pair that serves every promise flow.
+
+This spec covers only the `spacecat-shared-ims-client` contract. The cross-repo
+flow (the `x-promise-audience` header, auth-service mint, api-service exchange,
+UI cache) is designed in LLMO-6623 and its per-repo sub-tasks.
+
+## Problem Statement
+
+### Current State
+
+`ImsPromiseClient.createFrom(context, type)` reads a single, fixed set of env
+vars from `context.env`:
+
+- EMITTER: `IMS_PROMISE_EMITTER_CLIENT_ID`, `IMS_PROMISE_EMITTER_CLIENT_SECRET`,
+  `IMS_PROMISE_EMITTER_DEFINITION_ID`
+- CONSUMER: `IMS_PROMISE_CONSUMER_CLIENT_ID`,
+  `IMS_PROMISE_CONSUMER_CLIENT_SECRET`
+- Both: `IMS_HOST`, `AUTOFIX_CRYPT_SECRET`, `AUTOFIX_CRYPT_SALT`
+
+There is no way to select a second pair. A consumer that needs a different
+IMS client pair (e.g. one holding the `semrush` scope) cannot get one without
+overwriting the shared env vars, which would move every promise flow onto that
+pair.
+
+The client sends no `scope` parameter at mint, exchange, or invalidate. The
+exchanged token's scope is governed by the promise definition's scope list
+intersected with the consumer's grants — so no code change is needed to
+"request" `semrush`; a dedicated pair whose definition carries `semrush` is
+enough.
+
+Separately, the validation error at `src/clients/ims-promise-client.js:60`
+is wrong: the message says the definition id is required "for CONSUMER type",
+but the check at line 59 requires it for the EMITTER type.
+
+### Desired State
+
+- `createFrom` accepts an optional pair selector. With no selector, behavior is
+  byte-for-byte identical (existing callers untouched).
+- With `{ pair: 'SEMRUSH' }`, it reads a prefixed set of env vars for the
+  dedicated pair.
+- The validation message matches the check.
+
+### Gap Analysis
+
+- No pair parameter on `createFrom`.
+- No env-var naming convention for additional pairs.
+- Misleading validation message.
+
+## Goals and Non-Goals
+
+### Goals
+
+- Optional, backward-compatible pair selector on `createFrom`.
+- A stable env-var naming contract for the `SEMRUSH` pair that auth-service and
+  api-service depend on.
+- Fix the EMITTER/CONSUMER validation message.
+
+### Non-Goals
+
+- The `x-promise-audience` header, and any auth-service / api-service / UI
+  change (their own sub-tasks).
+- Sending a `scope` parameter (scope is governed by the promise definition).
+- Changing the crypt keys — `AUTOFIX_CRYPT_SECRET` / `_SALT` stay shared across
+  all pairs.
+
+## Proposed Solution
+
+### API contract
+
+```
+ImsPromiseClient.createFrom(context, type, opts = {})
+```
+
+- `opts.pair` (optional string). Absent → current env names. `'SEMRUSH'` → the
+  prefixed names below. Any other value → throw (fail closed, clear message).
+
+### Env-var naming contract (the `SEMRUSH` pair)
+
+| Type | Env vars read from `context.env` |
+|------|----------------------------------|
+| EMITTER | `IMS_PROMISE_SEMRUSH_EMITTER_CLIENT_ID`, `IMS_PROMISE_SEMRUSH_EMITTER_CLIENT_SECRET`, `IMS_PROMISE_SEMRUSH_EMITTER_DEFINITION_ID` |
+| CONSUMER | `IMS_PROMISE_SEMRUSH_CONSUMER_CLIENT_ID`, `IMS_PROMISE_SEMRUSH_CONSUMER_CLIENT_SECRET` |
+| Both | `IMS_HOST`, `AUTOFIX_CRYPT_SECRET`, `AUTOFIX_CRYPT_SALT` (shared, unprefixed) |
+
+Naming rule: `IMS_PROMISE_{PAIR}_{TYPE}_{FIELD}` where `{PAIR}` is the
+uppercased selector. This is the contract Vault (LLMO-6931) loads and the
+downstream services read.
+
+### Validation fix
+
+Correct the message at `ims-promise-client.js:60` to say the definition id is
+required for the EMITTER type (matching the line-59 check).
+
+## Alternatives Considered
+
+| Approach | Pros | Cons | Verdict |
+|----------|------|------|---------|
+| `opts.pair` selector on `createFrom` | Backward compatible, one factory, callers opt in | Adds a param | Selected |
+| Separate `createSemrushFrom` factory | Explicit | Duplicates the factory; doesn't generalize to future pairs | Rejected |
+| Pass raw client id/secret as args | Fully general | Leaks credential handling to every caller; loses the env-name contract | Rejected |
+
+### Decision Rationale
+
+`opts.pair` keeps a single factory and a single place that owns the env-name
+contract, stays backward compatible, and generalizes to any future pair by name.
+
+## Success Criteria
+
+### Functional Requirements
+
+- [ ] `createFrom(context, type)` unchanged — same env vars, same errors.
+- [ ] `createFrom(context, type, { pair: 'SEMRUSH' })` reads the prefixed env
+      vars for both EMITTER and CONSUMER.
+- [ ] Missing a required prefixed env var throws a clear error.
+- [ ] An unknown `opts.pair` throws.
+- [ ] Validation message matches the EMITTER check.
+
+### Validation Plan
+
+- [ ] Unit tests in `test/clients/ims-promise-client.test.js` (mock-context +
+      nock, no `process.env`): default path unchanged, `SEMRUSH` resolution for
+      both types, missing-prefixed-env throws, unknown-pair throws.
+- [ ] Coverage stays at the package bar: 100% lines/statements, 97% branches.
+
+## Dependencies
+
+### Internal Dependencies
+
+- Downstream consumers of this contract: spacecat-auth-service (LLMO-6929),
+  spacecat-api-service (LLMO-6930), Vault config (LLMO-6931). They are blocked
+  on this package publishing (~1.15.0).
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| A change accidentally alters the default (no-pair) path | Low | High | Test asserts the default env names and errors are unchanged; the pair branch is additive |
+| Env-name contract drifts from what Vault loads / services read | Medium | Medium | This table is the single source; the sub-tasks reference it |
+
+## References
+
+- Parent: LLMO-6623 (dedicated IMS promise-token pair for the Semrush proxy).
+- Cross-repo design and rollout: LLMO-6623 description + the code-side plan.
+- `src/clients/ims-promise-client.js` (current `createFrom`, validation at :59-60).
+
+---
+
+## Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-08-11 | Char | Initial draft |

--- a/packages/spacecat-shared-ims-client/src/clients/ImsPromiseClient.d.ts
+++ b/packages/spacecat-shared-ims-client/src/clients/ImsPromiseClient.d.ts
@@ -17,7 +17,7 @@ export class ImsPromiseClient {
    * Named IMS emitter/consumer credential pairs. Absent selector => the default
    * (unprefixed) pair. `SEMRUSH` => the dedicated Semrush-scoped pair.
    */
-  static PROMISE_PAIR: { SEMRUSH: 'SEMRUSH' };
+  static readonly PROMISE_PAIR: { readonly SEMRUSH: 'SEMRUSH' };
 
   /**
    * Creates a new ImsPromiseClient instance from the given UniversalContext and of the
@@ -25,16 +25,16 @@ export class ImsPromiseClient {
    * @param {UniversalContext} context The UniversalContext to use for creating
    *                                   the ImsPromiseClient.
    * @param {string} type The type of the client, either 'emitter' or 'consumer'.
-   * @param {{ pair?: 'SEMRUSH' }} [opts] Optional credential-pair selector. Absent
-   *                                   reads the default IMS_PROMISE_{EMITTER,CONSUMER}_*
-   *                                   env vars; 'SEMRUSH' reads IMS_PROMISE_SEMRUSH_*.
+   * @param {object} [opts] Optional credential-pair selector. Absent reads the
+   *                                   default IMS_PROMISE_{EMITTER,CONSUMER}_* env
+   *                                   vars; 'SEMRUSH' reads IMS_PROMISE_SEMRUSH_*.
    *                                   An unknown value throws.
    * @returns {ImsPromiseClient} The ImsPromiseClient instance.
    */
   static createFrom(
     context: UniversalContext,
     type: string,
-    opts?: { pair?: 'SEMRUSH' },
+    opts?: { pair?: (typeof ImsPromiseClient.PROMISE_PAIR)[keyof typeof ImsPromiseClient.PROMISE_PAIR] },
   ): ImsPromiseClient;
 
   /**

--- a/packages/spacecat-shared-ims-client/src/clients/ImsPromiseClient.d.ts
+++ b/packages/spacecat-shared-ims-client/src/clients/ImsPromiseClient.d.ts
@@ -14,14 +14,28 @@ import type { UniversalContext } from '@adobe/helix-universal';
 
 export class ImsPromiseClient {
   /**
+   * Named IMS emitter/consumer credential pairs. Absent selector => the default
+   * (unprefixed) pair. `SEMRUSH` => the dedicated Semrush-scoped pair.
+   */
+  static PROMISE_PAIR: { SEMRUSH: 'SEMRUSH' };
+
+  /**
    * Creates a new ImsPromiseClient instance from the given UniversalContext and of the
    * given type, either an emitter or consumer client.
    * @param {UniversalContext} context The UniversalContext to use for creating
    *                                   the ImsPromiseClient.
    * @param {string} type The type of the client, either 'emitter' or 'consumer'.
+   * @param {{ pair?: 'SEMRUSH' }} [opts] Optional credential-pair selector. Absent
+   *                                   reads the default IMS_PROMISE_{EMITTER,CONSUMER}_*
+   *                                   env vars; 'SEMRUSH' reads IMS_PROMISE_SEMRUSH_*.
+   *                                   An unknown value throws.
    * @returns {ImsPromiseClient} The ImsPromiseClient instance.
    */
-  static createFrom(context: UniversalContext, type: string): ImsPromiseClient;
+  static createFrom(
+    context: UniversalContext,
+    type: string,
+    opts?: { pair?: 'SEMRUSH' },
+  ): ImsPromiseClient;
 
   /**
    * Returns a promise token for the given access token.

--- a/packages/spacecat-shared-ims-client/src/clients/ims-promise-client.js
+++ b/packages/spacecat-shared-ims-client/src/clients/ims-promise-client.js
@@ -25,39 +25,50 @@ export default class ImsPromiseClient extends ImsBaseClient {
     CONSUMER: 'consumer',
   };
 
-  static createFrom(context, type) {
-    const { log = console } = context;
+  /**
+   * Named IMS emitter/consumer credential pairs. Absent selector => the default
+   * (unprefixed) pair. `SEMRUSH` => the dedicated Semrush-scoped pair, read from
+   * `IMS_PROMISE_SEMRUSH_*` env vars (see docs/specs/ims-client-promise-pair-selector).
+   */
+  static PROMISE_PAIR = {
+    SEMRUSH: 'SEMRUSH',
+  };
 
-    let imsHost;
+  static createFrom(context, type, opts = {}) {
+    const { log = console } = context;
+    const { pair } = opts;
+
+    if (pair !== undefined
+      && !Object.values(ImsPromiseClient.PROMISE_PAIR).includes(pair)) {
+      throw new Error(`Unknown IMS promise client pair: ${pair}`);
+    }
+    const prefix = pair ? `${pair}_` : '';
+
+    const { env } = context;
+    const imsHost = env.IMS_HOST;
+    const encryption = {
+      secret: env.AUTOFIX_CRYPT_SECRET,
+      salt: env.AUTOFIX_CRYPT_SALT,
+    };
+
     let clientId;
     let clientSecret;
     let promiseDefinitionId;
-    const encryption = {};
 
     if (type === ImsPromiseClient.CLIENT_TYPE.EMITTER) {
-      ({
-        IMS_HOST: imsHost,
-        IMS_PROMISE_EMITTER_CLIENT_ID: clientId,
-        IMS_PROMISE_EMITTER_CLIENT_SECRET: clientSecret,
-        IMS_PROMISE_EMITTER_DEFINITION_ID: promiseDefinitionId,
-        AUTOFIX_CRYPT_SECRET: encryption.secret,
-        AUTOFIX_CRYPT_SALT: encryption.salt,
-      } = context.env);
+      clientId = env[`IMS_PROMISE_${prefix}EMITTER_CLIENT_ID`];
+      clientSecret = env[`IMS_PROMISE_${prefix}EMITTER_CLIENT_SECRET`];
+      promiseDefinitionId = env[`IMS_PROMISE_${prefix}EMITTER_DEFINITION_ID`];
     } else if (type === ImsPromiseClient.CLIENT_TYPE.CONSUMER) {
-      ({
-        IMS_HOST: imsHost,
-        IMS_PROMISE_CONSUMER_CLIENT_ID: clientId,
-        IMS_PROMISE_CONSUMER_CLIENT_SECRET: clientSecret,
-        AUTOFIX_CRYPT_SECRET: encryption.secret,
-        AUTOFIX_CRYPT_SALT: encryption.salt,
-      } = context.env);
+      clientId = env[`IMS_PROMISE_${prefix}CONSUMER_CLIENT_ID`];
+      clientSecret = env[`IMS_PROMISE_${prefix}CONSUMER_CLIENT_SECRET`];
     } else {
       throw new Error('Unknown IMS promise client type.');
     }
 
     if (!hasText(imsHost) || !hasText(clientId) || !hasText(clientSecret)
       || (type === ImsPromiseClient.CLIENT_TYPE.EMITTER && !hasText(promiseDefinitionId))) {
-      throw new Error('Context param must include properties: imsHost, clientId, and clientSecret and for CONSUMER type also promiseDefinitionId.');
+      throw new Error('Context param must include properties: imsHost, clientId, and clientSecret and for EMITTER type also promiseDefinitionId.');
     }
 
     return new ImsPromiseClient({

--- a/packages/spacecat-shared-ims-client/src/clients/ims-promise-client.js
+++ b/packages/spacecat-shared-ims-client/src/clients/ims-promise-client.js
@@ -30,9 +30,9 @@ export default class ImsPromiseClient extends ImsBaseClient {
    * (unprefixed) pair. `SEMRUSH` => the dedicated Semrush-scoped pair, read from
    * `IMS_PROMISE_SEMRUSH_*` env vars (see docs/specs/ims-client-promise-pair-selector).
    */
-  static PROMISE_PAIR = {
+  static PROMISE_PAIR = Object.freeze({
     SEMRUSH: 'SEMRUSH',
-  };
+  });
 
   static createFrom(context, type, opts = {}) {
     const { log = console } = context;

--- a/packages/spacecat-shared-ims-client/test/clients/ims-promise-client.test.js
+++ b/packages/spacecat-shared-ims-client/test/clients/ims-promise-client.test.js
@@ -138,6 +138,16 @@ describe('ImsPromiseClient', () => {
       )).to.not.throw();
     });
 
+    it('does not read the SEMRUSH env vars without the selector', () => {
+      // semrushContext has only prefixed vars; without the selector the default
+      // (unprefixed) names resolve to nothing, so construction must throw. This
+      // documents that the prefix routing is load-bearing.
+      expect(() => ImsPromiseClient.createFrom(
+        semrushContext,
+        ImsPromiseClient.CLIENT_TYPE.EMITTER,
+      )).to.throw('Context param must include properties');
+    });
+
     it('resolves the SEMRUSH consumer env vars', () => {
       expect(() => ImsPromiseClient.createFrom(
         semrushContext,

--- a/packages/spacecat-shared-ims-client/test/clients/ims-promise-client.test.js
+++ b/packages/spacecat-shared-ims-client/test/clients/ims-promise-client.test.js
@@ -49,7 +49,7 @@ describe('ImsPromiseClient', () => {
 
   describe('constructor and createFrom', () => {
     it('throws errors for missing configuration using createFrom', () => {
-      const expectedError = 'Context param must include properties: imsHost, clientId, and clientSecret and for CONSUMER type also promiseDefinitionId.';
+      const expectedError = 'Context param must include properties: imsHost, clientId, and clientSecret and for EMITTER type also promiseDefinitionId.';
       expect(() => ImsPromiseClient.createFrom({
         env: {},
         log: console,
@@ -85,6 +85,100 @@ describe('ImsPromiseClient', () => {
         },
         log: console,
       }, 'randomtype')).to.throw('Unknown IMS promise client type.');
+    });
+  });
+
+  describe('createFrom pair selector', () => {
+    const testAccessToken = 'eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjEyMzQ1IiwidHlwZSI6ImFjY2Vzc190b2tlbiIsImNsaWVudF9pZCI6ImV4YW1wbGVfYXBwIiwidXNlcl9pZCI6Ijk4NzY1NDc4OTBBQkNERUYxMjM0NTY3OEBhYmNkZWYxMjM0NTY3ODkuZSIsImFzIjoiaW1zLW5hMSIsImFhX2lkIjoiMTIzNDU2Nzg5MEFCQ0RFRjEyMzQ1Njc4QGFkb2JlLmNvbSIsImNyZWF0ZWRfYXQiOiIxNzEwMjQ3MDAwMDAwIn0.MRDpxgxSHDj4DmA182hPnjMAnKkly-VUJ_bXpQ-J8EQ';
+    let semrushContext;
+
+    beforeEach(() => {
+      semrushContext = {
+        log: console,
+        env: {
+          IMS_HOST: DUMMY_HOST,
+          IMS_PROMISE_SEMRUSH_EMITTER_CLIENT_ID: 'semrushEmitterClientId',
+          IMS_PROMISE_SEMRUSH_EMITTER_CLIENT_SECRET: 'semrushEmitterClientSecret',
+          IMS_PROMISE_SEMRUSH_EMITTER_DEFINITION_ID: 'semrushDefinitionId',
+          IMS_PROMISE_SEMRUSH_CONSUMER_CLIENT_ID: 'semrushConsumerClientId',
+          IMS_PROMISE_SEMRUSH_CONSUMER_CLIENT_SECRET: 'semrushConsumerClientSecret',
+        },
+      };
+    });
+
+    it('defaults to the unprefixed pair when no selector is given', () => {
+      // mockContext holds only unprefixed env vars, so these succeed only if
+      // the default (unprefixed) names are read.
+      expect(() => ImsPromiseClient.createFrom(
+        mockContext,
+        ImsPromiseClient.CLIENT_TYPE.EMITTER,
+      )).to.not.throw();
+      expect(() => ImsPromiseClient.createFrom(
+        mockContext,
+        ImsPromiseClient.CLIENT_TYPE.CONSUMER,
+        {},
+      )).to.not.throw();
+    });
+
+    it('throws for an unknown pair', () => {
+      expect(() => ImsPromiseClient.createFrom(
+        semrushContext,
+        ImsPromiseClient.CLIENT_TYPE.EMITTER,
+        { pair: 'BOGUS' },
+      )).to.throw('Unknown IMS promise client pair: BOGUS');
+    });
+
+    it('resolves the SEMRUSH emitter env vars', () => {
+      // semrushContext has no unprefixed vars, so this succeeds only if the
+      // IMS_PROMISE_SEMRUSH_EMITTER_* names are read.
+      expect(() => ImsPromiseClient.createFrom(
+        semrushContext,
+        ImsPromiseClient.CLIENT_TYPE.EMITTER,
+        { pair: ImsPromiseClient.PROMISE_PAIR.SEMRUSH },
+      )).to.not.throw();
+    });
+
+    it('resolves the SEMRUSH consumer env vars', () => {
+      expect(() => ImsPromiseClient.createFrom(
+        semrushContext,
+        ImsPromiseClient.CLIENT_TYPE.CONSUMER,
+        { pair: ImsPromiseClient.PROMISE_PAIR.SEMRUSH },
+      )).to.not.throw();
+    });
+
+    it('throws when a required SEMRUSH env var is missing', () => {
+      delete semrushContext.env.IMS_PROMISE_SEMRUSH_EMITTER_CLIENT_ID;
+      expect(() => ImsPromiseClient.createFrom(
+        semrushContext,
+        ImsPromiseClient.CLIENT_TYPE.EMITTER,
+        { pair: ImsPromiseClient.PROMISE_PAIR.SEMRUSH },
+      )).to.throw('Context param must include properties');
+    });
+
+    it('mints using the SEMRUSH emitter client id and definition id', async () => {
+      nock(`https://${DUMMY_HOST}`)
+        .post(
+          IMS_TOKEN_ENDPOINT,
+          (body) => body.match('name="client_id"\r\n\r\nsemrushEmitterClientId')
+            && body.match('name="promise_definition_id"\r\n\r\nsemrushDefinitionId'),
+        )
+        .reply(200, {
+          promise_token: 'semrushPromiseToken',
+          token_type: 'promise_token',
+          expires_in: 14399,
+        });
+
+      const client = ImsPromiseClient.createFrom(
+        semrushContext,
+        ImsPromiseClient.CLIENT_TYPE.EMITTER,
+        { pair: ImsPromiseClient.PROMISE_PAIR.SEMRUSH },
+      );
+      const result = await client.getPromiseToken(testAccessToken);
+      expect(result).to.deep.equal({
+        promise_token: 'semrushPromiseToken',
+        token_type: 'promise_token',
+        expires_in: 14399,
+      });
     });
   });
 


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Adds an optional credential-pair selector to `ImsPromiseClient.createFrom` in `spacecat-shared-ims-client`, and fixes a misleading validation error message in the same factory.

## 2. Reasoning
LLMO-6623 needs the Semrush-facing promise-token paths to use a dedicated IMS emitter/consumer pair (scoped for Semrush UDH) instead of the single shared pair that serves every promise flow today. The client currently reads one hard-coded set of `IMS_PROMISE_{EMITTER,CONSUMER}_*` env vars with no way to select a second pair. This is the dependency-root change: nothing downstream can select the Semrush pair until the client supports it.

## 3. High-level overview of the changes
- `createFrom(context, type)` gains an optional third argument, `opts`.
  - No selector (today's call) reads the same `IMS_PROMISE_{EMITTER,CONSUMER}_*` env vars as before — existing callers are unchanged.
  - `{ pair: 'SEMRUSH' }` reads `IMS_PROMISE_SEMRUSH_{EMITTER,CONSUMER}_*` for the dedicated pair.
  - Any other `pair` value throws (fail closed), rather than silently falling back to the default pair.
- The crypt keys (`AUTOFIX_CRYPT_SECRET` / `_SALT`) and `IMS_HOST` stay shared/unprefixed across all pairs.
- Fixes the `createFrom` validation message: it said the promise definition id is required "for CONSUMER type", but the check requires it for the EMITTER type. Message now matches the check.
- The client still sends no `scope` parameter at mint/exchange/invalidate; exchanged-token scope is governed by the promise definition, so no code change is needed to obtain the `semrush` scope — only the dedicated pair.

## 4. Required information
- Jira / issue: [LLMO-6928](https://jira.corp.adobe.com/browse/LLMO-6928) (parent [LLMO-6623](https://jira.corp.adobe.com/browse/LLMO-6623))
- Spec: `docs/specs/ims-client-promise-pair-selector/spec.md` (in this PR)

## 5. Spec deviations
- None

## 6. Affected / used mysticat-workspace projects
- spacecat-auth-service — contract: will call `createFrom(context, EMITTER, { pair: 'SEMRUSH' })` and depends on the `IMS_PROMISE_SEMRUSH_*` env-var names defined here (LLMO-6929).
- spacecat-api-service — contract: will select the Semrush consumer/emitter via the same selector and env-var names (LLMO-6930).
- Both consume this package by version and are blocked on it publishing (~1.15.0).

## 8. Test plan
- (a) Local: unit tests cover the default (unprefixed) path unchanged, `SEMRUSH` resolution for both emitter and consumer, a missing prefixed env var, and an unknown pair value. No cross-service e2e is possible from this repo — the pair is exercised end-to-end in the consumer PRs (auth-service mint, api-service exchange).
- (b) Per-env: none. This is a library; it ships via semantic-release on merge to `main`. Verification happens in the consumer services once they bump to the published version.

## 9. Deployment & merge order
- Blocks [LLMO-6929](https://jira.corp.adobe.com/browse/LLMO-6929) (spacecat-auth-service) and [LLMO-6930](https://jira.corp.adobe.com/browse/LLMO-6930) (spacecat-api-service): both bump to the version this PR publishes.
- Order: merge this PR → semantic-release publishes ~1.15.0 → the auth-service and api-service PRs bump to it and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
