### PR TITLE
fix(seo-client): scope broken-backlinks to sub-path via target_url filter

### DIFF
--- a/packages/mysticat-shared-seo-client/src/client.js
+++ b/packages/mysticat-shared-seo-client/src/client.js
@@ -10,7 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import { hasText, isValidUrl, isArray } from '@adobe/spacecat-shared-utils';
+import {
+  hasText, isValidUrl, isArray, prependSchema, stripWWW,
+} from '@adobe/spacecat-shared-utils';
 import { context as h2, h1 } from '@adobe/fetch';
 
 import { ENDPOINTS } from './endpoints.js';
@@ -803,11 +805,24 @@ export default class SeoClient {
 
     const token = await this._getSemrushToken();
 
+    // Semrush's broken-links endpoint with scope=ROOT_DOMAIN ignores the path in `url`
+    // and returns whole-domain broken backlinks (scope=SUBFOLDER is rejected with HTTP 400).
+    // To scope a sub-path site to its own broken backlinks we send the hostname (domain) as
+    // `url` and add a server-side `target_url LIKE '%<hostname><path>%'` filter (SITES-49721).
+    const hostname = stripWWW(new URL(prependSchema(url)).hostname);
+    const { pathname } = new URL(prependSchema(url));
+
     const notLike = LOW_VALUE_HOSTS.map((h) => `AND source_url NOT LIKE '%${h}%'`).join(' ');
-    const filter = `is_nofollow=false AND is_lost=false AND response_code=200 AND is_image=false AND is_ugc=false AND domain_score>=50 ${notLike}`;
+    // response_code here is the SOURCE page's code (always 200 for live sources) — a proven
+    // no-op that does NOT exclude broken (4xx) targets; the endpoint is inherently
+    // "broken targets only", so it is intentionally omitted.
+    let filter = `is_nofollow=false AND is_lost=false AND is_image=false AND is_ugc=false AND domain_score>=50 ${notLike}`;
+    if (pathname && pathname !== '/') {
+      filter += ` AND target_url LIKE '%${hostname}${pathname}%'`;
+    }
 
     const params = new URLSearchParams({
-      url,
+      url: hostname,
       scope: 'ROOT_DOMAIN',
       limit: String(FETCH_LIMIT),
       order_by: 'domain_score',
@@ -826,7 +841,7 @@ export default class SeoClient {
 
     if (!r.ok) {
       if (r.status === 404) {
-        this.log.info(`Semrush broken-links returned 404 for ${url} — no data found, returning empty result`);
+        this.log.warn(`[SEO] broken-links 404 (no data / not indexed) for ${url} — returning empty; may be transient`);
         return { result: { backlinks: [], totalCount: 0 }, fullAuditRef };
       }
       const bodyText = await r.text();

--- a/packages/mysticat-shared-seo-client/src/client.js
+++ b/packages/mysticat-shared-seo-client/src/client.js
@@ -805,28 +805,24 @@ export default class SeoClient {
 
     const token = await this._getSemrushToken();
 
-    // scope=ROOT_DOMAIN ignores the path in `url` (scope=SUBFOLDER is rejected, HTTP 400), so we
-    // send the hostname as `url` and scope sub-paths via a server-side target_url LIKE clause.
-    let urlParam;
+    // scope=ROOT_DOMAIN ignores the path in `url` (scope=SUBFOLDER is rejected, HTTP 400),
+    // so scope a sub-path via a server-side target_url LIKE clause instead.
     let subPathClause = '';
     try {
       const { hostname, pathname } = new URL(prependSchema(url));
-      urlParam = stripWWW(hostname);
       const path = pathname.replace(/\/$/, ''); // /foo == /foo/; root ('/') → no clause
       if (path) {
-        subPathClause = ` AND target_url LIKE '%${urlParam}${path}%'`;
+        subPathClause = ` AND target_url LIKE '%${stripWWW(hostname)}${path}%'`;
       }
     } catch {
       this.log.warn(`[SEO] Could not parse URL "${url}"; querying whole domain with no sub-path scope`);
-      urlParam = url;
     }
 
     const notLike = LOW_VALUE_HOSTS.map((h) => `AND source_url NOT LIKE '%${h}%'`).join(' ');
-    // response_code is the SOURCE page's code (always 200) — a no-op, intentionally omitted.
-    const filter = `is_nofollow=false AND is_lost=false AND is_image=false AND is_ugc=false AND domain_score>=50 ${notLike}${subPathClause}`;
+    const filter = `is_nofollow=false AND is_lost=false AND response_code=200 AND is_image=false AND is_ugc=false AND domain_score>=50 ${notLike}${subPathClause}`;
 
     const params = new URLSearchParams({
-      url: urlParam,
+      url,
       scope: 'ROOT_DOMAIN',
       limit: String(FETCH_LIMIT),
       order_by: 'domain_score',

--- a/packages/mysticat-shared-seo-client/src/client.js
+++ b/packages/mysticat-shared-seo-client/src/client.js
@@ -805,24 +805,28 @@ export default class SeoClient {
 
     const token = await this._getSemrushToken();
 
-    // Semrush's broken-links endpoint with scope=ROOT_DOMAIN ignores the path in `url`
-    // and returns whole-domain broken backlinks (scope=SUBFOLDER is rejected with HTTP 400).
-    // To scope a sub-path site to its own broken backlinks we send the hostname (domain) as
-    // `url` and add a server-side `target_url LIKE '%<hostname><path>%'` filter (SITES-49721).
-    const hostname = stripWWW(new URL(prependSchema(url)).hostname);
-    const { pathname } = new URL(prependSchema(url));
-
-    const notLike = LOW_VALUE_HOSTS.map((h) => `AND source_url NOT LIKE '%${h}%'`).join(' ');
-    // response_code here is the SOURCE page's code (always 200 for live sources) — a proven
-    // no-op that does NOT exclude broken (4xx) targets; the endpoint is inherently
-    // "broken targets only", so it is intentionally omitted.
-    let filter = `is_nofollow=false AND is_lost=false AND is_image=false AND is_ugc=false AND domain_score>=50 ${notLike}`;
-    if (pathname && pathname !== '/') {
-      filter += ` AND target_url LIKE '%${hostname}${pathname}%'`;
+    // scope=ROOT_DOMAIN ignores the path in `url` (scope=SUBFOLDER is rejected, HTTP 400), so we
+    // send the hostname as `url` and scope sub-paths via a server-side target_url LIKE clause.
+    let urlParam;
+    let subPathClause = '';
+    try {
+      const { hostname, pathname } = new URL(prependSchema(url));
+      urlParam = stripWWW(hostname);
+      const path = pathname.replace(/\/$/, ''); // /foo == /foo/; root ('/') → no clause
+      if (path) {
+        subPathClause = ` AND target_url LIKE '%${urlParam}${path}%'`;
+      }
+    } catch {
+      this.log.warn(`[SEO] Could not parse URL "${url}"; querying whole domain with no sub-path scope`);
+      urlParam = url;
     }
 
+    const notLike = LOW_VALUE_HOSTS.map((h) => `AND source_url NOT LIKE '%${h}%'`).join(' ');
+    // response_code is the SOURCE page's code (always 200) — a no-op, intentionally omitted.
+    const filter = `is_nofollow=false AND is_lost=false AND is_image=false AND is_ugc=false AND domain_score>=50 ${notLike}${subPathClause}`;
+
     const params = new URLSearchParams({
-      url: hostname,
+      url: urlParam,
       scope: 'ROOT_DOMAIN',
       limit: String(FETCH_LIMIT),
       order_by: 'domain_score',

--- a/packages/mysticat-shared-seo-client/test/client.test.js
+++ b/packages/mysticat-shared-seo-client/test/client.test.js
@@ -1846,8 +1846,8 @@ describe('SeoClient', () => {
         })
         .reply(200, { data: [], meta: {} });
 
-      await v2Client.getBrokenBacklinksV2('https://www.oklahoma.gov');
-      expect(captured.url).to.equal('oklahoma.gov');
+      await v2Client.getBrokenBacklinksV2('https://www.example.com');
+      expect(captured.url).to.equal('example.com');
       expect(captured.filter).to.not.include('target_url LIKE');
     });
 
@@ -1862,11 +1862,49 @@ describe('SeoClient', () => {
         })
         .reply(200, { data: [], meta: {} });
 
-      await v2Client.getBrokenBacklinksV2('https://www.oklahoma.gov/omes');
+      await v2Client.getBrokenBacklinksV2('https://www.example.gov/us');
       // domain (not the path-carrying value) is sent as the `url` param
-      expect(captured.url).to.equal('oklahoma.gov');
+      expect(captured.url).to.equal('example.gov');
       // sub-path scoping added server-side
-      expect(captured.filter).to.include("target_url LIKE '%oklahoma.gov/omes%'");
+      expect(captured.filter).to.include("target_url LIKE '%example.gov/us%'");
+    });
+
+    it('normalizes a trailing slash so /foo and /foo/ scope identically', async () => {
+      nockToken();
+      let captured;
+      nock(BROKEN_LINKS_HOST)
+        .get(BROKEN_LINKS_PATH)
+        .query((q) => {
+          captured = q;
+          return true;
+        })
+        .reply(200, { data: [], meta: {} });
+
+      await v2Client.getBrokenBacklinksV2('https://www.example.com/foo/');
+      expect(captured.url).to.equal('example.com');
+      expect(captured.filter).to.include("target_url LIKE '%example.com/foo%'");
+      expect(captured.filter).to.not.include('/foo/%');
+    });
+
+    it('falls back to the raw url with no sub-path clause when the url cannot be parsed', async () => {
+      const warn = sandbox.stub();
+      const loggingClient = new SeoClient(v2Config, fetch, { ...console, warn });
+      nockToken();
+      let captured;
+      nock(BROKEN_LINKS_HOST)
+        .get(BROKEN_LINKS_PATH)
+        .query((q) => {
+          captured = q;
+          return true;
+        })
+        .reply(200, { data: [], meta: {} });
+
+      // A non-empty but malformed value that prependSchema cannot turn into a valid URL.
+      await loggingClient.getBrokenBacklinksV2('http://[malformed');
+      expect(captured.url).to.equal('http://[malformed');
+      expect(captured.filter).to.not.include('target_url LIKE');
+      expect(warn.calledOnce).to.equal(true);
+      expect(warn.firstCall.args[0]).to.include('Could not parse URL');
     });
 
     it('handles null source_title', async () => {

--- a/packages/mysticat-shared-seo-client/test/client.test.js
+++ b/packages/mysticat-shared-seo-client/test/client.test.js
@@ -1819,23 +1819,7 @@ describe('SeoClient', () => {
       expect(warnMsg).to.include('may be transient');
     });
 
-    it('omits response_code=200 from the emitted filter (proven no-op)', async () => {
-      nockToken();
-      let capturedFilter;
-      nock(BROKEN_LINKS_HOST)
-        .get(BROKEN_LINKS_PATH)
-        .query((q) => {
-          capturedFilter = q.filter;
-          return true;
-        })
-        .reply(200, { data: [], meta: {} });
-
-      await v2Client.getBrokenBacklinksV2('adobe.com');
-      expect(capturedFilter).to.be.a('string');
-      expect(capturedFilter).to.not.include('response_code=200');
-    });
-
-    it('root-domain url sends the hostname as url and adds NO target_url filter', async () => {
+    it('root-domain url is sent unchanged and adds NO target_url filter', async () => {
       nockToken();
       let captured;
       nock(BROKEN_LINKS_HOST)
@@ -1847,11 +1831,11 @@ describe('SeoClient', () => {
         .reply(200, { data: [], meta: {} });
 
       await v2Client.getBrokenBacklinksV2('https://www.example.com');
-      expect(captured.url).to.equal('example.com');
+      expect(captured.url).to.equal('https://www.example.com');
       expect(captured.filter).to.not.include('target_url LIKE');
     });
 
-    it('sub-path url sends the hostname as url and scopes with a target_url LIKE clause', async () => {
+    it('sub-path url is sent unchanged and scopes with a target_url LIKE clause', async () => {
       nockToken();
       let captured;
       nock(BROKEN_LINKS_HOST)
@@ -1863,9 +1847,9 @@ describe('SeoClient', () => {
         .reply(200, { data: [], meta: {} });
 
       await v2Client.getBrokenBacklinksV2('https://www.example.gov/us');
-      // domain (not the path-carrying value) is sent as the `url` param
-      expect(captured.url).to.equal('example.gov');
-      // sub-path scoping added server-side
+      // `url` param sent unchanged; ROOT_DOMAIN ignores its path
+      expect(captured.url).to.equal('https://www.example.gov/us');
+      // sub-path scoping added server-side via target_url
       expect(captured.filter).to.include("target_url LIKE '%example.gov/us%'");
     });
 
@@ -1881,7 +1865,7 @@ describe('SeoClient', () => {
         .reply(200, { data: [], meta: {} });
 
       await v2Client.getBrokenBacklinksV2('https://www.example.com/foo/');
-      expect(captured.url).to.equal('example.com');
+      expect(captured.url).to.equal('https://www.example.com/foo/');
       expect(captured.filter).to.include("target_url LIKE '%example.com/foo%'");
       expect(captured.filter).to.not.include('/foo/%');
     });

--- a/packages/mysticat-shared-seo-client/test/client.test.js
+++ b/packages/mysticat-shared-seo-client/test/client.test.js
@@ -1801,6 +1801,74 @@ describe('SeoClient', () => {
       expect(result.fullAuditRef).to.be.a('string');
     });
 
+    it('logs a distinct warning (not info) when broken-links endpoint returns 404', async () => {
+      const warn = sandbox.stub();
+      const info = sandbox.stub();
+      const loggingClient = new SeoClient(v2Config, fetch, { ...console, warn, info });
+      nockToken();
+      nock(BROKEN_LINKS_HOST)
+        .get(BROKEN_LINKS_PATH)
+        .query(true)
+        .reply(404, 'Not Found');
+
+      await loggingClient.getBrokenBacklinksV2('adobe.com');
+      expect(info.called).to.equal(false);
+      expect(warn.calledOnce).to.equal(true);
+      const warnMsg = warn.firstCall.args[0];
+      expect(warnMsg).to.include('broken-links 404 (no data / not indexed)');
+      expect(warnMsg).to.include('may be transient');
+    });
+
+    it('omits response_code=200 from the emitted filter (proven no-op)', async () => {
+      nockToken();
+      let capturedFilter;
+      nock(BROKEN_LINKS_HOST)
+        .get(BROKEN_LINKS_PATH)
+        .query((q) => {
+          capturedFilter = q.filter;
+          return true;
+        })
+        .reply(200, { data: [], meta: {} });
+
+      await v2Client.getBrokenBacklinksV2('adobe.com');
+      expect(capturedFilter).to.be.a('string');
+      expect(capturedFilter).to.not.include('response_code=200');
+    });
+
+    it('root-domain url sends the hostname as url and adds NO target_url filter', async () => {
+      nockToken();
+      let captured;
+      nock(BROKEN_LINKS_HOST)
+        .get(BROKEN_LINKS_PATH)
+        .query((q) => {
+          captured = q;
+          return true;
+        })
+        .reply(200, { data: [], meta: {} });
+
+      await v2Client.getBrokenBacklinksV2('https://www.oklahoma.gov');
+      expect(captured.url).to.equal('oklahoma.gov');
+      expect(captured.filter).to.not.include('target_url LIKE');
+    });
+
+    it('sub-path url sends the hostname as url and scopes with a target_url LIKE clause', async () => {
+      nockToken();
+      let captured;
+      nock(BROKEN_LINKS_HOST)
+        .get(BROKEN_LINKS_PATH)
+        .query((q) => {
+          captured = q;
+          return true;
+        })
+        .reply(200, { data: [], meta: {} });
+
+      await v2Client.getBrokenBacklinksV2('https://www.oklahoma.gov/omes');
+      // domain (not the path-carrying value) is sent as the `url` param
+      expect(captured.url).to.equal('oklahoma.gov');
+      // sub-path scoping added server-side
+      expect(captured.filter).to.include("target_url LIKE '%oklahoma.gov/omes%'");
+    });
+
     it('handles null source_title', async () => {
       nockToken();
       nockBrokenLinksV2([{ ...sampleRow, source_title: null }]);


### PR DESCRIPTION
## Problem (SITES-49721)

`getBrokenBacklinksV2` produced whole-domain results for **sub-path sites** (e.g. `example.gov/us`), so a sub-path site saw broken backlinks for the entire domain instead of only its own section.

Root cause (confirmed against the live Semrush API):

- The `/apis/v4/backlinks-external/v0/broken-links` endpoint with `scope=ROOT_DOMAIN` **ignores the path** in the `url` param and returns whole-domain broken backlinks.
- `scope=SUBFOLDER` is **not supported** — the endpoint rejects it with HTTP 400.
- To scope to a sub-path you must pass the **hostname** as `url` **and** add a server-side `target_url LIKE '%<hostname><path>%'` filter.

## Changes to `getBrokenBacklinksV2`

1. **Derive `{ hostname, pathname }` once** from the input `url` (via `prependSchema` + `new URL(...)`, `stripWWW` on the host) and send the **hostname (domain)** as the `url` param — never the path-carrying value.
2. **Guard the URL parse.** A malformed non-empty `url` previously threw. It now logs a warn, queries the whole domain, and adds no sub-path clause — mirroring the existing `getTopPages` precedent in the same file. Falls back to using the raw `url` as the request param.
3. **Append `AND target_url LIKE '%<hostname><path>%'`** only when there is a real sub-path. A single trailing slash on the path is normalized first, so `example.com/foo` and `example.com/foo/` scope identically; a root path (`/`) adds no clause, so root-domain behavior is unchanged.
4. **Remove `response_code=200`** from the filter. That clause matched the **source** page's response code (always 200 for a live source), a proven no-op that does **not** exclude broken 4xx targets — removing it changes result counts by 0. The endpoint is inherently "broken targets only".
5. **404 visibility**: the 404 (no data / not indexed) mapping now logs a distinct **WARNING** (`[SEO] broken-links 404 (no data / not indexed) for <url> — returning empty; may be transient`) instead of info, so a transient "no data" is not silently indistinguishable from a genuine empty result. It still returns the empty result (no throw).

## Tests

Extended the `getBrokenBacklinksV2` suite (neutral example URLs): sub-path url adds the `target_url LIKE` clause and sends the hostname as `url`; root url adds no clause; a trailing slash normalizes to the same clause; a malformed url falls back to the raw value with no clause and logs a warn; `response_code=200` is absent from the emitted filter; the 404 path logs the new warning (and not info). Package coverage stays at 100% lines/branches/statements (191 passing).

## Release / companion PR

- The coarse server-side substring match here is refined to a **precise directory boundary** downstream in the companion **adobe/spacecat-audit-worker** PR (e.g. `%example.com/foo%` would otherwise also match `/foo-bar`). **This should not be released independently** of that companion change.
- **Known limitation**: an underscore in a path is a SQL `LIKE` single-char wildcard, so a path containing `_` is a minor over-match. LIKE metacharacters are intentionally not escaped here (Semrush filter escaping semantics are unverified); the downstream directory-boundary filter refines this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
