### PR TITLE
fix(data-access): remove deprecated brand pendingSemrushProvisioning attribute (SITES-49448)

### DIFF
--- a/packages/spacecat-shared-data-access/src/models/brand/brand.model.js
+++ b/packages/spacecat-shared-data-access/src/models/brand/brand.model.js
@@ -34,6 +34,14 @@ import BaseModel from '../base/base.model.js';
  * `Organization.semrushWorkspaceId` is a DISTINCT field and stays — do not
  * reintroduce a brand mirror by symbol-name sweep.
  *
+ * NOTE: there is also no `pendingSemrushProvisioning` attribute. That
+ * "Save as pending" staging blob (`{primaryUrl, markets, generatePrompts}`,
+ * mapped to `brands.pending_semrush_provisioning`) was removed in SITES-49448
+ * once the brand/market management model made pending brands carry no
+ * markets, models chosen per market, and the primary URL a `site_id`
+ * selection at create time — the blob's shape no longer matches anything the
+ * product writes.
+ *
  * @class Brand
  * @extends BaseModel
  */

--- a/packages/spacecat-shared-data-access/src/models/brand/brand.schema.js
+++ b/packages/spacecat-shared-data-access/src/models/brand/brand.schema.js
@@ -49,15 +49,6 @@ const schema = new SchemaBuilder(Brand, BrandCollection)
     type: 'string',
     validate: (value) => value == null || hasText(value),
   })
-  // Nullable JSONB blob holding deferred Semrush provisioning data for a
-  // pending (draft) brand. Maps to brands.pending_semrush_provisioning
-  // (migration 20260618120000). Validated loosely here (object-or-null); the
-  // DB CHECK enforces the object shape and the controller owns field-level
-  // validation and the activate-flow consumption semantics.
-  .addAttribute('pendingSemrushProvisioning', {
-    type: 'any',
-    validate: (value) => value == null || (typeof value === 'object' && !Array.isArray(value)),
-  })
   // Uniqueness guarantee on the write-of-record column
   // (brands.semrush_sub_workspace_id, mysticat-data-service migration
   // 20260702091920), so findBySemrushSubWorkspaceId returns at most one row.

--- a/packages/spacecat-shared-data-access/test/unit/models/brand/brand.schema.test.js
+++ b/packages/spacecat-shared-data-access/test/unit/models/brand/brand.schema.test.js
@@ -85,43 +85,4 @@ describe('Brand Schema', () => {
       expect(attributes.semrushSubWorkspaceId.postgrestField).to.be.undefined;
     });
   });
-
-  describe('pendingSemrushProvisioning attribute', () => {
-    it('exists with a nullable object validator', () => {
-      const attr = attributes.pendingSemrushProvisioning;
-      expect(attr).to.exist;
-      expect(attr.type).to.equal('any');
-      expect(attr.validate).to.be.a('function');
-    });
-
-    it('accepts an object (the draft provisioning blob)', () => {
-      expect(attributes.pendingSemrushProvisioning.validate({
-        primaryUrl: 'https://acme.com',
-        markets: [{ market: 'US', languageCode: 'en' }],
-      })).to.be.true;
-    });
-
-    it('accepts nullish (not a deferred draft, or cleared on activation)', () => {
-      expect(attributes.pendingSemrushProvisioning.validate(null)).to.be.true;
-      expect(attributes.pendingSemrushProvisioning.validate(undefined)).to.be.true;
-    });
-
-    it('accepts an empty object (loose by design — field validation lives in the controller)', () => {
-      expect(attributes.pendingSemrushProvisioning.validate({})).to.be.true;
-    });
-
-    it('rejects an array (must be an object)', () => {
-      expect(attributes.pendingSemrushProvisioning.validate([{ market: 'US' }])).to.be.false;
-    });
-
-    it('rejects a non-object scalar', () => {
-      expect(attributes.pendingSemrushProvisioning.validate('nope')).to.be.false;
-    });
-
-    // No postgrestField override: camelToSnake('pendingSemrushProvisioning') already
-    // produces the DB column name `pending_semrush_provisioning`.
-    it('uses the default camelToSnake column mapping (no override)', () => {
-      expect(attributes.pendingSemrushProvisioning.postgrestField).to.be.undefined;
-    });
-  });
 });


### PR DESCRIPTION
## What & why

Item 5 of the cross-repo SITES-49448 removal (Serenity post-GA cleanup — source: `docs/cleanup/post-ga-cleanup.md` §4 in serenity-docs, split out of SITES-49201). This PR removes the `pendingSemrushProvisioning` attribute from the `Brand` schema in `@adobe/spacecat-shared-data-access`.

`pendingSemrushProvisioning` mapped to `brands.pending_semrush_provisioning` (mysticat-data-service migration `20260618120000`), the "Save as pending" staging blob shaped `{primaryUrl, markets, generatePrompts}`. The brand/market management model (`docs/ui/brand-market-management.md`, serenity-docs) removes everything the blob staged: pending brands carry no markets, models are chosen per market, and the primary URL becomes a Site selection written to `brands.site_id` at create time. The column — and this attribute — are no longer needed.

**Live-data precondition** (verified against mysticat-prod 2026-08-07, per the ticket): 48 rows carry the blob (10 pending, 14 active, 24 deleted); no row outside `deleted` holds a non-empty `markets` array; only 2 deleted rows carry non-empty markets. Effectively nothing to drain.

### Full removal surface (this PR is only #5)
1. the column and its CHECK in mysticat-data-service, plus `schema.sql` and `docs/llmo-database-schema.md`
2. the stash write in `createBrandForOrg` (spacecat-api-service)
3. the `normalizePendingSemrushProvisioning` storage path
4. the activate-replay in `serenityController.activate`
5. **the `pendingSemrushProvisioning` attribute in spacecat-shared ← this PR**
6. the `PendingMarketsView` and `PendingEditModelsDialog` surfaces in project-elmo-ui

Items 1–4 (mysticat-data-service, spacecat-api-service) and item 6 (project-elmo-ui) are being handled in separate, parallel PRs — not part of this change.

## Changes

| File | Change |
|------|--------|
| `packages/spacecat-shared-data-access/src/models/brand/brand.schema.js` | Removed the `pendingSemrushProvisioning` attribute (and its comment block). |
| `packages/spacecat-shared-data-access/src/models/brand/brand.model.js` | Added a docblock breadcrumb (matching the SITES-49202 precedent style) noting the attribute is gone and why, so nobody reintroduces it by symbol-name sweep. |
| `packages/spacecat-shared-data-access/test/unit/models/brand/brand.schema.test.js` | Removed the `pendingSemrushProvisioning attribute` describe block. |

No changes were needed to `brand.model.js` getters/setters, `brand.collection.js`, or `index.d.ts` — the attribute was never exposed via a hand-written type declaration (`index.d.ts` only declares `name`/`status`/`semrushSubWorkspaceId`), so there's no public TS surface to update. Confirmed via repo-wide grep (`pendingSemrushProvisioning` / `pending_semrush_provisioning`) that no other file in spacecat-shared references it outside the three touched here and the auto-generated `CHANGELOG.md` (left untouched, historical).

## Semver

Shipping as **patch**, matching the precedent set by the `semrushWorkspaceId` mirror removal (SITES-49202, spacecat-shared #1867/#1880 — also see that PR's note that a squash-merge title *must* stay conventional-commit-formatted, e.g. `fix(data-access): …`, or semantic-release silently fails to publish). This is an internal `@adobe/` package; the attribute was never exposed via this package's `index.d.ts`. Note `spacecat-api-service` reads/writes the `pending_semrush_provisioning` column through its own storage layer (not through this package's Brand model accessors), so this removal doesn't change that layer's contract — and that repo's own test suite already has SITES-49448-labeled cases exercising the field's retirement, confirming coordinated, in-progress removal there.

## Validation
- `npm run lint -w packages/spacecat-shared-data-access`: clean.
- `npm test -w packages/spacecat-shared-data-access`: **2800 passing, 0 failing**, 100% line/statement/function coverage and 100% branch coverage on `src/models/brand`.

## Links
- Jira: SITES-49448