### PR TITLE
fix(http-utils): guard AuthInfo.hasOrganization against a non-string orgId

### DIFF
--- a/packages/spacecat-shared-http-utils/src/auth/auth-info.js
+++ b/packages/spacecat-shared-http-utils/src/auth/auth-info.js
@@ -103,6 +103,11 @@ export default class AuthInfo {
   hasFacsPermission(permission) { return this.getFacsPermissions().includes(permission); }
 
   hasOrganization(orgId) {
+    // Fail-closed on a missing or non-string org id, mirroring getFacsPermissions: an
+    // undefined orgId means "no access to check against", not an internal error.
+    if (typeof orgId !== 'string' || orgId.length === 0) {
+      return false;
+    }
     const [id] = orgId.split('@');
     return this.profile?.tenants?.some(
       (tenant) => tenant.id === id,

--- a/packages/spacecat-shared-http-utils/test/auth/auth-info.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/auth-info.test.js
@@ -258,6 +258,13 @@ describe('AuthInfo', () => {
       expect(authInfo.hasOrganization(123)).to.be.false;
     });
 
+    it('returns false when orgId is whitespace-only (passes the guard, fails the tenant match)', () => {
+      const authInfo = new AuthInfo().withProfile({
+        tenants: [{ id: 'ABC123' }],
+      });
+      expect(authInfo.hasOrganization(' ')).to.be.false;
+    });
+
     it('returns true when a tenant matches the bare orgId', () => {
       const authInfo = new AuthInfo().withProfile({
         tenants: [{ id: 'ABC123' }],

--- a/packages/spacecat-shared-http-utils/test/auth/auth-info.test.js
+++ b/packages/spacecat-shared-http-utils/test/auth/auth-info.test.js
@@ -229,6 +229,67 @@ describe('AuthInfo', () => {
     });
   });
 
+  describe('hasOrganization', () => {
+    it('returns false when orgId is undefined', () => {
+      const authInfo = new AuthInfo().withProfile({
+        tenants: [{ id: 'ABC123' }],
+      });
+      expect(authInfo.hasOrganization(undefined)).to.be.false;
+    });
+
+    it('returns false when orgId is null', () => {
+      const authInfo = new AuthInfo().withProfile({
+        tenants: [{ id: 'ABC123' }],
+      });
+      expect(authInfo.hasOrganization(null)).to.be.false;
+    });
+
+    it('returns false when orgId is an empty string', () => {
+      const authInfo = new AuthInfo().withProfile({
+        tenants: [{ id: 'ABC123' }],
+      });
+      expect(authInfo.hasOrganization('')).to.be.false;
+    });
+
+    it('returns false when orgId is not a string', () => {
+      const authInfo = new AuthInfo().withProfile({
+        tenants: [{ id: 'ABC123' }],
+      });
+      expect(authInfo.hasOrganization(123)).to.be.false;
+    });
+
+    it('returns true when a tenant matches the bare orgId', () => {
+      const authInfo = new AuthInfo().withProfile({
+        tenants: [{ id: 'ABC123' }],
+      });
+      expect(authInfo.hasOrganization('ABC123')).to.be.true;
+    });
+
+    it('returns true when a tenant matches the orgId with @AdobeOrg stripped', () => {
+      const authInfo = new AuthInfo().withProfile({
+        tenants: [{ id: 'ABC123' }],
+      });
+      expect(authInfo.hasOrganization('ABC123@AdobeOrg')).to.be.true;
+    });
+
+    it('returns false when no tenant matches', () => {
+      const authInfo = new AuthInfo().withProfile({
+        tenants: [{ id: 'OTHER' }],
+      });
+      expect(authInfo.hasOrganization('ABC123@AdobeOrg')).to.be.false;
+    });
+
+    it('returns undefined when profile is not set', () => {
+      const authInfo = new AuthInfo();
+      expect(authInfo.hasOrganization('ABC123')).to.be.undefined;
+    });
+
+    it('returns undefined when tenants is not in profile', () => {
+      const authInfo = new AuthInfo().withProfile({});
+      expect(authInfo.hasOrganization('ABC123')).to.be.undefined;
+    });
+  });
+
   describe('hasFacsPermission', () => {
     it('returns false when there are no facs permissions', () => {
       const authInfo = new AuthInfo().withProfile({});


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Guards `AuthInfo.hasOrganization` against a missing or non-string `orgId` so it resolves to "no access" instead of throwing.

## 2. Reasoning
`AuthInfo.hasOrganization(orgId)` called `orgId.split('@')` without guarding its argument, so an `undefined` org id raised a `TypeError` from inside the access-control path instead of resolving to "no access". On spacecat-api-service dev, this surfaced as 12,817 occurrences of the resulting `TypeError: Cannot read properties of undefined (reading 'split')` across 7 organization ids over 2026-08-20 through 2026-08-24, in `AccessControlUtil.hasAccess` -> `listBrandsForOrg`. The call sits behind a `try`/`catch`, so each request failed closed and surfaced as an internal error — an ordinary "this caller has no access to that org" outcome reported as a bug, leaving the brand-listing route unusable for the affected organizations. `getFacsPermissions`, directly above `hasOrganization` in the same class, already guards against an unexpected claim shape for this exact reason and carries a comment explaining the fail-closed intent; `hasOrganization` read as the same contract but did not hold it.

## 3. High-level overview of the changes
`hasOrganization` now returns `false` immediately when `orgId` is not a non-empty string, before attempting to split it. Behaviour delta:
- Before: `hasOrganization(undefined)` (or any non-string/empty `orgId`) threw a `TypeError`.
- After: `hasOrganization(undefined)` (or `null`, a number, or `''`) returns `false` — the caller is treated as lacking access to that organization, matching the existing fail-closed pattern used by `getFacsPermissions`.
- Valid string org ids (bare or with an `@AdobeOrg` suffix) are unaffected — same tenant-matching behaviour as before.

Both existing call sites in `read-only-admin-wrapper.js` already guard `imsOrgId` before calling `hasOrganization`, so this closes the gap for other/future callers reaching it with an unguarded value, such as `AccessControlUtil.hasAccess` in spacecat-api-service.

## 4. Required information
- Jira / issue: https://github.com/adobe/spacecat-shared/issues/1890

Closes #1890

## 6. Affected / used mysticat-workspace projects
- spacecat-api-service — consumed: this is where the `TypeError` was observed (dev, `AccessControlUtil.hasAccess` -> `listBrandsForOrg`). The fix only takes effect there once spacecat-api-service bumps its `@adobe/spacecat-shared-http-utils` dependency to a release containing this change.

## 8. Test plan
(a) Locally exercised `hasOrganization` directly via a Node REPL import against the built module: `hasOrganization(undefined)` and `hasOrganization(null)` both resolve to `false`, and `hasOrganization('ABC123@AdobeOrg')` against a profile with a matching tenant still resolves to `true`.
(b) Once released and consumed by spacecat-api-service, verify on dev by hitting the brand-listing route for one of the affected organization ids (e.g. `4eed02e2-a47d-48ba-8fef-0bdf2e4d0f28`) and confirming the response is a clean access-control outcome rather than a 500/internal error, then confirm the `TypeError: Cannot read properties of undefined (reading 'split')` signature stops appearing in Splunk/CloudWatch for `/aws/lambda/spacecat-services--api-service` on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
