### PR TITLE
feat(utils): add siteIdentityFromUrlString for Semrush primary_url (#348)

### DIFF
--- a/packages/spacecat-shared-utils/src/index.d.ts
+++ b/packages/spacecat-shared-utils/src/index.d.ts
@@ -167,6 +167,15 @@ export declare function canonicalizeUrl(
 export declare function composeBaseURL(domain: string): string;
 
 /**
+ * Derives a stable "site identity" (lowercased host + normalized path, no
+ * scheme/credentials/port/query/fragment) from a URL-ish string. Preserves the
+ * path so subpath-scoped sites are distinguishable. Returns null if unparseable.
+ * @param value - A URL or host(/path) string, with or without scheme.
+ * @returns The site identity, or null if unparseable.
+ */
+export declare function siteIdentityFromUrlString(value: string): string | null;
+
+/**
  * Composes an audit URL by applying a series of transformations to the given url.
  * @param {string} url - The url to compose the audit URL from.
  * @param {string} [userAgent] - Optional user agent to use in the audit URL.

--- a/packages/spacecat-shared-utils/src/index.js
+++ b/packages/spacecat-shared-utils/src/index.js
@@ -60,6 +60,7 @@ export { instrumentAWSClient, getTraceId, addTraceIdHeader } from './xray.js';
 export {
   canonicalizeUrl,
   composeBaseURL,
+  siteIdentityFromUrlString,
   composeAuditURL,
   prependSchema,
   stripPort,

--- a/packages/spacecat-shared-utils/src/url-helpers.js
+++ b/packages/spacecat-shared-utils/src/url-helpers.js
@@ -88,6 +88,53 @@ function composeBaseURL(domain) {
 }
 
 /**
+ * Derives a stable "site identity" from a URL-ish string: the lowercased host
+ * plus its normalized path, with no scheme, credentials, port, query or
+ * fragment. Unlike {@link composeBaseURL} (which also strips the path and
+ * `www.`), this preserves the path so two sites on the same host but different
+ * subpaths — e.g. `nba.com/kings` vs `nba.com/knicks` — yield distinct
+ * identities. It mirrors how Semrush normalizes `settings.ai.primary_url`.
+ *
+ * Normalization rules (fixed by tests, not left to callers):
+ * - The host is lowercased; the path is left case-sensitive.
+ * - Scheme, userinfo, port, query and fragment are stripped.
+ * - A single trailing slash is removed (`example.com/a/` -> `example.com/a`),
+ *   so a bare host and a bare-root URL agree (`example.com`).
+ * - A trailing `.html` is preserved — `example.com/x.html` (one page) and
+ *   `example.com/x` (a section) are deliberately distinct (SITES-49656).
+ * - `www.` is NOT collapsed against the apex, matching the `domain` derivation.
+ * - Returns `null` on unparseable input, so call sites keep their null handling.
+ *
+ * @param {string} value - A URL or host(/path) string, with or without scheme.
+ * @returns {string|null} The site identity, or `null` if unparseable.
+ */
+function siteIdentityFromUrlString(value) {
+  if (!hasText(value)) {
+    return null;
+  }
+  const trimmed = value.trim();
+  // Detect an existing scheme case-insensitively (prependSchema is
+  // case-sensitive); parse everything through URL so credentials/port/query/
+  // fragment fall away for free.
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+  try {
+    const url = new URL(withScheme);
+    const host = url.hostname.toLowerCase();
+    if (!host) {
+      return null;
+    }
+    const pathname = url.pathname.endsWith('/')
+      ? url.pathname.slice(0, -1)
+      : url.pathname;
+    return `${host}${pathname}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Composes an audit URL by applying a series of transformations to the given url.
  * @param {string} url - The url to compose the audit URL from.
  * @param {string} [userAgent] - Optional user agent to use in the audit URL.
@@ -638,6 +685,7 @@ export {
   getSpacecatRequestHeaders,
   resolveCanonicalUrl,
   composeBaseURL,
+  siteIdentityFromUrlString,
   composeAuditURL,
   prependSchema,
   stripPort,

--- a/packages/spacecat-shared-utils/test/index.test.js
+++ b/packages/spacecat-shared-utils/test/index.test.js
@@ -31,6 +31,7 @@ describe('Index Exports', () => {
     'CLOUDFLARE_LOGPUSH_FIELDS',
     'composeAuditURL',
     'composeBaseURL',
+    'siteIdentityFromUrlString',
     'dateAfterDays',
     'deepEqual',
     'DEFAULT_CPC_VALUE',

--- a/packages/spacecat-shared-utils/test/url-helpers.test.js
+++ b/packages/spacecat-shared-utils/test/url-helpers.test.js
@@ -18,6 +18,7 @@ import {
   canonicalizeUrl,
   composeAuditURL,
   composeBaseURL,
+  siteIdentityFromUrlString,
   prependSchema,
   stripPort,
   stripTrailingDot,
@@ -155,6 +156,57 @@ describe('URL Utility Functions', () => {
     it('should handle edge cases', () => {
       expect(composeBaseURL('')).to.equal('https://');
       expect(composeBaseURL('example')).to.equal('https://example');
+    });
+  });
+
+  describe('siteIdentityFromUrlString', () => {
+    it('keeps the host and preserves the path', () => {
+      expect(siteIdentityFromUrlString('https://www.nba.com/kings/')).to.equal('www.nba.com/kings');
+      expect(siteIdentityFromUrlString('nba.com/kings')).to.equal('nba.com/kings');
+      expect(siteIdentityFromUrlString('shangri-la.com/hongkong/kerry')).to.equal('shangri-la.com/hongkong/kerry');
+      expect(siteIdentityFromUrlString('quickbooks.intuit.com/au')).to.equal('quickbooks.intuit.com/au');
+    });
+
+    it('returns host-only (no trailing slash) for path-free URLs, matching a bare host', () => {
+      expect(siteIdentityFromUrlString('https://example.com')).to.equal('example.com');
+      expect(siteIdentityFromUrlString('https://example.com/')).to.equal('example.com');
+      expect(siteIdentityFromUrlString('example.com')).to.equal('example.com');
+      expect(siteIdentityFromUrlString('us.kisqali.com')).to.equal('us.kisqali.com');
+    });
+
+    it('strips a single trailing slash so /a/ and /a agree', () => {
+      expect(siteIdentityFromUrlString('experian.co.uk/business/')).to.equal('experian.co.uk/business');
+      expect(siteIdentityFromUrlString('experian.co.uk/business')).to.equal('experian.co.uk/business');
+    });
+
+    it('preserves a trailing .html (SITES-49656 — page vs section are distinct)', () => {
+      expect(siteIdentityFromUrlString('oklahoma.gov/omes.html')).to.equal('oklahoma.gov/omes.html');
+      expect(siteIdentityFromUrlString('oklahoma.gov/omes')).to.equal('oklahoma.gov/omes');
+    });
+
+    it('lowercases the host but leaves the path case-sensitive', () => {
+      expect(siteIdentityFromUrlString('HTTPS://Shop.Example.COM/UK/En')).to.equal('shop.example.com/UK/En');
+    });
+
+    it('strips scheme, userinfo, port, query and fragment', () => {
+      expect(siteIdentityFromUrlString('https://user:pass@shop.example.com:8443/uk?a=1&b=2#frag'))
+        .to.equal('shop.example.com/uk');
+      expect(siteIdentityFromUrlString('http://example.com:8080/shop')).to.equal('example.com/shop');
+    });
+
+    it('does not collapse www against the apex', () => {
+      expect(siteIdentityFromUrlString('www.example.com')).to.equal('www.example.com');
+      expect(siteIdentityFromUrlString('example.com')).to.equal('example.com');
+    });
+
+    it('returns null on empty or unparseable input', () => {
+      expect(siteIdentityFromUrlString('')).to.equal(null);
+      expect(siteIdentityFromUrlString('   ')).to.equal(null);
+      expect(siteIdentityFromUrlString(undefined)).to.equal(null);
+      expect(siteIdentityFromUrlString(null)).to.equal(null);
+      expect(siteIdentityFromUrlString('http://')).to.equal(null);
+      // parses successfully but yields an empty hostname
+      expect(siteIdentityFromUrlString('file:///etc/passwd')).to.equal(null);
     });
   });
 


### PR DESCRIPTION
## What
Adds `siteIdentityFromUrlString` to `spacecat-shared-utils`: derives a stable site identity (lowercased host + normalized path; strips scheme/userinfo/port/query/fragment; strips a single trailing slash; preserves a trailing `.html`; does not collapse `www.`; returns `null` on unparseable input).

## Why
serenity-docs#348 — Semrush `settings.ai.primary_url` is the URL a brand actually tracks (may carry a subdomain/subpath), distinct from the host-only `domain`. This is the shared primitive so the api-service (JS) and the data-service migration (Python) derive the same value under the same rules.

## Tests
8 new unit tests (subpath, trailing slash, `.html` preserved, case, scheme/userinfo/port/query/fragment stripping, www not collapsed, null cases). 100/97 coverage maintained.

Base is the session branch (this work layers on the PromiseTokenSession commit); will retarget to `main` once the base merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)