### PR TITLE
feat(ims-client): expose org groups and add public getGroupMembers

### DIFF
--- a/packages/spacecat-shared-ims-client/src/clients/ImsClient.d.ts
+++ b/packages/spacecat-shared-ims-client/src/clients/ImsClient.d.ts
@@ -46,9 +46,26 @@ export class ImsClient {
    *               firstName: string,
    *               lastName: string,
    *             }[],
+   *       groups: {
+   *               ident: string,
+   *               name: string,
+   *               role: string,
+   *             }[],
    *     }>} The organization details.
    */
   getImsOrganizationDetails(imsOrgId: string): Promise<object>;
+
+  /**
+   * Returns the normalized members of a single IMS organization group.
+   * @param {string} imsOrgId The IMS organization ID.
+   * @param {string} groupId The IMS group ident.
+   * @returns {Promise<object[]>} The de-duped, allow-filtered group members.
+   * @throws {Error} If a param is missing or the IMS request fails.
+   */
+  getGroupMembers(
+    imsOrgId: string,
+    groupId: string,
+  ): Promise<{ email: string; firstName: string; lastName: string }[]>;
 
   /**
    * Returns the user profile for the given IMS access token.

--- a/packages/spacecat-shared-ims-client/src/clients/ims-client.js
+++ b/packages/spacecat-shared-ims-client/src/clients/ims-client.js
@@ -126,38 +126,63 @@ export default class ImsClient extends ImsBaseClient {
     return group.items || [];
   }
 
-  async #getUsersInAdminGroup(imsOrgId, groups) {
-    if (!Array.isArray(groups)) {
+  /**
+   * Normalizes a raw array of IMS user "items" into the reduced shape we care about,
+   * de-duping by email and filtering out disallowed email domains. Users without a
+   * usable email fall back to their username.
+   *
+   * De-dupe is keyed by email address and is last-write-wins: when multiple items share
+   * the same email, the last one encountered replaces earlier ones.
+   *
+   * @param {object[]} items - The raw IMS user items.
+   * @returns {{email: string, firstName: string, lastName: string}[]} The normalized,
+   *   allow-filtered, de-duped members.
+   */
+  static #normalizeGroupMembers(items) {
+    if (!Array.isArray(items)) {
       return [];
     }
 
     // Store users by their email address initially to de-dupe the entries
     const users = {};
-    for (const group of groups) {
-      // Only process Administrators groups
-      if (group?.role === 'GRP_ADMIN') {
-        // eslint-disable-next-line no-await-in-loop
-        const groupUsers = await this.#getUsersByImsGroupId(imsOrgId, group?.ident);
-        for (const user of groupUsers) {
-          // Fallback to username if email is not set
-          const newUser = { ...user };
-          if (!hasText(newUser.email)) {
-            newUser.email = newUser.username;
-          }
-          if (emailAddressIsAllowed(newUser.email)) {
-            // Reduce fields in user object to those we need
-            users[newUser.email] = {
-              email: newUser.email,
-              firstName: newUser.firstName,
-              lastName: newUser.lastName,
-            };
-          }
-        }
+    for (const user of items) {
+      const newUser = { ...user };
+      // Fallback to username if email is not set
+      if (!hasText(newUser.email)) {
+        newUser.email = newUser.username;
+      }
+      if (emailAddressIsAllowed(newUser.email)) {
+        // Reduce fields in user object to those we need
+        users[newUser.email] = {
+          email: newUser.email,
+          firstName: newUser.firstName,
+          lastName: newUser.lastName,
+        };
       }
     }
 
     // Transform the object "map" back to a de-duped array
     return Object.keys(users).map((email) => users[email]);
+  }
+
+  async #getUsersInAdminGroup(imsOrgId, groups) {
+    if (!Array.isArray(groups)) {
+      return [];
+    }
+
+    // Gather the raw user items across every Administrators group, then normalize once so
+    // de-dupe and allow-filtering are applied across group boundaries.
+    const allItems = [];
+    for (const group of groups) {
+      // Only process Administrators groups
+      if (group?.role === 'GRP_ADMIN') {
+        // eslint-disable-next-line no-await-in-loop
+        const groupUsers = await this.#getUsersByImsGroupId(imsOrgId, group?.ident);
+        allItems.push(...groupUsers);
+      }
+    }
+
+    return ImsClient.#normalizeGroupMembers(allItems);
   }
 
   async getServiceAccessToken() {
@@ -322,6 +347,16 @@ export default class ImsClient extends ImsBaseClient {
     const admins = await this.#getUsersInAdminGroup(imsOrgId, orgDetails?.groups);
     this.log.debug(`IMS Org ID ${imsOrgId} has ${admins.length} known admin users.`); // remove?
 
+    // Expose the org's group catalog so consumers can discover and enumerate groups.
+    // Drop entries with no usable ident so consumers never receive an undefined group id.
+    const groups = (orgDetails?.groups || [])
+      .filter((group) => hasText(group.ident))
+      .map((group) => ({
+        ident: group.ident,
+        name: group.groupName || group.name,
+        role: group.role,
+      }));
+
     return {
       imsOrgId,
       tenantId,
@@ -329,7 +364,31 @@ export default class ImsClient extends ImsBaseClient {
       orgType: orgDetails?.orgType,
       countryCode: orgDetails?.countryCode,
       admins,
+      groups,
     };
+  }
+
+  /**
+   * Returns the normalized members of a single IMS organization group.
+   * @param {string} imsOrgId The IMS organization ID.
+   * @param {string} groupId The IMS group ident.
+   * @returns {Promise<{email: string, firstName: string, lastName: string}[]>}
+   *   The de-duped, allow-filtered group members.
+   * @throws {Error} If a param is missing or the IMS request fails.
+   * @remarks Results are capped at the IMS default page size (currently 50 members) and
+   *   are NOT paginated, so groups larger than that are silently truncated. Callers
+   *   targeting groups that may exceed the page size must account for this truncation.
+   */
+  async getGroupMembers(imsOrgId, groupId) {
+    if (!hasText(imsOrgId)) {
+      throw new Error('imsOrgId param is required.');
+    }
+    if (!hasText(groupId)) {
+      throw new Error('groupId param is required.');
+    }
+
+    const items = await this.#getUsersByImsGroupId(imsOrgId, groupId);
+    return ImsClient.#normalizeGroupMembers(items);
   }
 
   /**

--- a/packages/spacecat-shared-ims-client/test/clients/ims-client.test.js
+++ b/packages/spacecat-shared-ims-client/test/clients/ims-client.test.js
@@ -139,6 +139,44 @@ describe('ImsClient', () => {
       expect(orgDetails.admins).to.have.length(2);
       expect(orgDetails.admins[0].email).to.equal('test-user-1@example.com');
       expect(orgDetails.admins[1].email).to.equal('test-user-2@example.com');
+
+      expect(orgDetails.groups).to.deep.equal([
+        { ident: GROUP_1_ID, name: 'Administrators', role: 'GRP_ADMIN' },
+        { ident: GROUP_2_ID, name: 'Developers', role: 'GRP_ADMIN' },
+      ]);
+    });
+
+    it('normalizes the org group catalog and drops entries with no ident', async () => {
+      mockImsTokenResponse()
+        // Mock the request for the organization's product context
+        .post('/ims/fetch_pc_by_org/v1')
+        .reply(200, IMS_FETCH_PC_BY_ORG_RESPONSE)
+        // Mock the request for the organization's details — non-admin groups so no
+        // member endpoints are hit; one group names via `groupName`, the other via `name`,
+        // and a third has no ident so it must be excluded from the catalog
+        .get(`/ims/organizations/${testOrgId}/v2`)
+        .query({ client_id: mockContext.env.IMS_CLIENT_ID })
+        .reply(200, {
+          orgName: 'Example Org Human Readable Name',
+          orgType: 'Enterprise',
+          countryCode: 'CA',
+          groups: [
+            { groupName: 'Developers', role: 'GRP_MEMBER', ident: '111' },
+            { name: 'Marketing', role: 'GRP_MEMBER', ident: '222' },
+            // No ident — must be filtered out of the returned catalog
+            { groupName: 'Ghost Group', role: 'GRP_MEMBER' },
+          ],
+        });
+
+      const orgDetails = await client.getImsOrganizationDetails(testOrgId);
+
+      expect(orgDetails.admins).to.be.an('array');
+      expect(orgDetails.admins).to.have.length(0);
+      // `groupName` and `name` both map to `name`; the identless group is dropped
+      expect(orgDetails.groups).to.deep.equal([
+        { ident: '111', name: 'Developers', role: 'GRP_MEMBER' },
+        { ident: '222', name: 'Marketing', role: 'GRP_MEMBER' },
+      ]);
     });
 
     it('should handle IMS service token request failures', async () => {
@@ -378,6 +416,7 @@ describe('ImsClient', () => {
       const orgDetails = await client.getImsOrganizationDetails(testOrgId2);
       expect(orgDetails.admins).to.be.an('array');
       expect(orgDetails.admins).to.have.length(0);
+      expect(orgDetails.groups).to.deep.equal([]);
     });
 
     it('should handle IMS organizations with no users in a group', async () => {
@@ -402,6 +441,128 @@ describe('ImsClient', () => {
       const orgDetails = await client.getImsOrganizationDetails(testOrgId);
       expect(orgDetails.admins).to.be.an('array');
       expect(orgDetails.admins).to.have.length(0);
+    });
+  });
+
+  describe('getGroupMembers', () => {
+    const testOrgId = '1234567890ABCDEF12345678@AdobeOrg';
+    const testGroupId = '987654321';
+    const membersPath = `/ims/organizations/${testOrgId}/groups/${testGroupId}/members`;
+    let client;
+
+    beforeEach(() => {
+      client = ImsClient.createFrom(mockContext);
+      client.retryBaseDelayMs = 0;
+    });
+
+    it('throws when imsOrgId is missing', async () => {
+      await expect(client.getGroupMembers('', testGroupId)).to.be.rejectedWith('imsOrgId param is required.');
+    });
+
+    it('throws when groupId is missing', async () => {
+      await expect(client.getGroupMembers(testOrgId, '')).to.be.rejectedWith('groupId param is required.');
+    });
+
+    it('returns the normalized members of the group', async () => {
+      mockImsTokenResponse()
+        .get(membersPath)
+        .query({ client_id: mockContext.env.IMS_CLIENT_ID })
+        .reply(200, IMS_FETCH_GROUP_1_MEMBERS_RESPONSE);
+
+      const members = await client.getGroupMembers(testOrgId, testGroupId);
+      expect(members).to.deep.equal([
+        { email: 'test-user-1@example.com', firstName: 'Test', lastName: 'User 1' },
+      ]);
+    });
+
+    it('falls back to username when a member has no email', async () => {
+      mockImsTokenResponse()
+        .get(membersPath)
+        .query({ client_id: mockContext.env.IMS_CLIENT_ID })
+        .reply(200, {
+          items: [
+            { username: 'fallback-user@example.com', firstName: 'Fallback', lastName: 'User' },
+          ],
+        });
+
+      const members = await client.getGroupMembers(testOrgId, testGroupId);
+      expect(members).to.deep.equal([
+        { email: 'fallback-user@example.com', firstName: 'Fallback', lastName: 'User' },
+      ]);
+    });
+
+    it('filters out members whose email domain is in the ignore list', async () => {
+      mockImsTokenResponse()
+        .get(membersPath)
+        .query({ client_id: mockContext.env.IMS_CLIENT_ID })
+        .reply(200, {
+          items: [
+            { email: 'ignored@techacct.adobe.com', firstName: 'Ignored', lastName: 'User' },
+            { email: 'kept@example.com', firstName: 'Kept', lastName: 'User' },
+          ],
+        });
+
+      const members = await client.getGroupMembers(testOrgId, testGroupId);
+      expect(members).to.deep.equal([
+        { email: 'kept@example.com', firstName: 'Kept', lastName: 'User' },
+      ]);
+    });
+
+    it('filters out a member with neither email nor username', async () => {
+      mockImsTokenResponse()
+        .get(membersPath)
+        .query({ client_id: mockContext.env.IMS_CLIENT_ID })
+        .reply(200, {
+          items: [
+            // No email and no username — no usable key, so it is dropped
+            { firstName: 'No', lastName: 'Contact' },
+            { email: 'kept@example.com', firstName: 'Kept', lastName: 'User' },
+          ],
+        });
+
+      const members = await client.getGroupMembers(testOrgId, testGroupId);
+      expect(members).to.deep.equal([
+        { email: 'kept@example.com', firstName: 'Kept', lastName: 'User' },
+      ]);
+    });
+
+    it('de-dupes members with duplicate emails', async () => {
+      mockImsTokenResponse()
+        .get(membersPath)
+        .query({ client_id: mockContext.env.IMS_CLIENT_ID })
+        .reply(200, {
+          items: [
+            { email: 'dupe@example.com', firstName: 'First', lastName: 'Entry' },
+            { email: 'dupe@example.com', firstName: 'Second', lastName: 'Entry' },
+          ],
+        });
+
+      const members = await client.getGroupMembers(testOrgId, testGroupId);
+      expect(members).to.have.length(1);
+      expect(members[0].email).to.equal('dupe@example.com');
+      // Later entries overwrite earlier ones with the same email
+      expect(members[0].firstName).to.equal('Second');
+    });
+
+    it('returns an empty array when the members payload is malformed', async () => {
+      mockImsTokenResponse()
+        .get(membersPath)
+        .query({ client_id: mockContext.env.IMS_CLIENT_ID })
+        // `items` is present but not an array (malformed IMS response)
+        .reply(200, { items: { not: 'an array' } });
+
+      const members = await client.getGroupMembers(testOrgId, testGroupId);
+      expect(members).to.deep.equal([]);
+    });
+
+    it('throws when the members endpoint responds non-ok', async () => {
+      mockImsTokenResponse()
+        .get(membersPath)
+        .query(true)
+        .reply(404);
+
+      await expect(client.getGroupMembers(testOrgId, testGroupId))
+        .to.be.rejectedWith('IMS getUsersByImsGroupId request failed with status: 404');
     });
   });
 

--- a/packages/spacecat-shared-ims-client/test/clients/ims-sample-responses.js
+++ b/packages/spacecat-shared-ims-client/test/clients/ims-sample-responses.js
@@ -21,8 +21,11 @@ export const IMS_FETCH_PC_BY_ORG_RESPONSE = {
   ],
 };
 
-export const GROUP_1_ID = 123456789;
-export const GROUP_2_ID = 222223333;
+// IMS group idents are strings: they are handed back to consumers via the org
+// group catalog and passed into getGroupMembers(imsOrgId, groupId), which requires
+// a non-empty string groupId.
+export const GROUP_1_ID = '123456789';
+export const GROUP_2_ID = '222223333';
 
 export const IMS_FETCH_ORG_DETAILS_RESPONSE = {
   orgName: 'Example Org Human Readable Name',


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Exposes IMS organization group membership from the `spacecat-shared-ims-client` package: `getImsOrganizationDetails` now also returns a normalized group catalog, and a new public `getGroupMembers(imsOrgId, groupId)` lists the members of any organization group.

## 2. Reasoning
The `spacecat-fulfillment-worker` ABV Semrush provisioning notification needs organization group membership to pick a meaningful workspace owner (a system administrator who is also an ABV product admin or user) and to render a per-administrator entitlement table in a threaded reply. Today the client only surfaces the Administrators group internally; there is no public way to enumerate an org's groups or list an arbitrary group's members. This PR adds that generic capability so the worker can build on it.

## 3. High-level overview of the changes
- `getImsOrganizationDetails(imsOrgId)` return value gains a `groups` field: a normalized `{ ident, name, role }[]` catalog of the organization's IMS groups (`name` resolved from the raw `groupName`/`name`). This is purely additive — every existing field is unchanged.
- New public method `getGroupMembers(imsOrgId, groupId)` returns the de-duped, allow-filtered `{ email, firstName, lastName }[]` members of a single group. It validates both parameters and surfaces IMS request failures.
- Internal refactor: the per-user normalization (email→username fallback, disallowed-domain filtering, de-dupe by email) that lived inline in the private Administrators-group path is extracted into a shared private helper reused by both the admin path and the new public method, so both return the identical shape. Existing Administrators-group behaviour (including cross-group de-duplication) is preserved.
- No product-specific naming is baked into the client; consumers supply the group name/id they care about.

## 4. Required information
- Jira / issue: none — internal follow-up enabling a downstream worker change; no ticket.

## 5. Affected / used mysticat-workspace projects
- `spacecat-fulfillment-worker` — consumer. A follow-up PR bumps this dependency to consume `getGroupMembers` and the new `groups` field for the ABV Semrush provisioning owner-derivation + threaded entitlement table.

## 7. Test plan
- (a) Verified locally against the package unit suite with the IMS endpoints mocked (nock): the new `getGroupMembers` normalization/validation/error paths and the added `groups` field on `getImsOrganizationDetails`, plus the unchanged Administrators-group behaviour.
- (b) dev/stage/prod: no standalone runtime verification for this library change — it is exercised end-to-end through the consuming `spacecat-fulfillment-worker` PR (provision a net-new paid ABV org and confirm the derived workspace owner + system-administrator entitlement table appear in the ABV Semrush provisioning thread).

## 8. Deployment & merge order
- This PR is the foundation: it must merge first and semantic-release must publish the new `@adobe/spacecat-shared-ims-client` version (expected `1.15.0`).
- `spacecat-fulfillment-worker` ABV Semrush provisioning-thread PR — depends-on this: it bumps `@adobe/spacecat-shared-ims-client` to the published version and cannot merge until this is released.
- Sequence: merge + publish this → bump the dependency in the worker PR → merge the worker PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
