### PR TITLE
feat(data-access): compound AND filter and orderBy column for postgrest queries

### DIFF
--- a/packages/spacecat-shared-data-access/CLAUDE.md
+++ b/packages/spacecat-shared-data-access/CLAUDE.md
@@ -178,7 +178,7 @@ This is the same client instance used internally by entity collections — same 
 async findByStatus(status) {
   return this.all(
     (attrs, op) => op.eq(attrs.status, status),
-    { limit: 100, order: { field: 'createdAt', direction: 'desc' } }
+    { limit: 100, orderBy: { attribute: 'createdAt', direction: 'desc' } }
   );
 }
 ```

--- a/packages/spacecat-shared-data-access/src/models/base/base.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/base/base.collection.js
@@ -429,12 +429,24 @@ class BaseCollection {
     }
 
     const hasExplicitOrderBy = isObject(options.orderBy) && hasText(options.orderBy.attribute);
+    let explicitAscending;
+    if (hasExplicitOrderBy) {
+      const { toDbMap } = this.fieldMaps;
+      if (!Object.prototype.hasOwnProperty.call(toDbMap, options.orderBy.attribute)) {
+        this.#logAndThrowError(`Failed to query [${this.entityName}]: unknown orderBy attribute [${options.orderBy.attribute}]`);
+      }
+      const direction = options.orderBy.direction === undefined
+        ? 'asc'
+        : String(options.orderBy.direction).toLowerCase();
+      if (direction !== 'asc' && direction !== 'desc') {
+        this.#logAndThrowError(`Failed to query [${this.entityName}]: invalid orderBy direction [${options.orderBy.direction}]`);
+      }
+      explicitAscending = direction === 'asc';
+    }
     const orderFields = hasExplicitOrderBy
       ? [this.#toDbField(options.orderBy.attribute)]
       : this.#getOrderFields(indexName, keys);
-    const ascending = hasExplicitOrderBy
-      ? options.orderBy.direction !== 'desc'
-      : options.order === 'asc';
+    const ascending = hasExplicitOrderBy ? explicitAscending : options.order === 'asc';
     let query = this.postgrestService
       .from(this.tableName)
       .select(select);

--- a/packages/spacecat-shared-data-access/src/models/base/base.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/base/base.collection.js
@@ -428,8 +428,13 @@ class BaseCollection {
       this.#logAndThrowError(`Failed to query [${this.entityName}]: query proxy [${options.index}] not found`);
     }
 
-    const orderFields = this.#getOrderFields(indexName, keys);
-    const ascending = options.order === 'asc';
+    const hasExplicitOrderBy = isObject(options.orderBy) && hasText(options.orderBy.attribute);
+    const orderFields = hasExplicitOrderBy
+      ? [this.#toDbField(options.orderBy.attribute)]
+      : this.#getOrderFields(indexName, keys);
+    const ascending = hasExplicitOrderBy
+      ? options.orderBy.direction !== 'desc'
+      : options.order === 'asc';
     let query = this.postgrestService
       .from(this.tableName)
       .select(select);

--- a/packages/spacecat-shared-data-access/src/models/base/index.d.ts
+++ b/packages/spacecat-shared-data-access/src/models/base/index.d.ts
@@ -33,6 +33,7 @@ export interface QueryOptions {
   index?: string;
   limit?: number;
   order?: string;
+  orderBy?: { attribute: string; direction?: 'asc' | 'desc' };
   attributes?: string[];
   cursor?: string;
   /**

--- a/packages/spacecat-shared-data-access/src/util/postgrest.utils.js
+++ b/packages/spacecat-shared-data-access/src/util/postgrest.utils.js
@@ -152,6 +152,7 @@ const applyWhere = (query, whereFn, toDbMap) => {
     like: (field, value) => ({ type: 'like', field, value }),
     ilike: (field, value) => ({ type: 'ilike', field, value }),
     contains: (field, value) => ({ type: 'contains', field, value }),
+    and: (...conditions) => ({ type: 'and', conditions: conditions.filter(Boolean) }),
   };
 
   const expression = whereFn(attrs, op);
@@ -159,37 +160,43 @@ const applyWhere = (query, whereFn, toDbMap) => {
     return query;
   }
 
-  switch (expression.type) {
-    case 'eq':
-      return query.eq(expression.field, expression.value);
-    case 'ne':
-      return query.neq(expression.field, expression.value);
-    case 'gt':
-      return query.gt(expression.field, expression.value);
-    case 'gte':
-      return query.gte(expression.field, expression.value);
-    case 'lt':
-      return query.lt(expression.field, expression.value);
-    case 'lte':
-      return query.lte(expression.field, expression.value);
-    case 'in':
-      return query.in(
-        expression.field,
-        Array.isArray(expression.value) ? expression.value : [expression.value],
-      );
-    case 'is':
-      return query.is(expression.field, expression.value);
-    case 'like':
-      return query.like(expression.field, expression.value);
-    case 'ilike':
-      return query.ilike(expression.field, expression.value);
-    case 'contains': {
-      const value = Array.isArray(expression.value) ? expression.value : [expression.value];
-      return query.contains(expression.field, value);
+  const applyExpr = (q, expr) => {
+    switch (expr.type) {
+      case 'and':
+        return (expr.conditions || []).reduce((acc, cond) => applyExpr(acc, cond), q);
+      case 'eq':
+        return q.eq(expr.field, expr.value);
+      case 'ne':
+        return q.neq(expr.field, expr.value);
+      case 'gt':
+        return q.gt(expr.field, expr.value);
+      case 'gte':
+        return q.gte(expr.field, expr.value);
+      case 'lt':
+        return q.lt(expr.field, expr.value);
+      case 'lte':
+        return q.lte(expr.field, expr.value);
+      case 'in':
+        return q.in(
+          expr.field,
+          Array.isArray(expr.value) ? expr.value : [expr.value],
+        );
+      case 'is':
+        return q.is(expr.field, expr.value);
+      case 'like':
+        return q.like(expr.field, expr.value);
+      case 'ilike':
+        return q.ilike(expr.field, expr.value);
+      case 'contains': {
+        const value = Array.isArray(expr.value) ? expr.value : [expr.value];
+        return q.contains(expr.field, value);
+      }
+      default:
+        throw new Error(`Unsupported where operator: ${expr.type}`);
     }
-    default:
-      throw new Error(`Unsupported where operator: ${expression.type}`);
-  }
+  };
+
+  return applyExpr(query, expression);
 };
 
 export {

--- a/packages/spacecat-shared-data-access/test/unit/models/site-ims-org-access/site-ims-org-access.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site-ims-org-access/site-ims-org-access.collection.test.js
@@ -604,4 +604,45 @@ describe('SiteImsOrgAccessCollection', () => {
       expect(createInstanceFromRowStub.callCount).to.equal(DEFAULT_PAGE_SIZE + 1);
     });
   });
+
+  describe('all (PostgREST orderBy)', () => {
+    function makeChainableQuery(result) {
+      const q = {};
+      [
+        'select', 'order', 'eq', 'gte', 'lte', 'in',
+        'is', 'like', 'ilike', 'contains', 'neq', 'range',
+      ].forEach((m) => { q[m] = sinon.stub().returns(q); });
+      q.then = (resolve) => resolve(result); // `await query` yields {data,error}
+      return q;
+    }
+
+    beforeEach(() => {
+      // createElectroMocks wires a matching ElectroDB entity by default, which would
+      // route #all() through the ElectroDB branch of #queryByIndexKeys instead of the
+      // PostgREST branch that owns #queryPage. Force the PostgREST branch the same way
+      // scrape-job.collection.test.js's "postgrest accessor parity" suite does.
+      instance.entity = undefined;
+    });
+
+    it('orders by an explicit orderBy column and direction', async () => {
+      const query = makeChainableQuery({ data: [], error: null });
+      instance.postgrestService.from = sinon.stub().returns(query);
+
+      await instance.all(
+        {},
+        { orderBy: { attribute: 'updatedAt', direction: 'desc' }, limit: 10 },
+      );
+
+      sinon.assert.calledWith(query.order, 'updated_at', { ascending: false });
+    });
+
+    it('falls back to index-derived ordering when orderBy is absent (back-compat)', async () => {
+      const query = makeChainableQuery({ data: [], error: null });
+      instance.postgrestService.from = sinon.stub().returns(query);
+
+      await instance.all({}, { order: 'asc', limit: 10 });
+
+      expect(query.order.getCalls().some((c) => c.args[0] === 'updated_at')).to.equal(false);
+    });
+  });
 });

--- a/packages/spacecat-shared-data-access/test/unit/models/site-ims-org-access/site-ims-org-access.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site-ims-org-access/site-ims-org-access.collection.test.js
@@ -644,5 +644,56 @@ describe('SiteImsOrgAccessCollection', () => {
 
       expect(query.order.getCalls().some((c) => c.args[0] === 'updated_at')).to.equal(false);
     });
+
+    it('orders ascending when direction is "asc"', async () => {
+      const query = makeChainableQuery({ data: [], error: null });
+      instance.postgrestService.from = sinon.stub().returns(query);
+
+      await instance.all(
+        {},
+        { orderBy: { attribute: 'updatedAt', direction: 'asc' }, limit: 10 },
+      );
+
+      sinon.assert.calledWith(query.order, 'updated_at', { ascending: true });
+    });
+
+    it('defaults to ascending when direction is omitted', async () => {
+      const query = makeChainableQuery({ data: [], error: null });
+      instance.postgrestService.from = sinon.stub().returns(query);
+
+      await instance.all({}, { orderBy: { attribute: 'updatedAt' }, limit: 10 });
+
+      sinon.assert.calledWith(query.order, 'updated_at', { ascending: true });
+    });
+
+    it('treats direction case-insensitively ("DESC" -> descending)', async () => {
+      const query = makeChainableQuery({ data: [], error: null });
+      instance.postgrestService.from = sinon.stub().returns(query);
+
+      await instance.all(
+        {},
+        { orderBy: { attribute: 'updatedAt', direction: 'DESC' }, limit: 10 },
+      );
+
+      sinon.assert.calledWith(query.order, 'updated_at', { ascending: false });
+    });
+
+    it('throws on an unknown orderBy attribute', async () => {
+      const query = makeChainableQuery({ data: [], error: null });
+      instance.postgrestService.from = sinon.stub().returns(query);
+
+      await expect(instance.all({}, { orderBy: { attribute: 'bogusField' }, limit: 10 }))
+        .to.be.rejectedWith(/unknown orderBy attribute/);
+    });
+
+    it('throws on an invalid orderBy direction', async () => {
+      const query = makeChainableQuery({ data: [], error: null });
+      instance.postgrestService.from = sinon.stub().returns(query);
+
+      await expect(instance.all(
+        {},
+        { orderBy: { attribute: 'updatedAt', direction: 'sideways' }, limit: 10 },
+      )).to.be.rejectedWith(/invalid orderBy direction/);
+    });
   });
 });

--- a/packages/spacecat-shared-data-access/test/unit/util/postgrest.utils.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/util/postgrest.utils.test.js
@@ -308,4 +308,33 @@ describe('postgrest utils', () => {
     sinon.assert.calledOnceWithExactly(query.like, 'url', 'https://%');
     sinon.assert.calledOnceWithExactly(query.ilike, 'url', '%tenant%');
   });
+
+  it('applies compound AND by chaining each condition', () => {
+    const query = { ilike: sinon.stub().returnsThis(), eq: sinon.stub().returnsThis() };
+    const result = applyWhere(query, (attr, op) => op.and(
+      op.ilike(attr.baseURL, '%sem%'),
+      op.eq(attr.deliveryType, 'aem_edge'),
+    ), { baseURL: 'base_url', deliveryType: 'delivery_type' });
+
+    expect(result).to.equal(query);
+    sinon.assert.calledOnceWithExactly(query.ilike, 'base_url', '%sem%');
+    sinon.assert.calledOnceWithExactly(query.eq, 'delivery_type', 'aem_edge');
+  });
+
+  it('handles empty and single-condition AND', () => {
+    const query = { eq: sinon.stub().returnsThis() };
+    expect(applyWhere(query, (_a, op) => op.and(), {})).to.equal(query);
+    applyWhere(query, (attr, op) => op.and(op.eq(attr.isLive, true)), { isLive: 'is_live' });
+    sinon.assert.calledOnceWithExactly(query.eq, 'is_live', true);
+  });
+
+  it('applies a nested AND', () => {
+    const query = { eq: sinon.stub().returnsThis(), ilike: sinon.stub().returnsThis() };
+    applyWhere(query, (attr, op) => op.and(
+      op.eq(attr.isLive, true),
+      op.and(op.ilike(attr.baseURL, '%x%')),
+    ), { isLive: 'is_live', baseURL: 'base_url' });
+    sinon.assert.calledOnceWithExactly(query.eq, 'is_live', true);
+    sinon.assert.calledOnceWithExactly(query.ilike, 'base_url', '%x%');
+  });
 });


### PR DESCRIPTION
  ## What
  
  Two additive capabilities on the PostgREST query layer of `@adobe/spacecat-shared-data-access`:
  
  1. **`op.and(...conditions)`** in the `where` builder (`src/util/postgrest.utils.js`) — combine multiple column predicates with `AND` in a single query.
  2. **`orderBy: { attribute, direction }`** option on `all()` / `#queryPage` (`src/models/base/base.collection.js`) — order results by an arbitrary model attribute (mapped to its DB column), `asc`/`desc`, with the existing id tiebreaker preserved.
  
  ## Why
  
  The Experience Success Studio back-office `/sites` page currently downloads the **entire** sites dataset and filters/sorts it client-side — a slow initial load and an unbounded payload that grows with every site. Moving that work server-side requires the data-access layer to do two things it couldn't before:
  
  - **Filter on multiple columns at once** (e.g. baseURL substring **AND** deliveryType **AND** isLive). `applyWhere` previously applied only a *single* condition, so combined server-side filters were impossible.
  - **Order by a non-index column** (e.g. `updatedAt` desc). Ordering was previously locked to the index-derived sort key.
  
  These two primitives unblock the `spacecat-api-service` `GET /sites` filtered/sorted endpoint that the back-office consumes.
  
  ## How
  
  - `applyWhere` gains an `and` operator returning `{ type: 'and', conditions }`; a recursive `applyExpr` applies each sub-condition to the query in sequence (PostgREST chains filters as `AND`). Every existing single-condition operator path is unchanged.
  - `#queryPage` honors `options.orderBy` when `orderBy.attribute` is set (attribute → DB column via the existing field map; direction `asc`/`desc`), keeping the id tiebreaker; when `orderBy` is absent, ordering is byte-for-byte as before.
  
  ## Scope & backward compatibility
  
  - **Strictly additive.** Single-expression `where` and index-derived ordering behave identically to before.
  - **PostgREST path only** — the ElectroDB path is untouched.
  - Full package unit suite (2785 tests) passes; coverage and lint gates green.
  
  ## Testing
  
  - New unit tests: compound / nested / empty `op.and` (`test/unit/util/postgrest.utils.test.js`); `orderBy` column+direction and the no-`orderBy` fallback exercised against the real PostgREST query path (`test/unit/models/.../*.collection.test.js`).
  
  ## Downstream / follow-ups
  
  - Consumed by `spacecat-api-service` `GET /sites` (separate PR), which whitelists sortable columns and validates direction — so unknown-column / casing concerns are handled at the API boundary.
  - Minor: `orderBy` (and the already-absent `where` / `between`) could be added to the `QueryOptions` type in `src/models/base/index.d.ts`; best folded into the consumer PR. 
