### PR TITLE
test(utils): pin path dot-segment cases in the site-identity corpus

### DIFF
--- a/packages/spacecat-shared-utils/test/fixtures/site-identity-corpus.json
+++ b/packages/spacecat-shared-utils/test/fixtures/site-identity-corpus.json
@@ -40,6 +40,13 @@
     { "input": "example.com/a%2Fb", "identity": "example.com/a%2Fb", "why": "an already-encoded path is NOT double-encoded" },
     { "input": "foo_bar.com/x", "identity": "foo_bar.com/x", "why": "an underscore host is accepted; IDNA2003 would reject it" },
     { "input": "example.com.", "identity": "example.com.", "why": "a trailing dot is left alone by both" },
-    { "input": "http://[::1]/x", "identity": "[::1]/x", "why": "an IPv6 literal keeps its brackets" }
+    { "input": "http://[::1]/x", "identity": "[::1]/x", "why": "an IPv6 literal keeps its brackets" },
+    { "input": "example.com/a/../b", "identity": "example.com/b", "why": "WHATWG resolves a '..' segment while parsing; urlsplit does not" },
+    { "input": "example.com/a/./b", "identity": "example.com/a/b", "why": "a '.' segment is dropped, not kept as a literal path element" },
+    { "input": "example.com/x/..", "identity": "example.com", "why": "a trailing '..' leaves a trailing slash, which then reduces to the bare host" },
+    { "input": "example.com/x/y/../../z", "identity": "example.com/z", "why": "consecutive '..' segments each pop one ancestor" },
+    { "input": "example.com/a/%2E%2E/c", "identity": "example.com/c", "why": "a percent-encoded '..' is still a dot segment, and the case is ignored" },
+    { "input": "example.com/a/..%2fb", "identity": "example.com/a/..%2fb", "why": "%2f is NOT decoded, so this is one ordinary segment and survives intact" },
+    { "input": "example.com/a//b", "identity": "example.com/a//b", "why": "an empty segment is preserved; only dot segments are resolved" }
   ]
 }

--- a/packages/spacecat-shared-utils/test/url-helpers.test.js
+++ b/packages/spacecat-shared-utils/test/url-helpers.test.js
@@ -1376,7 +1376,7 @@ describe('URL Utility Functions', () => {
     // and is asserted by tests/unit/test_site_identity.py. The hash below pins the two
     // together: editing either copy alone fails that copy's own suite, which is the
     // signal to sync the other. Update it deliberately when adding cases to both.
-    const CORPUS_SHA256 = '7eda5d669725b4fafe1dfc5ea81a4705d545b57bfbc3d72edd1a281c7f955575';
+    const CORPUS_SHA256 = '0fc160c95f4208f232e1770e7893821390b6df259332afc13cef41caebb0ee78';
     const corpusPath = new URL('./fixtures/site-identity-corpus.json', import.meta.url);
     const corpusRaw = readFileSync(corpusPath);
     const corpus = JSON.parse(corpusRaw);


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract

Adds path dot-segment cases to the shared site-identity conformance corpus, so the contract `siteIdentityFromUrlString` already implements is pinned rather than assumed.

## 2. Reasoning

`siteIdentityFromUrlString` delegates to `new URL()`, which resolves `.` and `..` while parsing and treats a percent-encoded `%2e` as a literal dot. Its Python counterpart in `mysticat-data-service` did neither, so the two halves of the pair disagreed on every URL whose path carried a dot segment.

The two write and compare the same Semrush field. This side wrote `a.com/b` for `a.com/a/../b` while a reconcile on the other side computed `a.com/a/../b`, so the project reported drift on every run and had a correct value rewritten each time — the precise failure the corpus exists to prevent.

The divergence survived the original convergence work because nothing exercised it: the randomized run that established the pair never generated a dot segment or a `%2e`, and none of the forty pinned cases carried one. It surfaced during a review of the data-service side.

## 3. High-level overview of the changes

No source change. The JavaScript behaviour was already correct; what was missing is the coverage that would have caught the other half drifting from it.

- Seven cases are added to the corpus: a `..` segment resolving against its ancestor, a `.` segment being dropped, a trailing dot segment reducing to the bare host, consecutive `..` segments, and a percent-encoded `%2E%2E` treated as a dot segment regardless of case.
- Two of them pin the contract in the opposite direction, which is the easier half to get wrong: `%2f` is **not** decoded, so `/a/..%2fb` stays a single ordinary segment, and an empty segment survives, so `/a//b` keeps its doubled slash. Without these a "fix" on either side could over-normalize and re-introduce the disagreement from the other direction.
- `CORPUS_SHA256` moves to the new fixture's digest.

Operationally nothing changes here. The behavioural correction ships on the Python side.

## 4. Required information

- Jira / issue: https://github.com/adobe/serenity-docs/issues/348
- Other: the corpus contract itself is documented in the fixture's own `description` field, and in the module docstring of the Python half

## 5. Affected / used mysticat-workspace projects

- **mysticat-data-service** — contract. Holds the byte-identical copy of this corpus and the Python half of the pair. Each suite pins the sha256 of its own copy, so the two files must move together; this PR and the data-service one carry the same fixture bytes.

## 6. Additional information outside the code

The two implementations were run head-to-head rather than trusted to the fixture. After the Python-side correction they agree across 3,000 randomized inputs built specifically from dot-segment, `%2e`, `%2f`, empty-segment and internationalized-host shapes, with no divergences. The exact WHATWG behaviour each case pins was read off Node's own `URL` rather than inferred.

The two corpus copies were compared by digest after the change and are byte-identical (`0fc160c95f4208f232e1770e7893821390b6df259332afc13cef41caebb0ee78`).

## 7. Test plan

**Locally, beyond unit tests:** the differential run described in section 6 — both implementations over the randomized dot-segment corpora, compared element-wise.

**Verification after merge:** no runtime surface changes, so there is nothing to exercise on an environment. The meaningful check is that the two copies stay in lockstep: if either is edited alone, that copy's own suite fails on the pinned digest, which is the signal to sync the other.

## 8. Deployment & merge order

- https://github.com/adobe/mysticat-data-service/pull/919 — related. Carries the Python-side correction and the same fixture bytes.

No ordering constraint in either direction: the languages share no runtime dependency, and each suite validates only its own copy. Merging them close together keeps the two corpora from sitting divergent on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
