### PR TITLE
feat(tokowaka-client): add setApplyStaleForSuggestions to toggle applyStale without redeploy

### DIFF
--- a/packages/spacecat-shared-tokowaka-client/src/index.js
+++ b/packages/spacecat-shared-tokowaka-client/src/index.js
@@ -774,6 +774,7 @@ class TokowakaClient {
       return {
         succeededSuggestions: [],
         failedSuggestions: ineligibleSuggestions,
+        suggestionIdsHavingPatches: new Set(),
       };
     }
 
@@ -829,8 +830,9 @@ class TokowakaClient {
 
         // Upload to S3
         const s3Path = await this.uploadConfig(fullUrl, config);
-        // eslint-disable-next-line max-len
-        const suggestionIdsFromNewPatches = newConfig.patches.map((patch) => patch.suggestionId).filter(Boolean);
+        const suggestionIdsFromNewPatches = newConfig.patches
+          .map((patch) => patch.suggestionId)
+          .filter(Boolean);
         return { s3Path, fullUrl, suggestionIdsFromNewPatches };
       },
       URL_CONFIG_CONCURRENCY,
@@ -1518,9 +1520,14 @@ class TokowakaClient {
         const updated = { ...currentData, edgeDeployed: deploymentTimestamp };
         // Only mirror applyStale for suggestions that actually produced a patch — e.g.
         // prerender-only suggestions deploy successfully but never generate one, so there
-        // is nothing for applyStale to keep alive.
+        // is nothing for applyStale to keep alive. Matches the edgeDeployed contract
+        // (present-when-true, absent otherwise) instead of ever writing an explicit false.
         if (suggestionIdsHavingPatches.has(s.getId())) {
-          updated.applyStale = applyStale;
+          if (applyStale) {
+            updated.applyStale = true;
+          } else {
+            delete updated.applyStale;
+          }
         }
         const statusesToExcludeFromOptimization = ['STALE', 'LAST_MOD_MISSING'];
         if (statusesToExcludeFromOptimization.includes(updated.edgeOptimizeStatus)) {

--- a/packages/spacecat-shared-tokowaka-client/src/index.js
+++ b/packages/spacecat-shared-tokowaka-client/src/index.js
@@ -741,7 +741,9 @@ class TokowakaClient {
    * @param {Object} site - Site entity
    * @param {Object} opportunity - Opportunity entity
    * @param {Array} suggestions - Array of suggestion entities to deploy
-   * @returns {Promise<Object>} - Deployment result with succeeded/failed suggestions
+   * @returns {Promise<Object>} - Deployment result with succeeded/failed suggestions, plus
+   *   suggestionIdsHavingPatches: a Set of suggestion IDs for which a patch was actually generated
+   *   (excludes e.g. prerender-only suggestions, which deploy successfully with no patch).
    */
   async deploySuggestions(site, opportunity, suggestions, metadata = {}) {
     const { applyStale = false } = metadata;
@@ -827,17 +829,24 @@ class TokowakaClient {
 
         // Upload to S3
         const s3Path = await this.uploadConfig(fullUrl, config);
-        return { s3Path, fullUrl };
+        // eslint-disable-next-line max-len
+        const suggestionIdsFromNewPatches = newConfig.patches.map((patch) => patch.suggestionId).filter(Boolean);
+        return { s3Path, fullUrl, suggestionIdsFromNewPatches };
       },
       URL_CONFIG_CONCURRENCY,
     );
 
     const s3Paths = [];
     const deployedUrls = []; // Track URLs for batch CDN invalidation
+    // Suggestions whose deploy actually produced a patch (e.g. excludes prerender-only
+    // suggestions, which deploy successfully but never generate a patch) — used to scope
+    // the applyStale suggestion.data mirror to suggestions that have a patch to keep alive.
+    const suggestionIdsHavingPatches = new Set();
     processed.forEach((entry) => {
       if (entry) {
         s3Paths.push(entry.s3Path);
         deployedUrls.push(entry.fullUrl);
+        entry.suggestionIdsFromNewPatches.forEach((id) => suggestionIdsHavingPatches.add(id));
       }
     });
 
@@ -855,6 +864,7 @@ class TokowakaClient {
       cdnInvalidations,
       succeededSuggestions: eligibleSuggestions,
       failedSuggestions: ineligibleSuggestions,
+      suggestionIdsHavingPatches,
     };
   }
 
@@ -1479,8 +1489,13 @@ class TokowakaClient {
   }
 
   /**
-   * Deploys per-URL suggestions via deploySuggestions(), stamps them with edgeDeployed,
-   * and returns { succeededSuggestions, failedSuggestions }.
+   * Deploys per-URL suggestions via deploySuggestions(), stamps them with edgeDeployed and
+   * mirrors metadata.applyStale onto suggestion.data (display-only; the functional flag lives
+   * on the S3 patch itself, set inside deploySuggestions). The applyStale mirror is scoped to
+   * suggestions in deploySuggestions()'s suggestionIdsHavingPatches — suggestions that deploy
+   * successfully without producing a patch (e.g. prerender-only) are left without the field,
+   * since there is no patch for applyStale to keep alive. Returns
+   * { succeededSuggestions, failedSuggestions }.
    * Throws if the underlying deployment throws.
    * @param {Object} site
    * @param {Object} opportunity
@@ -1495,10 +1510,18 @@ class TokowakaClient {
       // eslint-disable-next-line max-len
       const result = await this.deploySuggestions(site, opportunity, validSuggestions, metadata);
       const deploymentTimestamp = Date.now();
+      const { applyStale = false } = metadata;
+      const suggestionIdsHavingPatches = result.suggestionIdsHavingPatches ?? new Set();
 
       const succeeded = result.succeededSuggestions.map((s) => {
         const currentData = s.getData();
         const updated = { ...currentData, edgeDeployed: deploymentTimestamp };
+        // Only mirror applyStale for suggestions that actually produced a patch — e.g.
+        // prerender-only suggestions deploy successfully but never generate one, so there
+        // is nothing for applyStale to keep alive.
+        if (suggestionIdsHavingPatches.has(s.getId())) {
+          updated.applyStale = applyStale;
+        }
         const statusesToExcludeFromOptimization = ['STALE', 'LAST_MOD_MISSING'];
         if (statusesToExcludeFromOptimization.includes(updated.edgeOptimizeStatus)) {
           delete updated.edgeOptimizeStatus;

--- a/packages/spacecat-shared-tokowaka-client/src/index.js
+++ b/packages/spacecat-shared-tokowaka-client/src/index.js
@@ -1902,6 +1902,138 @@ class TokowakaClient {
       }
     }
   }
+
+  /**
+   * Sets or clears the `applyStale` flag for already-deployed per-URL suggestions, both on the
+   * S3 patch (functional source of truth) and mirrored onto suggestion.data (display-only) —
+   * without redeploying. Pattern / domain-wide suggestions and suggestions with no matching S3
+   * patch are ineligible and returned in failedSuggestions. CDN cache is invalidated for every
+   * URL whose config was actually modified.
+   *
+   * @param {Object} site - Site entity
+   * @param {Object} opportunity - Opportunity entity
+   * @param {Array} suggestions - Suggestion entities to update (expected to already be
+   *   filtered to deployed suggestions by the caller)
+   * @param {Object} options
+   * @param {boolean} options.applyStale - true to set applyStale, false to clear it
+   * @param {string} [options.updatedBy]
+   * @returns {Promise<{ succeededSuggestions: Array, failedSuggestions: Array }>}
+   */
+  async setApplyStaleForSuggestions(
+    site,
+    opportunity,
+    suggestions,
+    { applyStale, updatedBy } = {},
+  ) {
+    const baseURL = getEffectiveBaseURL(site);
+
+    const perUrlSuggestions = suggestions.filter((s) => {
+      const data = s.getData();
+      return data?.url && !Array.isArray(data?.allowedRegexPatterns);
+    });
+
+    const failedSuggestions = suggestions
+      .filter((s) => !perUrlSuggestions.includes(s))
+      .map((s) => ({
+        suggestion: s,
+        reason: 'Only per-URL suggestions support applyStale',
+        statusCode: 400,
+      }));
+
+    if (perUrlSuggestions.length === 0) {
+      return { succeededSuggestions: [], failedSuggestions };
+    }
+
+    const suggestionsByUrl = groupSuggestionsByUrlPath(perUrlSuggestions, baseURL, this.log);
+    const updatedUrls = [];
+    const succeededIds = new Set();
+
+    for (const [urlPath, urlSuggestions] of Object.entries(suggestionsByUrl)) {
+      const fullUrl = new URL(urlPath, baseURL).toString();
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const existingConfig = await this.fetchConfig(fullUrl);
+        const patches = existingConfig?.patches ?? [];
+        let modified = false;
+
+        const updatedPatches = patches.map((patch) => {
+          const matchedSuggestion = urlSuggestions.find((s) => s.getId() === patch.suggestionId);
+          if (!matchedSuggestion) {
+            return patch;
+          }
+          succeededIds.add(matchedSuggestion.getId());
+
+          if (applyStale) {
+            if (patch.applyStale === true) {
+              return patch;
+            }
+            modified = true;
+            return { ...patch, applyStale: true };
+          }
+
+          if (!patch.applyStale) {
+            return patch;
+          }
+          modified = true;
+          const { applyStale: _, ...rest } = patch;
+          return rest;
+        });
+
+        urlSuggestions.forEach((s) => {
+          if (!succeededIds.has(s.getId())) {
+            failedSuggestions.push({
+              suggestion: s,
+              reason: 'No patch found for suggestion',
+              statusCode: 400,
+            });
+          }
+        });
+
+        if (modified) {
+          // eslint-disable-next-line no-await-in-loop
+          await this.uploadConfig(fullUrl, { ...existingConfig, patches: updatedPatches });
+          updatedUrls.push(fullUrl);
+        }
+      } catch (err) {
+        this.log.error(`[apply-stale-failed] Failed to process URL ${fullUrl}: ${err.message}`, err);
+        urlSuggestions.forEach((s) => {
+          if (!succeededIds.has(s.getId())) {
+            failedSuggestions.push({ suggestion: s, reason: 'Internal server error', statusCode: 500 });
+          }
+        });
+      }
+    }
+
+    const succeededSuggestions = perUrlSuggestions
+      .filter((s) => succeededIds.has(s.getId()))
+      .map((s) => {
+        const currentData = s.getData();
+        const updated = { ...currentData };
+        if (applyStale) {
+          updated.applyStale = true;
+        } else {
+          delete updated.applyStale;
+        }
+        s.setData(updated);
+        s.setUpdatedBy(updatedBy);
+        return s;
+      });
+
+    if (succeededSuggestions.length > 0) {
+      await saveSuggestions(this.dataAccess, succeededSuggestions);
+    }
+
+    if (updatedUrls.length > 0) {
+      try {
+        await this.invalidateCdnCache({ urls: updatedUrls });
+        this.log.info(`[apply-stale] Updated applyStale on ${updatedUrls.length} URL(s) and invalidated CDN`);
+      } catch (err) {
+        this.log.warn(`[apply-stale-failed] CDN invalidation failed for ${updatedUrls.length} URL(s), S3 configs already updated: ${err.message}`, err);
+      }
+    }
+
+    return { succeededSuggestions, failedSuggestions };
+  }
 }
 
 // Export the client as default and base classes for custom implementations

--- a/packages/spacecat-shared-tokowaka-client/src/utils/suggestion-utils.js
+++ b/packages/spacecat-shared-tokowaka-client/src/utils/suggestion-utils.js
@@ -197,7 +197,7 @@ export async function saveSuggestions(dataAccess, suggestions, queueContext) {
  * @returns {Object} The mutated suggestion (not yet persisted)
  */
 export function stripSuggestion(suggestion, actorFallback, updatedBy) {
-  suggestion.setData(omitKeys(suggestion.getData(), ['edgeDeployed', 'tokowakaDeployed']));
+  suggestion.setData(omitKeys(suggestion.getData(), ['edgeDeployed', 'tokowakaDeployed', 'applyStale']));
   suggestion.setUpdatedBy(updatedBy ?? actorFallback);
   return suggestion;
 }

--- a/packages/spacecat-shared-tokowaka-client/test/index.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/index.test.js
@@ -7223,4 +7223,246 @@ describe('TokowakaClient', () => {
       expect(urls[0]).to.include('/page2');
     });
   });
+
+  describe('setApplyStaleForSuggestions', () => {
+    let fetchConfigStub;
+    let uploadConfigStub;
+    let invalidateCdnCacheStub;
+    let saveManyStub;
+
+    function makeDeployedSuggestion(id, urlPath) {
+      return {
+        getId: () => id,
+        getData: () => ({ url: `https://example.com${urlPath}`, edgeDeployed: Date.now() }),
+        setData: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+      };
+    }
+
+    beforeEach(() => {
+      fetchConfigStub = sinon.stub(client, 'fetchConfig');
+      uploadConfigStub = sinon.stub(client, 'uploadConfig').resolves('s3-path');
+      invalidateCdnCacheStub = sinon.stub(client, 'invalidateCdnCache').resolves([]);
+      saveManyStub = client.dataAccess.Suggestion.saveMany;
+    });
+
+    it('sets applyStale on the matching patch and mirrors it onto suggestion.data', async () => {
+      fetchConfigStub.resolves({
+        url: 'https://example.com/page1',
+        patches: [{ suggestionId: 'sugg-1', op: 'replace' }],
+      });
+
+      const s1 = makeDeployedSuggestion('sugg-1', '/page1');
+      const result = await client.setApplyStaleForSuggestions(
+        mockSite,
+        mockOpportunity,
+        [s1],
+        { applyStale: true, updatedBy: 'user@example.com' },
+      );
+
+      expect(uploadConfigStub).to.have.been.calledOnce;
+      const [, uploadedConfig] = uploadConfigStub.firstCall.args;
+      expect(uploadedConfig.patches[0].applyStale).to.equal(true);
+      expect(invalidateCdnCacheStub).to.have.been.calledOnce;
+      expect(s1.setData).to.have.been.calledWith(sinon.match({ applyStale: true }));
+      expect(s1.setUpdatedBy).to.have.been.calledWith('user@example.com');
+      expect(saveManyStub).to.have.been.calledOnce;
+      expect(result.succeededSuggestions).to.deep.equal([s1]);
+      expect(result.failedSuggestions).to.have.length(0);
+    });
+
+    it('clears applyStale from the matching patch and removes it from suggestion.data', async () => {
+      fetchConfigStub.resolves({
+        url: 'https://example.com/page1',
+        patches: [{ suggestionId: 'sugg-1', op: 'replace', applyStale: true }],
+      });
+
+      const s1 = makeDeployedSuggestion('sugg-1', '/page1');
+      await client.setApplyStaleForSuggestions(
+        mockSite,
+        mockOpportunity,
+        [s1],
+        { applyStale: false },
+      );
+
+      const [, uploadedConfig] = uploadConfigStub.firstCall.args;
+      expect(uploadedConfig.patches[0]).to.not.have.property('applyStale');
+      expect(s1.setData).to.have.been.calledWith(sinon.match((data) => !('applyStale' in data)));
+    });
+
+    it('skips the S3 upload but still saves the suggestion when the patch already matches', async () => {
+      fetchConfigStub.resolves({
+        url: 'https://example.com/page1',
+        patches: [{ suggestionId: 'sugg-1', op: 'replace', applyStale: true }],
+      });
+
+      const s1 = makeDeployedSuggestion('sugg-1', '/page1');
+      const result = await client.setApplyStaleForSuggestions(
+        mockSite,
+        mockOpportunity,
+        [s1],
+        { applyStale: true },
+      );
+
+      expect(uploadConfigStub).to.not.have.been.called;
+      expect(invalidateCdnCacheStub).to.not.have.been.called;
+      expect(saveManyStub).to.have.been.calledOnce;
+      expect(result.succeededSuggestions).to.deep.equal([s1]);
+    });
+
+    it('skips the S3 upload but still saves the suggestion when clearing an already-unset flag', async () => {
+      fetchConfigStub.resolves({
+        url: 'https://example.com/page1',
+        patches: [{ suggestionId: 'sugg-1', op: 'replace' }],
+      });
+
+      const s1 = makeDeployedSuggestion('sugg-1', '/page1');
+      const result = await client.setApplyStaleForSuggestions(
+        mockSite,
+        mockOpportunity,
+        [s1],
+        { applyStale: false },
+      );
+
+      expect(uploadConfigStub).to.not.have.been.called;
+      expect(invalidateCdnCacheStub).to.not.have.been.called;
+      expect(saveManyStub).to.have.been.calledOnce;
+      expect(result.succeededSuggestions).to.deep.equal([s1]);
+    });
+
+    it('fails the suggestion when the URL has no existing config', async () => {
+      fetchConfigStub.resolves(null);
+
+      const s1 = makeDeployedSuggestion('sugg-1', '/page1');
+      const result = await client.setApplyStaleForSuggestions(
+        mockSite,
+        mockOpportunity,
+        [s1],
+        { applyStale: true },
+      );
+
+      expect(uploadConfigStub).to.not.have.been.called;
+      expect(result.succeededSuggestions).to.have.length(0);
+      expect(result.failedSuggestions).to.deep.equal([
+        { suggestion: s1, reason: 'No patch found for suggestion', statusCode: 400 },
+      ]);
+    });
+
+    it('fails suggestions with no matching patch on their URL', async () => {
+      fetchConfigStub.resolves({
+        url: 'https://example.com/page1',
+        patches: [{ suggestionId: 'other-sugg', op: 'replace' }],
+      });
+
+      const s1 = makeDeployedSuggestion('sugg-1', '/page1');
+      const result = await client.setApplyStaleForSuggestions(
+        mockSite,
+        mockOpportunity,
+        [s1],
+        { applyStale: true },
+      );
+
+      expect(uploadConfigStub).to.not.have.been.called;
+      expect(saveManyStub).to.not.have.been.called;
+      expect(result.succeededSuggestions).to.have.length(0);
+      expect(result.failedSuggestions).to.deep.equal([
+        { suggestion: s1, reason: 'No patch found for suggestion', statusCode: 400 },
+      ]);
+    });
+
+    it('fails pattern/domain-wide suggestions without fetching any config', async () => {
+      const patternSugg = {
+        getId: () => 'dw-1',
+        getData: () => ({ isDomainWide: true, allowedRegexPatterns: ['/.*'] }),
+      };
+
+      const result = await client.setApplyStaleForSuggestions(
+        mockSite,
+        mockOpportunity,
+        [patternSugg],
+        { applyStale: true },
+      );
+
+      expect(fetchConfigStub).to.not.have.been.called;
+      expect(result.succeededSuggestions).to.have.length(0);
+      expect(result.failedSuggestions).to.deep.equal([
+        {
+          suggestion: patternSugg,
+          reason: 'Only per-URL suggestions support applyStale',
+          statusCode: 400,
+        },
+      ]);
+    });
+
+    it('only invalidates CDN for URLs that actually changed', async () => {
+      fetchConfigStub.onFirstCall().resolves({
+        patches: [{ suggestionId: 'sugg-1' }],
+      });
+      fetchConfigStub.onSecondCall().resolves({
+        patches: [{ suggestionId: 'sugg-2', applyStale: true }],
+      });
+
+      const s1 = makeDeployedSuggestion('sugg-1', '/page1');
+      const s2 = makeDeployedSuggestion('sugg-2', '/page2');
+      await client.setApplyStaleForSuggestions(
+        mockSite,
+        mockOpportunity,
+        [s1, s2],
+        { applyStale: true },
+      );
+
+      expect(uploadConfigStub).to.have.been.calledOnce;
+      expect(invalidateCdnCacheStub).to.have.been.calledOnce;
+      const { urls } = invalidateCdnCacheStub.firstCall.args[0];
+      expect(urls).to.have.length(1);
+      expect(urls[0]).to.include('/page1');
+    });
+
+    it('logs and fails remaining suggestions on that URL when fetchConfig throws', async () => {
+      fetchConfigStub.rejects(new Error('S3 transient error'));
+
+      const s1 = makeDeployedSuggestion('sugg-1', '/page1');
+      const result = await client.setApplyStaleForSuggestions(
+        mockSite,
+        mockOpportunity,
+        [s1],
+        { applyStale: true },
+      );
+
+      expect(result.succeededSuggestions).to.have.length(0);
+      expect(result.failedSuggestions).to.deep.equal([
+        { suggestion: s1, reason: 'Internal server error', statusCode: 500 },
+      ]);
+    });
+
+    it('logs a warning and still returns success when CDN invalidation throws', async () => {
+      fetchConfigStub.resolves({
+        patches: [{ suggestionId: 'sugg-1' }],
+      });
+      invalidateCdnCacheStub.rejects(new Error('CDN rate limit'));
+
+      const s1 = makeDeployedSuggestion('sugg-1', '/page1');
+      const result = await client.setApplyStaleForSuggestions(
+        mockSite,
+        mockOpportunity,
+        [s1],
+        { applyStale: true },
+      );
+
+      expect(result.succeededSuggestions).to.deep.equal([s1]);
+      expect(log.warn).to.have.been.called;
+    });
+
+    it('returns empty results and never fetches config when given no suggestions', async () => {
+      const result = await client.setApplyStaleForSuggestions(
+        mockSite,
+        mockOpportunity,
+        [],
+        { applyStale: true },
+      );
+
+      expect(fetchConfigStub).to.not.have.been.called;
+      expect(result).to.deep.equal({ succeededSuggestions: [], failedSuggestions: [] });
+    });
+  });
 });

--- a/packages/spacecat-shared-tokowaka-client/test/index.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/index.test.js
@@ -2034,6 +2034,30 @@ describe('TokowakaClient', () => {
       expect(result.succeededSuggestions).to.have.length(2);
       expect(result.failedSuggestions).to.have.length(0);
       expect(s3Client.send).to.have.been.called;
+      expect(result.suggestionIdsHavingPatches).to.deep.equal(new Set(['sugg-1', 'sugg-2']));
+    });
+
+    it('should exclude prerender suggestions from suggestionIdsHavingPatches (no patch generated)', async () => {
+      const prerenderOpportunity = {
+        getId: () => 'opp-prerender-123',
+        getType: () => 'prerender',
+      };
+      const prerenderSuggestions = [
+        {
+          getId: () => 'prerender-sugg-1',
+          getUpdatedAt: () => '2025-01-15T10:00:00.000Z',
+          getData: () => ({ url: 'https://example.com/page1' }),
+        },
+      ];
+
+      const result = await client.deploySuggestions(
+        mockSite,
+        prerenderOpportunity,
+        prerenderSuggestions,
+      );
+
+      expect(result.succeededSuggestions).to.have.length(1);
+      expect(result.suggestionIdsHavingPatches).to.deep.equal(new Set());
     });
 
     it('should throw error if metaconfig does not exist', async () => {
@@ -6959,6 +6983,84 @@ describe('TokowakaClient', () => {
       expect(deploySuggestionsStub).to.have.been.calledOnce;
       const [,, , metadata] = deploySuggestionsStub.firstCall.args;
       expect(metadata).to.deep.equal({});
+    });
+
+    it('should stamp applyStale: true onto suggestion data when metadata.applyStale is true', async () => {
+      const s1 = makeSuggestion('s1', { url: 'https://example.com/page1', transformRules: {} });
+
+      deploySuggestionsStub.resolves({
+        succeededSuggestions: [s1],
+        failedSuggestions: [],
+        suggestionIdsHavingPatches: new Set(['s1']),
+      });
+
+      await client.deployToEdge({
+        site: mockSite,
+        opportunity: mockOpportunity,
+        targetSuggestions: [s1],
+        allSuggestions: [s1],
+        metadata: { applyStale: true },
+      });
+
+      expect(s1.getData()).to.have.property('applyStale', true);
+    });
+
+    it('should stamp applyStale: false onto suggestion data when metadata.applyStale is absent', async () => {
+      const s1 = makeSuggestion('s1', { url: 'https://example.com/page1', transformRules: {} });
+
+      deploySuggestionsStub.resolves({
+        succeededSuggestions: [s1],
+        failedSuggestions: [],
+        suggestionIdsHavingPatches: new Set(['s1']),
+      });
+
+      await client.deployToEdge({
+        site: mockSite,
+        opportunity: mockOpportunity,
+        targetSuggestions: [s1],
+        allSuggestions: [s1],
+      });
+
+      expect(s1.getData()).to.have.property('applyStale', false);
+    });
+
+    it('should not stamp applyStale onto suggestion data when the suggestion produced no patch (e.g. prerender-only)', async () => {
+      const s1 = makeSuggestion('s1', { url: 'https://example.com/page1', transformRules: {} });
+
+      deploySuggestionsStub.resolves({
+        succeededSuggestions: [s1],
+        failedSuggestions: [],
+        suggestionIdsHavingPatches: new Set(),
+      });
+
+      await client.deployToEdge({
+        site: mockSite,
+        opportunity: mockOpportunity,
+        targetSuggestions: [s1],
+        allSuggestions: [s1],
+        metadata: { applyStale: true },
+      });
+
+      expect(s1.getData()).to.not.have.property('applyStale');
+    });
+
+    it('should default to an empty suggestionIdsHavingPatches set when deploySuggestions omits it', async () => {
+      const s1 = makeSuggestion('s1', { url: 'https://example.com/page1', transformRules: {} });
+
+      deploySuggestionsStub.resolves({
+        succeededSuggestions: [s1],
+        failedSuggestions: [],
+      });
+
+      await client.deployToEdge({
+        site: mockSite,
+        opportunity: mockOpportunity,
+        targetSuggestions: [s1],
+        allSuggestions: [s1],
+        metadata: { applyStale: true },
+      });
+
+      expect(s1.getData()).to.not.have.property('applyStale');
     });
   });
 

--- a/packages/spacecat-shared-tokowaka-client/test/index.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/index.test.js
@@ -7005,7 +7005,7 @@ describe('TokowakaClient', () => {
       expect(s1.getData()).to.have.property('applyStale', true);
     });
 
-    it('should stamp applyStale: false onto suggestion data when metadata.applyStale is absent', async () => {
+    it('should leave applyStale absent from suggestion data when metadata.applyStale is absent', async () => {
       const s1 = makeSuggestion('s1', { url: 'https://example.com/page1', transformRules: {} });
 
       deploySuggestionsStub.resolves({
@@ -7021,7 +7021,27 @@ describe('TokowakaClient', () => {
         allSuggestions: [s1],
       });
 
-      expect(s1.getData()).to.have.property('applyStale', false);
+      expect(s1.getData()).to.not.have.property('applyStale');
+    });
+
+    it('should clear a stale applyStale: true from a prior deploy when redeploying without it', async () => {
+      const s1 = makeSuggestion('s1', { url: 'https://example.com/page1', transformRules: {} });
+      s1.setData({ ...s1.getData(), applyStale: true });
+
+      deploySuggestionsStub.resolves({
+        succeededSuggestions: [s1],
+        failedSuggestions: [],
+        suggestionIdsHavingPatches: new Set(['s1']),
+      });
+
+      await client.deployToEdge({
+        site: mockSite,
+        opportunity: mockOpportunity,
+        targetSuggestions: [s1],
+        allSuggestions: [s1],
+      });
+
+      expect(s1.getData()).to.not.have.property('applyStale');
     });
 
     it('should not stamp applyStale onto suggestion data when the suggestion produced no patch (e.g. prerender-only)', async () => {

--- a/packages/spacecat-shared-tokowaka-client/test/utils/suggestion-utils.test.js
+++ b/packages/spacecat-shared-tokowaka-client/test/utils/suggestion-utils.test.js
@@ -16,6 +16,7 @@ import {
   groupSuggestionsByUrlPath,
   filterEligibleSuggestions,
   saveSuggestions,
+  stripSuggestion,
   SUGGESTION_BULK_UPDATE_TYPE,
 } from '../../src/utils/suggestion-utils.js';
 
@@ -442,6 +443,40 @@ describe('Suggestion Utils', () => {
         expect(error.message).to.include('1 of 1701 suggestions failed');
         expect(error.message).to.include('DB error');
       }
+    });
+  });
+
+  describe('stripSuggestion', () => {
+    it('clears edgeDeployed, tokowakaDeployed and applyStale, and sets updatedBy', () => {
+      const suggestion = {
+        data: {
+          edgeDeployed: 1700000000000,
+          tokowakaDeployed: 1700000000000,
+          applyStale: true,
+          other: 'kept',
+        },
+        getData() { return this.data; },
+        setData(data) { this.data = data; },
+        setUpdatedBy: sinon.stub(),
+      };
+
+      const result = stripSuggestion(suggestion, 'tokowaka-rollback', undefined);
+
+      expect(result.getData()).to.deep.equal({ other: 'kept' });
+      expect(suggestion.setUpdatedBy.calledWith('tokowaka-rollback')).to.be.true;
+    });
+
+    it('prefers the explicit updatedBy over the fallback', () => {
+      const suggestion = {
+        data: { applyStale: true },
+        getData() { return this.data; },
+        setData(data) { this.data = data; },
+        setUpdatedBy: sinon.stub(),
+      };
+
+      stripSuggestion(suggestion, 'tokowaka-rollback', 'user@example.com');
+
+      expect(suggestion.setUpdatedBy.calledWith('user@example.com')).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## Summary
- New `TokowakaClient.setApplyStaleForSuggestions(site, opportunity, suggestions, { applyStale, updatedBy })` sets or clears `applyStale` on already-deployed, per-URL suggestions **without redeploying**: updates the matching S3 patch and mirrors the same value onto `suggestion.data`, invalidating CDN only for URLs actually changed.
- Eligibility: only per-URL suggestions (pattern/domain-wide are excluded) that have a matching patch already in S3 are eligible; everything else is returned in `failedSuggestions` with a reason, mirroring the `rollbackSuggestions`/`deploySuggestions` result shape.
- This is the shared-client half of a new customer-facing "keep this optimization alive" toggle that doesn't require a full redeploy. Companion PR: adobe/spacecat-api-service (new `PATCH .../suggestions/edge-apply-stale` endpoint, to follow).

Builds on top of the not-yet-merged `applyStale` deploy-time plumbing from adobe/spacecat-shared#1878 (this PR's diff includes those commits since #1878 hasn't merged yet).

## Test plan
- [x] `npm test -w packages/spacecat-shared-tokowaka-client` — 100% line/branch/statement coverage
- [x] `npm run lint -w packages/spacecat-shared-tokowaka-client` — clean
- [x] New tests cover: set/clear on matching patch, mirror onto suggestion.data, no-op-but-still-succeeds when patch already matches, ineligible suggestions (no patch, pattern/domain-wide, no existing config), multi-URL CDN invalidation scoping, and S3/CDN error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)