### PR TITLE
feat(data-access): paginated sites query filtered by entitlement tier/productCode

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/site/site.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/site/site.collection.js
@@ -244,7 +244,8 @@ class SiteCollection extends BaseCollection {
    *   applied to the sites table (e.g. baseURL substring / deliveryType / isLive).
    * @param {object} [options.orderBy] - `{ attribute, direction }`; defaults to
    *   `updatedAt` desc. Always followed by an `id` tiebreaker for stable paging.
-   * @param {number} [options.limit] - Max parent rows to return (exact).
+   * @param {number} [options.limit] - Max parent rows to return (exact). A
+   *   non-positive or non-integer value falls back to DEFAULT_PAGE_SIZE.
    * @param {string} [options.cursor] - Base64 offset cursor (see decodeCursor).
    * @param {boolean} [options.returnCursor] - Return `{ data, cursor }` shape.
    * @returns {Promise<Site[] | { data: Site[], cursor: string|null }>}
@@ -307,9 +308,11 @@ class SiteCollection extends BaseCollection {
       query = query.order(idField, { ascending });
     }
 
-    // Honor the exact limit (no cap, no +1) so the api-service N+1 hasMore
-    // detection stays symmetric with Site.all's postgrest path.
-    const effectiveLimit = Number.isInteger(limit) ? limit : DEFAULT_PAGE_SIZE;
+    // Honor the exact (positive) limit (no cap, no +1) so the api-service N+1
+    // hasMore detection stays symmetric with Site.all's postgrest path. A
+    // non-positive or non-integer limit falls back to DEFAULT_PAGE_SIZE so a
+    // caller-supplied 0/negative can't produce an inverted PostgREST range.
+    const effectiveLimit = Number.isInteger(limit) && limit > 0 ? limit : DEFAULT_PAGE_SIZE;
     const offset = decodeCursor(cursor);
     query = query.range(offset, offset + effectiveLimit - 1);
 

--- a/packages/spacecat-shared-data-access/src/models/site/site.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/site/site.collection.js
@@ -14,6 +14,13 @@ import { hasText, isValidHelixPreviewUrl, isValidUrl } from '@adobe/spacecat-sha
 
 import DataAccessError from '../../errors/data-access.error.js';
 import BaseCollection from '../base/base.collection.js';
+import {
+  applyWhere,
+  decodeCursor,
+  DEFAULT_PAGE_SIZE,
+  encodeCursor,
+  toDbField,
+} from '../../util/postgrest.utils.js';
 
 import Site, { AEM_CS_HOST, getAuthoringType } from './site.model.js';
 
@@ -204,6 +211,118 @@ class SiteCollection extends BaseCollection {
       options,
     );
     return sites;
+  }
+
+  /**
+   * Returns sites filtered by entitlement tier and/or product code, paginated,
+   * and composable with a caller-supplied `where` and `orderBy` — all in a
+   * SINGLE PostgREST query via a two-level inner-join embed
+   * (sites -> site_enrollments -> entitlements).
+   *
+   * PostgREST resource embedding NESTS matching children under each parent row
+   * (it does not flatten into a cartesian product), so `.range()` offset
+   * pagination stays correct over DISTINCT parent sites even when a site has
+   * multiple matching enrollments. `!inner` at both embed levels turns the
+   * embedded filter into an INNER JOIN, excluding sites with no matching
+   * enrollment/entitlement (a plain embedded filter is a LEFT JOIN on older
+   * PostgREST servers, which would return non-matching sites with an empty
+   * embed instead of dropping them).
+   *
+   * Kept symmetric with `Site.all(..., { returnCursor: true, limit })`: it
+   * honors the EXACT `limit` passed (no silent cap, no +1) because the
+   * api-service caller does N+1 hasMore detection (passes `limit =
+   * effectiveLimit + 1` and slices), and returns `{ data, cursor }` when
+   * `returnCursor` is set, else a bare array. This lets the controller call it
+   * almost identically to `Site.all`.
+   *
+   * @param {object} [filter]
+   * @param {string} [filter.tier] - Entitlement tier (e.g. 'PAID', 'FREE_TRIAL').
+   * @param {string} [filter.productCode] - Entitlement product code (e.g. 'LLMO').
+   *   At least one of `tier` / `productCode` is required.
+   * @param {object} [options]
+   * @param {Function} [options.where] - Caller `where` fn `(attrs, op) => expr`
+   *   applied to the sites table (e.g. baseURL substring / deliveryType / isLive).
+   * @param {object} [options.orderBy] - `{ attribute, direction }`; defaults to
+   *   `updatedAt` desc. Always followed by an `id` tiebreaker for stable paging.
+   * @param {number} [options.limit] - Max parent rows to return (exact).
+   * @param {string} [options.cursor] - Base64 offset cursor (see decodeCursor).
+   * @param {boolean} [options.returnCursor] - Return `{ data, cursor }` shape.
+   * @returns {Promise<Site[] | { data: Site[], cursor: string|null }>}
+   */
+  async allByEnrollmentFiltered(
+    { tier, productCode } = {},
+    {
+      where, orderBy, limit, cursor, returnCursor,
+    } = {},
+  ) {
+    if (!hasText(tier) && !hasText(productCode)) {
+      throw new DataAccessError('tier or productCode is required', this);
+    }
+
+    // The embed must be selected for PostgREST to filter on it. The nested
+    // array PostgREST returns per site is stripped below before hydrating the
+    // Site model (the Site model has no such attribute).
+    const select = '*, site_enrollments!inner(entitlements!inner(tier, product_code))';
+
+    let query = this.postgrestService
+      .from(this.tableName)
+      .select(select);
+
+    if (hasText(tier)) {
+      query = query.eq('site_enrollments.entitlements.tier', tier);
+    }
+    if (hasText(productCode)) {
+      query = query.eq('site_enrollments.entitlements.product_code', productCode);
+    }
+
+    // Caller-supplied where composes on the sites table
+    // (base_url / delivery_type / is_live).
+    query = applyWhere(query, where, this.fieldMaps.toDbMap);
+
+    // Ordering mirrors base.collection #queryPage: a primary sort (default
+    // updatedAt desc) plus a stable id tiebreaker so page boundaries never
+    // straddle equal sort keys.
+    const hasOrderBy = hasText(orderBy?.attribute);
+    const orderField = hasOrderBy
+      ? toDbField(orderBy.attribute, this.fieldMaps.toDbMap)
+      : 'updated_at';
+    const ascending = hasOrderBy
+      ? String(orderBy.direction).toLowerCase() !== 'desc'
+      : false;
+    query = query.order(orderField, { ascending });
+    const idField = this.fieldMaps.toDbMap[this.idName];
+    if (idField !== orderField) {
+      query = query.order(idField, { ascending });
+    }
+
+    // Honor the exact limit (no cap, no +1) so the api-service N+1 hasMore
+    // detection stays symmetric with Site.all's postgrest path.
+    const effectiveLimit = Number.isInteger(limit) ? limit : DEFAULT_PAGE_SIZE;
+    const offset = decodeCursor(cursor);
+    query = query.range(offset, offset + effectiveLimit - 1);
+
+    const { data, error } = await query;
+    if (error) {
+      this.log.error(`[SiteCollection] Failed to query sites by enrollment filter - ${error.message}`, error);
+      throw new DataAccessError('Failed to query sites by enrollment filter', this, error);
+    }
+
+    const instances = (data || []).map((row) => {
+      // Drop the embed PostgREST nests on each parent row so it cannot leak
+      // onto the hydrated Site record.
+      const siteRow = { ...row };
+      delete siteRow.site_enrollments;
+      return this.createInstanceFromRow(siteRow);
+    });
+
+    if (returnCursor) {
+      const nextCursor = instances.length === effectiveLimit
+        ? encodeCursor(offset + effectiveLimit)
+        : null;
+      return { data: instances, cursor: nextCursor };
+    }
+
+    return instances;
   }
 
   async allByOrganizationIdAndProjectName(organizationId, projectName) {

--- a/packages/spacecat-shared-data-access/src/models/site/site.collection.js
+++ b/packages/spacecat-shared-data-access/src/models/site/site.collection.js
@@ -281,14 +281,26 @@ class SiteCollection extends BaseCollection {
 
     // Ordering mirrors base.collection #queryPage: a primary sort (default
     // updatedAt desc) plus a stable id tiebreaker so page boundaries never
-    // straddle equal sort keys.
+    // straddle equal sort keys. An explicit orderBy is validated the same way
+    // Site.all does — a clear error beats an opaque PostgREST 400 (unknown
+    // column) or a silently-wrong sort direction.
     const hasOrderBy = hasText(orderBy?.attribute);
-    const orderField = hasOrderBy
-      ? toDbField(orderBy.attribute, this.fieldMaps.toDbMap)
-      : 'updated_at';
-    const ascending = hasOrderBy
-      ? String(orderBy.direction).toLowerCase() !== 'desc'
-      : false;
+    let orderField = 'updated_at';
+    let ascending = false;
+    if (hasOrderBy) {
+      const { toDbMap } = this.fieldMaps;
+      if (!Object.prototype.hasOwnProperty.call(toDbMap, orderBy.attribute)) {
+        throw new DataAccessError(`unknown orderBy attribute: ${orderBy.attribute}`, this);
+      }
+      const direction = orderBy.direction === undefined
+        ? 'asc'
+        : String(orderBy.direction).toLowerCase();
+      if (direction !== 'asc' && direction !== 'desc') {
+        throw new DataAccessError(`invalid orderBy direction: ${orderBy.direction}`, this);
+      }
+      orderField = toDbField(orderBy.attribute, toDbMap);
+      ascending = direction === 'asc';
+    }
     query = query.order(orderField, { ascending });
     const idField = this.fieldMaps.toDbMap[this.idName];
     if (idField !== orderField) {

--- a/packages/spacecat-shared-data-access/test/it/site/site.test.js
+++ b/packages/spacecat-shared-data-access/test/it/site/site.test.js
@@ -627,6 +627,130 @@ describe('Site IT', async () => {
     });
   });
 
+  describe('allByEnrollmentFiltered', () => {
+    // Seeded enrollment graph (see fixtures):
+    //   78fec9c7 -> ASO/PAID        56a691db -> LLMO/PAID
+    //   5d6d4439 -> LLMO/FREE_TRIAL
+    const PAID_SITE_ASO = '78fec9c7-2141-4600-b7b1-ea5c78752b91';
+    const PAID_SITE_LLMO = '56a691db-d32e-4308-ac99-a21de0580557';
+    const FREE_TRIAL_SITE_LLMO = '5d6d4439-6659-46c2-b646-92d110fa5a52';
+    const PAID_LLMO_ENTITLEMENT = '5bc610a9-bc59-48d8-937e-4808ade2ecb1';
+
+    it('returns only sites enrolled at the given tier as hydrated Site instances', async () => {
+      const sites = await Site.allByEnrollmentFiltered({ tier: 'PAID' }, { limit: 50 });
+
+      expect(sites).to.be.an('array');
+      const ids = sites.map((s) => s.getId()).sort();
+      expect(ids).to.eql([PAID_SITE_LLMO, PAID_SITE_ASO]);
+
+      // real Site instances, with the inner-join embed stripped from the record
+      expect(sites[0].getBaseURL()).to.be.a('string');
+      expect(sites[0].record.siteEnrollments).to.be.undefined;
+      expect(sites[0].record.site_enrollments).to.be.undefined;
+    });
+
+    it('narrows the tier result by product code', async () => {
+      const sites = await Site.allByEnrollmentFiltered(
+        { tier: 'PAID', productCode: 'LLMO' },
+        { limit: 50 },
+      );
+
+      expect(sites.map((s) => s.getId())).to.eql([PAID_SITE_LLMO]);
+    });
+
+    it('filters by product code alone (across tiers)', async () => {
+      const sites = await Site.allByEnrollmentFiltered({ productCode: 'LLMO' }, { limit: 50 });
+
+      const ids = sites.map((s) => s.getId()).sort();
+      expect(ids).to.eql([PAID_SITE_LLMO, FREE_TRIAL_SITE_LLMO]);
+    });
+
+    it('composes a caller-supplied where on the sites table', async () => {
+      const [site] = await Site.allByEnrollmentFiltered(
+        { tier: 'PAID', productCode: 'LLMO' },
+        { limit: 1 },
+      );
+      const { hostname } = new URL(site.getBaseURL());
+
+      const matched = await Site.allByEnrollmentFiltered(
+        { tier: 'PAID', productCode: 'LLMO' },
+        { where: (attrs, op) => op.ilike(attrs.baseURL, `%${hostname}%`), limit: 50 },
+      );
+      expect(matched.map((s) => s.getId())).to.eql([PAID_SITE_LLMO]);
+
+      const none = await Site.allByEnrollmentFiltered(
+        { tier: 'PAID', productCode: 'LLMO' },
+        { where: (attrs, op) => op.ilike(attrs.baseURL, '%no-such-host-zzzzz%'), limit: 50 },
+      );
+      expect(none).to.eql([]);
+    });
+
+    it('paginates DISTINCT parent sites via the offset cursor (returnCursor)', async () => {
+      const orderBy = { attribute: 'siteId', direction: 'asc' };
+
+      const page1 = await Site.allByEnrollmentFiltered(
+        { tier: 'PAID' },
+        { orderBy, limit: 1, returnCursor: true },
+      );
+      expect(page1.data).to.have.lengthOf(1);
+      expect(page1.cursor).to.be.a('string');
+
+      const page2 = await Site.allByEnrollmentFiltered(
+        { tier: 'PAID' },
+        {
+          orderBy, limit: 1, cursor: page1.cursor, returnCursor: true,
+        },
+      );
+      expect(page2.data).to.have.lengthOf(1);
+
+      const page3 = await Site.allByEnrollmentFiltered(
+        { tier: 'PAID' },
+        {
+          orderBy, limit: 1, cursor: page2.cursor, returnCursor: true,
+        },
+      );
+      expect(page3.data).to.have.lengthOf(0);
+      expect(page3.cursor).to.be.null;
+
+      const seen = [page1.data[0].getId(), page2.data[0].getId()];
+      expect(new Set(seen).size).to.equal(2); // no parent-row duplication
+      expect([...seen].sort()).to.eql([PAID_SITE_LLMO, PAID_SITE_ASO]);
+    });
+
+    it('returns a parent site exactly once even with multiple matching enrollments', async () => {
+      const { SiteEnrollment } = getDataAccess();
+      // Give the ASO/PAID site a SECOND enrollment that is also tier=PAID so it
+      // has two rows matching the inner-join filter. PostgREST must nest both
+      // under one parent site row, not duplicate the site.
+      const extraEnrollment = await SiteEnrollment.create({
+        siteId: PAID_SITE_ASO,
+        entitlementId: PAID_LLMO_ENTITLEMENT,
+        updatedBy: 'system',
+      });
+
+      try {
+        const sites = await Site.allByEnrollmentFiltered({ tier: 'PAID' }, { limit: 50 });
+        const ids = sites.map((s) => s.getId());
+
+        expect(ids.filter((id) => id === PAID_SITE_ASO)).to.have.lengthOf(1);
+        expect([...ids].sort()).to.eql([PAID_SITE_LLMO, PAID_SITE_ASO]);
+      } finally {
+        await extraEnrollment.remove();
+      }
+    });
+
+    it('returns an empty array when the tier has no enrollments', async () => {
+      const sites = await Site.allByEnrollmentFiltered({ tier: 'PLG' }, { limit: 50 });
+
+      expect(sites).to.eql([]);
+    });
+
+    it('throws when neither tier nor productCode is supplied', async () => {
+      await expect(Site.allByEnrollmentFiltered({}))
+        .to.be.rejectedWith('tier or productCode is required');
+    });
+  });
+
   it('removes a site', async () => {
     const site = await Site.findById(sampleData.sites[0].getId());
 

--- a/packages/spacecat-shared-data-access/test/unit/models/site/site.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/site.collection.test.js
@@ -706,6 +706,16 @@ describe('SiteCollection', () => {
       expect(chain.range).to.have.been.calledOnceWithExactly(0, DEFAULT_PAGE_SIZE - 1);
     });
 
+    it('treats a zero or negative limit as no limit (DEFAULT_PAGE_SIZE)', async () => {
+      setupChain({ data: [], error: null });
+      await instance.allByEnrollmentFiltered({ tier: 'PAID' }, { limit: 0 });
+      expect(chain.range).to.have.been.calledOnceWithExactly(0, DEFAULT_PAGE_SIZE - 1);
+
+      setupChain({ data: [], error: null });
+      await instance.allByEnrollmentFiltered({ tier: 'PAID' }, { limit: -5 });
+      expect(chain.range).to.have.been.calledOnceWithExactly(0, DEFAULT_PAGE_SIZE - 1);
+    });
+
     it('maps rows to Site instances and strips the embedded enrollments from the record', async () => {
       setupChain({ data: [siteRow('s1'), siteRow('s2')], error: null });
 

--- a/packages/spacecat-shared-data-access/test/unit/models/site/site.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/site.collection.test.js
@@ -12,10 +12,12 @@
 
 import { expect, use as chaiUse } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { stub } from 'sinon';
+import sinon, { stub } from 'sinon';
 import sinonChai from 'sinon-chai';
 
+import DataAccessError from '../../../../src/errors/data-access.error.js';
 import Site from '../../../../src/models/site/site.model.js';
+import { encodeCursor, DEFAULT_PAGE_SIZE } from '../../../../src/util/postgrest.utils.js';
 
 import { createElectroMocks } from '../../util.js';
 
@@ -522,6 +524,235 @@ describe('SiteCollection', () => {
         [{ siteId: 'cfa88998-a0a0-4136-b21d-0ff2aa127443' }],
         options,
       );
+    });
+  });
+
+  describe('allByEnrollmentFiltered', () => {
+    const SELECT_WITH_EMBED = '*, site_enrollments!inner(entitlements!inner(tier, product_code))';
+    const TIER_PATH = 'site_enrollments.entitlements.tier';
+    const PRODUCT_CODE_PATH = 'site_enrollments.entitlements.product_code';
+
+    let chain;
+    let fromStub;
+
+    // Builds a chainable PostgREST query-builder mock where every builder method
+    // returns the same chain object, and the terminal `.range(...)` resolves to
+    // the awaited `{ data, error }` result (mirrors supabase/postgrest-js).
+    function setupChain(result) {
+      chain = {};
+      [
+        'select', 'eq', 'neq', 'gt', 'gte', 'lt', 'lte',
+        'in', 'is', 'like', 'ilike', 'contains', 'order',
+      ].forEach((method) => {
+        chain[method] = sinon.stub().returns(chain);
+      });
+      chain.range = sinon.stub().resolves(result);
+      fromStub = sinon.stub().returns(chain);
+      instance.postgrestService.from = fromStub;
+      return { chain, fromStub };
+    }
+
+    const siteRow = (id, extra = {}) => ({
+      id,
+      base_url: `https://${id}.example.com`,
+      delivery_type: 'aem_edge',
+      is_live: true,
+      // embedded rows PostgREST returns for the inner-join filter
+      site_enrollments: [{ entitlements: { tier: 'PAID', product_code: 'ASO' } }],
+      ...extra,
+    });
+
+    it('throws DataAccessError when neither tier nor productCode is supplied', async () => {
+      await expect(instance.allByEnrollmentFiltered())
+        .to.be.rejectedWith(DataAccessError, 'tier or productCode is required');
+      await expect(instance.allByEnrollmentFiltered({}))
+        .to.be.rejectedWith(DataAccessError, 'tier or productCode is required');
+      await expect(instance.allByEnrollmentFiltered({ tier: '', productCode: '' }))
+        .to.be.rejectedWith(DataAccessError, 'tier or productCode is required');
+    });
+
+    it('builds the nested inner-join embed select and tier eq filter', async () => {
+      setupChain({ data: [], error: null });
+
+      await instance.allByEnrollmentFiltered({ tier: 'PAID' }, { limit: 10 });
+
+      expect(fromStub).to.have.been.calledOnceWithExactly('sites');
+      expect(chain.select).to.have.been.calledOnceWithExactly(SELECT_WITH_EMBED);
+      expect(chain.eq).to.have.been.calledOnceWithExactly(TIER_PATH, 'PAID');
+      expect(chain.range).to.have.been.calledOnceWithExactly(0, 9);
+    });
+
+    it('adds the product_code eq filter when productCode is supplied', async () => {
+      setupChain({ data: [], error: null });
+
+      await instance.allByEnrollmentFiltered({ tier: 'PAID', productCode: 'LLMO' }, { limit: 10 });
+
+      expect(chain.eq).to.have.been.calledTwice;
+      expect(chain.eq).to.have.been.calledWithExactly(TIER_PATH, 'PAID');
+      expect(chain.eq).to.have.been.calledWithExactly(PRODUCT_CODE_PATH, 'LLMO');
+    });
+
+    it('supports filtering by productCode alone (no tier)', async () => {
+      setupChain({ data: [], error: null });
+
+      await instance.allByEnrollmentFiltered({ productCode: 'LLMO' }, { limit: 10 });
+
+      expect(chain.eq).to.have.been.calledOnceWithExactly(PRODUCT_CODE_PATH, 'LLMO');
+    });
+
+    it('applies a caller-supplied where (ilike on baseURL → base_url) on top of the tier filter', async () => {
+      setupChain({ data: [], error: null });
+
+      await instance.allByEnrollmentFiltered(
+        { tier: 'PAID' },
+        { where: (attrs, op) => op.ilike(attrs.baseURL, '%acme%'), limit: 5 },
+      );
+
+      expect(chain.eq).to.have.been.calledOnceWithExactly(TIER_PATH, 'PAID');
+      expect(chain.ilike).to.have.been.calledOnceWithExactly('base_url', '%acme%');
+    });
+
+    it('defaults to updated_at desc ordering with an id tiebreaker', async () => {
+      setupChain({ data: [], error: null });
+
+      await instance.allByEnrollmentFiltered({ tier: 'PAID' }, { limit: 10 });
+
+      expect(chain.order).to.have.been.calledTwice;
+      expect(chain.order.firstCall).to.have.been.calledWithExactly('updated_at', { ascending: false });
+      expect(chain.order.secondCall).to.have.been.calledWithExactly('id', { ascending: false });
+    });
+
+    it('applies orderBy (mapped to db column) with an id tiebreaker and decodes the cursor offset', async () => {
+      setupChain({ data: [], error: null });
+
+      await instance.allByEnrollmentFiltered(
+        { tier: 'PAID' },
+        { orderBy: { attribute: 'baseURL', direction: 'asc' }, limit: 10, cursor: encodeCursor(20) },
+      );
+
+      expect(chain.order.firstCall).to.have.been.calledWithExactly('base_url', { ascending: true });
+      expect(chain.order.secondCall).to.have.been.calledWithExactly('id', { ascending: true });
+      expect(chain.range).to.have.been.calledOnceWithExactly(20, 29);
+    });
+
+    it('omits the id tiebreaker when ordering by the id field itself', async () => {
+      setupChain({ data: [], error: null });
+
+      await instance.allByEnrollmentFiltered(
+        { tier: 'PAID' },
+        { orderBy: { attribute: 'siteId', direction: 'asc' }, limit: 10 },
+      );
+
+      expect(chain.order).to.have.been.calledOnceWithExactly('id', { ascending: true });
+    });
+
+    it('orders descending when orderBy.direction is desc', async () => {
+      setupChain({ data: [], error: null });
+
+      await instance.allByEnrollmentFiltered(
+        { tier: 'PAID' },
+        { orderBy: { attribute: 'baseURL', direction: 'desc' }, limit: 10 },
+      );
+
+      expect(chain.order.firstCall).to.have.been.calledWithExactly('base_url', { ascending: false });
+      expect(chain.order.secondCall).to.have.been.calledWithExactly('id', { ascending: false });
+    });
+
+    it('honors the exact limit passed (no silent cap or +1) via range', async () => {
+      setupChain({ data: [], error: null });
+
+      await instance.allByEnrollmentFiltered({ tier: 'PAID' }, { limit: 51, cursor: encodeCursor(50) });
+
+      expect(chain.range).to.have.been.calledOnceWithExactly(50, 100);
+    });
+
+    it('defaults limit to DEFAULT_PAGE_SIZE when none is supplied', async () => {
+      setupChain({ data: [], error: null });
+
+      await instance.allByEnrollmentFiltered({ tier: 'PAID' });
+
+      expect(chain.range).to.have.been.calledOnceWithExactly(0, DEFAULT_PAGE_SIZE - 1);
+    });
+
+    it('maps rows to Site instances and strips the embedded enrollments from the record', async () => {
+      setupChain({ data: [siteRow('s1'), siteRow('s2')], error: null });
+
+      const result = await instance.allByEnrollmentFiltered({ tier: 'PAID' }, { limit: 10 });
+
+      expect(result).to.be.an('array').with.lengthOf(2);
+      expect(result[0].getId()).to.equal('s1');
+      expect(result[1].getId()).to.equal('s2');
+      // the embed leaked by PostgREST must not survive onto the model record
+      expect(result[0].record.siteEnrollments).to.be.undefined;
+      expect(result[0].record.site_enrollments).to.be.undefined;
+    });
+
+    it('returns { data, cursor } with a next cursor when a full page is returned (returnCursor)', async () => {
+      setupChain({ data: [siteRow('s1'), siteRow('s2')], error: null });
+
+      const result = await instance.allByEnrollmentFiltered(
+        { tier: 'PAID' },
+        { limit: 2, returnCursor: true },
+      );
+
+      expect(result).to.be.an('object');
+      expect(result.data.map((s) => s.getId())).to.deep.equal(['s1', 's2']);
+      expect(result.cursor).to.equal(encodeCursor(2));
+    });
+
+    it('returns a null cursor when a partial page is returned (returnCursor)', async () => {
+      setupChain({ data: [siteRow('s1')], error: null });
+
+      const result = await instance.allByEnrollmentFiltered(
+        { tier: 'PAID' },
+        { limit: 2, returnCursor: true },
+      );
+
+      expect(result.data).to.have.lengthOf(1);
+      expect(result.cursor).to.be.null;
+    });
+
+    it('carries the decoded offset into the next cursor (returnCursor)', async () => {
+      setupChain({ data: [siteRow('s1'), siteRow('s2')], error: null });
+
+      const result = await instance.allByEnrollmentFiltered(
+        { tier: 'PAID' },
+        { limit: 2, cursor: encodeCursor(4), returnCursor: true },
+      );
+
+      expect(result.cursor).to.equal(encodeCursor(6));
+    });
+
+    it('returns a bare array (not a cursor envelope) when returnCursor is falsy', async () => {
+      setupChain({ data: [siteRow('s1')], error: null });
+
+      const result = await instance.allByEnrollmentFiltered({ tier: 'PAID' }, { limit: 10 });
+
+      expect(result).to.be.an('array').with.lengthOf(1);
+    });
+
+    it('returns an empty array when no rows match', async () => {
+      setupChain({ data: [], error: null });
+
+      const result = await instance.allByEnrollmentFiltered({ tier: 'PLG' }, { limit: 10 });
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('treats a null data payload as an empty result set', async () => {
+      setupChain({ data: null, error: null });
+
+      const result = await instance.allByEnrollmentFiltered({ tier: 'PAID' }, { limit: 10 });
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('throws DataAccessError and logs on a PostgREST error', async () => {
+      setupChain({ data: null, error: { message: 'boom' } });
+
+      await expect(instance.allByEnrollmentFiltered({ tier: 'PAID' }, { limit: 10 }))
+        .to.be.rejectedWith(DataAccessError, 'Failed to query sites by enrollment filter');
+      expect(mockLogger.error).to.have.been.called;
     });
   });
 });

--- a/packages/spacecat-shared-data-access/test/unit/models/site/site.collection.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/site/site.collection.test.js
@@ -658,6 +658,38 @@ describe('SiteCollection', () => {
       expect(chain.order.secondCall).to.have.been.calledWithExactly('id', { ascending: false });
     });
 
+    it('defaults an explicit orderBy without a direction to ascending', async () => {
+      setupChain({ data: [], error: null });
+
+      await instance.allByEnrollmentFiltered(
+        { tier: 'PAID' },
+        { orderBy: { attribute: 'baseURL' }, limit: 10 },
+      );
+
+      expect(chain.order.firstCall).to.have.been.calledWithExactly('base_url', { ascending: true });
+      expect(chain.order.secondCall).to.have.been.calledWithExactly('id', { ascending: true });
+    });
+
+    it('throws DataAccessError on an unknown orderBy attribute', async () => {
+      setupChain({ data: [], error: null });
+
+      await expect(instance.allByEnrollmentFiltered(
+        { tier: 'PAID' },
+        { orderBy: { attribute: 'notAColumn' }, limit: 10 },
+      )).to.be.rejectedWith(DataAccessError, 'unknown orderBy attribute: notAColumn');
+      expect(chain.order).to.not.have.been.called;
+    });
+
+    it('throws DataAccessError on an invalid orderBy direction', async () => {
+      setupChain({ data: [], error: null });
+
+      await expect(instance.allByEnrollmentFiltered(
+        { tier: 'PAID' },
+        { orderBy: { attribute: 'baseURL', direction: 'sideways' }, limit: 10 },
+      )).to.be.rejectedWith(DataAccessError, 'invalid orderBy direction: sideways');
+      expect(chain.order).to.not.have.been.called;
+    });
+
     it('honors the exact limit passed (no silent cap or +1) via range', async () => {
       setupChain({ data: [], error: null });
 


### PR DESCRIPTION

  ## Summary

  Adds `SiteCollection.allByEnrollmentFiltered(...)` — a single-query, paginated
  way to fetch sites filtered by entitlement **tier** and/or **product code**,
  composable with a caller-supplied `where` and `orderBy`. Intended for the
  api-service sites listing that needs tier/product filtering with stable
  pagination.

  ## What's new
  
  `allByEnrollmentFiltered({ tier, productCode }, { where, orderBy, limit, cursor, returnCursor })` on `SiteCollection`:

  - Filters via a two-level inner-join embed (`sites -> site_enrollments -> entitlements`) in a **single PostgREST query** — no N+1 / batch-fetch round-trips.
  - Requires at least one of `tier` / `productCode` (throws `DataAccessError` otherwise).
  - Returns hydrated `Site` instances; the embedded enrollments array is stripped before hydration so it can't leak onto the record.
  - Offset-cursor pagination: honors the **exact** `limit` (no silent cap, no +1) and returns `{ data, cursor }` when `returnCursor` is set, else a bare array — kept symmetric with `Site.all`.
  - Default sort `updatedAt desc` plus an `id` tiebreaker for stable page boundaries; validates `orderBy` (unknown attribute / invalid direction throw a clear `DataAccessError`), matching `Site.all` / base `#queryPage`.

  ## Why embedding (not a flat join)

  PostgREST resource embedding nests matching children under each parent row
  instead of flattening into a cartesian product, so `.range()` offset pagination
  stays correct over DISTINCT parent sites even when a site has multiple matching
  enrollments. `!inner` at both embed levels turns the embedded filters into INNER
  JOINs, excluding sites with no matching enrollment/entitlement.

  ## Testing
  
  - **22 unit tests** (stubbed PostgREST chain): tier/product filters, `where` composition, ordering + id tiebreaker, cursor/limit math, hydration + embed-stripping, error handling, and `orderBy` validation.
  - **8 integration tests** against seeded fixtures: tier / product / combined filtering, `where` composition, distinct-parent pagination, dedup across multiple matching enrollments, and the empty + validation cases.
  - `npm run lint` and `npm test` (data-access) green; coverage thresholds met.
