### PR TITLE
fix(data-access): publish brand semrushWorkspaceId mirror removal (SITES-49202)

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/brand/brand.model.js
+++ b/packages/spacecat-shared-data-access/src/models/brand/brand.model.js
@@ -27,6 +27,13 @@ import BaseModel from '../base/base.model.js';
  * sub-workspace itself is never deleted). See serenity-docs
  * brand-semrush-provisioning-v2-phase1-sync.md §6.
  *
+ * NOTE: there is no brand-level `semrushWorkspaceId` accessor. The deprecated
+ * read-only mirror (attribute, index, `findBySemrushWorkspaceId`,
+ * `allBySemrushWorkspaceId`, `setSemrushWorkspaceId`) was removed in SITES-49202;
+ * `semrushSubWorkspaceId` above is the write-of-record. The identically-named
+ * `Organization.semrushWorkspaceId` is a DISTINCT field and stays — do not
+ * reintroduce a brand mirror by symbol-name sweep.
+ *
  * @class Brand
  * @extends BaseModel
  */


### PR DESCRIPTION
## What & why

**Release-trigger for the §5 PR B removal that never published.**

[PR #1867](https://github.com/adobe/spacecat-shared/pull/1867) removed the deprecated brand `semrushWorkspaceId` mirror, but it was **squash-merged under a non-conventional title** (`SITES-49202: remove deprecated brand semrushWorkspaceId mirror …`). semantic-release could not derive a release type from that header, so it **published nothing** — the removal is on `main` but `@adobe/spacecat-shared-data-access` is still **4.21.0** on npm and in `package.json`, with no `chore(release)` after the merge.

**PR C** (mysticat-data-service — dropping the `brands.semrush_workspace_id` column + `sync_semrush_workspace_id_from_sub` trigger) is gated on PR B being **released**, not merely merged, so it is currently **blocked**. This PR carries a conventional `fix(data-access):` header so the squash commit is parseable and semantic-release cuts **4.21.1**, publishing the already-merged removal and unblocking PR C.

> ⚠️ **Merge with a conventional squash title** (this PR's title is already `fix(data-access): …`). Do not overwrite it with a bare `SITES-…:` title, or this will hit the same no-release gap #1867 did.

## Change

One genuine doc touch on the `Brand` class docblock (`brand.model.js`): a breadcrumb that there is **no brand-level `semrushWorkspaceId` accessor** — the mirror (attribute, index, `findBySemrushWorkspaceId`, `allBySemrushWorkspaceId`, `setSemrushWorkspaceId`) was removed in SITES-49202 — and that the identically-named `Organization.semrushWorkspaceId` is a **distinct field that stays**, so nobody reintroduces the brand mirror by a symbol-name sweep.

## Semver

Same rationale as #1867 — patch is intentional (internal package, zero verified consumers; the removed API is already gone from `main`). This PR simply gets that patch **published**.

## Links
- Follows: #1867 (§5 PR B, merged but unreleased)
- Jira: https://jira.corp.adobe.com/browse/SITES-49202
