### PR TITLE
chore: retire the legacy Semrush proxy host from client docs and mocks

### DIFF
--- a/packages/spacecat-shared-project-engine-client/mock/brand-url-validation.js
+++ b/packages/spacecat-shared-project-engine-client/mock/brand-url-validation.js
@@ -71,7 +71,7 @@ function isGoParseableUrl(raw) {
  * never an import — see {@link Context}). Kept a pure function so it is unit-tested on its own (the
  * route handler is coverage-excluded), the same convention as {@link resolveUrl} / {@link tagId}.
  *
- * Live contract (write-probed 2026-07-13 against prod `adobe-hackathon.semrush.com`, throwaway
+ * Live contract (write-probed 2026-07-13 against prod `www.semrush.com`, throwaway
  * benchmarks in the LLMO-Dev-2 dev sub-workspace, serenity-docs#25): a brand URL MUST be a literal,
  * lower-case `https://` URL. `BrandURLRequest.URL` carries the go-validator tags
  * `required,url,startswith=https://`, evaluated in that order — and each tag's semantics are go's,

--- a/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}.js
+++ b/packages/spacecat-shared-project-engine-client/mock/counterfact/routes/v2/workspaces/{id}/projects/{project_id}/aio/tags/{tag_id}.js
@@ -32,7 +32,7 @@
  * nullable in the overlay so a literal `null` passes Counterfact's request validation.
  * `children_count`/`path` are derived at read time, so they are not part of the update. Returns
  * 200 `TreeNodeResponse` and 404 `{ message: 'not found' }` for an unknown `tag_id` — both
- * verified 2026-07-01 against prod (`adobe-hackathon.semrush.com`); the vendored swagger's
+ * verified 2026-07-01 against prod (`www.semrush.com`); the vendored swagger's
  * 201/no-404 is corrected by overlay CR11/CR12. Materialized into `.counterfact/routes/` by the
  * mock runner; excluded from coverage.
  */

--- a/packages/spacecat-shared-project-engine-client/mock/url-resolve.js
+++ b/packages/spacecat-shared-project-engine-client/mock/url-resolve.js
@@ -20,7 +20,7 @@
  * its own (the route handler is coverage-excluded), the same convention as {@link tagId} /
  * `parentIdField`.
  *
- * Live contract (verified 2026-07-03 against prod `adobe-hackathon.semrush.com` — serenity-docs#25
+ * Live contract (verified 2026-07-03 against prod `www.semrush.com` — serenity-docs#25
  * §0): `primary_url` strips the scheme and a leading `www.` but PRESERVES any other subdomain and
  * the path (`http://www.lovesac.com/products` → `lovesac.com/products`; `https://blog.hubspot.com`
  * → `blog.hubspot.com`); `domain` is the registrable apex, stripping the subdomain too

--- a/packages/spacecat-shared-project-engine-client/spec/overlays/corrections.yaml
+++ b/packages/spacecat-shared-project-engine-client/spec/overlays/corrections.yaml
@@ -53,7 +53,7 @@ info:
 #      model.AIOBenchmarkWithCounters upstream, so this correction became redundant. Dropped.
 # CR11 aio-update-tag (PATCH /v2/.../aio/tags/{tag_id}) responds 200, not 201. The vendored swagger
 #      declares the success response under 201; the live API responds 200 OK (verified 2026-07-01
-#      against prod `adobe-hackathon.semrush.com`, workspace bb0f4e1c-… child, PATCH re-parent+rename
+#      against prod `www.semrush.com`, workspace bb0f4e1c-… child, PATCH re-parent+rename
 #      of a tag → 200 with the updated TreeNodeResponse). Move the response 201→200 so the type, the
 #      mock, and the live API agree. Remove if Semrush changes the status upstream.
 # CR12 aio-update-tag returns 404 (not 500) for an unknown tag id. The vendored swagger declares no

--- a/packages/spacecat-shared-project-engine-client/src/client.js
+++ b/packages/spacecat-shared-project-engine-client/src/client.js
@@ -28,7 +28,7 @@ import { createRetryingFetch, toTokenGetter } from './internal.js';
 /**
  * @typedef {object} SerenityProjectEngineApiClientOptions
  * @property {string} baseUrl Base URL of the Project Engine API — the origin of
- *   `SEMRUSH_PROJECTS_BASE_URL` (e.g. `https://adobe-hackathon.semrush.com`), or the Counterfact
+ *   `SEMRUSH_PROJECTS_BASE_URL` (e.g. `https://www.semrush.com`), or the Counterfact
  *   mock's origin for E2E / local dev. Only `protocol//host` is used; any path is dropped and the
  *   client appends the fixed `/enterprise/projects/api` prefix itself, matching the deployed
  *   api-service transport (`rest-transport.js`).

--- a/packages/spacecat-shared-project-engine-client/test/mock/brand-url-validation.test.js
+++ b/packages/spacecat-shared-project-engine-client/test/mock/brand-url-validation.test.js
@@ -14,7 +14,7 @@ import { expect } from 'chai';
 import { brandUrlHttpsTag } from '../../mock/brand-url-validation.js';
 
 // Every value below was POSTed to the LIVE Semrush `create_brand_urls` during the 2026-07-13
-// write-probe (prod `adobe-hackathon.semrush.com`, throwaway benchmarks in the LLMO-Dev-2 dev
+// write-probe (prod `www.semrush.com`, throwaway benchmarks in the LLMO-Dev-2 dev
 // sub-workspace, serenity-docs#25), and the expectation is the tag prod actually answered with.
 // `BrandURLRequest.URL` is `required,url,startswith=https://`, evaluated in that order — so the
 // cases that matter are the ones where go's semantics differ from JS's: a case-SENSITIVE

--- a/packages/spacecat-shared-user-manager-client/README.md
+++ b/packages/spacecat-shared-user-manager-client/README.md
@@ -21,7 +21,7 @@ import { createSerenityUserManagerApiClient } from '@adobe/spacecat-shared-user-
 const client = createSerenityUserManagerApiClient({
   // origin only — the client appends `/enterprise/users/api` itself. The host is shared with
   // Project Engine (`SEMRUSH_PROJECTS_BASE_URL`), or the Counterfact mock's origin for E2E.
-  baseUrl: 'https://adobe-hackathon.semrush.com',
+  baseUrl: 'https://www.semrush.com',
   // a raw IMS JWT, or a (sync/async) getter resolved per request
   authToken: () => getCurrentImsToken(),
 });
@@ -131,6 +131,6 @@ generated types. `test/overlay.test.js` covers the overlay applier itself.
 - Pydantic v2 is the default target; switch the `--output-model-type` flag in
   `generate:pydantic` if a consumer needs v1.
 - The base host is shared with Project Engine (`SEMRUSH_PROJECTS_BASE_URL`, e.g. the dev
-  `https://adobe-hackathon.semrush.com`); only the basePath differs (`/enterprise/users/api`
+  `https://www.semrush.com`); only the basePath differs (`/enterprise/users/api`
   vs `/enterprise/projects/api`). The live API authenticates on `Authorization: Bearer <IMS>` —
   Semrush accepts the IMS bearer directly (see [Spec corrections](#spec-corrections)).

--- a/packages/spacecat-shared-user-manager-client/docs/mock-statefulness.md
+++ b/packages/spacecat-shared-user-manager-client/docs/mock-statefulness.md
@@ -39,7 +39,7 @@ a cycle guard); `delete` is a transitive cascade. The pure layer is unit-tested 
 
 ## Live-fidelity validation (replayed 2026-06-26)
 
-Every op was replayed against the **real** gateway (`adobe-hackathon.semrush.com`,
+Every op was replayed against the **real** gateway (`www.semrush.com`,
 `/enterprise/users/api` — the client's documented base URL) under a funded test parent
 workspace (a real provisioned workspace id, kept in the team's `local/` handover notes, not
 committed to this public repo) — one throwaway child, `trap`-cleaned, parent `family` asserted

--- a/packages/spacecat-shared-user-manager-client/mock/quota.js
+++ b/packages/spacecat-shared-user-manager-client/mock/quota.js
@@ -17,7 +17,7 @@
  * model the live Semrush gateway exposes at `GET /v1/workspaces/{id}/resources` and enforces on a
  * resource transfer.
  *
- * Model (live-verified 2026-07-02 against `adobe-hackathon.semrush.com`; see the
+ * Model (live-verified 2026-07-02 against `www.semrush.com`; see the
  * dynamic-allocation plan "Gate 0"):
  * - Every metered workspace holds per-product `{ used, drafted, total }` for `ai`'s `projects` and
  *   `prompts` (plus `weekly_prompts`, always `0` — provisioning is daily-only). `total` is the

--- a/packages/spacecat-shared-user-manager-client/src/client.js
+++ b/packages/spacecat-shared-user-manager-client/src/client.js
@@ -27,7 +27,7 @@ import { createRetryingFetch, toTokenGetter } from './internal.js';
  * @typedef {object} SerenityUserManagerApiClientOptions
  * @property {string} baseUrl Base URL of the User Manager API — the origin of
  *   `SEMRUSH_PROJECTS_BASE_URL` (the host is shared with Project Engine, e.g.
- *   `https://adobe-hackathon.semrush.com`), or the Counterfact mock's origin for E2E / local dev.
+ *   `https://www.semrush.com`), or the Counterfact mock's origin for E2E / local dev.
  *   Only `protocol//host` is used; any path is dropped and the client appends the fixed
  *   `/enterprise/users/api` prefix itself, matching the deployed api-service transport
  *   (`rest-transport.js`).


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Replaces the legacy `adobe-hackathon` Semrush proxy host with `https://www.semrush.com` in the project-engine-client and user-manager-client packages — JSDoc examples, Counterfact mocks, the spec overlay, README, and docs. No behavior change.

## 2. Reasoning
The legacy proxy host is being decommissioned: Semrush UDH accepts Adobe IMS tokens natively at `https://www.semrush.com`, and prod spacecat-api-service already runs against the new host (Vault flipped 2026-08-19). Both clients take their base URL from the caller (`SEMRUSH_PROJECTS_BASE_URL` / `SEMRUSH_USERS_BASE_URL`), so nothing functional lives here — but the examples and mock fixtures still named the old host, and anything copied from them would target a host that is about to be shut down.

## 3. High-level overview of the changes
- `spacecat-shared-project-engine-client`: JSDoc base-URL example in `src/client.js`, the swagger `spec/overlays/corrections.yaml`, Counterfact mock fixtures (`url-resolve.js`, `brand-url-validation.js`, the aio-tags route), and the brand-url-validation test now use the UDH host.
- `spacecat-shared-user-manager-client`: JSDoc example in `src/client.js`, `README.md`, `docs/mock-statefulness.md`, and the `mock/quota.js` fixture likewise.
- All occurrences are examples or mock data; the string values are internally consistent, so the mocks and tests behave exactly as before.

## 4. Required information
- Other: part of a coordinated sweep removing the legacy proxy host; the only functional change lives in https://github.com/adobe/mysticat-data-service/pull/947 (script default), with a docs/examples-only companion in https://github.com/adobe/spacecat-api-service/pull/3109 and one in serenity-docs.

## 7. Test plan
- Nothing runtime-visible to verify: consumers pass the real base URL via env/Vault, which this PR does not touch. Prod api-service already runs against `https://www.semrush.com`.

## 8. Deployment & merge order
- https://github.com/adobe/mysticat-data-service/pull/947 — related (same sweep, independent to merge).
- https://github.com/adobe/spacecat-api-service/pull/3109 — related (same sweep, independent to merge).

No ordering constraints; all sweep PRs are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)